### PR TITLE
docs(docs): add ADR-0008 for deterministic pre-validation before AI analysis

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -31,3 +31,4 @@ by Michael Nygard.
 | [ADR-0005](adr-0005.md)  | ✅ Accepted | 2026-02-21 | Hierarchical Configuration Resolution with Walk-Up Discovery         |
 | [ADR-0006](adr-0006.md)  | ✅ Accepted | 2026-02-22 | Two-View Repository Data Model via Generics and Composition          |
 | [ADR-0007](adr-0007.md)  | ✅ Accepted | 2026-02-22 | Preflight Validation Pattern                                         |
+| [ADR-0008](adr-0008.md)  | ✅ Accepted | 2026-02-22 | Deterministic Pre-Validation Before AI Analysis                      |

--- a/docs/adrs/adr-0008.md
+++ b/docs/adrs/adr-0008.md
@@ -1,0 +1,127 @@
+# ADR-0008: Deterministic Pre-Validation Before AI Analysis
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev's `check` command sends commit data to an AI model for message quality
+analysis. Some properties of a commit message — whether a scope identifier exists in the
+configured scope list, whether a multi-scope string uses the correct comma-without-space
+format — are entirely deterministic. They can be evaluated locally by string matching or a
+list lookup, with no ambiguity and no need for language understanding.
+
+Delegating deterministic checks to the AI has two costs:
+
+- **Token waste**: The AI must re-derive facts that are already known. Prompt space consumed
+  by re-checking "is `cli` a valid scope?" is prompt space unavailable for semantic analysis.
+
+- **Non-determinism risk**: AI models are probabilistic. A check that has a single correct
+  answer may occasionally receive a wrong answer if evaluated by the model rather than by
+  code. Deterministic code is always correct for deterministic questions.
+
+Three alternative approaches were considered:
+
+- **AI-only validation**: Delegate all checks, including scope validity, to the model. Simple
+  to implement, but wastes tokens on checks the model may get wrong and the code could get
+  right every time.
+
+- **Separate validation pass**: Run deterministic checks independently, report their results
+  separately from the AI analysis, and present two parallel result sets to the user. This
+  adds a distinct reporting path with its own UX and output format.
+
+- **Pre-validation with in-payload reporting**: Run deterministic checks before the AI call,
+  embed *passing* results in the YAML payload as authoritative facts, and let the AI focus on
+  everything else. Failing checks are not recorded — the AI may surface them, or they may
+  not warrant a finding.
+
+## Decision
+
+We will run deterministic checks on each commit immediately before constructing the AI
+payload, and include *passing* checks in the `pre_validated_checks` field of
+`CommitInfoForAI`. The AI is instructed to treat entries in this list as authoritative and
+to skip re-verifying them.
+
+### Data structure
+
+`CommitInfoForAI` carries the results as a `Vec<String>` alongside the commit data it
+already holds:
+
+```rust
+pub struct CommitInfoForAI {
+    #[serde(flatten)]
+    pub base: CommitInfo<CommitAnalysisForAI>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_validated_checks: Vec<String>,
+}
+```
+
+The field is omitted from the serialised YAML when empty, so commits with no passing checks
+produce no extra output.
+
+### Checks performed
+
+`CommitInfoForAI::run_pre_validation_checks()` accepts the project's `valid_scopes` list
+and performs two checks:
+
+| Check                  | Condition recorded                                                                    |
+|------------------------|---------------------------------------------------------------------------------------|
+| Multi-scope format     | Scope contains commas with no surrounding spaces (e.g. `cli,git`)                    |
+| Scope validity         | All scope parts are present in the configured scope list (when the list is non-empty) |
+
+Only *passing* checks are recorded. A failing check produces no entry; the AI handles it as
+it would any other potential issue.
+
+### Call site
+
+The checks are applied in `src/claude/client.rs`, after the AI view is constructed and
+before the system prompt is generated:
+
+```rust
+for commit in &mut ai_repo_view.commits {
+    commit.run_pre_validation_checks(valid_scopes);
+}
+```
+
+The results are then serialised into the YAML payload the AI receives, so the model sees
+them alongside the commit message and diff.
+
+## Consequences
+
+**Positive:**
+
+- **Token efficiency.** Scope validity and format checks consume a few bytes of input rather
+  than requiring the model to reason about the scope list. The AI can apply its capacity to
+  semantic concerns: tone, clarity, description completeness.
+
+- **Guaranteed correctness for deterministic facts.** A scope that passes the local check is
+  in the list. The AI cannot contradict that fact with a probabilistic guess. This eliminates
+  a class of spurious findings on valid scopes.
+
+- **Seamless integration with existing AI analysis.** Pre-validated results arrive in the
+  same YAML structure as the rest of the commit data. No separate reporting path, no
+  additional command output, no user-facing change for the common case.
+
+- **Omitted when empty.** `skip_serializing_if = "Vec::is_empty"` keeps the YAML compact for
+  commits where no checks pass (no scope present, unconfigured scope list).
+
+**Negative:**
+
+- **Passing-only recording is asymmetric.** Failing checks are invisible to the caller of
+  `run_pre_validation_checks()`. Code that needs to know which checks failed must re-run the
+  check logic independently. This is acceptable today because only the AI output path needs
+  the results, but would require revisiting if a separate human-facing validation report were
+  added.
+
+- **Silent no-op on empty scope list.** Scope validity is only checked when `valid_scopes`
+  is non-empty. Projects without a configured scope list get no local scope validation. This
+  is correct behaviour, but the silence may be surprising when debugging a missing scope
+  configuration.
+
+**Neutral:**
+
+- **Checks grow with project needs.** `run_pre_validation_checks()` is a single method with
+  no extension point. Adding a new deterministic check means adding code to that method and
+  updating tests. For the current small set of checks this is fine; a registry or trait-based
+  approach would add abstraction without benefit at this scale.


