### PR TITLE
feat(claude,cli): add config dir source tracking and diagnostic output

### DIFF
--- a/src/claude/context.rs
+++ b/src/claude/context.rs
@@ -8,7 +8,7 @@ pub mod patterns;
 pub use branch::BranchAnalyzer;
 pub use discovery::{
     config_source_label, load_config_content, load_project_scopes, resolve_context_dir,
-    ConfigSourceLabel, ProjectDiscovery,
+    resolve_context_dir_with_source, ConfigDirSource, ConfigSourceLabel, ProjectDiscovery,
 };
 pub use files::FileAnalyzer;
 pub use patterns::WorkPatternAnalyzer;

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -299,11 +299,15 @@ impl CheckCommand {
         guidelines: &Option<String>,
         valid_scopes: &[crate::data::context::ScopeDefinition],
     ) {
-        use crate::claude::context::{config_source_label, resolve_context_dir, ConfigSourceLabel};
+        use crate::claude::context::{
+            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+        };
 
-        let context_dir = resolve_context_dir(self.context_dir.as_deref());
+        let (context_dir, dir_source) =
+            resolve_context_dir_with_source(self.context_dir.as_deref());
 
         println!("📋 Project guidance files status:");
+        println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
 
         // Check commit guidelines
         let guidelines_source = if guidelines.is_some() {

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -544,11 +544,14 @@ impl CreatePrCommand {
         &self,
         project_context: &crate::data::context::ProjectContext,
     ) -> Result<()> {
-        use crate::claude::context::{config_source_label, ConfigSourceLabel};
+        use crate::claude::context::{
+            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+        };
 
-        let context_dir = crate::claude::context::resolve_context_dir(None);
+        let (context_dir, dir_source) = resolve_context_dir_with_source(None);
 
         println!("📋 Project guidance files status:");
+        println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
 
         // Check PR guidelines (for PR commands)
         let pr_guidelines_source = if project_context.pr_guidelines.is_some() {

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -686,7 +686,8 @@ impl TwiddleCommand {
         let mut context = CommitContext::new();
 
         // 1. Discover project context
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
+        let (context_dir, dir_source) =
+            crate::claude::context::resolve_context_dir_with_source(self.context_dir.as_deref());
 
         // ProjectDiscovery takes repo root and context directory
         let repo_root = std::path::PathBuf::from(".");
@@ -697,7 +698,7 @@ impl TwiddleCommand {
                 debug!("Discovery successful");
 
                 // Show diagnostic information about loaded guidance files
-                self.show_guidance_files_status(&project_context, &context_dir)?;
+                self.show_guidance_files_status(&project_context, &context_dir, &dir_source)?;
 
                 context.project = project_context;
             }
@@ -841,10 +842,12 @@ impl TwiddleCommand {
         &self,
         project_context: &crate::data::context::ProjectContext,
         context_dir: &std::path::Path,
+        dir_source: &crate::claude::context::ConfigDirSource,
     ) -> Result<()> {
         use crate::claude::context::{config_source_label, ConfigSourceLabel};
 
         println!("📋 Project guidance files status:");
+        println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
 
         // Check commit guidelines
         let guidelines_source = if project_context.commit_guidelines.is_some() {
@@ -1098,11 +1101,15 @@ impl TwiddleCommand {
         guidelines: &Option<String>,
         valid_scopes: &[crate::data::context::ScopeDefinition],
     ) {
-        use crate::claude::context::{config_source_label, ConfigSourceLabel};
+        use crate::claude::context::{
+            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+        };
 
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
+        let (context_dir, dir_source) =
+            resolve_context_dir_with_source(self.context_dir.as_deref());
 
         println!("📋 Project guidance files status:");
+        println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
 
         // Check commit guidelines
         let guidelines_source = if guidelines.is_some() {


### PR DESCRIPTION
## Description

This PR introduces `ConfigDirSource` enum to track how the configuration directory was resolved, and surfaces this information in the diagnostic output of all commands that display project guidance file status (`check`, `create-pr`, and `twiddle`).

Previously, when commands printed guidance file status, users had no visibility into *which* config directory was being used or *how* it was selected. This made it difficult to diagnose configuration issues, especially when the resolution path (CLI flag, environment variable, walk-up discovery, or default) wasn't obvious. The new diagnostic line now shows both the resolved path and its source, e.g.:

```
📋 Project guidance files status:
   📂 Config dir: .omni-dev (walk-up)
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
No related issue — this is a developer experience improvement for config diagnostics.

## Changes Made

**Core Changes:**
- Added `ConfigDirSource` enum (`CliFlag`, `EnvVar`, `WalkUp`, `Default`) in `src/claude/context/discovery.rs` to identify how the context directory was resolved
- Implemented `fmt::Display` for `ConfigDirSource` with human-readable labels: `--context-dir`, `OMNI_DEV_CONFIG_DIR`, `walk-up`, `default`
- Refactored `resolve_context_dir` into `resolve_context_dir_with_source` which returns `(PathBuf, ConfigDirSource)` capturing both the resolved path and resolution method
- Kept original `resolve_context_dir` as a convenience wrapper that calls `resolve_context_dir_with_source` and discards the source
- Exported `resolve_context_dir_with_source` and `ConfigDirSource` from `src/claude/context.rs`
- Updated `check.rs` to use `resolve_context_dir_with_source` and print config dir path + source in guidance files status output
- Updated `create_pr.rs` to use `resolve_context_dir_with_source` and print config dir path + source in guidance files status output
- Updated `twiddle.rs` in two places: the main commit flow and the standalone guidance display path, both now pass `dir_source` through and display the config dir line

**Testing:**
- Added `with_source_cli_flag` test: verifies CLI flag override returns `CliFlag` source
- Added `with_source_env_var` test: verifies `OMNI_DEV_CONFIG_DIR` env var returns `EnvVar` source
- Added `with_source_cli_beats_env` test: verifies CLI flag takes priority over env var
- Added `with_source_walk_up_or_default` test: verifies walk-up or default fallback behavior
- Added `display_config_dir_source_cli_flag` test: verifies `--context-dir` display string
- Added `display_config_dir_source_env_var` test: verifies `OMNI_DEV_CONFIG_DIR` display string
- Added `display_config_dir_source_walk_up` test: verifies `walk-up` display string
- Added `display_config_dir_source_default` test: verifies `default` display string

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`resolve_context_dir_with_source` and `ConfigDirSource::Display`)
- [ ] Integration tests updated/added
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (all resolution paths: CLI flag, env var, walk-up, default)
- [x] Tested that existing `resolve_context_dir` callers are unaffected
- [x] Backward compatibility verified — `resolve_context_dir` signature unchanged

### Test Commands
```bash
# Core test suite
cargo test

# Run discovery-specific tests
cargo test resolve_context_dir_with_source
cargo test display_config_dir_source

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `resolve_context_dir_with_source` is now the canonical implementation; `resolve_context_dir` is a thin wrapper
- [x] User experience — the new diagnostic line helps users understand which config directory is active and why
- [x] Backward compatibility — all existing callers of `resolve_context_dir` continue to work unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact — source tracking adds only a trivial enum tag to an already-executed resolution function

## Security Considerations
- [x] No security implications — this change only surfaces diagnostic information about config directory resolution that the user already controls

## Breaking Changes

None. The existing `resolve_context_dir` function signature is unchanged. The new `resolve_context_dir_with_source` function is additive, and `ConfigDirSource` is a newly exported type.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `ConfigDirSource` enum could be surfaced in structured YAML output (e.g., as a field in the `view` command) for programmatic consumption
- Additional resolution methods (e.g., workspace config, project-level override) could be added as new enum variants without breaking changes

**Alternatives Considered:**
- Returning a string label instead of an enum — rejected in favor of the enum to enable pattern matching and future extensibility without stringly-typed comparisons