### PR TITLE
docs(docs): add ADRs for token-budget batch planning and multi-layer retry strategy

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -32,3 +32,5 @@ by Michael Nygard.
 | [ADR-0006](adr-0006.md)  | ✅ Accepted | 2026-02-22 | Two-View Repository Data Model via Generics and Composition          |
 | [ADR-0007](adr-0007.md)  | ✅ Accepted | 2026-02-22 | Preflight Validation Pattern                                         |
 | [ADR-0008](adr-0008.md)  | ✅ Accepted | 2026-02-22 | Deterministic Pre-Validation Before AI Analysis                      |
+| [ADR-0009](adr-0009.md)  | ✅ Accepted | 2026-02-22 | Token-Budget-Aware Batch Planning                                    |
+| [ADR-0010](adr-0010.md)  | ✅ Accepted | 2026-02-22 | Multi-Layer Retry Strategy                                           |

--- a/docs/adrs/adr-0009.md
+++ b/docs/adrs/adr-0009.md
@@ -1,0 +1,137 @@
+# ADR-0009: Token-Budget-Aware Batch Planning
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev's `twiddle` and `check` commands process a branch's commits by sending them to an
+AI model. A single branch may contain anywhere from one commit to dozens, and commit sizes
+vary enormously: a one-line typo fix may occupy a few hundred tokens while a large
+refactoring diff may consume tens of thousands.
+
+Two naive approaches were considered first:
+
+- **One AI request per commit.** Correct and simple, but wasteful: the model receives no
+  cross-commit context, and the number of API round-trips equals the number of commits.
+  For a branch with twenty commits, twenty sequential API calls add significant latency even
+  with parallelism, because each round-trip incurs network and model startup overhead.
+
+- **One AI request for all commits.** Minimises round-trips, but fails when the total
+  token cost of all commits exceeds the model's input context window. Commit diffs are
+  unbounded in size; a branch touching many large files may produce hundreds of thousands
+  of tokens of diff content. Sending everything in one request is not reliably possible.
+
+The core tension is between *minimising round-trips* (favouring large batches) and *staying
+within the model's context window* (requiring bounded batches). The right batch boundary is
+not a fixed commit count but a function of each commit's actual token cost.
+
+Three batching strategies were evaluated:
+
+- **Fixed-count batching** (the original `--batch-size` flag). Simple to implement and
+  explain, but ignores commit size. A batch of five large commits may exceed the context
+  window while a batch of five small commits wastes most of it. The flag has been removed.
+
+- **Token-budget-aware bin-packing.** Groups commits by estimated token cost so that each
+  batch fits within the model's context window. Requires token estimation, but produces
+  batches that are as large as possible without overflowing.
+
+- **Dynamic splitting at request time.** Send all commits in one request; if it fails,
+  bisect and retry. Simpler planning but results in wasted AI calls on predictably oversized
+  inputs.
+
+## Decision
+
+We will plan batches in `src/claude/batch.rs` using a **first-fit-decreasing bin-packing
+algorithm** driven by per-commit token estimates. This runs before any AI calls are made,
+so no tokens are wasted on requests that are certain to exceed the context window.
+
+### Token estimation
+
+Each commit's token cost is estimated without reading diff files into memory. The
+`estimate_commit_tokens` function uses `fs::metadata` (a single `stat` syscall) to get the
+diff file size, then sums it with the lengths of the diff summary, original message, and
+proposed message fields. The character count is converted to a token estimate and a fixed
+per-commit metadata overhead of 120 tokens is added to account for YAML field formatting.
+
+The available batch capacity subtracts the system prompt token count and a fixed
+`RepositoryViewForAI` envelope overhead of 150 tokens from the model's input context limit,
+then applies a 10% headroom factor (`BATCH_CAPACITY_FACTOR = 0.90`) to absorb YAML
+serialisation variance (indentation, literal block markers) that shifts actual token counts
+beyond the character-based estimate.
+
+### Bin-packing algorithm
+
+`plan_batches` sorts commits largest-first (first-fit-decreasing order), then places each
+commit into the first existing batch with sufficient remaining capacity. If no batch fits,
+a new solo batch is created. This greedy approach produces near-optimal packing for typical
+commit distributions without requiring an exponential search.
+
+Commits that individually exceed the batch capacity receive solo batches. These rely on
+progressive diff reduction at request time to bring the actual payload within
+the model's limits.
+
+### Map-reduce execution
+
+The batch plan drives a two-phase execution in `twiddle` and `check`:
+
+**Map phase:** batches are processed in parallel, bounded by a Tokio semaphore whose size
+is the `--concurrency` flag (default 4). Each batch becomes a single AI request, returning
+amendments (`twiddle`) or a check report (`check`).
+
+**Reduce phase (twiddle only):** after all batches complete, an optional cross-commit
+coherence pass refines the amendments for consistency in terminology and scope naming across
+commits. The coherence pass is skipped when all commits fit into a single batch (the AI
+already saw all commits together and produced a coherent result), and can be disabled
+explicitly with `--no-coherence`.
+
+### Concurrency control
+
+`--concurrency` (default 4) controls the number of simultaneous AI requests. It replaced
+the now-removed `--batch-size` flag. The two flags are not equivalent: `--batch-size`
+controlled how many commits were grouped per request (count-based); `--concurrency`
+controls how many requests run in parallel. Batch membership is now determined entirely by
+token budget, not by a count.
+
+## Consequences
+
+**Positive:**
+
+- **Context window is respected without manual tuning.** The batch planner adapts to the
+  model in use and the actual sizes of commits. A branch with one large commit and ten small
+  ones produces two batches without any user configuration.
+
+- **Round-trips are minimised within constraints.** The bin-packing algorithm groups as
+  many commits as possible into each request. For typical branches where all commits fit in
+  one batch, the tool makes a single AI call regardless of commit count.
+
+- **Cross-commit context is preserved within batches.** When multiple commits share a
+  batch, the AI sees them together and can apply consistent reasoning (e.g. unified scope
+  naming, related change descriptions). The coherence pass extends this across batch
+  boundaries.
+
+- **Planning is cheap.** Token estimation uses `stat` syscalls, not file reads. For a
+  branch with fifty commits, planning completes in milliseconds before any AI call is made.
+
+**Negative:**
+
+- **Estimates are approximate.** The character-to-token ratio varies by language and diff
+  content. The 10% headroom absorbs typical variance, but an unusually token-dense commit
+  (e.g. a diff of minified JavaScript) could still exceed the context window despite a
+  passing estimate. Progressive diff reduction handles this at request time.
+
+- **Bin-packing order differs from commit order.** The first-fit-decreasing sort reorders
+  commits by size before placing them, so the batches do not necessarily contain commits in
+  chronological order. The original commit indices are preserved in `CommitBatch` to
+  reconstruct the correct order for output.
+
+- **Solo batches for oversized commits receive no cross-commit context.** A commit that
+  exceeds the budget by itself is sent alone, so the AI cannot reason about it in relation
+  to adjacent commits.
+
+**Neutral:**
+
+- **The coherence pass is a separate AI call.** It adds one additional API round-trip for
+  branches with multiple batches. The cost is accepted because consistency across batch
+  boundaries is otherwise lost.

