### PR TITLE
feat(cli): add --no-ai flag to twiddle command for direct YAML output

### DIFF
--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -308,6 +308,8 @@ Options:
           Disable contextual analysis (use basic prompting only)
       --batch-size <BATCH_SIZE>
           Maximum number of commits to process in a single batch (default: 4) [default: 4]
+      --no-ai
+          Skip AI processing and only output repository YAML
   -h, --help
           Print help
 


### PR DESCRIPTION
## Description

This PR implements a new `--no-ai` flag for the twiddle command that bypasses AI processing and outputs repository YAML directly with original commit messages. This feature enables users to generate amendment files without requiring Claude API access, which is useful for manual editing workflows or when the API is unavailable.

The implementation preserves all existing twiddle functionality while providing a lightweight alternative for users who prefer manual commit message editing or need to work without AI assistance. This addresses use cases where users want to quickly generate amendment files for batch processing or when working in environments without API access.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

Feature request: Enable twiddle command usage without AI dependency

## Changes Made

**Core Changes:**
- Added `--no-ai` boolean flag to TwiddleCommand struct for bypassing AI processing
- Implemented new `execute_no_ai()` method that generates amendments with original commit messages
- Integrated non-AI flow seamlessly with existing amendment application logic

**Functionality:**
- Direct YAML output with original commit messages preserved
- Support for all output modes: save-only, auto-apply, and interactive
- Reuses existing amendment file handling for consistent user experience
- Creates temporary amendment files when needed for user editing

**Documentation:**
- Updated command help text to describe the new flag
- Integration test snapshots updated to reflect help output changes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration test snapshots updated for help output
- [x] Command parsing correctly handles new flag

**Manual Testing:**
- [x] Tested `--no-ai` flag generates amendments with original messages
- [x] Verified save-only mode works with `--no-ai --save-only`
- [x] Confirmed auto-apply mode functions with `--no-ai --auto-apply`
- [x] Tested interactive mode allows editing before applying
- [x] Backward compatibility verified - existing twiddle commands work unchanged

**Test Coverage:**
- New code follows existing patterns with established test coverage
- Overall project coverage maintained

### Test Commands
```bash
# Core test suite
cargo test

# Test new flag functionality
omni-dev twiddle --no-ai
omni-dev twiddle --no-ai --save-only amendments.yaml
omni-dev twiddle --no-ai --auto-apply

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling
- [x] User experience
- [x] Backward compatibility

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact

- [x] Performance improvement (describe below)

The `--no-ai` flag significantly improves performance for users who don't need AI-enhanced commit messages. It eliminates network latency and API processing time, making the twiddle command instantaneous for local operations.

## Security Considerations

- [x] No security implications

This change reduces the attack surface by providing an option that doesn't require external API communication.

## Breaking Changes

None. This is a purely additive feature that doesn't affect existing functionality.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Could add a configuration option to make `--no-ai` the default behavior
- Consider adding a `--format` flag to support different output formats beyond YAML

**Known Limitations:**
- When using `--no-ai`, commit messages are not enhanced with conventional commit formatting
- Users must manually edit messages if they want to improve them

**Alternatives Considered:**
- Separate command for non-AI operations (rejected to avoid command proliferation)
- Environment variable control (kept flag for explicit user control)