### PR TITLE
docs(docs): add ADR-0013 for self-describing YAML output with field presence tracking

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,3 +36,4 @@ by Michael Nygard.
 | [ADR-0010](adr-0010.md)  | ✅ Accepted | 2026-02-22 | Multi-Layer Retry Strategy                                           |
 | [ADR-0011](adr-0011.md)  | ✅ Accepted | 2026-02-23 | Compile-Time Model Registry with Identifier Normalization            |
 | [ADR-0012](adr-0012.md)  | ✅ Accepted | 2026-02-23 | Three-Level Issue Severity with `--strict` Exit-Code Promotion       |
+| [ADR-0013](adr-0013.md)  | ✅ Accepted | 2026-02-23 | Self-Describing YAML Output with Field Presence Tracking             |

--- a/docs/adrs/adr-0013.md
+++ b/docs/adrs/adr-0013.md
@@ -1,0 +1,143 @@
+# ADR-0013: Self-Describing YAML Output with Field Presence Tracking
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev serializes a `RepositoryView` to YAML and passes it verbatim to AI
+models as prompt input. The YAML contains many fields, but which fields are
+populated depends on the command (`view` vs `info` vs `check`) and the
+current repository state (whether commits exist, whether a PR template exists,
+whether the branch has open pull requests, and so on).
+
+An AI model receiving this YAML needs to know, without external documentation
+or parsing the entire document, which fields are actually available in the
+current output. Without that information a model may hallucinate field
+references (e.g., referencing `branch_info.branch` when the `view` command
+was used and that field is absent) or conservatively avoid fields that are
+present but whose existence it cannot confirm.
+
+Four approaches were evaluated:
+
+- **No tracking.** The model inspects the YAML to determine what is present.
+  This forces the model to parse and navigate the full document, and it still
+  cannot distinguish a field that is absent from one that is present but
+  empty. It also provides no human-readable explanation of what each field
+  means.
+
+- **Static documentation in the system prompt.** All fields are documented
+  once in the system prompt, always listed as potentially present. The model
+  cannot distinguish runtime availability from theoretical availability, so
+  it must hedge every reference. Documentation and code diverge independently.
+
+- **External schema (JSON Schema or separate doc).** A schema file describes
+  the output structure. The schema is accurate about field shapes but not
+  about runtime presence; it must be consulted out-of-band. AI models do not
+  have reliable access to external files at inference time. Keeping the schema
+  in sync with the code is a separate maintenance burden.
+
+- **Self-describing output with inline field presence tracking.** Embed
+  documentation metadata directly in the serialized output. Each field is
+  listed with a description, an optional source git command, and a `present`
+  flag computed from the actual runtime data before serialization. The model
+  reads one document and knows both what each field means and whether it
+  exists in the current output.
+
+## Decision
+
+We will embed a `FieldExplanation` value in every `RepositoryView` that
+documents all output fields and tracks which are present at runtime.
+
+### Data model
+
+`FieldExplanation` contains a prose `text` introduction (including explicit
+guidance for AI consumers) and a `Vec<FieldDocumentation>`. Each
+`FieldDocumentation` entry carries:
+
+- `name` — the YAML field path (e.g., `commits[].hash`, `branch_info.branch`)
+- `text` — a description of what the field contains
+- `command` — the git command that produces the data, when applicable
+- `present` — a boolean set at output time to reflect actual data availability
+
+### Presence computation
+
+`RepositoryView::update_field_presence()` iterates over all documented fields
+and sets each `present` flag based on the live data:
+
+- **Always-present fields** (`working_directory.*`, `remotes`, `ai.scratch`)
+  are set to `true` unconditionally.
+- **Commit-dependent fields** (`commits[].*`) are set to `true` only when
+  the commits list is non-empty.
+- **Optional fields** (`versions.omni_dev`, `branch_info.branch`,
+  `pr_template`, `pr_template_location`, `branch_prs`) are set to `true`
+  only when the corresponding `Option` is `Some`.
+- **Array-element fields** (`branch_prs[].*`) are set to `true` only when
+  the array exists and is non-empty.
+- **Unknown field names** — any name not matched by an explicit arm — are
+  set to `false` by a catch-all.
+
+For pure output commands (`view`, `info`) presence tracking is triggered
+through `RepositoryView::to_yaml_output(&mut self)`, which calls
+`update_field_presence()` then serializes. For commands that also pass the
+view to AI (`twiddle`, `check`, `create_pr`), `update_field_presence()` is
+called in the view-builder method so the AI receives accurate `present` flags
+in its input YAML before any output occurs.
+
+### Drift protection
+
+A test constructs a fully-populated `RepositoryView` (all `Option` fields
+set, commits non-empty, PRs non-empty), calls `update_field_presence()`, and
+asserts that every `FieldDocumentation` entry has `present = true`. Any entry
+whose name is not matched by an explicit arm falls through to the catch-all
+(`false`) and fails the test, catching the divergence at test time.
+
+## Consequences
+
+**Positive:**
+
+- **AI consumers are self-orienting.** The explanation section is part of the
+  YAML the model reads, so the model knows the field inventory and runtime
+  availability without consulting external documentation or parsing the full
+  document. The `present = true` guarantee is stated explicitly in the
+  explanation text.
+
+- **Always accurate.** Presence flags are computed from the same data object
+  that is serialized, so they cannot lag behind the actual output. Adding a
+  new command that populates a previously-optional field automatically causes
+  that field's flag to flip to `true` in that command's output.
+
+- **Human-readable.** Running any output command and reading the `explanation`
+  block is sufficient to understand the full field vocabulary, the source of
+  each value, and which fields are available in that invocation. No separate
+  schema or documentation file is required.
+
+**Negative:**
+
+- **Two locations must be maintained.** Field names appear in both
+  `FieldExplanation::default()` (as `name` values) and in the `match` arms
+  of `update_field_presence()`. A name misspelled or omitted in one location
+  causes a field to show `present = false` with data present, or to be
+  undocumented. The drift-protection test catches this, but only at test time,
+  not at compile time.
+
+- **No compile-time link to struct fields.** If a struct field is renamed, the
+  corresponding `FieldDocumentation` name and match arm must be updated
+  manually. The compiler does not connect string literals to struct field
+  identifiers.
+
+**Neutral:**
+
+- **Output size increases.** The `explanation` section adds one entry per
+  documented field (currently 29) to every YAML output, adding roughly two to
+  three kilobytes per invocation. This is acceptable for interactive use.
+  The stripped-down `single_commit_view()` and `multi_commit_view()` used
+  during batch AI dispatch omit the explanation to keep per-commit prompt
+  sizes small.
+
+- **`present = false` fields remain in the explanation.** Fields that are not
+  present in the current output are still listed (with `present = false`) in
+  the explanation section. This is intentional: a consumer can see the full
+  field vocabulary and understand which fields might appear in other contexts,
+  while knowing exactly what is available now.


