### PR TITLE
docs(docs): add ADR-0012 for three-level issue severity with --strict promotion

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,3 +35,4 @@ by Michael Nygard.
 | [ADR-0009](adr-0009.md)  | ✅ Accepted | 2026-02-22 | Token-Budget-Aware Batch Planning                                    |
 | [ADR-0010](adr-0010.md)  | ✅ Accepted | 2026-02-22 | Multi-Layer Retry Strategy                                           |
 | [ADR-0011](adr-0011.md)  | ✅ Accepted | 2026-02-23 | Compile-Time Model Registry with Identifier Normalization            |
+| [ADR-0012](adr-0012.md)  | ✅ Accepted | 2026-02-23 | Three-Level Issue Severity with `--strict` Exit-Code Promotion       |

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -1,0 +1,135 @@
+# ADR-0012: Three-Level Issue Severity with `--strict` Exit-Code Promotion
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev validates commit messages against configurable guidelines and reports every
+issue it finds. Issues are not all equally important: a missing conventional commit type
+is a structural violation that should block CI; not including a body on a large change is
+advisable but not critical; using a period at the end of the subject line is a style
+preference. A single severity category forces an all-or-nothing choice: either the tool
+blocks on every issue (over-strict, noisy) or no issue blocks anything (under-strict,
+useless for CI enforcement).
+
+Four approaches were evaluated:
+
+- **Binary pass/fail.** Each commit either passes or fails. The pass threshold is a
+  single boolean that teams must tune at the tool level. Teams wanting to enforce body
+  guidelines must accept that style nits also block; teams tolerant of style nits cannot
+  also enforce body guidelines through the same mechanism. The model cannot express
+  graduated importance.
+
+- **Advisory-only, no exit-code signalling.** All issues are informational. CI pipelines
+  receive no machine-readable signal; enforcement is left entirely to human review.
+  This loses the primary value of automated commit checking.
+
+- **Per-rule severity configuration.** Each individual rule carries its own severity,
+  configured separately. This offers maximum flexibility but requires teams to configure
+  every rule, creates a large configuration surface, and makes it hard to read a guidelines
+  file and reason about its CI behaviour at a glance.
+
+- **Section-level severity tiers with an opt-in strict mode.** Severity is declared once
+  per guideline section, not per rule. A `--strict` flag lets teams promote warnings to
+  blocking. A third, non-blocking tier (`info`) carries suggestions that are always
+  advisory. This is the approach taken by ESLint (`error`/`warn`/`off`), the TypeScript
+  compiler (`--strict`), mypy (`--strict`), and GCC/Clang (`-Werror`).
+
+## Decision
+
+We will define three severity levels — `error`, `warning`, and `info` — and map them to
+exit codes through a `--strict` flag.
+
+### Severity levels
+
+| Level     | Meaning                                          | Exit code without `--strict` | Exit code with `--strict` |
+|-----------|--------------------------------------------------|------------------------------|---------------------------|
+| `error`   | Structural violation; always blocks              | 1                            | 1                         |
+| `warning` | Advisory issue; blocks only in strict mode       | 0                            | 2                         |
+| `info`    | Suggestion; never affects exit code              | 0                            | 0                         |
+
+A clean run (no issues, or only `info` issues) always exits 0.
+
+### Severity declaration
+
+Severity is declared in the guidelines file, not in application code. The
+`default-commit-guidelines.md` template opens with a `Severity Levels` table that maps
+each guideline section to one of the three levels. Project-specific guidelines files
+follow the same convention. This keeps the severity policy co-located with the rules it
+governs and allows per-project overrides without changing the binary.
+
+The default mapping is:
+
+| Severity  | Sections                                                                |
+|-----------|-------------------------------------------------------------------------|
+| `error`   | Commit Format, Types, Scopes, Subject Line, Accuracy, Breaking Changes  |
+| `warning` | Body Guidelines                                                         |
+| `info`    | Subject Line Style                                                      |
+
+### Implementation
+
+`IssueSeverity` (`src/data/check.rs`) is the canonical Rust type. `CheckReport::exit_code(strict: bool)`
+implements the mapping: it returns `1` if `error_count > 0`, returns `2` if `strict &&
+warning_count > 0`, and returns `0` otherwise. `info_count` is never consulted for exit
+code purposes.
+
+Severity values arrive from the AI response as strings. `IssueSeverity::from_str` parses
+them case-insensitively; an unrecognised value defaults to `Warning` and emits a
+`tracing::debug!` log rather than failing hard.
+
+The `--strict` flag is part of the public CLI contract. It is also used internally: the
+`omni-dev git commit message check` invocation within the `commit-twiddle` flow passes
+`--strict --quiet` to ensure warnings surface in that automated context.
+
+## Consequences
+
+**Positive:**
+
+- **CI pipelines have a fine-grained contract.** Teams can fail on `error` only (normal
+  mode) or on `error` and `warning` (strict mode) without changing the guidelines file.
+  The exit code distinction (1 vs 2) allows CI scripts to differentiate the two failure
+  classes if needed.
+
+- **`info` is permanently non-blocking.** Suggestions and educational notes reach the
+  developer without ever triggering a CI failure, regardless of `--strict`. This
+  preserves the value of informational output without creating noise-driven pressure to
+  suppress it.
+
+- **Severity policy is readable at a glance.** The `Severity Levels` table at the top
+  of every guidelines file is the single source of truth. A contributor can determine
+  what will block CI by reading two lines of Markdown, not by tracing application code.
+
+- **Per-project override is built in.** Because severity is defined in the guidelines
+  file rather than in code, any project can promote or demote a section's severity by
+  supplying a custom `.omni-dev/commit-guidelines.md`. No configuration keys or
+  application changes are required.
+
+- **The pattern is immediately familiar.** Developers who have used ESLint, TypeScript,
+  mypy, or GCC with `-Werror` already understand the mental model. Onboarding friction
+  is low.
+
+**Negative:**
+
+- **Severity granularity is at the section level, not the rule level.** Every rule within
+  a section shares the same severity. A team that wants to treat one body-guideline rule
+  as an error while leaving others as warnings must either fork the guidelines file into
+  multiple sections or accept the coarser granularity.
+
+- **`info` cannot be promoted, even with `--strict`.** The strict flag only promotes
+  `warning` to blocking. Teams wanting `info`-level issues to block must relabel them as
+  `warning` in their guidelines file. This may surprise users who expect `--strict` to
+  mean "everything blocks".
+
+**Neutral:**
+
+- **Unknown severity strings default to `warning`.** An unrecognised severity value in
+  an AI response does not cause a parse failure; it silently becomes a `warning`. This
+  keeps the tool resilient against model variation but means a typo in a custom prompt
+  or guidelines file will produce warnings rather than an error surfacing the typo.
+
+- **`--strict` is part of the internal CLI contract.** The `commit-twiddle` flow
+  hard-codes `--strict` when invoking `omni-dev git commit message check`. Changes to
+  the strict-mode exit code semantics therefore affect both external CI usage and
+  internal tool composition.


