### PR TITLE
feat(claude): add fresh mode for generating commit messages from scratch

### DIFF
--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -38,9 +38,23 @@ impl ClaudeClient {
 
     /// Generate commit message amendments from repository view
     pub async fn generate_amendments(&self, repo_view: &RepositoryView) -> Result<AmendmentFile> {
+        self.generate_amendments_with_options(repo_view, false)
+            .await
+    }
+
+    /// Generate commit message amendments from repository view with options
+    ///
+    /// If `fresh` is true, ignores existing commit messages and generates new ones
+    /// based solely on the diff content.
+    pub async fn generate_amendments_with_options(
+        &self,
+        repo_view: &RepositoryView,
+        fresh: bool,
+    ) -> Result<AmendmentFile> {
         // Convert to AI-enhanced view with diff content
-        let ai_repo_view = RepositoryViewForAI::from_repository_view(repo_view.clone())
-            .context("Failed to enhance repository view with diff content")?;
+        let ai_repo_view =
+            RepositoryViewForAI::from_repository_view_with_options(repo_view.clone(), fresh)
+                .context("Failed to enhance repository view with diff content")?;
 
         // Convert repository view to YAML
         let repo_yaml = crate::data::to_yaml(&ai_repo_view)
@@ -65,9 +79,24 @@ impl ClaudeClient {
         repo_view: &RepositoryView,
         context: &CommitContext,
     ) -> Result<AmendmentFile> {
+        self.generate_contextual_amendments_with_options(repo_view, context, false)
+            .await
+    }
+
+    /// Generate contextual commit message amendments with options
+    ///
+    /// If `fresh` is true, ignores existing commit messages and generates new ones
+    /// based solely on the diff content.
+    pub async fn generate_contextual_amendments_with_options(
+        &self,
+        repo_view: &RepositoryView,
+        context: &CommitContext,
+        fresh: bool,
+    ) -> Result<AmendmentFile> {
         // Convert to AI-enhanced view with diff content
-        let ai_repo_view = RepositoryViewForAI::from_repository_view(repo_view.clone())
-            .context("Failed to enhance repository view with diff content")?;
+        let ai_repo_view =
+            RepositoryViewForAI::from_repository_view_with_options(repo_view.clone(), fresh)
+                .context("Failed to enhance repository view with diff content")?;
 
         // Convert repository view to YAML
         let repo_yaml = crate::data::to_yaml(&ai_repo_view)

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -310,6 +310,8 @@ Options:
           Maximum number of commits to process in a single batch (default: 4) [default: 4]
       --no-ai
           Skip AI processing and only output repository YAML
+      --fresh
+          Ignore existing commit messages and generate fresh ones based solely on diffs
   -h, --help
           Print help
 


### PR DESCRIPTION
## Description

This PR implements a new "fresh mode" capability that allows AI to generate commit messages based purely on code changes, ignoring existing commit messages. This is particularly valuable when existing messages are unclear, misleading, or incomplete, as it forces the AI to analyze only the diff content and provide a fresh perspective on what the changes accomplish.

The implementation adds a `--fresh` CLI flag to the twiddle command that, when enabled, replaces original commit messages with placeholder text before sending to the AI. This ensures the AI focuses solely on the actual code changes rather than being influenced by potentially poor existing message text.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Part of ongoing improvements to commit message generation capabilities.

## Changes Made

**Core Changes:**
- Added `generate_amendments_with_options()` method to `ClaudeClient` with `fresh` parameter for controlling message hiding behavior
- Added `generate_contextual_amendments_with_options()` for contextual fresh mode support
- Implemented `from_repository_view_with_options()` in `RepositoryViewForAI` to support message replacement
- When fresh mode is enabled, replaces original commit messages with "(Original message hidden - generate fresh message from diff)" placeholder
- Added `--fresh` CLI flag to `TwiddleCommand` in `src/cli/git.rs`
- Integrated fresh mode support into both single-batch and multi-batch processing flows
- Added user feedback message "🔄 Fresh mode: ignoring existing commit messages..." when fresh mode is active

**Documentation:**
- Added comprehensive inline documentation for new methods explaining fresh mode behavior
- Updated help text snapshot to include `--fresh` flag documentation
- Flag description: "Ignore existing commit messages and generate fresh ones based solely on diffs"

**Testing:**
- Updated integration test snapshot for help output to include new `--fresh` flag

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration tests updated with new help output snapshot
- [ ] New tests added for new functionality
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (fresh mode generates messages from diffs only)
- [x] Tested without fresh flag (existing behavior preserved)
- [x] Verified fresh mode works in both contextual and non-contextual modes
- [x] Backward compatibility verified (fresh mode is opt-in)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Test fresh mode functionality
cargo run -- twiddle --fresh

# Test without fresh mode (existing behavior)
cargo run -- twiddle

# Test with contextual mode
cargo run -- twiddle --fresh --contextual
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes (new options pattern for controlling AI behavior)
- [x] Error handling (proper error propagation through new methods)
- [x] User experience (clear feedback when fresh mode is active)
- [x] Backward compatibility (existing behavior unchanged when flag not used)

**Specific Review Points:**
- Message replacement logic in `from_repository_view_with_options()` - verify all original messages are properly hidden
- Dual-path processing in twiddle command (both batch and non-batch modes) - ensure fresh mode works correctly in both
- User feedback placement - appears at the right time in both processing modes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The fresh mode adds minimal overhead (simple string replacement) and does not impact AI processing time or API calls.

## Security Considerations
- [x] No security implications

This feature only affects how commit messages are presented to the AI - it does not change authentication, data handling, or external API interaction patterns.

## Breaking Changes

None. This is a purely additive feature that introduces a new opt-in CLI flag. Existing behavior is completely unchanged when the flag is not used.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider adding configuration option to make fresh mode the default behavior
- Could extend to support partial fresh mode (hide only certain commits)
- May want to add fresh mode indicator in amendment output for clarity

**Use Cases:**
This feature is particularly valuable for:
- Fixing commits with generic messages like "WIP", "update", or "fixes"
- Getting unbiased AI suggestions when commit messages are confusing
- Generating messages for commits imported from other repositories
- Training scenarios where you want to compare AI-generated vs human-written messages

**Implementation Notes:**
The implementation uses a simple but effective approach: replacing the original message with a clear placeholder that explicitly tells the AI to ignore it. This is more reliable than trying to filter out messages from the prompt, as it ensures the AI sees consistent structure while understanding it should focus on diffs.