--- a/docs/adrs/adr-0010.md
+++ b/docs/adrs/adr-0010.md
@@ -1,0 +1,143 @@
+# ADR-0010: Multi-Layer Retry Strategy
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev's `twiddle` and `check` commands make AI API calls that can fail in several
+distinct ways:
+
+- **Batch-level failure.** A batch of multiple commits sent in a single request fails
+  entirely — due to a transient network error, a rate limit, or a model-side error. The
+  failure says nothing about whether individual commits within the batch would succeed
+  alone.
+
+- **Response parse failure.** The AI returns a successful HTTP response but the content is
+  not valid YAML, or the YAML does not conform to the expected schema. This occurs
+  occasionally when the model produces malformed output despite receiving a valid prompt.
+
+- **Persistent single-commit failure.** A specific commit fails even when sent alone,
+  suggesting a commit-specific problem (e.g. a diff that consistently confuses the model)
+  rather than a transient infrastructure issue.
+
+A single retry policy cannot address all three failure modes well:
+
+- Retrying a failed batch as a whole risks hitting the same context-window or model issue
+  again. It does not isolate which commit(s) caused the failure.
+- Immediately surfacing a batch failure to the user abandons commits that might have
+  succeeded individually.
+- Silently swallowing all failures (or retrying indefinitely) provides no user control.
+
+Three single-policy alternatives were evaluated:
+
+- **No retry.** Simple but fragile. Any transient failure propagates immediately to the
+  user, who must re-run the entire command. Transient network and rate-limit errors are
+  common enough in production AI API usage that this is not acceptable.
+
+- **Uniform exponential backoff.** Appropriate for rate-limit errors, but adds latency for
+  every failure regardless of cause, and does not distinguish between a flaky network and
+  a commit-specific model failure.
+
+- **Interactive retry only.** Lets the user decide on every failure. Correct in principle
+  but requires user attention for failures that are trivially recoverable automatically,
+  making the common case unnecessarily interactive.
+
+## Decision
+
+We will use a **three-layer retry strategy** numbered in execution order from innermost to
+outermost — from most-automatic to most-interactive.
+
+### Layer 1 — Parse/request retry (check only)
+
+Implemented in `src/claude/client.rs` as `check_commits_with_retry`.
+
+For the `check` command, each AI request is retried up to two additional times (three total
+attempts) when the request fails or the response cannot be parsed as a valid check report. A
+warning is printed on each failed attempt. This is the innermost layer: it wraps every
+individual AI call, absorbing occasional model output instability without user involvement.
+
+This layer is not applied to `twiddle`. Amendment YAML parsing is structurally simpler than
+check-report parsing, and amendment generation failures are handled by layers 2 and 3.
+Convergence of retry behaviour between the two commands is deferred until evidence of
+amendment parse failures accumulates.
+
+### Layer 2 — Split-and-retry (batch failures)
+
+Implemented in `src/cli/git/twiddle.rs` and `src/cli/git/check.rs`.
+
+When a batch of more than one commit fails after layer 1 exhausts its attempts, the batch
+is automatically split and each commit is retried as a solo request. A warning is printed
+(`warning: batch of N failed, retrying individually: <error>`), but no user input is
+required. This isolates the failure: commits that succeed individually are preserved; commits
+that also fail individually fall through to layer 3.
+
+Solo batches that fail are not split further (there is nothing to split); they fall directly
+to layer 3.
+
+### Layer 3 — Interactive retry (persistent failures)
+
+Implemented in `run_interactive_retry_twiddle_check` (`twiddle.rs`) and
+`run_interactive_retry_check` (`check.rs`).
+
+Commits that remain failed after layers 1 and 2 are presented to the user one at a time.
+The user is prompted to retry the commit individually or skip it. This gives the user
+explicit control over commits with persistent failures without abandoning the rest of the
+run.
+
+### Layer interactions
+
+The layers compose from innermost to outermost. For a multi-commit batch in `check`:
+
+1. The batch is sent as a single AI request; layer 1 retries up to three times on failure.
+2. If the batch still fails, each commit is retried individually (layer 2); layer 1 retries
+   again for each individual request.
+3. For each individual commit that still fails, the user is prompted (layer 3).
+
+For `twiddle`, layer 1 does not apply; a failing batch goes directly to layer 2 (split),
+and individual failures go to layer 3.
+
+For a single-commit batch in either command, layer 2 does not apply; failures go directly
+to layer 3 (after layer 1 retries for check).
+
+## Consequences
+
+**Positive:**
+
+- **Transient failures are absorbed automatically.** Network blips and occasional model
+  errors are retried without user involvement. The common case (transient failure of one
+  commit in a multi-commit batch) resolves automatically via layer 2.
+
+- **Failure isolation.** A batch failure does not discard the results of all commits in the
+  batch. Layer 1 determines which specific commits are problematic, preserving the work
+  done on commits that succeed individually.
+
+- **User control for persistent failures.** Layer 3 ensures the user is never left with a
+  silent partial result. They can retry individual problematic commits or skip them with
+  full awareness.
+
+**Negative:**
+
+- **Asymmetric behaviour between `twiddle` and `check`.** Layer 1 (parse/request retry)
+  applies only to `check`. A user who encounters a transient amendment parse failure in
+  `twiddle` will reach layer 3 (interactive prompt) sooner than an equivalent failure in
+  `check`. This inconsistency is a known limitation to be revisited if amendment parse
+  failures become common in practice.
+
+- **No backoff between retries.** Split-and-retry and parse/request retry do not introduce
+  delays between attempts. Under sustained rate limiting, rapid retries may compound the
+  problem. This is accepted for now given the bounded retry counts; a backoff mechanism
+  can be added if rate-limit errors become frequent.
+
+- **Layer 2 doubles API calls on batch failure.** When a batch of N commits fails, the
+  split-and-retry sends N additional requests. Under rate limits this may temporarily
+  increase pressure. The trade-off is accepted because the alternative — discarding all N
+  commits — is strictly worse for the user.
+
+**Neutral:**
+
+- **Interactive retry requires stdin.** Layer 3 reads from stdin, which means the command
+  cannot be used non-interactively (e.g. in CI) when commits reach layer 3. This is
+  intentional: persistent failures require human judgement and are not appropriate to
+  silently swallow in automation.


