### PR TITLE
fix(claude): use exact provider string matching in prompt_style()

### DIFF
--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -97,11 +97,28 @@ CRITICAL YAML FORMATTING REQUIREMENTS:
 pub const SYSTEM_PROMPT: &str = BASIC_SYSTEM_PROMPT;
 
 /// Generates a contextual system prompt based on project and commit context (Phase 3).
+///
+/// # Note
+///
+/// This is a convenience wrapper that hardcodes [`PromptStyle::Claude`].
+/// Use [`generate_contextual_system_prompt_for_provider`] when the active provider is
+/// known at the call site (i.e. via [`crate::claude::ai::AiClientMetadata::prompt_style`]).
 pub fn generate_contextual_system_prompt(context: &CommitContext) -> String {
     generate_contextual_system_prompt_for_provider(context, PromptStyle::Claude)
 }
 
 /// Generates a contextual system prompt with provider-specific handling.
+///
+/// Provider-specific behaviour is limited to the commit-guidelines section:
+/// - [`PromptStyle::Claude`]: frames guidelines as a literal template to reproduce exactly.
+/// - [`PromptStyle::OpenAi`]: frames guidelines as guidance to follow, with explicit
+///   bullet-point instructions to avoid copying the guideline text verbatim.
+///
+/// The base prompt (`BASIC_SYSTEM_PROMPT`), verbosity hints, branch context, work-pattern
+/// context, and scope-consistency guidance are identical across providers.  Check prompts,
+/// coherence prompts, and user prompts are not provider-specific because the observed
+/// behavioural difference (template-reproduction vs. guidance-interpretation) only manifests
+/// when the guidelines section is present.
 pub fn generate_contextual_system_prompt_for_provider(
     context: &CommitContext,
     provider: PromptStyle,
@@ -452,6 +469,12 @@ Start immediately with "title:" and provide only YAML content. Ensure the title 
 }
 
 /// Generates a PR system prompt with project context and guidelines.
+///
+/// # Note
+///
+/// This is a convenience wrapper that hardcodes [`PromptStyle::Claude`].
+/// Use [`generate_pr_system_prompt_with_context_for_provider`] when the active provider is
+/// known at the call site (i.e. via [`crate::claude::ai::AiClientMetadata::prompt_style`]).
 pub fn generate_pr_system_prompt_with_context(
     context: &crate::data::context::CommitContext,
 ) -> String {
@@ -459,6 +482,13 @@ pub fn generate_pr_system_prompt_with_context(
 }
 
 /// Generates a PR system prompt with provider-specific handling.
+///
+/// Provider-specific behaviour applies to the template-filling instructions:
+/// - [`PromptStyle::Claude`]: brief reminder that the PR template is to be filled out,
+///   not copied — Claude handles this correctly with minimal instruction.
+/// - [`PromptStyle::OpenAi`]: explicit bullet-point instructions with a concrete example
+///   of what "fill out" means, because OpenAI models need more explicit guidance to avoid
+///   reproducing placeholder text verbatim.
 pub fn generate_pr_system_prompt_with_context_for_provider(
     context: &crate::data::context::CommitContext,
     provider: PromptStyle,


### PR DESCRIPTION
## Description

This PR fixes incorrect provider detection in `prompt_style()` (issue #100, partial). The previous implementation used `contains()`-based substring matching on a lowercased provider string, which was fragile and could misclassify providers if naming conventions changed. The fix replaces this with exact `match` against the canonical provider strings set by each `AiClient` implementation.

Additionally, this PR adds documentation to the hardcoded-Claude wrapper functions (`generate_contextual_system_prompt` and `generate_pr_system_prompt_with_context`) directing callers to the `_for_provider` variants when the active provider is known, and documents the intentional scope of provider-specific behaviour in the `_for_provider` functions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Fixes #100 (partial — ADR still to be written)

## Changes Made

**Core Changes:**
- Replaced `contains()`-based, case-insensitive provider detection in `AiClientMetadata::prompt_style()` with an exact `match` on `self.provider.as_str()`, matching `"OpenAI"` and `"Ollama"` to `PromptStyle::OpenAi` and defaulting everything else (including `"Anthropic"` and `"Anthropic Bedrock"`) to `PromptStyle::Claude`

**Documentation:**
- Added doc comment to `prompt_style()` listing the exact provider strings matched and the default behaviour for unrecognised providers
- Added `# Note` sections to `generate_contextual_system_prompt` and `generate_pr_system_prompt_with_context` directing callers to use the `_for_provider` variants when the provider is known
- Documented the intentional scope of provider-specific behaviour in `generate_contextual_system_prompt_for_provider`: only the commit-guidelines section differs; base prompt, verbosity hints, branch/work-pattern context, scope-consistency guidance, check prompts, coherence prompts, and user prompts are provider-agnostic
- Documented provider-specific behaviour in `generate_pr_system_prompt_with_context_for_provider`: Claude receives a brief reminder to fill out the template; OpenAI receives explicit bullet-point instructions with a concrete example to prevent verbatim reproduction of placeholder text

**Testing:**
- Added unit tests in `src/claude/ai.rs` covering: `"OpenAI"` → `OpenAi`, `"Ollama"` → `OpenAi`, `"Anthropic"` → `Claude`, `"Anthropic Bedrock"` → `Claude`, unknown provider → `Claude`, and case-sensitive matching (`"openai"` and `"ollama"` must not match as `OpenAi`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 unit tests for `prompt_style()`)

**Manual Testing:**
- [x] Backward compatibility verified — behaviour for known providers is unchanged; only the implementation mechanism changed from substring match to exact match

### Test Commands
```bash
# Run the new unit tests specifically
cargo test prompt_style

# Full test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the match arms must correspond exactly to the provider strings returned by each `AiClient::get_metadata()` implementation

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. The observable behaviour for all known providers (`"OpenAI"`, `"Ollama"`, `"Anthropic"`, `"Anthropic Bedrock"`) is identical to before. The only change is that previously a provider string like `"openai-compatible"` would have been matched as `OpenAi` via substring matching; it now falls through to the `Claude` default. This is the corrected behaviour.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- An ADR documenting the rationale for the two-prompt-style model and the provider-specific behavioural differences is still to be written (tracked in #100)

**Alternatives Considered:**
- Keeping substring matching but fixing the case sensitivity — rejected because exact matching is more explicit and self-documenting; any new provider must be consciously opted in to `PromptStyle::OpenAi` rather than accidentally matching by name