### PR DESCRIPTION
## Description

This PR adds ADR-0012, which documents the architectural decision to introduce three severity levels (`error`, `warning`, `info`) for commit message validation issues in omni-dev. The ADR also formalizes the `--strict` flag that promotes warnings to blocking exit codes, enabling teams to configure CI pipelines with fine-grained control over what constitutes a build failure.

The core motivation is that a single severity category forces an all-or-nothing choice: blocking on every issue is too noisy, while blocking on nothing makes automated checking useless for CI enforcement. Three tiers — mirroring the approach of ESLint, TypeScript `--strict`, mypy, and GCC `-Werror` — provide a graduated model that fits real-world team needs.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #109

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0012.md` documenting the three-level severity decision, including context, four alternatives evaluated, the chosen decision, and consequences
- Registered ADR-0012 in the ADR index table in `docs/adrs/README.md`

**ADR Content Coverage:**
- Defines `error`, `warning`, and `info` severity levels with their exit code semantics (`error=1`, `strict+warning=2`, `info=0` always)
- Documents `IssueSeverity` type (`src/data/check.rs`) and `CheckReport::exit_code(strict: bool)` implementation contract
- Explains section-level severity declaration in guidelines files (co-located policy, not per-rule configuration)
- Covers the default severity mapping for each guideline section
- Documents that `--strict` is part of both the external CLI contract and the internal `commit-twiddle` flow

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no new code)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified ADR document is well-formed Markdown
- [x] Verified ADR-0012 entry correctly linked in `docs/adrs/README.md`
- [x] Backward compatibility verified (documentation-only; no functional changes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes — the ADR formalizes the severity contract that implementation code must honour
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility — the exit code semantics described (1 for error, 2 for strict+warning, 0 otherwise) must remain consistent with the existing implementation

Key areas to review in `docs/adrs/adr-0012.md`:
- Accuracy of the exit code table and `CheckReport::exit_code(strict)` contract description
- Correctness of the default severity mapping table (which guideline sections are `error` vs `warning` vs `info`)
- Completeness of the consequences section, particularly the noted limitation that `info` cannot be promoted even with `--strict`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only change)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Implementation PRs for `IssueSeverity` and `CheckReport::exit_code(strict)` should reference this ADR
- The `--strict` flag documentation in the CLI help text should cross-reference ADR-0012

**Known Limitations:**
- Severity granularity is at the section level, not the rule level; teams needing per-rule control must split guideline sections
- `info`-level issues cannot be promoted to blocking even with `--strict`; teams requiring this must relabel issues as `warning` in their guidelines file

**Alternatives Considered:**
- Binary pass/fail (too coarse; cannot express graduated importance)
- Advisory-only with no exit-code signalling (loses CI enforcement value)
- Per-rule severity configuration (maximum flexibility but large configuration surface; hard to reason about at a glance)