### PR TITLE
docs(docs): document four-tier config resolution with walk-up discovery and XDG support

### DIFF
--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -8,8 +8,15 @@ All `.omni-dev` configuration files now support local overrides through the `.om
 
 ## Priority Order
 
+Local overrides are the highest-priority tier in the full resolution chain:
+
 1. `.omni-dev/local/{filename}` - **Local override (highest priority)**
 2. `.omni-dev/{filename}` - Shared project configuration
+3. `$XDG_CONFIG_HOME/omni-dev/{filename}` - XDG global config
+4. `$HOME/.omni-dev/{filename}` - Legacy global fallback
+
+See [Configuration Guide](configuration.md) for the full resolution chain
+including config directory selection (walk-up discovery, env var, CLI flag).
 
 ## Supported Override Files
 


### PR DESCRIPTION
## Description

This PR updates configuration documentation across four files to accurately reflect the expanded config resolution system introduced in issues #173–#177. The documentation now describes a two-phase resolution model: first selecting the config *directory*, then resolving individual config *files* within it.

The key changes document:
- A new two-phase config resolution model (directory selection + file resolution)
- Walk-up discovery for automatic monorepo support
- XDG Base Directory compliance as a new global config tier
- Updated internals documentation with new functions and enums

## Type of Change
- [x] Documentation update

## Related Issue
Fixes #173, #174, #175, #176, #177

## Changes Made

**Config Directory Resolution (new two-phase model):**
- Documents the config *directory* selection chain: `--context-dir` CLI flag → `OMNI_DEV_CONFIG_DIR` env var → walk-up discovery → CWD-relative default
- Explains walk-up discovery: searches from CWD upward to the `.git` boundary, enabling monorepos to automatically pick up the nearest `.omni-dev/` config
- Notes that explicit overrides (`--context-dir`, `OMNI_DEV_CONFIG_DIR`) disable walk-up, giving full control when needed

**Config File Resolution (three-tier expanded to four-tier):**
- Adds XDG global tier (`$XDG_CONFIG_HOME/omni-dev/`) between project and legacy global (`$HOME/.omni-dev/`), with XDG checked first to encourage migration
- Explains the `xdg_config_dir()` helper and why it uses `std::env::var` directly instead of `dirs::config_dir()` (macOS `~/Library/Application Support/` issue)
- Updates all priority tables across docs to show the four-tier chain consistently

**Monorepo Guidance:**
- Replaces the old `--context-dir`-per-package pattern with walk-up-based directory layout
- Shows a directory tree with `.omni-dev/` at each package boundary
- Documents `OMNI_DEV_CONFIG_DIR` env var as an alternative to `--context-dir`

**Documentation (`docs/plan/config-internals.md`):**
- Splits "Resolution Chain" into separate "Config Directory Resolution" and "Config File Resolution Chain" sections
- Documents `resolve_context_dir_with_source()`, `ConfigDirSource` enum, `walk_up_find_config_dir()`, and `xdg_config_dir()` functions
- Updates key source files table with new functions (`resolve_context_dir_with_source`, `resolve_context_dir`, `walk_up_find_config_dir`, `xdg_config_dir`, `ConfigDirSource`, `ConfigSourceLabel`) and diagnostic display entries for `check.rs`, `twiddle.rs`, and `create_pr.rs`
- Records issues #173–#177 in the related issues section

**Files Modified:**
- `docs/configuration-best-practices.md` — Updated priority tables, "When to use each tier" section, stale config warning, and quality checklist
- `docs/configuration.md` — Rewrote Local Override Support and Global Configuration Fallback sections; updated monorepo usage example to use walk-up layout
- `docs/local-overrides.md` — Expanded priority order list from two tiers to four tiers with cross-reference to configuration guide
- `docs/plan/config-internals.md` — Split and expanded resolution chain docs; updated key source files table; added related issues

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change)

**Manual Testing:**
- [x] Reviewed all four modified files for accuracy against implemented behavior
- [x] Verified priority tables are consistent across all documents
- [x] Confirmed cross-references between documents are correct

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the docs correctly note that `$HOME/.omni-dev/` remains supported as a legacy fallback
- [x] Accuracy of the four-tier priority tables across all four files (they should be consistent)
- [x] Monorepo walk-up example in `docs/configuration.md` — the directory tree and explanation should clearly convey how walk-up works without `--context-dir`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a documentation-only update. The underlying behavior described was already implemented in #173–#177; these docs simply bring the documentation into alignment with the code.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider adding a `omni-dev config show-resolution` diagnostic command that prints the resolved config directory and source at runtime, complementing the `ConfigDirSource` diagnostic output already in the check/twiddle/create-pr commands.

**Known Limitations:**
- The internals doc (`docs/plan/config-internals.md`) is a developer-facing reference and may drift from code over time; consider auto-generating parts of it from source in the future.

**Alternatives Considered:**
- Keeping a single "Resolution Chain" section in the internals doc rather than splitting it — rejected because the two-phase model (directory then file) is a meaningful architectural distinction worth calling out separately.