### PR TITLE
fix(cli,core): resolve multiple tokio runtime instances (issue #222)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,10 +38,10 @@ pub enum Commands {
 
 impl Cli {
     /// Executes the CLI command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
-            Commands::Ai(ai_cmd) => ai_cmd.execute(),
-            Commands::Git(git_cmd) => git_cmd.execute(),
+            Commands::Ai(ai_cmd) => ai_cmd.execute().await,
+            Commands::Git(git_cmd) => git_cmd.execute().await,
             Commands::Commands(commands_cmd) => commands_cmd.execute(),
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::HelpAll(help_cmd) => help_cmd.execute(),

--- a/src/cli/ai.rs
+++ b/src/cli/ai.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use crossterm::{
     event::{self, Event, KeyCode, KeyModifiers},
@@ -26,9 +26,9 @@ pub enum AiSubcommand {
 
 impl AiCommand {
     /// Executes the AI command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
-            AiSubcommand::Chat(cmd) => cmd.execute(),
+            AiSubcommand::Chat(cmd) => cmd.execute().await,
         }
     }
 }
@@ -43,7 +43,7 @@ pub struct ChatCommand {
 
 impl ChatCommand {
     /// Executes the chat command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         let ai_info = crate::utils::preflight::check_ai_credentials(self.model.as_deref())?;
         eprintln!(
             "Connected to {} (model: {})",
@@ -53,8 +53,7 @@ impl ChatCommand {
 
         let client = crate::claude::create_default_claude_client(self.model, None)?;
 
-        let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
-        rt.block_on(chat_loop(&client))
+        chat_loop(&client).await
     }
 }
 

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -15,7 +15,7 @@ pub use info::InfoCommand;
 pub use twiddle::TwiddleCommand;
 pub use view::ViewCommand;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 /// Parses a `--beta-header key:value` string into a `(key, value)` tuple.
@@ -113,56 +113,41 @@ pub enum CreateSubcommands {
 
 impl GitCommand {
     /// Executes the git command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
-            GitSubcommands::Commit(commit_cmd) => commit_cmd.execute(),
-            GitSubcommands::Branch(branch_cmd) => branch_cmd.execute(),
+            GitSubcommands::Commit(commit_cmd) => commit_cmd.execute().await,
+            GitSubcommands::Branch(branch_cmd) => branch_cmd.execute().await,
         }
     }
 }
 
 impl CommitCommand {
     /// Executes the commit command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
-            CommitSubcommands::Message(message_cmd) => message_cmd.execute(),
+            CommitSubcommands::Message(message_cmd) => message_cmd.execute().await,
         }
     }
 }
 
 impl MessageCommand {
     /// Executes the message command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
             MessageSubcommands::View(view_cmd) => view_cmd.execute(),
             MessageSubcommands::Amend(amend_cmd) => amend_cmd.execute(),
-            MessageSubcommands::Twiddle(twiddle_cmd) => {
-                // Use tokio runtime for async execution
-                let rt =
-                    tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
-                rt.block_on(twiddle_cmd.execute())
-            }
-            MessageSubcommands::Check(check_cmd) => {
-                // Use tokio runtime for async execution
-                let rt =
-                    tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
-                rt.block_on(check_cmd.execute())
-            }
+            MessageSubcommands::Twiddle(twiddle_cmd) => twiddle_cmd.execute().await,
+            MessageSubcommands::Check(check_cmd) => check_cmd.execute().await,
         }
     }
 }
 
 impl BranchCommand {
     /// Executes the branch command.
-    pub fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> Result<()> {
         match self.command {
             BranchSubcommands::Info(info_cmd) => info_cmd.execute(),
-            BranchSubcommands::Create(create_cmd) => {
-                // Use tokio runtime for async execution
-                let rt = tokio::runtime::Runtime::new()
-                    .context("Failed to create tokio runtime for PR creation")?;
-                rt.block_on(create_cmd.execute())
-            }
+            BranchSubcommands::Create(create_cmd) => create_cmd.execute().await,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use std::process;
 use clap::Parser;
 use omni_dev::Cli;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Initialize tracing subscriber with RUST_LOG environment variable support
     // Default to "warn" level if RUST_LOG is not set
     tracing_subscriber::fmt()
@@ -15,7 +16,7 @@ fn main() {
 
     let cli = Cli::parse();
 
-    if let Err(e) = cli.execute() {
+    if let Err(e) = cli.execute().await {
         eprintln!("Error: {e}");
 
         // Print the full error chain if available


### PR DESCRIPTION
## Description

This PR resolves issue #222 by eliminating multiple ad-hoc tokio runtime instances throughout the command execution stack. Previously, each async subcommand (e.g., `twiddle`, `check`, `create`) created its own `tokio::runtime::Runtime` inline using `Runtime::new().block_on(...)`. This PR replaces all of these with a single `#[tokio::main]` entry point in `main()`, propagating `async` through the entire command execution hierarchy.

The result is a cleaner, more idiomatic async Rust architecture where all async operations share a single tokio runtime rather than spawning isolated runtimes per subcommand.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Related Issue

Fixes #222

## Changes Made

**Core Changes:**
- Converted `main()` in `src/main.rs` to `async fn main()` with `#[tokio::main]` attribute and updated `cli.execute()` call to `.await`
- Made `Cli::execute` in `src/cli.rs` async, propagating `.await` to `AiCommand::execute` and `GitCommand::execute`
- Made `AiCommand::execute` and `ChatCommand::execute` in `src/cli/ai.rs` async; removed inline `tokio::runtime::Runtime::new()` from `ChatCommand::execute`, replacing `rt.block_on(chat_loop(&client))` with `chat_loop(&client).await`
- Made `GitCommand::execute`, `CommitCommand::execute`, `MessageCommand::execute`, and `BranchCommand::execute` in `src/cli/git.rs` async; removed inline `tokio::runtime::Runtime::new()` calls from `twiddle`, `check`, and `create` subcommand dispatch, replacing `rt.block_on(cmd.execute())` with `cmd.execute().await`

**Cleanup:**
- Removed unused `anyhow::Context` import from `src/cli/ai.rs` (was only needed for `Runtime::new().context(...)`)
- Removed unused `anyhow::Context` import from `src/cli/git.rs` (same reason)

**Documentation:**
- No documentation changes required; this is a purely internal refactoring with no user-facing behavioral changes

**Testing:**
- Existing test suite validates correctness of the refactoring
- No new tests required as the change is structural (async propagation), not functional

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable — structural refactoring)
- [ ] Integration tests updated/added (not applicable)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (all subcommands: `chat`, `commit message twiddle`, `commit message check`, `branch create`)
- [x] Tested error/edge cases (missing credentials, invalid args)
- [x] Backward compatibility verified (no user-facing behavioral change)

### Test Commands

```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
cargo build --release
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the async propagation through `Cli::execute` → `GitCommand::execute` → `CommitCommand::execute` → `MessageCommand::execute` is the key change; verify the chain is complete and correct
- [x] Error handling — ensure no error context is lost from the removed `Context` import usages
- [ ] Security implications (none)
- [ ] Performance impact (minor positive: eliminates overhead of creating multiple tokio runtimes)
- [ ] User experience (no change)
- [ ] Backward compatibility (fully preserved)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (structural refactoring; covered by existing tests)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the PR Guidelines

## Performance Impact

- [x] Performance improvement — eliminates the overhead of creating, initializing, and tearing down multiple tokio runtimes (one per async subcommand invocation). All async operations now share the single runtime created by `#[tokio::main]`.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely internal refactoring. All user-facing CLI behavior and output remain identical.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the inline `Runtime::new().block_on(...)` pattern but centralizing it to a shared runtime instance — rejected in favor of the idiomatic `#[tokio::main]` approach which is simpler and avoids passing a runtime handle through the call stack.

**Known Limitations:**
- None introduced by this change.