### PR TITLE
refactor(claude): clean up ModelRegistry code quality issues from issue #104

### DIFF
--- a/src/claude/model_config.rs
+++ b/src/claude/model_config.rs
@@ -139,8 +139,8 @@ impl ModelRegistry {
             return Some(spec);
         }
 
-        // Try fuzzy matching for Bedrock-style identifiers
-        self.find_model_by_fuzzy_match(api_identifier)
+        // Try normalizing the identifier and looking up again
+        self.find_model_by_normalized_id(api_identifier)
     }
 
     /// Returns the max output tokens for a model, with fallback to provider defaults.
@@ -192,7 +192,7 @@ impl ModelRegistry {
     ///
     /// Handles Bedrock-style (`us.anthropic.claude-3-7-sonnet-20250219-v1:0`),
     /// AWS-style (`anthropic.claude-3-haiku-20240307-v1:0`), and standard identifiers.
-    fn find_model_by_fuzzy_match(&self, api_identifier: &str) -> Option<&ModelSpec> {
+    fn find_model_by_normalized_id(&self, api_identifier: &str) -> Option<&ModelSpec> {
         let core_identifier = self.extract_core_model_identifier(api_identifier);
         self.by_identifier.get(&core_identifier)
     }
@@ -400,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn fuzzy_model_matching() {
+    fn normalized_id_matching() {
         let registry = ModelRegistry::load().unwrap();
 
         // Test Bedrock-style identifiers


### PR DESCRIPTION
## Description

This PR addresses a series of code quality issues in `src/claude/model_config.rs` identified in issue #104. The changes are purely refactoring — no functional behavior is altered. The four commits progressively improve the `ModelRegistry` implementation by removing dead code, enforcing Rust's `#[must_use]` convention on pure getters, replacing magic number literals with named constants, and correcting misleading method names to accurately reflect the normalization-based lookup semantics.

## Type of Change

- [x] Refactoring (no functional changes)

## Related Issue

Relates to #104

## Changes Made

**Dead Code Removal:**
- Removed `models_match_fuzzy` method from `ModelRegistry` — it performed a plain `==` comparison on already-normalized identifiers, making it fully redundant with the preceding `HashMap::get` call
- Collapsed `find_model_by_fuzzy_match` body to a single `self.by_identifier.get(&core_identifier)` call, eliminating the now-unnecessary loop

**`#[must_use]` Annotations (STYLE-0014 compliance):**
- Added `#[must_use]` to all thirteen pure getter methods on `ModelRegistry`: `get_model_spec`, `get_max_output_tokens`, `get_input_context`, `get_all_models`, `get_models_by_provider`, `get_models_by_provider_and_tier`, `get_default_model`, `get_provider_config`, `get_tier_info`, `get_beta_headers`, `get_max_output_tokens_with_beta`, `get_input_context_with_beta`
- Added `#[must_use]` to the `get_model_registry` free function

**Named Constants (STYLE-0016 compliance):**
- Introduced `FALLBACK_MAX_OUTPUT_TOKENS: usize = 4096` constant to replace the bare literal in `get_max_output_tokens`
- Introduced `FALLBACK_INPUT_CONTEXT: usize = 100_000` constant to replace the bare literal in `get_input_context`
- Both constants are documented to clarify their role as last-resort fallback values

**Method Renaming for Semantic Accuracy:**
- Renamed `find_model_by_fuzzy_match` → `find_model_by_normalized_id` to accurately describe the normalization-then-exact-lookup mechanism (not approximate/fuzzy matching)
- Renamed test `fuzzy_model_matching` → `normalized_id_matching` to match
- Updated call-site comment from "Try fuzzy matching for Bedrock-style identifiers" to "Try normalizing the identifier and looking up again"

**Documentation:**
- Updated doc comment on the renamed method to explicitly describe supported identifier formats (Bedrock-style, AWS-style, standard)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Test `normalized_id_matching` (formerly `fuzzy_model_matching`) continues to validate Bedrock-style, AWS-style, and standard identifier normalization

**Manual Testing:**
- [x] Backward compatibility verified — all changes are internal implementation details with no public API changes

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run the specific renamed test
cargo test normalized_id_matching
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the dead `models_match_fuzzy` loop has been removed; confirm the remaining single `HashMap::get` call is sufficient for all identifier lookup scenarios
- [x] Backward compatibility — all changed methods are `pub` getters; their signatures and return types are unchanged, only annotations and names of private helpers differ

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement — the redundant loop over `by_identifier` in `find_model_by_fuzzy_match` has been eliminated. Model lookups that previously iterated over all stored identifiers after a failed `HashMap::get` now return immediately.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. All changes are to private/internal methods or are purely additive annotations. The public API surface of `ModelRegistry` is unchanged.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- The `models_match_fuzzy` loop could have been retained with a more sophisticated matching algorithm (e.g., substring or edit-distance matching). However, since `extract_core_model_identifier` already normalizes all known identifier formats to the canonical key stored in `by_identifier`, the loop was provably unreachable and was removed instead.