### PR TITLE
docs(docs): clarify ADR-0013 implementation and drift-protection rationale

### DIFF
--- a/docs/adrs/adr-0013.md
+++ b/docs/adrs/adr-0013.md
@@ -36,7 +36,10 @@ Four approaches were evaluated:
   the output structure. The schema is accurate about field shapes but not
   about runtime presence; it must be consulted out-of-band. AI models do not
   have reliable access to external files at inference time. Keeping the schema
-  in sync with the code is a separate maintenance burden.
+  in sync with the code is a separate maintenance burden. An embedded JSON
+  Schema (the `$schema` convention) avoids the out-of-band problem but still
+  cannot represent runtime presence — the schema describes the shape of the
+  type, not which optional fields the current invocation actually populated.
 
 - **Self-describing output with inline field presence tracking.** Embed
   documentation metadata directly in the serialized output. Each field is
@@ -82,16 +85,12 @@ For pure output commands (`view`, `info`) presence tracking is triggered
 through `RepositoryView::to_yaml_output(&mut self)`, which calls
 `update_field_presence()` then serializes. For commands that also pass the
 view to AI (`twiddle`, `check`, `create_pr`), `update_field_presence()` is
-called in the view-builder method so the AI receives accurate `present` flags
-in its input YAML before any output occurs.
-
-### Drift protection
-
-A test constructs a fully-populated `RepositoryView` (all `Option` fields
-set, commits non-empty, PRs non-empty), calls `update_field_presence()`, and
-asserts that every `FieldDocumentation` entry has `present = true`. Any entry
-whose name is not matched by an explicit arm falls through to the catch-all
-(`false`) and fails the test, catching the divergence at test time.
+called in the view-builder method. This is necessary because
+`RepositoryViewForAI::from_repository_view` converts the view via
+`map_commits`, which preserves `self.explanation` verbatim. The resulting
+`RepositoryViewForAI` is serialized directly into the AI prompt, so the
+explanation section — including all `present` flags — is part of what the
+model reads as its input context, not just a side-effect of terminal output.
 
 ## Consequences
 
@@ -119,8 +118,11 @@ whose name is not matched by an explicit arm falls through to the catch-all
   `FieldExplanation::default()` (as `name` values) and in the `match` arms
   of `update_field_presence()`. A name misspelled or omitted in one location
   causes a field to show `present = false` with data present, or to be
-  undocumented. The drift-protection test catches this, but only at test time,
-  not at compile time.
+  undocumented. A test mitigates this: it constructs a fully-populated
+  `RepositoryView`, calls `update_field_presence()`, and asserts every
+  documented field has `present = true`. Any entry whose name is unmatched
+  falls through to the catch-all (`false`) and fails the test. This catches
+  divergence at test time, but not at compile time.
 
 - **No compile-time link to struct fields.** If a struct field is renamed, the
   corresponding `FieldDocumentation` name and match arm must be updated


### PR DESCRIPTION
## Description

This PR revises ADR-0013 (`docs/adrs/adr-0013.md`) to more accurately describe the implemented self-describing YAML approach and its design rationale. The changes address two areas where the ADR's language was imprecise or incomplete relative to the actual implementation.

The first revision expands the JSON Schema alternative discussion to explain why even an embedded `$schema` convention cannot represent runtime field presence — the schema describes the *shape of the type*, not which optional fields a particular invocation actually populated. This distinction is important context for why the self-describing inline approach was chosen.

The second revision replaces the standalone "Drift protection" subsection with an inline explanation of why `update_field_presence()` must be called in the view-builder method rather than as a terminal output side-effect. The key insight documented is that `RepositoryViewForAI::from_repository_view` preserves `self.explanation` verbatim via `map_commits`, so the `present` flags become part of the AI model's input context — not just a serialization artifact.

The drift-protection test description is also reframed to clarify that it mitigates name mismatches between `FieldExplanation` entries and `match` arms in `update_field_presence()`, catching divergence at test time but not at compile time.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #103

## Changes Made

**Documentation:**
- Expanded JSON Schema alternative discussion in `docs/adrs/adr-0013.md` to distinguish type-level shape (what `$schema` describes) from invocation-level field population (what inline presence tracking captures)
- Replaced the "Drift protection" subsection with an inline paragraph explaining the architectural reason `update_field_presence()` is called before AI serialization: `RepositoryViewForAI::from_repository_view` preserves `self.explanation` verbatim, making presence flags part of the model's input context
- Reworded the drift-protection test description to clarify it detects name mismatches between `FieldExplanation` entries and `match` arms in `update_field_presence()`, catching divergence at test time but not compile time

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Reviewed ADR content for accuracy against the implementation
- [x] Backward compatibility verified (documentation-only change)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The key review question is whether the revised ADR language accurately reflects the actual behaviour of `RepositoryViewForAI::from_repository_view` and the `update_field_presence()` call site — reviewers familiar with the implementation should verify the descriptions match the code.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a documentation-only change with no impact on runtime behaviour.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Context:**
This ADR documents design decisions for Issue #103 (self-describing YAML output). The revisions bring the ADR language into closer alignment with the actual implementation, particularly around the architectural coupling between `RepositoryViewForAI` and the `explanation` field's role as AI input context rather than purely a serialization output.

**Known Limitations:**
- The ADR acknowledges that the drift-protection mechanism only catches name mismatches at test time, not compile time. This is an inherent limitation of the string-based field naming approach and is now more clearly documented.