### PR TITLE
fix(cli): add explicit head branch parameter to gh pr create command

### DIFF
--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -2161,12 +2161,21 @@ impl CreatePrCommand {
             debug!("Branch '{}' already exists on remote 'origin'", branch_name);
         }
 
-        // Create PR using gh CLI
+        // Create PR using gh CLI with explicit head branch
         debug!("Creating PR with gh CLI - title: '{}'", title);
         debug!("PR description length: {} characters", description.len());
 
         let pr_result = Command::new("gh")
-            .args(["pr", "create", "--title", title, "--body", description])
+            .args([
+                "pr",
+                "create",
+                "--head",
+                branch_name,
+                "--title",
+                title,
+                "--body",
+                description,
+            ])
             .output()
             .context("Failed to create pull request")?;
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the `gh pr create` command by adding an explicit `--head` parameter to specify the source branch. Previously, the command relied on GitHub CLI's implicit branch detection, which could fail in certain scenarios where the current branch context was ambiguous or when working with multiple remotes.

The change ensures that pull request creation is more reliable by explicitly specifying which branch should be used as the head branch for the PR, preventing errors related to branch ambiguity.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Relates to pull request creation reliability in multi-remote environments

## Changes Made

**Core Changes:**
- Modified the `CreatePrCommand` implementation to include `--head` parameter with the branch name
- Updated the `gh pr create` command arguments to explicitly specify the source branch
- Ensured branch name is passed correctly to prevent ambiguity in PR creation

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Verified command construction includes new parameter

**Manual Testing:**
- [x] Tested PR creation with explicit head branch specification
- [x] Verified PR is created from correct branch in multi-remote scenarios
- [x] Tested with branches that have upstream tracking and without
- [x] Confirmed backward compatibility with existing workflows

**Test Coverage:**
- Existing test coverage maintained
- Manual verification of gh CLI integration

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling
- [x] Backward compatibility

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This change is backward compatible and only adds explicit branch specification to improve reliability.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider adding more explicit parameters for other gh CLI options to improve reliability
- Add integration tests specifically for multi-remote scenarios

**Known Limitations:**
- Still requires gh CLI to be installed and authenticated
- Depends on GitHub CLI's behavior for PR creation