### PR TITLE
refactor(claude,cli): deduplicate models.yaml embed into shared constant

### DIFF
--- a/src/claude/model_config.rs
+++ b/src/claude/model_config.rs
@@ -9,6 +9,9 @@ use std::sync::OnceLock;
 use anyhow::Result;
 use serde::Deserialize;
 
+/// Embedded models YAML configuration, loaded at compile time.
+pub(crate) const MODELS_YAML: &str = include_str!("../templates/models.yaml");
+
 /// Beta header that unlocks enhanced model limits.
 #[derive(Debug, Deserialize, Clone)]
 pub struct BetaHeader {
@@ -101,8 +104,7 @@ pub struct ModelRegistry {
 impl ModelRegistry {
     /// Loads the model registry from embedded YAML.
     pub fn load() -> Result<Self> {
-        let yaml_content = include_str!("../templates/models.yaml");
-        let config: ModelConfiguration = serde_yaml::from_str(yaml_content)?;
+        let config: ModelConfiguration = serde_yaml::from_str(MODELS_YAML)?;
 
         // Build lookup maps
         let mut by_identifier = HashMap::new();

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -3,6 +3,8 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+use crate::claude::model_config::MODELS_YAML;
+
 /// Configuration operations.
 #[derive(Parser)]
 pub struct ConfigCommand {
@@ -58,9 +60,7 @@ impl ModelsCommand {
 impl ShowCommand {
     /// Executes the show command.
     pub fn execute(self) -> Result<()> {
-        // Print the embedded models.yaml file
-        let yaml_content = include_str!("../templates/models.yaml");
-        println!("{yaml_content}");
+        println!("{MODELS_YAML}");
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

This PR eliminates code duplication by extracting the `include_str!("../templates/models.yaml")` macro call into a single shared constant. Previously, the models.yaml file was embedded twice in the binary - once in `model_config.rs` for the model registry and once in `cli/config.rs` for the config show command. This refactoring consolidates the embed into one location, improving maintainability and ensuring consistency.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

N/A - This is a code quality improvement identified during development.

## Changes Made

**Core Changes:**
- Added `pub(crate) const MODELS_YAML: &str` constant in `src/claude/model_config.rs` with documentation comment
- Updated `ModelRegistry::load()` to use the shared `MODELS_YAML` constant instead of inline `include_str!`
- Modified `src/cli/config.rs` to import and use `MODELS_YAML` from the claude module
- Removed redundant `include_str!` call and comment from `ShowCommand::execute()`

**Documentation:**
- Added doc comment explaining the purpose of the `MODELS_YAML` constant

**Testing:**
- No new tests required - this is a pure refactoring with no functional changes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A - refactoring only)
- [ ] Integration tests updated/added (N/A)
- [ ] Performance tests (if applicable) (N/A)

**Manual Testing:**
- [x] Tested happy path scenarios (`omni-dev config models show` produces identical output)
- [x] Backward compatibility verified (no API changes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify config show still works
cargo run -- config models show
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications (N/A)
- [ ] Performance impact (N/A - compile-time embedding unchanged)
- [x] Architecture changes (constant visibility is `pub(crate)`)
- [ ] Error handling (N/A)
- [ ] User experience (N/A)
- [x] Backward compatibility (confirmed - no external API changes)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A - internal refactoring)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A - refactoring)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The `include_str!` macro is evaluated at compile time, so consolidating it into a single constant has no runtime performance impact. The binary size remains unchanged as the string is only embedded once either way.

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the duplicate `include_str!` calls - rejected because it violates DRY principle and could lead to inconsistencies if the path ever changes
- Making the constant `pub` instead of `pub(crate)` - rejected because external crates don't need access to the raw YAML content

Closes #96