### PR TITLE
feat(data): write diffs to files instead of embedding in YAML

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -134,7 +134,7 @@ impl RepositoryView {
                 "commits[].analysis.file_changes.files_deleted" => !self.commits.is_empty(),
                 "commits[].analysis.file_changes.file_list" => !self.commits.is_empty(),
                 "commits[].analysis.diff_summary" => !self.commits.is_empty(),
-                "commits[].analysis.diff_content" => !self.commits.is_empty(),
+                "commits[].analysis.diff_file" => !self.commits.is_empty(),
                 "versions.omni_dev" => self.versions.is_some(),
                 "ai.scratch" => true,
                 "branch_info.branch" => self.branch_info.is_some(),
@@ -266,8 +266,9 @@ impl Default for FieldExplanation {
                     present: false,
                 },
                 FieldDocumentation {
-                    name: "commits[].analysis.diff_content".to_string(),
-                    text: "Full diff content showing line-by-line changes with added, removed, and context lines".to_string(),
+                    name: "commits[].analysis.diff_file".to_string(),
+                    text: "Path to file containing full diff content showing line-by-line changes with added, removed, and context lines.\n\
+                           AI assistants should read this file to understand the specific changes made in the commit.".to_string(),
                     command: Some("git show <commit>".to_string()),
                     present: false,
                 },


### PR DESCRIPTION
# Pull Request

## Description
This PR replaces inline diff content with file paths to improve memory usage and enable AI assistants to access detailed diff information through file reads. The change modifies the YAML output format to reference external diff files in the AI scratch directory.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Change diff_content field to diff_file in CommitAnalysis struct
- Write diff content to temporary files in AI scratch directory  
- Update field documentation for AI assistant guidance
- Maintain backward compatibility by keeping similar data structure

## Testing
- [x] All existing tests pass
- [x] Manual testing performed

### Test Commands
```bash
cargo test
cargo clippy
cargo fmt --check
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
This change improves memory efficiency by avoiding large diff content in YAML output while providing better access patterns for AI assistants that need to analyze commit changes.