### PR TITLE
feat(claude): implement walk-up config directory discovery

### DIFF
--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -1500,7 +1500,11 @@ mod tests {
     #[test]
     fn context_dir_default() {
         let result = crate::claude::context::resolve_context_dir(None);
-        assert_eq!(result, std::path::PathBuf::from(".omni-dev"));
+        // Walk-up may find .omni-dev in the real repo, or fall back to ".omni-dev"
+        assert!(
+            result.ends_with(".omni-dev"),
+            "expected path ending in .omni-dev, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR implements automatic discovery of `.omni-dev/` configuration directories by walking up from the current working directory to the repository root. This enables monorepo support where subdirectories can have their own configuration that takes precedence over parent configurations, while still falling back gracefully to the nearest ancestor config or the default `.omni-dev` path.

Previously, `resolve_context_dir()` only checked the `--context-dir` CLI flag, the `OMNI_DEV_CONFIG_DIR` environment variable, or fell back to a hardcoded `.omni-dev` relative path. With this change, when neither explicit override is set, omni-dev walks up from the current working directory toward the repository root to discover the nearest `.omni-dev/` directory. This is particularly useful in monorepos where different packages may have their own `.omni-dev/` configuration.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Closes #176

## Changes Made

**Core Changes:**
- Added `walk_up_find_config_dir(start: &Path) -> Option<PathBuf>` function in `src/claude/context/discovery.rs` that searches upward from a given path for a `.omni-dev/` directory, stopping at the repository boundary (`.git` directory or file)
- Updated `resolve_context_dir()` in `src/claude/context/discovery.rs` to include walk-up discovery as step 3 in the priority chain (after CLI override and env var, before the `.omni-dev` fallback)
- Updated the priority order documentation on `resolve_context_dir()` to reflect the new 4-step resolution: CLI override → env var → walk-up discovery → default fallback

**Testing:**
- Added 8 new unit tests for `walk_up_find_config_dir()` covering: finding config in start directory, finding config in parent, finding config at repo root, nearest directory wins over root, stops at git boundary, returns `None` when no config exists, handles git worktree file format (`.git` as a file), and no config in repo returns `None`
- Added `make_repo_tree()` helper that creates a temporary directory with a `.git` marker for use in walk-up tests
- Updated 3 existing tests that asserted `result == PathBuf::from(".omni-dev")` to use `result.ends_with(".omni-dev")` so they pass correctly when the walk-up discovers the real repo's `.omni-dev/` directory during test execution:
  - `resolve_context_dir_returns_default()` in `src/claude/context/discovery.rs`
  - `resolve_context_dir_empty_env_var()` in `src/claude/context/discovery.rs`
  - `context_dir_default()` in `src/cli/git/twiddle.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass (updated assertions to accommodate walk-up behavior in real repo context)
- [x] New tests added for new functionality (8 new tests for `walk_up_find_config_dir`)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (walk-up finds nearest config)
- [x] Tested error/edge cases (no config in repo, git worktree support, boundary stopping)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified (explicit overrides still take priority; default fallback preserved)

**Test Coverage:**
- New code coverage: ~100% of new `walk_up_find_config_dir` function (8 tests covering all branches)

### Test Commands
```bash
# Core test suite
cargo test

# Run walk-up specific tests
cargo test walk_up

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes (new priority step 3 in config resolution)
- [x] Error handling (`current_dir()` failure is handled gracefully — falls through to default)
- [x] Backward compatibility (explicit `--context-dir` and `OMNI_DEV_CONFIG_DIR` still fully bypass walk-up)

The key design decisions to review:
- **Nearest wins**: The function returns the first `.omni-dev/` found walking upward, so the closest config to the CWD takes priority over ancestors.
- **Repo boundary enforcement**: Walk-up stops when it encounters a `.git` entry (directory or file), preventing config discovery from escaping the repository boundary.
- **Git worktree support**: The `.git` file format used by git worktrees is handled correctly via `.exists()` rather than `.is_dir()`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] Potential performance impact (describe below)

Walk-up discovery performs filesystem stat calls for each directory level between the CWD and the repository root. In typical repositories this is a small number of calls (< 10), and the operation only occurs when no explicit config override is set. The impact is negligible for normal usage.

## Security Considerations

- [x] No security implications

Walk-up strictly respects repository boundaries (`.git` marker) and does not follow symlinks or escape the repository. No user input is used to construct paths beyond the standard CWD.

## Breaking Changes

None. This change is purely additive:
- Explicit `--context-dir` and `OMNI_DEV_CONFIG_DIR` overrides continue to work exactly as before and disable walk-up entirely.
- Projects without a `.omni-dev/` directory in any ancestor will fall through to the existing `.omni-dev` default.
- Projects that do have a `.omni-dev/` directory at the repo root will now have it discovered automatically when running from subdirectories — this is the intended and desirable new behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Could add a `--no-walk-up` flag to explicitly disable walk-up discovery without needing to set `OMNI_DEV_CONFIG_DIR`
- XDG config directory could potentially also benefit from a similar walk-up mechanism

**Alternatives Considered:**
- Walking downward from the repo root: Rejected in favor of nearest-wins semantics, which is more intuitive for monorepo use cases where a package-specific config should override the root config.
- Using `git rev-parse --show-toplevel`: Rejected to avoid spawning a subprocess; the `.git` marker heuristic is sufficient and more performant.