### PR TITLE
feat(claude): modify twiddle command to include all commits in amendment responses

### DIFF
--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -81,6 +81,8 @@ Analysis Priority:
 3. Third: Apply the exact format specification provided in the user prompt
 4. Last: Are there any important implications or impacts to highlight?
 
+CRITICAL OUTPUT REQUIREMENT: You MUST include ALL commits in your response, regardless of whether they need changes or not. If a commit message is already perfect, include it unchanged. Never skip commits from the amendments array.
+
 Respond with a YAML amendment file in this exact format:
 ```yaml
 amendments:
@@ -261,17 +263,19 @@ CRITICAL ANALYSIS STEPS:
 3. **CHOOSE APPROPRIATE TYPE**: Select commit type (feat/fix/refactor/etc.) based on actual changes, not file locations
 4. **SELECT MEANINGFUL SCOPE**: Choose scope based on functionality affected, not just directory names
 
-Focus on commits that:
-- Don't follow conventional commit format
-- Have unclear or vague descriptions that don't reflect actual code changes
-- Use past tense instead of imperative mood
-- Are too verbose or too brief for the actual changes made
-- Could benefit from proper type/scope classification based on real functionality
-- Have generic messages that don't describe what the code actually does
+MANDATORY: Include ALL commits in the amendments array - both those that need improvement AND those that are already well-formatted.
+
+For each commit, analyze whether improvements are needed:
+- Check if it follows conventional commit format
+- Verify descriptions accurately reflect the actual code changes
+- Ensure imperative mood is used (not past tense)
+- Confirm verbosity matches the scope of changes made
+- Validate type/scope classification based on real functionality
+- Ensure messages describe what the code actually does (not generic descriptions)
 
 Remember: File paths and directory names are just hints. The diff content shows the real changes.
 
-Include ALL commits in the amendments array. Even if a commit message is already well-formatted, include it with its current message. This allows users to review and potentially modify all commits."#,
+CRITICAL: Even if a commit message is perfect and needs no changes, include it in the amendments array with its current message unchanged. This allows users to review all commits and make manual adjustments if desired. DO NOT skip any commits from the amendments array."#,
         repo_yaml
     )
 }
@@ -305,10 +309,11 @@ pub fn generate_contextual_user_prompt(repo_yaml: &str, context: &CommitContext)
     prompt.push('\n');
 
     // Add context-specific focus areas
-    prompt.push_str("Focus on commits that:\n");
-    prompt.push_str("- Don't follow conventional commit format\n");
-    prompt.push_str("- Have unclear or vague descriptions\n");
-    prompt.push_str("- Use past tense instead of imperative mood\n");
+    prompt.push_str("MANDATORY: Include ALL commits in the amendments array - both those needing improvement AND those already well-formatted.\n\n");
+    prompt.push_str("For each commit, analyze whether improvements are needed:\n");
+    prompt.push_str("- Check if it follows conventional commit format\n");
+    prompt.push_str("- Verify descriptions are clear and accurate\n");
+    prompt.push_str("- Ensure imperative mood is used (not past tense)\n");
 
     // Add significance-based criteria
     if context.is_significant_change() {
@@ -362,7 +367,7 @@ pub fn generate_contextual_user_prompt(repo_yaml: &str, context: &CommitContext)
         }
     }
 
-    prompt.push_str("\nInclude ALL commits in the amendments array. Even if a commit message is already well-formatted, include it with its current message. This allows users to review and potentially modify all commits.");
+    prompt.push_str("\nCRITICAL: Include ALL commits in the amendments array. Even if a commit message is perfect and needs no changes, include it with its current message unchanged. This allows users to review all commits and make manual adjustments if desired. DO NOT skip any commits from the amendments array.");
 
     prompt
 }


### PR DESCRIPTION
# Pull Request

## Description
This PR modifies the twiddle command to ensure that ALL commits are included in amendment responses, regardless of whether they already have good commit messages. Previously, the system would skip commits with well-formatted messages, but now all commits are included in the amendment file to allow users complete control over which commits to review and modify.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issue
This addresses user feedback about incomplete commit coverage in AI-assisted commit message improvement workflows.

## Changes Made
- Modified prompt templates in `src/claude/prompts.rs` to enforce mandatory inclusion of ALL commits
- Added explicit "CRITICAL OUTPUT REQUIREMENT" section to prevent AI from skipping commits
- Changed language from selective "Focus on commits that" to comprehensive "For each commit, analyze whether"
- Updated both basic and contextual prompt generation functions
- Strengthened enforcement with multiple redundant instructions to ensure complete coverage

## Testing
- [x] All existing tests pass
- [x] Manual testing performed
- [x] Code compiles without warnings

### Test Commands
```bash
cargo test
cargo clippy -- -D warnings
cargo fmt --check
cargo build
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
This change ensures users receive complete commit analysis coverage, enabling them to review all commits in their range and make informed decisions about which messages to actually modify. The enhancement maintains all existing functionality while providing comprehensive coverage that was previously missing.

🤖 Generated with [Claude Code](https://claude.ai/code)