### PR TITLE
chore(claude): add request/response logging to AI clients

### DIFF
--- a/src/claude/claude_ai_client.rs
+++ b/src/claude/claude_ai_client.rs
@@ -9,6 +9,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::pin::Pin;
+use tracing::{debug, info};
 
 /// Claude API request message
 #[derive(Serialize)]
@@ -84,6 +85,19 @@ impl AiClient for ClaudeAiClient {
     ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
         // Use Box::pin to wrap the async block in a Pin<Box<...>>
         Box::pin(async move {
+            debug!(
+                system_prompt_len = system_prompt.len(),
+                user_prompt_len = user_prompt.len(),
+                model = %self.model,
+                "Preparing Claude API request"
+            );
+
+            debug!(
+                system_prompt = %system_prompt,
+                user_prompt = %user_prompt,
+                "Claude API request content"
+            );
+
             // Build request to Claude API
             let request = ClaudeRequest {
                 model: self.model.clone(),
@@ -94,6 +108,13 @@ impl AiClient for ClaudeAiClient {
                     content: user_prompt.to_string(),
                 }],
             };
+
+            info!(
+                url = "https://api.anthropic.com/v1/messages",
+                model = %self.model,
+                max_tokens = self.get_max_tokens(),
+                "Sending request to Claude API"
+            );
 
             // Send request to Claude API
             let response = self
@@ -122,8 +143,13 @@ impl AiClient for ClaudeAiClient {
                 .await
                 .map_err(|e| ClaudeError::InvalidResponseFormat(e.to_string()))?;
 
+            debug!(
+                content_count = claude_response.content.len(),
+                "Received Claude API response"
+            );
+
             // Extract text content from response
-            claude_response
+            let result = claude_response
                 .content
                 .first()
                 .filter(|c| c.content_type == "text")
@@ -131,7 +157,20 @@ impl AiClient for ClaudeAiClient {
                 .ok_or_else(|| {
                     ClaudeError::InvalidResponseFormat("No text content in response".to_string())
                         .into()
-                })
+                });
+
+            if let Ok(ref text) = result {
+                debug!(
+                    response_len = text.len(),
+                    "Successfully extracted text content from Claude API response"
+                );
+                debug!(
+                    response_content = %text,
+                    "Claude API response content"
+                );
+            }
+
+            result
         })
     }
 


### PR DESCRIPTION
# Pull Request

## Description
Add comprehensive request/response debug logging to both Claude and Bedrock AI clients to improve observability and debugging capabilities.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made
- Added debug logging for request preparation with prompt lengths and model info in both AI clients
- Added info logging for API endpoints and request parameters
- Added comprehensive response logging including content count, response length, and metadata
- Added full request/response content logging at debug level for detailed troubleshooting
- Enhanced Bedrock client logging to include response ID, type, usage statistics, and stop reason
- Standardized logging format and content across both Claude and Bedrock AI client implementations

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Commands
```bash
cargo test
cargo clippy
cargo fmt --check
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
This enhancement enables developers to use `RUST_LOG=debug` to see complete request/response content for AI API calls, which is invaluable for debugging AI integration issues. The logging includes both metadata (lengths, models, usage stats) and full content at debug level.

🤖 Generated with [Claude Code](https://claude.ai/code)