### PR TITLE
docs(docs,claude): add commit-twiddle skill and STYLE-0023 commit validation rule

### DIFF
--- a/.claude/skills/commit-twiddle/SKILL.md
+++ b/.claude/skills/commit-twiddle/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: commit-twiddle
+description: Validates and corrects commit messages against project guidelines after a commit is created. Invoke automatically after every git commit to ensure messages conform to .omni-dev/commit-guidelines.md.
+argument-hint: [commit-hash|range]
+allowed-tools: Bash(mkdir *), Read, Write, Edit, "omni-dev *"
+---
+
+# Commit Twiddle
+
+Validate and correct commit messages to conform to `.omni-dev/commit-guidelines.md`.
+
+If `$ARGUMENTS` is provided, use it as the commit hash or range. Otherwise default to `HEAD`.
+
+## Step 1 — Analyse
+
+```bash
+omni-dev git commit message view $ARGUMENTS
+```
+
+The output is self-describing. Read the `explanation.fields` section to understand all
+available fields, then extract the values needed for Step 2.
+
+Key fields to look at:
+- `commits[].original_message` — the current message
+- `commits[].analysis.detected_type` and `detected_scope` — what omni-dev detected
+- `commits[].analysis.diff_file` — read this file to understand what actually changed
+- `ai.scratch` — base path for temporary files
+
+## Step 2 — Craft corrected messages
+
+For each commit, write a corrected message that conforms to the guidelines. Constraints:
+
+- **Type and scope** must match the actual changes — read the diff if uncertain
+- **Scope** must be one of the values defined in `.omni-dev/scopes.yaml`
+- **Subject line** must be lowercase, imperative mood, no trailing period, ≤72 chars total
+- **No `Co-Authored-By` footers** — do not add AI attribution lines
+- **Body** required for changes >50 lines or architectural changes; wrap at 72 cols
+
+Write the amendments file to `<ai.scratch>/amendments-<random-8-hex>.yaml`:
+
+```yaml
+amendments:
+  - commit: "<exactly 40 lowercase hex chars>"   # full SHA, not abbreviated
+    message: |
+      <type>(<scope>): <subject>
+
+      <optional body wrapped at 72 cols>
+
+      <optional footers — no Co-Authored-By>
+```
+
+Create the directory if the write fails:
+
+```bash
+mkdir -p <ai.scratch>
+```
+
+## Step 3 — Apply
+
+```bash
+omni-dev git commit message amend <ai.scratch>/amendments-<random-8-hex>.yaml
+```
+
+## Constraints
+
+- The target commit must be at the **branch tip with no merge commit above it**. If a
+  merge commit is present the amend will fail — work on the branch before merging.
+- Use the **exact 40-character SHA** from the `commits[].hash` field. An abbreviated
+  hash silently skips the amendment or errors.
+- If the message is already correct, do nothing and say so.
+
+## Troubleshooting
+
+If `omni-dev` is not installed: https://crates.io/crates/omni-dev (requires ≥ v0.3.0)

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -86,14 +86,10 @@ This skill performs the complete end-to-end release process for omni-dev, from v
     ```bash
     git add Cargo.toml Cargo.lock CHANGELOG.md docs/
     git commit -m "$(cat <<'EOF'
-    chore: prepare release vX.Y.Z
+    chore(release): prepare release vX.Y.Z
 
     - Update version from PREV to X.Y.Z
     - Update CHANGELOG.md with release notes
-
-    🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
     EOF
     )"
     ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ omni-dev is a powerful Git commit message analysis and amendment toolkit written
 ### Configuration
 - `Cargo.toml` - Rust package configuration and dependencies
 - `.github/` - GitHub Actions CI/CD workflows
-- `.claude/commands/` - Claude-specific command definitions
+- `.claude/skills/` - Claude skill definitions
 
 ### Documentation
 - `README.md` - Main project documentation
@@ -125,11 +125,8 @@ The project includes a comprehensive model registry system:
 - **Configuration Commands**: Use `omni-dev config models show` to view available models
 - **Dynamic Limits**: Token limits are automatically applied based on model specifications
 
-### Command Structure
-Claude commands are organized in `.claude/commands/`:
-- `commit-twiddle*` - Commit message modification commands
-- `pr-create*` - Pull request creation commands
-- Variants include debug, release, and standard modes
+### Skill Structure
+Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 
 ### Working with Git
 Common git operations in this project:

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -21,6 +21,7 @@ which tags apply to the changes and search this file for those tags. Each rule h
 | Changing visibility (`pub`, `pub(crate)`)        | `api-design`, `module-organization`      |
 | Adding constants or replacing magic values       | `code-style`, `naming`                   |
 | Writing commit messages                          | `commits`                                |
+| After creating commits (before push / PR)        | `commits`                                |
 | Suppressing a lint or considering `unsafe`       | `code-style`, `unsafe`                   |
 | Writing or updating an ADR                       | `adrs`                                   |
 | Reviewing code for style compliance              | All tags relevant to the changed code    |
@@ -37,7 +38,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0023`) and include:
+Assign the next sequential ID (currently next is `STYLE-0024`) and include:
 
 1. A **Tags** line immediately after the heading — a comma-separated list of category labels
    from the tag vocabulary below.