### PR DESCRIPTION
## Description

This PR documents the architectural decision (ADR-0013) to embed field documentation and runtime presence flags directly in the serialized YAML output produced by omni-dev. The ADR captures why and how `RepositoryView` serialization includes an `explanation` block that lists every output field with its description, source git command, and a `present` boolean computed at runtime.

The motivation: AI consumers receiving YAML output from omni-dev cannot reliably know which fields are populated in a given invocation without either parsing the full document or consulting external documentation. Both approaches are fragile. By embedding a self-describing `explanation` block, an AI model can determine the full field vocabulary and exact runtime availability from a single document, without hallucinating missing fields or ignoring available ones.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #103

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0013.md` — full ADR documenting the self-describing YAML output design, including data model, presence computation rules, drift-protection test strategy, and evaluation of four alternative approaches
- Updated `docs/adrs/README.md` — registered ADR-0013 in the ADR index table

**ADR Content Highlights:**
- Documents the `FieldExplanation` and `FieldDocumentation` data model (`name`, `text`, `command`, `present` fields)
- Describes presence computation rules for always-present fields (`working_directory.*`, `remotes`, `ai.scratch`), commit-dependent fields (`commits[].*`), and optional fields (`branch_info.branch`, `pr_template`, `branch_prs`)
- Explains the drift-protection test strategy: a fully-populated `RepositoryView` must have `present = true` for every documented field, catching divergence at test time
- Evaluates four alternatives (no tracking, static system prompt docs, external schema, inline self-describing output) and justifies the chosen design
- Documents the known trade-off: field names appear in two locations (`FieldExplanation::default()` and `update_field_presence()` match arms), with no compile-time enforcement

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (tests described in ADR; implementation is in the corresponding code PR)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Reviewed ADR content for accuracy against existing implementation
- [x] Verified ADR index entry is correctly formatted and linked

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the ADR describes a design pattern (self-describing output) that affects how all omni-dev YAML output is structured and consumed by AI models
- [ ] Security implications
- [ ] Performance impact
- [ ] Error handling
- [ ] User experience
- [ ] Backward compatibility

The most important review areas are:
- Accuracy of the presence computation rules as documented in the ADR vs. actual implementation in `update_field_presence()`
- Completeness of the four alternatives evaluation — are there approaches that were not considered?
- Clarity of the drift-protection test strategy section for future contributors

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (tests exist in code; this PR is docs-only)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

This is a documentation-only change (ADR). The ADR itself notes that the self-describing output pattern adds approximately 2–3 KB per YAML invocation (one entry per documented field, currently 29 fields), which is deemed acceptable for interactive use. The stripped-down `single_commit_view()` and `multi_commit_view()` omit the explanation to keep per-commit prompt sizes small.

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This PR adds documentation only and does not change any code behavior.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- A compile-time link between `FieldDocumentation` name strings and actual struct field identifiers would eliminate the two-location maintenance burden identified as a negative consequence in the ADR. This would require a proc-macro or similar mechanism.
- As new fields are added to `RepositoryView`, the ADR's documented field list and the drift-protection test will need to be updated in tandem.

**Known Limitations:**
- Field name accuracy in the ADR depends on keeping `FieldExplanation::default()` and `update_field_presence()` in sync. The drift-protection test catches drift at test time, but not at compile time.

**Alternatives Considered:**
- All four alternatives are documented in ADR-0013 itself: no tracking, static system-prompt documentation, external schema (JSON Schema), and the chosen self-describing inline approach.