### PR TITLE
fix(claude,git): implement scope pre-validation to prevent check conflicts

### DIFF
--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -462,7 +462,7 @@ impl ClaudeClient {
 
         // Run deterministic pre-validation checks before sending to AI
         for commit in &mut ai_repo_view.commits {
-            commit.run_pre_validation_checks();
+            commit.run_pre_validation_checks(valid_scopes);
         }
 
         // Generate system prompt with scopes


### PR DESCRIPTION
## Description

This PR fixes validation conflicts between deterministic pre-validation checks and AI-based checking in the commit message validation system. Previously, pre-validation and AI checking could disagree on scope validity, causing inconsistent and confusing validation results.

The fix implements a deterministic scope validation system that runs before AI checking and records successful validations. The AI is then instructed to respect these pre-validated results, eliminating conflicts and ensuring consistent validation behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #136

## Changes Made

**Core Changes:**
- Modified `CommitInfoForAI::run_pre_validation_checks()` to accept valid scopes and perform deterministic scope validity checking
- Added scope validity verification that records successful checks in `pre_validated_checks` field
- Updated `ClaudeClient::check_commit_messages()` to pass valid scopes to pre-validation pipeline
- Enhanced check system prompt to include authoritative guidance on pre-validated results

**Validation Logic:**
- Added deterministic scope validity check that verifies scopes against the project's defined scope list
- Implemented clear distinction between scope validity (error level) and scope appropriateness (info level)
- Added protection against AI contradicting pre-validated scope validity results

**Documentation:**
- Updated prompt instructions to clarify the difference between scope validity and appropriateness checks
- Added comprehensive guidance on respecting pre-validated check results

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Validation logic maintains existing behavior for valid scenarios
- [x] Pre-validation correctly identifies valid scopes from project scope list

**Manual Testing:**
- [x] Tested commit messages with valid scopes show consistent validation
- [x] Verified AI no longer flags pre-validated valid scopes as invalid
- [x] Confirmed scope appropriateness suggestions still work at info level
- [x] Tested multi-scope commit messages (comma-separated scopes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Test commit validation specifically
cargo test commit::tests
cargo test claude::tests
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Logic for determining scope validity vs appropriateness
- [x] Integration between pre-validation and AI checking systems
- [x] Prompt instructions that prevent AI from contradicting pre-validated results
- [x] Handling of multi-scope commit messages (comma-separated)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The pre-validation scope check is a simple string comparison operation that runs once per commit and has negligible performance overhead.

## Security Considerations
- [x] No security implications

This change only affects internal validation logic and does not touch any security-sensitive areas.

## Breaking Changes
None. This is a bug fix that maintains all existing APIs and behavior while resolving validation conflicts.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Technical Details:**
- The `run_pre_validation_checks()` method signature change is internal and maintains backward compatibility through the existing call sites
- Pre-validated checks are stored as strings in the `pre_validated_checks` field and communicated to the AI through the system prompt
- The fix handles both single scopes (`cli`) and multi-scopes (`claude,git`) correctly

**Future Enhancements:**
- Could extend pre-validation to other deterministic checks (format validation, type detection)
- Pre-validation results could be cached to improve performance for large commit batches

**Root Cause:**
The original issue occurred because scope validity was being checked both deterministically (in pre-validation) and heuristically (by AI), with no coordination between the two systems. This led to scenarios where pre-validation would pass a scope as valid, but the AI would flag it as invalid, creating user confusion.