@@ -48,19 +49,19 @@ Assign the next sequential ID (currently next is `STYLE-0023`) and include:
 
 **Tag vocabulary** (extend as needed):
 
-| Tag                  | Covers                                            |
-|----------------------|---------------------------------------------------|
-| `meta`               | Style guide structure and process                 |
+| Tag                  | Covers                                             |
+|----------------------|----------------------------------------------------|
+| `meta`               | Style guide structure and process                  |
 | `error-handling`     | Error types, context messages, panics, suppression |
-| `module-organization`| File layout, visibility, cohesion                 |
-| `naming`             | Naming conventions for types, functions, files    |
-| `commits`            | Commit message format, scope rules, discipline    |
-| `documentation`      | Doc comments, examples                            |
-| `testing`            | Test structure, fixtures, snapshots               |
+| `module-organization`| File layout, visibility, cohesion                  |
+| `naming`             | Naming conventions for types, functions, files     |
+| `commits`            | Commit message format, scope rules, discipline     |
+| `documentation`      | Doc comments, examples                             |
+| `testing`            | Test structure, fixtures, snapshots                |
 | `code-style`         | Imports, clippy, constants, function length        |
-| `api-design`         | Ownership, must_use, type safety, string params   |
-| `unsafe`             | Unsafe code policy                                |
-| `adrs`               | Architecture Decision Record format and process   |
+| `api-design`         | Ownership, must_use, type safety, string params    |
+| `unsafe`             | Unsafe code policy                                 |
+| `adrs`               | Architecture Decision Record format and process    |
 
 A rule may have **multiple tags** — e.g., a rule about error messages in tests could be
 tagged `error-handling, testing`.
@@ -1146,3 +1147,35 @@ A consistent structure makes ADRs scannable and sets clear expectations for both
 and reviewers. Extra sections blur the boundary between architectural decisions and
 operational guidance (which belongs in the style guide) or implementation detail (which
 belongs in code comments or docs).
+
+---
+
+## STYLE-0023: Validate commit messages with omni-dev after creation
+
+**Tags:** `commits`
+
+### Situation
+
+After creating one or more commits and before pushing or opening a pull request.
+
+### Guidance
+
+After every `git commit`, invoke the `commit-twiddle` skill to validate and fix the
+message against the guidelines in `.omni-dev/commit-guidelines.md`. The skill calls
+`omni-dev git commit message view` to analyse the commit, then
+`omni-dev git commit message amend` to rewrite the message if needed.
+
+**Constraints to observe:**
+
+- The target commit must be at the branch tip with **no merge commit above it**. If a
+  merge commit is present the amend step will fail — work on a branch before merging.
+- The amendments file requires the **exact 40-character SHA** from the commit output.
+  An abbreviated hash silently skips the amendment or errors.
+- Do **not** include a `Co-Authored-By` footer unless a human co-author contributed.
+  AI tool attribution footers must not be added to commit messages.
+
+### Motivation
+
+Running the twiddle step after commit creation catches scope, casing, and footer
+violations before they reach the remote, avoiding the costly reset-and-redo cycle
+required to rewrite history once a commit has been merged to `main`.


