### PR TITLE
fix(claude): always load omni-dev config regardless of directory existence

### DIFF
--- a/src/claude/context/discovery.rs
+++ b/src/claude/context/discovery.rs
@@ -41,11 +41,9 @@ impl ProjectDiscovery {
             exists = context_dir_path.exists(),
             "Looking for context directory"
         );
-        if context_dir_path.exists() {
-            debug!("Loading omni-dev config");
-            self.load_omni_dev_config(&mut context, &context_dir_path)?;
-            debug!("Config loading completed");
-        }
+        debug!("Loading omni-dev config");
+        self.load_omni_dev_config(&mut context, &context_dir_path)?;
+        debug!("Config loading completed");
 
         // 2. Standard git configuration files
         self.load_git_config(&mut context)?;


### PR DESCRIPTION
## Description

This PR fixes a bug in the Claude context discovery system where omni-dev configuration would not be loaded if the context directory didn't exist. The fix removes an unnecessary directory existence check that was preventing configuration loading in valid scenarios.

Previously, the `ProjectDiscovery::discover` method would only attempt to load omni-dev configuration if the context directory existed. This caused issues when the configuration needed to be loaded even if the directory wasn't present, leading to incomplete context discovery.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Relates to #134

## Changes Made

**Core Changes:**
- Removed conditional directory existence check in `src/claude/context/discovery.rs`
- Modified `discover` method to always call `load_omni_dev_config` regardless of context directory presence
- Simplified control flow by removing unnecessary if-condition wrapper

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests needed (fix maintains existing behavior contract)

**Manual Testing:**
- [x] Tested configuration loading with existing context directories
- [x] Tested configuration loading without context directories
- [x] Verified no regression in standard git configuration loading
- [x] Confirmed debug logging works correctly in both scenarios

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
cargo build --release

# Test Claude context discovery specifically
cargo test claude::context
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling in `load_omni_dev_config` method
- [x] Backward compatibility with existing workflows
- [x] Debug logging consistency

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The change removes an unnecessary filesystem check, which could marginally improve performance by eliminating the directory existence test.

## Security Considerations
- [x] No security implications

This change only affects internal configuration loading logic and doesn't modify any external interfaces or data handling.

## Breaking Changes
None. This is a pure bug fix that maintains all existing API contracts.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Root Cause Analysis:**
The issue was caused by an overly restrictive conditional check that assumed configuration loading should only happen when the context directory exists. However, the `load_omni_dev_config` method is designed to handle missing directories gracefully, making the check unnecessary and potentially harmful.

**Impact:**
This fix ensures that omni-dev configuration is consistently loaded during Claude context discovery, improving reliability and ensuring complete context information is available regardless of project directory structure.