### PR TITLE
docs(docs): add ADR-0003 for hybrid git integration strategy

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,4 +25,5 @@ by Michael Nygard.
 |--------------------------|-------------|------------|--------------------------------------------------|
 | [ADR-0000](adr-0000.md)  | ✅ Accepted | 2026-02-10 | Use Architecture Decision Records                 |
 | [ADR-0001](adr-0001.md)  | ✅ Accepted | 2026-02-10 | YAML as Primary Human Data Exchange Format        |
-| [ADR-0002](adr-0002.md)  | 🟡 Proposed | 2026-02-20 | Multi-Provider AI Abstraction via Trait Objects   |
+| [ADR-0002](adr-0002.md)  | 🟡 Proposed | 2026-02-20 | Multi-Provider AI Abstraction via Trait Objects    |
+| [ADR-0003](adr-0003.md)  | 🟡 Proposed | 2026-02-20 | Hybrid Git Integration — git2 for Reads, Shell for Complex Mutations |

--- a/docs/adrs/adr-0003.md
+++ b/docs/adrs/adr-0003.md
@@ -1,0 +1,116 @@
+# ADR-0003: Hybrid Git Integration — git2 for Reads, Shell for Complex Mutations
+
+## Status
+
+🟡 Proposed
+
+## Context
+
+omni-dev performs two fundamentally different categories of git operations:
+
+1. **High-volume reads** — walking commits, computing diffs, inspecting trees, checking
+   repository status, enumerating branches and remotes. These happen on every invocation of
+   `view`, `check`, `info`, and `twiddle`, often touching dozens of commits in a single run.
+
+2. **Multi-step mutations** — amending a commit message (either at HEAD or at an arbitrary
+   point in history via interactive rebase). These happen only during the `twiddle --apply`
+   workflow and involve coordinated sequences of git operations with error recovery.
+
+Rust has two mature options for git integration:
+
+- **git2** (libgit2 bindings) — in-process, type-safe access to repository data. Opening a
+  repo, walking a revwalk, and reading commit metadata incur no subprocess overhead. However,
+  libgit2's rebase API is low-level: it exposes the state machine but does not provide a
+  high-level "pause at commit X, amend its message, continue" operation. Implementing this
+  correctly would mean manually managing rebase state, conflict detection, reflog entries,
+  and hook execution.
+
+- **Shell `git` CLI** — the canonical implementation, battle-tested for complex workflows.
+  `git commit --amend` handles hooks (pre-commit, post-commit), reflog updates, and edge
+  cases automatically. `git rebase -i` with a custom `GIT_SEQUENCE_EDITOR` provides a
+  concise way to automate interactive rebase without reimplementing the state machine.
+  The trade-off is subprocess spawn overhead and text-based output parsing.
+
+A third option, **gitoxide** (`gix`), offers a pure-Rust alternative to libgit2 but was not
+mature enough at the time of initial development to cover the project's needs (particularly
+around SSH authentication and rebase support).
+
+## Decision
+
+We will use **git2 for repository reads** and **shell `git` commands for complex multi-step
+mutations**, choosing the tool that best fits each operation's characteristics.
+
+### git2 (in-process, type-safe)
+
+Used in `src/git/repository.rs`, `src/git/commit.rs`, `src/git/remote.rs`, and `src/git.rs`
+for:
+
+- Opening repositories and checking status
+- Walking commits via `Revwalk`
+- Reading commit metadata (author, message, timestamp)
+- Computing diffs and file-change analysis via `Diff`
+- Enumerating branches and remotes
+- Checking remote branch existence via `remote.connect_auth()`
+- Pushing branches via `remote.push()` (a straightforward single-call write that libgit2
+  handles well, including SSH authentication with agent forwarding)
+
+### Shell `git` (subprocess)
+
+Used in `src/git/amendment.rs` for the commit amendment workflow:
+
+- `git commit --amend -m <msg>` — amends HEAD, with hook execution and reflog updates
+  handled by git
+- `git rebase -i <base>` with `GIT_SEQUENCE_EDITOR=cp <sequence-file>` and
+  `GIT_EDITOR=true` — automates interactive rebase to pause at a target commit
+- `git rebase --continue` / `git rebase --abort` — controls the rebase lifecycle
+- `git rev-list`, `git log --format=%s`, `git rev-parse HEAD` — reads performed alongside
+  the rebase for convenience, since a shell context is already established
+
+### Shell `gh` (GitHub CLI)
+
+A third category exists for GitHub platform operations that have no git2 equivalent:
+
+- `gh repo view` — queries the default branch for a remote repository
+- `gh pr list` / `gh pr create` / `gh pr edit` — manages pull requests
+
+These are outside the scope of the git2-vs-shell decision but are noted for completeness.
+
+## Consequences
+
+**Positive:**
+
+- **Read performance.** In-process git2 reads avoid subprocess spawn overhead (~2–5 ms per
+  invocation on macOS). For a `view` or `check` command that walks 20+ commits and computes
+  diffs for each, this avoids dozens of subprocess calls.
+- **Type safety for reads.** `Commit`, `Diff`, `Tree`, `Oid`, and `Status` are real Rust
+  types with compile-time guarantees, eliminating an entire class of output-parsing bugs.
+- **Correct mutation semantics.** Shell `git commit --amend` and `git rebase -i` handle
+  hooks, reflog entries, conflict detection, and lock-file management that would need manual
+  reimplementation with libgit2.
+- **Concise rebase automation.** The `GIT_SEQUENCE_EDITOR` approach automates interactive
+  rebase in ~30 lines. The equivalent libgit2 implementation would be substantially larger
+  and harder to verify for correctness.
+- **Robust error recovery.** `git rebase --abort` is a single-command fallback that
+  guarantees the repository returns to a clean state. Manual state cleanup via libgit2 would
+  be error-prone.
+
+**Negative:**
+
+- **Two integration styles.** Contributors need to understand both the git2 API and the
+  shell `Command` pattern. This is mitigated by confining shell usage to a single module
+  (`src/git/amendment.rs`).
+- **Shell reads in amendment.rs.** A handful of reads (`git rev-list`, `git log`, `git
+  rev-parse`) use the shell rather than git2 for convenience. This is a pragmatic choice —
+  they run in the same context as the rebase commands — but it means the boundary is not
+  perfectly clean.
+
+**Neutral:**
+
+- **Push uses git2.** `push_branch()` in `src/git/repository.rs` is a write operation
+  performed via git2's `remote.push()`. Unlike amend/rebase, a push is a single atomic
+  call that libgit2 handles well, including SSH credential resolution. This fits naturally
+  with the git2 read path and does not require the multi-step orchestration that motivates
+  shell usage for mutations.
+- **gitoxide may change the calculus.** As the `gix` crate matures, it could offer a
+  pure-Rust alternative for both reads and writes. This decision can be revisited if
+  gitoxide reaches feature parity for the operations this project needs.