### PR DESCRIPTION
## Description

This PR introduces the `commit-twiddle` Claude skill and formalises post-commit validation as STYLE-0023 in the project style guide. Together, these changes establish a consistent workflow for validating and correcting commit messages after every `git commit` and before pushing or opening a pull request.

The commit-twiddle skill provides a structured three-step process: analyse the commit via `omni-dev git commit message view`, craft corrected amendments, then apply them with `omni-dev git commit message amend`. This catches scope, casing, and footer violations early — before commits reach the remote — avoiding the costly reset-and-redo cycle required to rewrite history once merged to `main`.

Additionally, this PR updates `CLAUDE.md` to reflect the rename from `.claude/commands/` to `.claude/skills/` (one subdirectory per skill with a `SKILL.md` file), and fixes the release skill to use `chore(release):` scope and remove AI attribution footers from commit templates.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

No issue linked — this is a developer workflow improvement.

## Changes Made

**New Skill:**
- Added `.claude/skills/commit-twiddle/SKILL.md` defining the three-step commit validation skill: analyse → craft amendments → apply with `omni-dev git commit message amend`
- Documents constraints: exact 40-character SHA required, no `Co-Authored-By` footers, target commit must be at branch tip with no merge commit above it

**Style Guide Updates:**
- Added STYLE-0023 to `docs/STYLE_GUIDE.md` requiring the `commit-twiddle` skill to be invoked after every `git commit` and before push or PR
- Added "After creating commits (before push / PR)" row to the when-to-apply tag matrix under the `commits` tag
- Advanced the next sequential style rule ID from `STYLE-0023` to `STYLE-0024`
- Minor table alignment fixes throughout the tag vocabulary section

**CLAUDE.md Updates:**
- Updated documentation to reflect the rename from `.claude/commands/` to `.claude/skills/`, describing the one-subdirectory-per-skill layout with a `SKILL.md` file per skill
- Replaced the old "Command Structure" section with the new "Skill Structure" section

**Release Skill Fixes:**
- Updated `.claude/skills/release/SKILL.md` to use `chore(release):` scope in the release commit template (was `chore:`)
- Removed `Co-Authored-By` and AI attribution footer lines from the release commit template

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation/skill files only — no executable code added)

**Manual Testing:**
- [x] Tested happy path scenarios (commit-twiddle skill instructions verified against actual `omni-dev` CLI)
- [x] Backward compatibility verified (no functional code changes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience — clarity of the commit-twiddle skill instructions for AI assistants
- [x] Backward compatibility — verify CLAUDE.md accurately reflects the new `.claude/skills/` structure

The key areas to review are:
- **`.claude/skills/commit-twiddle/SKILL.md`**: Confirm the three-step skill workflow is clear, complete, and consistent with how `omni-dev git commit message view` and `amend` actually behave
- **`docs/STYLE_GUIDE.md` STYLE-0023**: Verify the rule is specific enough to be actionable and correctly cross-references the skill

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This PR is purely additive — new skill file, new style guide rule, and documentation updates. No existing functionality is changed.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The commit-twiddle skill could be extended to handle commit ranges (e.g., `HEAD~3..HEAD`) for validating multiple commits in a single invocation
- Additional skills could follow the same pattern (one subdirectory, one `SKILL.md`) as the `.claude/skills/` structure scales

**Known Limitations:**
- The amend step requires the target commit to be at the branch tip with no merge commit above it; commits already merged to `main` cannot be amended via this skill

**Alternatives Considered:**
- A git hook approach was considered but ruled out in favour of an explicit skill invocation to keep the validation step visible and controllable by the developer/AI assistant