### PR TITLE
feat: add version information to command outputs

### DIFF
--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -123,7 +123,9 @@ impl MessageCommand {
 impl ViewCommand {
     /// Execute view command
     pub fn execute(self) -> Result<()> {
-        use crate::data::{FieldExplanation, FileStatusInfo, RepositoryView, WorkingDirectoryInfo};
+        use crate::data::{
+            FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo, WorkingDirectoryInfo,
+        };
         use crate::git::{GitRepository, RemoteInfo};
 
         let commit_range = self.commit_range.as_deref().unwrap_or("HEAD");
@@ -152,15 +154,21 @@ impl ViewCommand {
         // Parse commit range and get commits
         let commits = repo.get_commits_in_range(commit_range)?;
 
+        // Create version information
+        let versions = Some(VersionInfo {
+            omni_dev: env!("CARGO_PKG_VERSION").to_string(),
+        });
+
         // Build repository view
         let mut repo_view = RepositoryView {
+            versions,
             explanation: FieldExplanation::default(),
             working_directory,
             remotes,
-            commits,
             branch_info: None,
             pr_template: None,
             branch_prs: None,
+            commits,
         };
 
         // Update field presence based on actual data
@@ -206,7 +214,8 @@ impl InfoCommand {
     /// Execute info command
     pub fn execute(self) -> Result<()> {
         use crate::data::{
-            BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, WorkingDirectoryInfo,
+            BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo,
+            WorkingDirectoryInfo,
         };
         use crate::git::{GitRepository, RemoteInfo};
 
@@ -271,17 +280,23 @@ impl InfoCommand {
             .ok()
             .filter(|prs| !prs.is_empty());
 
+        // Create version information
+        let versions = Some(VersionInfo {
+            omni_dev: env!("CARGO_PKG_VERSION").to_string(),
+        });
+
         // Build repository view with branch info
         let mut repo_view = RepositoryView {
+            versions,
             explanation: FieldExplanation::default(),
             working_directory,
             remotes,
-            commits,
             branch_info: Some(BranchInfo {
                 branch: current_branch,
             }),
             pr_template,
             branch_prs,
+            commits,
         };
 
         // Update field presence based on actual data

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -12,6 +12,9 @@ pub use yaml::*;
 /// Complete repository view output structure
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RepositoryView {
+    /// Version information for the omni-dev tool
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub versions: Option<VersionInfo>,
     /// Explanation of field meanings and structure
     pub explanation: FieldExplanation,
     /// Working directory status information
@@ -72,6 +75,13 @@ pub struct FileStatusInfo {
     pub file: String,
 }
 
+/// Version information for tools and environment
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionInfo {
+    /// Version of the omni-dev tool
+    pub omni_dev: String,
+}
+
 /// Branch information for branch-specific commands
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BranchInfo {
@@ -116,6 +126,7 @@ impl RepositoryView {
                 "commits[].analysis.file_changes.file_list" => !self.commits.is_empty(),
                 "commits[].analysis.diff_summary" => !self.commits.is_empty(),
                 "commits[].analysis.diff_content" => !self.commits.is_empty(),
+                "versions.omni_dev" => self.versions.is_some(),
                 "branch_info.branch" => self.branch_info.is_some(),
                 "pr_template" => self.pr_template.is_some(),
                 "branch_prs" => self.branch_prs.is_some(),
@@ -248,6 +259,12 @@ impl Default for FieldExplanation {
                     name: "commits[].analysis.diff_content".to_string(),
                     text: "Full diff content showing line-by-line changes with added, removed, and context lines".to_string(),
                     command: Some("git show <commit>".to_string()),
+                    present: false,
+                },
+                FieldDocumentation {
+                    name: "versions.omni_dev".to_string(),
+                    text: "Version of the omni-dev tool".to_string(),
+                    command: Some("omni-dev --version".to_string()),
                     present: false,
                 },
                 FieldDocumentation {


### PR DESCRIPTION
# Pull Request

## Description
This PR adds version information to both `git commit message view` and `git branch info` commands in omni-dev. The `versions` field now appears first in the YAML output, providing immediate visibility into which version of the omni-dev tool is generating the output.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Add `VersionInfo` struct with omni_dev version field
- Include version information in both ViewCommand and InfoCommand 
- Reorder RepositoryView fields to put versions first in output
- Update field documentation and presence tracking
- Use env!("CARGO_PKG_VERSION") to get version from Cargo.toml
- Improve slash command documentation structure and troubleshooting

## Testing
- [x] All existing tests pass
- [x] Manual testing performed
- [x] Version field appears correctly in both commands

### Test Commands
```bash
cargo test
cargo clippy
cargo fmt --check
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
This enhancement improves debugging and compatibility tracking by providing clear version information in command outputs. The versions field appears first for immediate visibility to both users and AI assistants.