### PR TITLE
feat(cli): add --refine flag as opt-in alternative to fresh mode

### DIFF
--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -375,7 +375,9 @@ Options:
       --no-ai
           Skips AI processing and only outputs repository YAML
       --fresh
-          Ignores existing commit messages and generates fresh ones based solely on diffs
+          Ignores existing commit messages and generates fresh ones based solely on diffs. This is the default behavior
+      --refine
+          Uses existing commit messages as a starting point for AI refinement instead of generating fresh messages from scratch
       --check
           Runs commit message validation after applying amendments
   -h, --help


### PR DESCRIPTION
## Description

This PR changes the default behavior of the `twiddle` command so that **fresh mode** (ignoring existing commit messages and generating new ones purely from diffs) is the default. A new `--refine` flag is introduced as an explicit opt-in for users who want to use their existing commit messages as a starting point for AI refinement.

Previously, `--fresh` was an opt-in flag and the default behavior was to use existing messages. This inversion makes the more deterministic, diff-only generation the out-of-the-box experience, while still allowing users to leverage their existing messages when desired via `--refine`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes to existing `--fresh` behavior)

## Related Issue

No related issue.

## Changes Made

**Core Changes:**
- Added `--refine` flag to `TwiddleCommand` in `src/cli/git/twiddle.rs` that conflicts with `--fresh`
- Added `is_fresh()` helper method on `TwiddleCommand` that returns `true` unless `--refine` is explicitly set, making fresh the default behavior
- Updated all call sites of `generate_contextual_amendments_with_options` and `generate_amendments_with_options` to use `self.is_fresh()` instead of `self.fresh`
- Updated status messages to distinguish between "Refine mode" and "Fresh mode" (previously only "Fresh mode" was shown)
- Updated `--fresh` flag documentation to clarify it is the default behavior

**Testing:**
- Updated snapshot `tests/snapshots/integration_test__help_all_output.snap` to reflect new `--refine` flag in help output and updated `--fresh` description

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration tests updated (snapshot updated to include `--refine` in help output)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Backward compatibility verified — existing `--fresh` flag continues to work as before

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — the inversion of default behavior (fresh is now default rather than opt-in)
- [x] Backward compatibility — `--fresh` still works but is now a no-op (since fresh is default); `--refine` is the new meaningful override

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

The `--fresh` flag remains functional and accepted but its behavior is now the default. Users relying on `--fresh` explicitly will see no change in output. Users who previously relied on the default behavior (which used existing commit messages) will now need to pass `--refine` to restore that behavior.

**Backward Compatibility:**
- Existing scripts or aliases using `--fresh` will continue to work without modification
- The implicit default behavior has changed: existing commit messages are now ignored unless `--refine` is passed

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `--fresh` as opt-in and adding no new flag: rejected because fresh mode is the more reliable, deterministic behavior and should be the default for new users
- Removing `--fresh` entirely: rejected to maintain backward compatibility for users with existing scripts