### PR TITLE
feat(cli): add base branch support for PR creation and updates

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -146,6 +146,9 @@ pub struct PullRequest {
     pub url: String,
     /// PR description/body content
     pub body: String,
+    /// Base branch the PR targets
+    #[serde(default)]
+    pub base: String,
 }
 
 impl RepositoryView {

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_test.rs
-assertion_line: 239
 expression: help_output
 ---
 omni-dev - A comprehensive development toolkit
@@ -204,12 +203,10 @@ omni-dev git branch create pr - Create a pull request with AI-generated descript
 
 Create a pull request with AI-generated description
 
-Usage: pr [OPTIONS] [BASE_BRANCH]
-
-Arguments:
-  [BASE_BRANCH]  Base branch to compare against (defaults to main/master)
+Usage: pr [OPTIONS]
 
 Options:
+      --base <BRANCH>     Base branch for the PR to be merged into (defaults to main/master)
       --auto-apply        Skip confirmation prompt and create PR automatically
       --save-only <FILE>  Save generated PR details to file without creating PR
       --ready             Create PR as ready for review (overrides default)


### PR DESCRIPTION
## Description

This PR implements comprehensive base branch handling for the PR workflow, allowing users to specify custom target branches when creating or updating pull requests. This enhancement provides greater flexibility for projects using feature branch workflows or multiple release branches.

The implementation adds a `--base` flag to the `create pr` command and updates the underlying logic to properly resolve, validate, and apply base branch specifications. The feature includes intelligent fallback logic and interactive confirmation for base branch changes during PR updates.

**Key Benefits:**
- Enables targeting non-default branches (e.g., `develop`, `release/v2.0`)
- Provides clear visibility of base branch in PR operations
- Prevents accidental PR retargeting with confirmation prompts
- Supports both simple branch names and remote-prefixed formats

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Implements feature request for flexible base branch targeting in PR workflows.

## Changes Made

**Core CLI Changes:**
- Changed `base_branch` positional argument to `--base` flag in `CreatePrCommand` for better UX consistency
- Updated help text to clarify that base branch is where the PR will be merged into
- Modified `generate_repository_view()` to include intelligent base branch resolution logic with three-tier fallback:
  1. Check if branch exists as remote ref (e.g., `origin/main`)
  2. Try prepending primary remote name (e.g., `main` → `origin/main`)
  3. Fall back to auto-detected main branch if no base specified
- Added `strip_remote_prefix()` helper function to convert remote-prefixed branches to GitHub API format
- Enhanced base branch validation with detailed error messages showing both tried formats

**PR Creation Enhancement:**
- Updated `create_github_pr()` to accept and pass base branch parameter to GitHub CLI
- Added base branch display in PR creation output for user visibility
- Strips remote prefix before passing to `gh` CLI (e.g., `origin/main` → `main`)

**PR Update Enhancement:**
- Modified `update_github_pr()` to handle base branch changes with interactive confirmation
- Added comparison logic to detect base branch changes and prompt user before applying
- Displays current base → new base transition for clarity
- Only changes base branch if user explicitly confirms with 'y' or 'yes'
- Shows confirmation message after successful base branch change

**Data Structure Changes:**
- Added `base` field to `PullRequest` struct in `src/data/mod.rs` with `#[serde(default)]` for backward compatibility
- Updated GitHub API query to fetch `baseRefName` field for existing PRs
- Enhanced PR data population to include base branch information from API response

**Documentation:**
- Updated help text snapshot in integration tests to reflect new `--base <BRANCH>` flag format
- Removed positional argument documentation in favor of optional flag documentation

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration test snapshots updated to reflect new CLI interface
- [ ] New tests added for base branch resolution logic (recommended for future)

**Manual Testing:**
- [x] Tested PR creation with `--base develop` flag
- [x] Tested PR creation without `--base` flag (uses auto-detected main branch)
- [x] Tested base branch resolution with simple names (e.g., `main`)
- [x] Tested base branch resolution with remote-prefixed names (e.g., `origin/main`)
- [x] Tested PR update with base branch change confirmation flow
- [x] Tested PR update declining base branch change
- [x] Verified error messages for non-existent base branches
- [x] Confirmed base branch display in creation and update operations

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual testing examples
omni-dev git branch create pr --base develop
omni-dev git branch create pr --base origin/release/v2.0
omni-dev git branch create pr  # Uses auto-detected main branch
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience - Interactive confirmation flow for base branch changes
- [x] Error handling - Clear messages when base branch doesn't exist
- [x] Backward compatibility - Existing PRs without base field handled via `#[serde(default)]`
- [x] Branch resolution logic - Three-tier fallback ensures correct branch identification

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The base branch resolution adds minimal overhead (checking for remote refs), which is negligible compared to network operations involved in PR creation/updates.

## Security Considerations
- [x] No security implications

Changes are limited to CLI argument handling and GitHub API interactions through the existing `gh` CLI tool, which handles authentication and authorization.

## Breaking Changes

**CLI Interface Change:**
The `base_branch` positional argument has been changed to a `--base` flag. This is technically a breaking change for any scripts that used the positional argument.

**Migration Required:**
```bash
# Old usage (no longer works)
omni-dev git branch create pr develop

# New usage
omni-dev git branch create pr --base develop
```

**Backward Compatibility:**
- Omitting the base branch argument continues to work (uses auto-detected main branch)
- The `PullRequest` data structure remains backward compatible via `#[serde(default)]`
- Existing PRs will show empty base field in old data, but new fetches will populate it correctly

## Deployment Notes
- [x] No special deployment requirements

No configuration changes, environment variables, or migrations required.

## Additional Notes

**Future Enhancements:**
- Add unit tests specifically for `strip_remote_prefix()` helper function
- Add integration tests for base branch resolution logic scenarios
- Consider adding `--base` flag auto-completion for common branches
- Potentially add configuration option for default base branch per project

**Implementation Decisions:**
- Changed from positional to flag argument for consistency with other optional CLI parameters
- Interactive confirmation for base branch changes prevents accidental PR retargeting
- Three-tier resolution logic handles both user convenience (simple names) and explicitness (remote-prefixed names)
- Remote prefix stripping ensures GitHub API compatibility while maintaining internal consistency

**Alternatives Considered:**
- Keeping positional argument: Rejected for consistency with other flags and to avoid confusion with optional arguments
- Automatic base branch changes without confirmation: Rejected as too risky for accidental retargeting
- Using environment variable for default base: Deferred to future enhancement to keep this PR focused