### PR TITLE
feat(git): add automatic upstream branch configuration after push

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -447,6 +447,31 @@ impl GitRepository {
                     "Successfully pushed branch '{}' to remote '{}'",
                     branch_name, remote_name
                 );
+
+                // Set upstream branch after successful push
+                debug!("Setting upstream branch for '{}'", branch_name);
+                match self.repo.find_branch(branch_name, git2::BranchType::Local) {
+                    Ok(mut branch) => {
+                        let remote_ref = format!("{}/{}", remote_name, branch_name);
+                        match branch.set_upstream(Some(&remote_ref)) {
+                            Ok(_) => {
+                                info!(
+                                    "Successfully set upstream to '{}'/{}",
+                                    remote_name, branch_name
+                                );
+                            }
+                            Err(e) => {
+                                // Log but don't fail - the push succeeded
+                                error!("Failed to set upstream branch: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // Log but don't fail - the push succeeded
+                        error!("Failed to find local branch to set upstream: {}", e);
+                    }
+                }
+
                 Ok(())
             }
             Err(e) => {


### PR DESCRIPTION
## Description

This PR enhances the git push workflow by automatically setting the upstream branch after successful push operations. Previously, developers had to manually run `git push --set-upstream` when pushing new branches. This change eliminates that extra step by configuring the upstream relationship automatically.

The implementation adds logic to find the local branch after a successful push and set its upstream to the appropriate remote reference, improving the developer experience by automating a common manual step in the git workflow.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issue
Relates to improved developer experience and git workflow automation

## Changes Made

**Core Changes:**
- Added automatic upstream branch configuration after successful push operations
- Implemented logic to find local branch and set its upstream to the remote reference
- Added non-failing error handling to ensure push success is preserved even if upstream setting fails

**Implementation Details:**
- Find local branch using `git2::BranchType::Local` after push completion
- Set upstream to remote reference in format `remote_name/branch_name`
- Handle errors gracefully - log but don't fail the overall push operation

**Logging & Debugging:**
- Added debug logging for upstream setting process
- Added informational log when upstream is successfully set
- Added error logging for cases where branch lookup or upstream setting fails

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Verified push functionality remains intact

**Manual Testing:**
- [x] Tested pushing new branches - upstream is automatically set
- [x] Tested pushing existing branches - no errors occur
- [x] Verified error handling when upstream setting fails
- [x] Confirmed push success is preserved even if upstream configuration fails

**Test Coverage:**
- New code coverage: Integrated into existing push tests
- Overall project coverage: Maintained

### Test Commands