### PR TITLE
docs(docs): add ADR-0016 for clap derive hierarchical CLI structure

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -39,3 +39,4 @@ by Michael Nygard.
 | [ADR-0013](adr-0013.md)  | ✅ Accepted | 2026-02-23 | Self-Describing YAML Output with Field Presence Tracking                               |
 | [ADR-0014](adr-0014.md)  | ✅ Accepted | 2026-02-23 | Provider-Specific Prompt Engineering                                                   |
 | [ADR-0015](adr-0015.md)  | ✅ Accepted | 2026-02-23 | Dual Error Handling Strategy — `thiserror` for Domain Errors, `anyhow` for Propagation |
+| [ADR-0016](adr-0016.md)  | ✅ Accepted | 2026-02-24 | Clap Derive Macros with Hierarchical Subcommand Structure                              |

--- a/docs/adrs/adr-0016.md
+++ b/docs/adrs/adr-0016.md
@@ -1,0 +1,182 @@
+# ADR-0016: Clap Derive Macros with Hierarchical Subcommand Structure
+
+## Status
+
+✅ Accepted
+
+## Context
+
+omni-dev's command surface spans several distinct domains — git commit analysis,
+git branch operations, AI interaction, configuration display, and command template
+generation. Each domain has sub-operations that form a natural hierarchy: a git
+commit operation is meaningfully different from a git branch operation, and a commit
+message amendment is meaningfully different from a commit message view.
+
+Three CLI definition approaches were evaluated:
+
+- **Manual argument parsing.** `std::env::args()` is read and matched by hand.
+  Argument parsing, help text, shell completion, and error messages must all be
+  implemented from scratch. This is impractical for a command surface of this
+  complexity and produces an inconsistent user experience compared with
+  standard Rust tooling.
+
+- **Flat command structure with clap.** All leaf commands appear at the top level
+  (e.g., `omni-dev commit-view`, `omni-dev commit-amend`, `omni-dev branch-info`).
+  The command surface is easy to enumerate but does not reflect the domain model.
+  Related commands have no structural grouping, making the tool harder to discover
+  and document. As the command count grows, the flat list becomes difficult to
+  navigate.
+
+- **Builder-pattern clap.** Commands are constructed programmatically via
+  `Command::new().subcommand(…)` calls at runtime. The command tree is defined
+  procedurally, which gives flexibility but separates the command definition from
+  its argument types. Argument extraction requires manual `ArgMatches` lookups that
+  the compiler cannot type-check. Adding a command requires edits in at least two
+  places: the builder and the dispatch match.
+
+- **Derive-macro clap with hierarchical subcommands.** Each level of the hierarchy
+  is expressed as a pair: a `#[derive(Parser)]` struct that owns a
+  `#[command(subcommand)]` field, and a `#[derive(Subcommand)]` enum whose variants
+  name the next level. The command tree is defined entirely in Rust types; clap
+  generates help text, shell completions, and error messages from the derive
+  annotations. Dispatch is a chain of exhaustive `match` expressions that the
+  compiler verifies for completeness.
+
+## Decision
+
+We will define the CLI using clap derive macros with a hierarchical subcommand
+structure up to four levels deep.
+
+### Command tree
+
+The top-level struct `Cli` (`src/cli.rs`) owns a `Commands` subcommand enum with
+five variants. The full tree is:
+
+```
+omni-dev
+├── ai
+│   └── chat
+├── git
+│   ├── commit
+│   │   └── message
+│   │       ├── view    [4 levels deep]
+│   │       ├── amend   [4 levels deep]
+│   │       ├── twiddle [4 levels deep]
+│   │       └── check   [4 levels deep]
+│   └── branch
+│       ├── info
+│       └── create
+│           └── pr      [4 levels deep]
+├── commands
+│   └── generate
+│       ├── commit-twiddle
+│       ├── pr-create
+│       ├── pr-update
+│       └── all
+├── config
+│   └── models
+│       └── show
+└── help-all
+```
+
+Leaf commands for the `git` subtree are implemented in separate files under
+`src/cli/git/`; all intermediate nodes for that subtree live in `src/cli/git.rs`.
+All other subtrees follow the same layout within `src/cli/`.
+
+### Struct and enum pairing
+
+Every intermediate node is a matched pair:
+
+```rust
+#[derive(Parser)]
+pub struct FooCommand {
+    #[command(subcommand)]
+    pub command: FooSubcommands,
+}
+
+#[derive(Subcommand)]
+pub enum FooSubcommands {
+    Bar(BarCommand),
+}
+```
+
+Intermediate structs hold only a subcommand field. Leaf structs hold the actual
+arguments and flags for that command.
+
+### Async dispatch
+
+The full dispatch chain is async. `main` uses `#[tokio::main]` and calls
+`cli.execute().await`. Every intermediate `execute(self)` method is declared
+`async fn execute(self) -> Result<()>` and propagates to its child with `.await`.
+
+Leaf commands are either sync or async:
+
+- **Sync leaves** (`view`, `amend`, `info`, `show`, template generators) — called
+  directly without `.await` from their parent's async `execute`.
+- **Async leaves** (`twiddle`, `check`, `git branch create pr`, `ai chat`) — called
+  with `.await`.
+
+This gives a single tokio runtime for the process lifetime, created by the
+`#[tokio::main]` macro in `main.rs`.
+
+## Consequences
+
+**Positive:**
+
+- **Compile-time completeness.** The `match` at each dispatch level is exhaustive.
+  Adding a new subcommand variant without handling it is a compiler error, not a
+  runtime omission.
+
+- **Type-safe argument access.** Each leaf command receives a typed struct rather
+  than untyped `ArgMatches`. There are no string-keyed lookups and no runtime
+  panics from mismatched argument names.
+
+- **Help text and shell completions generated automatically.** Doc comments on
+  structs and variants become help strings. Shell completion scripts can be
+  generated via clap's `generate` API without additional code.
+
+- **Command definition and handler are co-located.** The struct that defines a
+  command's arguments is in the same file as the `impl` that executes it. There is
+  no separate registration or routing table to keep in sync.
+
+- **Domain structure is reflected in the command surface.** The four-level hierarchy
+  (`git → commit → message → view`) mirrors the domain decomposition. Users who
+  understand the domain can predict command paths; help text at each intermediate
+  level guides discovery.
+
+- **Single runtime.** `#[tokio::main]` creates one tokio runtime for the entire
+  process. There are no per-command `Runtime::new()` calls to forget or duplicate
+  when adding new async commands.
+
+**Negative:**
+
+- **Intermediate-node boilerplate.** Every level of nesting requires a paired struct
+  and enum that exist solely to hold a subcommand field. `CommitCommand`,
+  `MessageCommand`, `BranchCommand`, and `CreateCommand` each contain exactly one
+  field. This is unavoidable with clap's derive approach for deep hierarchies.
+
+- **Async propagates through all intermediate nodes.** Because dispatch is a chain
+  of `async fn execute` calls, every intermediate node must be async even when it
+  has no async work of its own. This is a consequence of Rust's async model: an
+  async fn cannot be called from a sync fn without blocking. The alternative —
+  per-command `Runtime::new()` — was used previously and was worse: it created
+  multiple runtimes and required each new async command author to remember the
+  pattern independently.
+
+- **Adding a command touches multiple files.** A new leaf requires: the leaf struct
+  and impl (one file), a variant in the parent enum, and a match arm in the parent
+  `execute`. For a new intermediate level, a new paired struct and enum are also
+  needed. This is more than a flat structure would require.
+
+**Neutral:**
+
+- **Four levels is the current maximum; the structure is open to extension.** The
+  nesting depth reflects the current domain model. A new domain area would add a
+  new top-level variant to `Commands`; a deeper sub-operation would add another
+  intermediate pair. Neither change affects existing subtrees.
+
+- **`help-all` traverses the derive-generated command tree.** `HelpGenerator` in
+  `src/cli/help.rs` calls `Cli::command()` (a clap derive method) to obtain the
+  `Command` tree and recurse through it. This provides comprehensive help output
+  without maintaining a separate list of commands, and sorts subcommands
+  lexicographically for deterministic output.