### PR DESCRIPTION
## Description

This PR adds two Architectural Decision Records (ADRs) documenting the design of the batch processing and retry systems used by the `twiddle` and `check` commands. These ADRs capture the rationale behind key architectural decisions for Issue #106, ensuring the design is clearly understood and maintainable going forward.

The two ADRs document:
1. **ADR-0009**: The token-budget-aware batch planning algorithm that groups commits by estimated token cost using a first-fit-decreasing bin-packing approach to maximise batch size while respecting the model's context window.
2. **ADR-0010**: The three-layer retry strategy that handles batch failures, parse failures, and persistent single-commit failures with progressively more interactive recovery mechanisms.

## Type of Change
- [x] Documentation update

## Related Issue
Relates to #106

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0009.md` — Token-Budget-Aware Batch Planning: documents the first-fit-decreasing bin-packing algorithm in `src/claude/batch.rs`, token estimation via `stat` syscalls, the 10% headroom factor (`BATCH_CAPACITY_FACTOR = 0.90`), map-reduce execution with Tokio semaphore-bounded concurrency, and the optional cross-commit coherence pass
- Added `docs/adrs/adr-0010.md` — Multi-Layer Retry Strategy: documents the three-layer retry design (Layer 1: parse/request retry for `check` via `check_commits_with_retry` in `src/claude/client.rs`; Layer 2: split-and-retry on batch failure in `twiddle.rs` and `check.rs`; Layer 3: interactive retry via `run_interactive_retry_twiddle_check` and `run_interactive_retry_check` for persistent failures), and explains the asymmetric behaviour between `twiddle` and `check` as a known limitation
- Updated `docs/adrs/README.md` index to include both new ADRs (ADR-0009 and ADR-0010) with their acceptance dates and titles

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Verified ADR documents render correctly in Markdown
- [x] Confirmed README index links to new ADR files correctly

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — Review ADR-0009 and ADR-0010 for accuracy against the actual implementation in `src/claude/batch.rs`, `src/claude/client.rs`, `src/cli/git/twiddle.rs`, and `src/cli/git/check.rs`

**Key areas to validate:**
- ADR-0009: Accuracy of the bin-packing algorithm description, token estimation approach (stat syscalls, 10% headroom), and map-reduce execution model with Tokio semaphore
- ADR-0010: Correctness of the three-layer retry composition, especially the asymmetric behaviour where Layer 1 (parse/request retry) applies only to `check` and not `twiddle`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations documented in ADR-0010:**
- Asymmetric retry behaviour between `twiddle` and `check`: Layer 1 (parse/request retry) applies only to `check`. Users encountering transient amendment parse failures in `twiddle` will reach Layer 3 (interactive prompt) sooner than equivalent failures in `check`. This inconsistency is a known limitation to be revisited if amendment parse failures become common in practice.
- No backoff between retries: Split-and-retry and parse/request retry do not introduce delays, which may compound issues under sustained rate limiting.
- Layer 2 doubles API calls on batch failure: when a batch of N commits fails, split-and-retry sends N additional requests.

**Alternatives Considered (documented in ADRs):**
- ADR-0009: Fixed-count batching (`--batch-size` flag, now removed), dynamic splitting at request time
- ADR-0010: No retry, uniform exponential backoff, interactive-retry-only strategies