### PR TITLE
docs(docs): add STYLE-0020 single-purpose commit guidelines

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -10,7 +10,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0020`) and include three subheadings:
+Assign the next sequential ID (currently next is `STYLE-0021`) and include three subheadings:
 
 - **Situation** — when this rule applies
 - **Guidance** — what to do (with examples where helpful)
@@ -379,6 +379,49 @@ with the scope definitions in `.omni-dev/scopes.yaml`.
 Keeping the detailed commit specification in `.omni-dev/commit-guidelines.md` allows the AI
 context system to consume it directly, avoiding duplication between this style guide and the
 machine-readable guidelines.
+
+### STYLE-0020: Single-purpose commits
+
+#### Situation
+
+Preparing a set of changes that involves refactoring, new functionality, or bug fixes.
+
+#### Guidance
+
+Each commit should do **one kind of work**. Keep refactoring commits separate from
+implementation commits, and both separate from bug-fix commits.
+
+If a refactoring would make a subsequent implementation or fix cleaner, land the refactoring
+as an **earlier** commit so that:
+
+1. The refactoring can be reviewed on its own terms (no behaviour change expected).
+2. The implementation commit starts from a cleaner baseline and is easier to understand.
+3. Either commit can be reverted independently if needed.
+
+```
+# Good — reviewable, bisectable, revertible
+git log --oneline
+a1b2c3  refactor(cli): extract shared repository-view builder
+d4e5f6  feat(cli): add --json output to check command
+
+# Bad — mixed intent, hard to review or revert half of it
+git log --oneline
+f7g8h9  feat(cli): add --json output and refactor repo-view builder
+```
+
+**Acceptable exceptions:**
+
+- Trivial renames or import cleanups that are a natural by-product of the implementation
+  (a few lines, not a standalone refactoring effort).
+- Prototype or spike branches where commit hygiene is deferred to a squash before merge.
+
+#### Motivation
+
+Single-purpose commits make `git bisect` reliable, code review focused, and reverts
+surgical. When refactoring is interleaved with behaviour changes, reviewers cannot tell
+whether a difference is a deliberate new behaviour or a mechanical restructuring — so they
+must verify every line as if it were new logic. Separating the two cuts review effort
+roughly in half.
 
 ---
 


### PR DESCRIPTION
## Description

This PR introduces STYLE-0020, a new style guideline that establishes the single-purpose commit principle for improved code review quality and git history maintainability. The guideline provides comprehensive guidance on separating refactoring work from implementation commits, ensuring each commit has a clear, singular purpose that can be reviewed and reverted independently.

The addition helps developers structure their work more effectively by keeping different types of changes (refactoring, new features, bug fixes) in separate commits, making code reviews more focused and git operations like bisect and revert more reliable.

## Type of Change
- [x] Documentation update

## Related Issue
Implements STYLE-0020 single-purpose commit guidelines

## Changes Made

**Documentation:**
- Added STYLE-0020 section to `docs/STYLE_GUIDE.md` with comprehensive single-purpose commit guidelines
- Included situation, guidance, and motivation subsections following the established style guide format
- Provided clear examples contrasting good vs bad commit organization practices
- Documented acceptable exceptions for trivial changes and prototype work
- Updated next sequential ID from STYLE-0020 to STYLE-0021 for future guidelines

## Testing

**Manual Testing:**
- [x] Verified documentation renders correctly in markdown
- [x] Confirmed consistent formatting with existing style guide entries
- [x] Validated sequential ID numbering system is maintained
- [x] Reviewed examples for clarity and accuracy

### Test Commands
```bash
# Verify documentation structure
markdown-lint docs/STYLE_GUIDE.md

# Check for formatting consistency
grep -n "STYLE-[0-9]" docs/STYLE_GUIDE.md
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Documentation clarity and completeness
- [x] Consistency with existing style guide format
- [x] Practical applicability of the guidelines
- [x] Quality of examples provided

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider adding tooling to automatically validate single-purpose commits in CI
- Potential integration with commit linting to enforce separation of concerns

**Motivation Behind Guidelines:**
The single-purpose commit principle directly addresses common code review challenges where refactoring and implementation changes are mixed together, making it difficult for reviewers to distinguish between mechanical changes and new logic. By separating these concerns, we reduce cognitive load during reviews and improve the reliability of git operations like bisect for debugging and surgical reverts when issues arise.