### PR TITLE
fix: resolve short commit hash ambiguity in rebase operations

### DIFF
--- a/src/git/amendment.rs
+++ b/src/git/amendment.rs
@@ -229,10 +229,10 @@ impl AmendmentHandler {
 
             if commit.starts_with(&commit_hash[..commit.len().min(commit_hash.len())]) {
                 // This is our target commit - mark it for editing
-                sequence_content.push_str(&format!("edit {} {}\n", &commit[..7], subject));
+                sequence_content.push_str(&format!("edit {} {}\n", commit, subject));
             } else {
                 // Other commits - just pick them
-                sequence_content.push_str(&format!("pick {} {}\n", &commit[..7], subject));
+                sequence_content.push_str(&format!("pick {} {}\n", commit, subject));
             }
         }
 


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes an issue where short commit hashes (7 characters) used in interactive rebase operations could be ambiguous, causing rebase failures with error messages like "short object ID 58c0f07 is ambiguous".

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issue
Fixes hash ambiguity errors in commit amendment operations

## Changes Made
- Modified `src/git/amendment.rs` to use full commit hashes instead of truncated 7-character hashes in rebase sequence generation
- Changed `&commit[..7]` to `commit` in both `edit` and `pick` commands within the rebase sequence
- This eliminates ambiguity when multiple git objects share the same 7-character prefix

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Commands
```bash
cargo test
cargo clippy
cargo fmt --check
```

Manual testing confirmed that commit amendment operations now complete successfully without hash ambiguity errors.

## Screenshots
N/A - This is an internal fix for git operations.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes
None - this is a backward-compatible bug fix.

## Additional Notes
This fix addresses a git-level issue where short hashes can become ambiguous as the repository grows. Using full hashes ensures reliable rebase operations regardless of repository size or object count.