### PR TITLE
fix(cli): consolidate --context-dir option across all create-pr call sites

### DIFF
--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -32,6 +32,10 @@ pub struct CreatePrCommand {
     /// Creates PR as draft (overrides default).
     #[arg(long, conflicts_with = "ready")]
     pub draft: bool,
+
+    /// Path to custom context directory (defaults to .omni-dev/).
+    #[arg(long)]
+    pub context_dir: Option<std::path::PathBuf>,
 }
 
 /// PR action choices.
@@ -99,7 +103,7 @@ impl CreatePrCommand {
         // 3. Show guidance files status early (before AI processing)
         use crate::claude::context::ProjectDiscovery;
         let repo_root = std::path::PathBuf::from(".");
-        let context_dir = std::path::PathBuf::from(".omni-dev");
+        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
         let discovery = ProjectDiscovery::new(repo_root, context_dir);
         let project_context = discovery.discover().unwrap_or_default();
         self.show_guidance_files_status(&project_context)?;
@@ -510,7 +514,7 @@ impl CreatePrCommand {
         let mut context = CommitContext::new();
 
         // 1. Discover project context
-        let context_dir = std::path::PathBuf::from(".omni-dev");
+        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
 
         // ProjectDiscovery takes repo root and context directory
         let repo_root = std::path::PathBuf::from(".");
@@ -548,7 +552,8 @@ impl CreatePrCommand {
             config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
         };
 
-        let (context_dir, dir_source) = resolve_context_dir_with_source(None);
+        let (context_dir, dir_source) =
+            resolve_context_dir_with_source(self.context_dir.as_deref());
 
         println!("📋 Project guidance files status:");
         println!("   📂 Config dir: {} ({dir_source})", context_dir.display());

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -236,13 +236,14 @@ Creates a pull request with AI-generated description
 Usage: pr [OPTIONS]
 
 Options:
-      --base <BRANCH>     Base branch for the PR to be merged into (defaults to main/master)
-      --model <MODEL>     Claude API model to use (if not specified, uses settings or default)
-      --auto-apply        Skips confirmation prompt and creates PR automatically
-      --save-only <FILE>  Saves generated PR details to file without creating PR
-      --ready             Creates PR as ready for review (overrides default)
-      --draft             Creates PR as draft (overrides default)
-  -h, --help              Print help
+      --base <BRANCH>              Base branch for the PR to be merged into (defaults to main/master)
+      --model <MODEL>              Claude API model to use (if not specified, uses settings or default)
+      --auto-apply                 Skips confirmation prompt and creates PR automatically
+      --save-only <FILE>           Saves generated PR details to file without creating PR
+      --ready                      Creates PR as ready for review (overrides default)
+      --draft                      Creates PR as draft (overrides default)
+      --context-dir <CONTEXT_DIR>  Path to custom context directory (defaults to .omni-dev/)
+  -h, --help                       Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR adds a `--context-dir` CLI argument to the `create-pr` command, enabling users to specify a custom path to the context directory instead of the hardcoded `.omni-dev/` default. Previously, three separate locations within `create_pr.rs` independently constructed the context directory path using `PathBuf::from(".omni-dev")` or `resolve_context_dir_with_source(None)`, making it impossible for users to override the context directory at runtime.

The fix consolidates all three call sites to use `resolve_context_dir` and `resolve_context_dir_with_source` with the user-supplied `--context-dir` value, ensuring consistent behavior across the guidance files status display, commit context discovery, and config source label resolution.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to the broader effort to make omni-dev context directory configurable at the CLI level.

## Changes Made

**Core Changes:**
- Added `context_dir: Option<std::path::PathBuf>` field to `CreatePrCommand` struct in `src/cli/git/create_pr.rs`
- Added `--context-dir <CONTEXT_DIR>` CLI argument with appropriate help text ("Path to custom context directory (defaults to .omni-dev/)")
- Updated guidance files status call site (`show_guidance_files_status`) to use `resolve_context_dir(self.context_dir.as_deref())` instead of hardcoded `PathBuf::from(".omni-dev")`
- Updated commit context discovery call site to use `resolve_context_dir(self.context_dir.as_deref())` instead of hardcoded `PathBuf::from(".omni-dev")`
- Updated config source label call site to use `resolve_context_dir_with_source(self.context_dir.as_deref())` instead of `resolve_context_dir_with_source(None)`

**Testing:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to reflect the new `--context-dir <CONTEXT_DIR>` argument in the `pr` subcommand help output

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Integration tests updated/added (help output snapshot updated)
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [x] Backward compatibility verified (default behavior unchanged when `--context-dir` is not provided)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Verify help output includes new flag
omni-dev pr --help
# Expected: shows --context-dir <CONTEXT_DIR> option

# Test with custom context dir
omni-dev pr --context-dir ./my-custom-context
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience
- [x] Backward compatibility

The key review concern is whether all three call sites within `CreatePrCommand` that use a context directory have been correctly updated. Previously, the second call site passed `None` to `resolve_context_dir_with_source` (ignoring any potential user preference), and the first two call sites hardcoded `.omni-dev`. All three are now consistently threaded through `self.context_dir.as_deref()`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. When `--context-dir` is not specified, `resolve_context_dir(None)` returns the same default `.omni-dev/` path as before, preserving full backward compatibility.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider supporting the context directory override via an environment variable (e.g., `OMNI_DEV_CONTEXT_DIR`) in addition to the CLI flag, consistent with how other settings are resolved.

**Alternatives Considered:**
- A global `--context-dir` flag at the top-level command was considered but rejected in favor of a command-scoped flag to keep the surface area minimal and avoid unintended interference with other subcommands.