### PR DESCRIPTION
## Description

This PR adds ADR-0008, which documents the architectural decision to run deterministic commit message checks locally before constructing the AI payload. This is part of Issue #107, which addresses pre-validation checks that can be evaluated entirely by code before invoking the AI model.

The core insight is that some commit message properties — whether a scope exists in the configured scope list, whether a multi-scope string uses the correct comma-without-space format — are fully deterministic. Delegating these to the AI wastes tokens and introduces non-determinism risk for questions that have a single correct answer.

The ADR documents the decision to run these checks before the AI call, embed *passing* results in the `pre_validated_checks` field of `CommitInfoForAI`, and instruct the AI to treat these as authoritative facts it need not re-verify.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #107

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0008.md` — full ADR for "Deterministic Pre-Validation Before AI Analysis", covering context, decision, data structure, checks performed, call site, and consequences
- Updated `docs/adrs/README.md` — registered ADR-0008 in the ADR index table with status ✅ Accepted and date 2026-02-22

**ADR Content Highlights:**
- Documents the two deterministic checks: multi-scope format (comma-without-space) and scope validity (against configured scope list)
- Specifies the `CommitInfoForAI` data structure with `pre_validated_checks: Vec<String>` field, including `skip_serializing_if = "Vec::is_empty"` for compact YAML output
- Documents the passing-only recording strategy and its trade-offs (asymmetry, silent no-op on empty scope list)
- Describes the call site in `src/claude/client.rs` where checks are applied before system prompt generation
- Evaluates three alternative approaches: AI-only validation, separate validation pass, and the chosen pre-validation with in-payload reporting

## Testing

**Automated Testing:**
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified ADR content is accurate and reflects the implementation in `src/claude/client.rs`
- [x] Confirmed ADR-0008 is correctly registered in the index table

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The key architectural decision documented here is the **passing-only recording strategy**: only checks that pass are embedded in the AI payload; failing checks are invisible to the caller of `run_pre_validation_checks()`. Reviewers should consider whether this asymmetry is acceptable long-term, or whether a future human-facing validation report would require revisiting this approach.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

This is a documentation-only PR. The implementation described in the ADR (pre-validation checks in `src/claude/client.rs`) reduces token consumption by offloading deterministic checks from the AI model, but that implementation is not part of this PR.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a documentation-only change adding an ADR to the existing ADR collection.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered (documented in ADR-0008):**
- AI-only validation: Simple but wastes tokens on deterministic checks the model may occasionally get wrong
- Separate validation pass: Adds a distinct reporting path with its own UX and output format
- Pre-validation with in-payload reporting (chosen): Runs checks before the AI call, embeds passing results in the YAML payload alongside existing commit data, no separate reporting path

**Known Limitations (documented in ADR-0008):**
- Passing-only recording is asymmetric — code needing to know which checks *failed* must re-run the check logic independently
- Scope validity silently skipped when `valid_scopes` is empty — projects without a configured scope list get no local scope validation
- `run_pre_validation_checks()` has no extension point; adding new deterministic checks requires editing the method directly

**Future Enhancements:**
- If a human-facing validation report is added, the passing-only recording strategy would need to be revisited to also capture failing checks
- A registry or trait-based approach could be introduced if the set of checks grows significantly