### PR DESCRIPTION
## Description

This PR adds ADR-0016, documenting the architectural decision to use clap derive macros with a hierarchical subcommand structure for the omni-dev CLI. This decision record captures the evaluation of four CLI definition approaches and explains why the derive-macro approach with a four-level command hierarchy was selected.

The ADR documents the struct/enum pairing convention at each intermediate node, the async dispatch strategy using a single tokio runtime via `#[tokio::main]`, and the trade-offs accepted (intermediate-node boilerplate vs. compile-time exhaustiveness and type safety).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #101

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0016.md` documenting the decision to use clap derive macros with hierarchical subcommand structure
- Registered ADR-0016 in the ADR index (`docs/adrs/README.md`) with status ✅ Accepted and date 2026-02-24

**ADR Content Covers:**
- Evaluation of four CLI approaches: manual parsing, flat clap structure, builder-pattern clap, and derive-macro clap
- Full four-level command tree (`omni-dev → git → commit → message → view/amend/twiddle/check`, etc.)
- Struct/enum pairing convention for intermediate and leaf nodes
- Async dispatch strategy using a single `#[tokio::main]` tokio runtime
- Positive consequences: compile-time exhaustiveness, type-safe argument access, automatic help/completion generation, co-located command definition and handler
- Negative consequences: intermediate-node boilerplate, async propagation through all intermediate nodes, multi-file touches when adding commands

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Documentation reviewed for accuracy and completeness
- [x] ADR index entry verified to be correctly formatted and linked

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes
- [ ] Error handling
- [ ] User experience
- [ ] Backward compatibility

The key review area is whether the ADR accurately reflects the implemented CLI structure and the trade-offs of the hierarchical derive-macro approach. Specifically:
- Accuracy of the command tree diagram (verify it matches `src/cli.rs` and `src/cli/git.rs`)
- Completeness of the consequences section — both positive (exhaustive match, type safety) and negative (boilerplate, async propagation)
- Whether the async dispatch description correctly describes sync vs. async leaf handling

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Manual argument parsing via `std::env::args()` — rejected due to impracticality at this command surface complexity and inconsistent UX
- Flat command structure with clap (`omni-dev commit-view`, `omni-dev commit-amend`) — rejected because it doesn't reflect the domain model and becomes hard to navigate as command count grows
- Builder-pattern clap via `Command::new().subcommand(…)` — rejected because it separates command definition from argument types, requires manual `ArgMatches` lookups the compiler cannot verify, and requires edits in multiple places per command

**Known Limitations:**
- Intermediate-node boilerplate is unavoidable with clap's derive approach for deep hierarchies; `CommitCommand`, `MessageCommand`, `BranchCommand`, and `CreateCommand` each contain exactly one field by design
- Every intermediate node must be `async` even when it has no async work, as a consequence of Rust's async model