### PR DESCRIPTION
## Description

This PR adds ADR-0003, documenting the architectural decision to use a hybrid approach for git integration in omni-dev. The decision establishes clear boundaries: git2 (libgit2 bindings) handles high-volume repository reads for performance and type safety, while shell git commands manage complex multi-step mutations like commit amending and interactive rebase.

This documentation captures the rationale behind the existing implementation patterns in the codebase, providing future contributors with context for why different git operations use different integration approaches.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Documents existing architectural patterns in the codebase for future reference and contributor onboarding.

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0003.md` with comprehensive documentation of the hybrid git integration strategy
- Updated `docs/adrs/README.md` to include ADR-0003 in the decision record index

**ADR-0003 Content:**
- Context section explaining the two categories of git operations (high-volume reads vs. multi-step mutations)
- Comparison of git2, shell git, and gitoxide approaches with trade-offs
- Decision section with clear boundaries for when to use each approach
- Detailed consequences (positive, negative, neutral) of the hybrid strategy
- Notes on potential future evolution with gitoxide

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A - documentation only)
- [ ] Integration tests updated/added (N/A - documentation only)
- [ ] Performance tests (if applicable) (N/A - documentation only)

**Manual Testing:**
- [x] Verified markdown renders correctly
- [x] Verified links in ADR index are correct
- [x] Confirmed ADR follows established format from ADR-0000 template

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications (N/A)
- [ ] Performance impact (N/A)
- [x] Architecture changes (review accuracy of documented patterns)
- [ ] Error handling (N/A)
- [ ] User experience (N/A)
- [ ] Backward compatibility (N/A)

**Specific review requests:**
- Verify the documented boundaries (git2 for reads, shell for mutations) accurately reflect the codebase
- Confirm the module references (`src/git/repository.rs`, `src/git/amendment.rs`, etc.) are correct
- Review the trade-off analysis for completeness

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A - docs only)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (N/A)
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- ADR may need revision if gitoxide matures to the point where it could replace either git2 or shell git usage
- Consider adding implementation examples or code snippets in a follow-up

**Key Decisions Documented:**
- git2 used for: opening repos, walking commits, reading metadata, computing diffs, enumerating branches/remotes, pushing branches
- Shell git used for: `git commit --amend`, `git rebase -i` with custom sequence editor, rebase lifecycle management
- Shell gh used for: GitHub platform operations (PR management, default branch queries)