### PR TITLE
feat(git,data): add per-file diff storage with FileDiffRef struct

### DIFF
--- a/src/claude/batch.rs
+++ b/src/claude/batch.rs
@@ -163,6 +163,7 @@ mod tests {
                 },
                 diff_summary: "test.rs | 10 ++++".to_string(),
                 diff_file: tmp.path().to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
             },
         };
         (commit, tmp)

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -1062,6 +1062,7 @@ mod tests {
                     },
                     diff_summary: "file.rs | 1 +".to_string(),
                     diff_file: diff_path.to_string_lossy().to_string(),
+                    file_diffs: Vec::new(),
                 },
             }],
         }

--- a/src/claude/context/patterns.rs
+++ b/src/claude/context/patterns.rs
@@ -393,6 +393,7 @@ mod tests {
                 },
                 diff_summary: String::new(),
                 diff_file: String::new(),
+                file_diffs: Vec::new(),
             },
         }
     }

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -1112,6 +1112,7 @@ mod tests {
                 },
                 diff_summary: String::new(),
                 diff_file: tmp.path().to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
             },
         };
         (commit, tmp)

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -1909,6 +1909,7 @@ mod tests {
                 },
                 diff_summary: String::new(),
                 diff_file: tmp.path().to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
             },
         };
         (commit, tmp)

--- a/src/data.rs
+++ b/src/data.rs
@@ -176,7 +176,11 @@ impl RepositoryView {
                 | "commits[].analysis.file_changes.files_deleted"
                 | "commits[].analysis.file_changes.file_list"
                 | "commits[].analysis.diff_summary"
-                | "commits[].analysis.diff_file" => !self.commits.is_empty(),
+                | "commits[].analysis.diff_file"
+                | "commits[].analysis.file_diffs"
+                | "commits[].analysis.file_diffs[].path"
+                | "commits[].analysis.file_diffs[].diff_file"
+                | "commits[].analysis.file_diffs[].byte_len" => !self.commits.is_empty(),
                 "versions.omni_dev" => self.versions.is_some(),
                 "branch_info.branch" => self.branch_info.is_some(),
                 "pr_template" => self.pr_template.is_some(),
@@ -382,6 +386,33 @@ impl Default for FieldExplanation {
                     text: "Path to file containing full diff content showing line-by-line changes with added, removed, and context lines.\n\
                            AI assistants should read this file to understand the specific changes made in the commit.".to_string(),
                     command: Some("git show <commit>".to_string()),
+                    present: false,
+                },
+                FieldDocumentation {
+                    name: "commits[].analysis.file_diffs".to_string(),
+                    text: "Array of per-file diff references, each containing the file path, \
+                           absolute path to the diff file on disk, and byte length of the diff content.\n\
+                           AI assistants can use these to analyze individual file changes without loading the full diff."
+                        .to_string(),
+                    command: None,
+                    present: false,
+                },
+                FieldDocumentation {
+                    name: "commits[].analysis.file_diffs[].path".to_string(),
+                    text: "Repository-relative path of the changed file.".to_string(),
+                    command: None,
+                    present: false,
+                },
+                FieldDocumentation {
+                    name: "commits[].analysis.file_diffs[].diff_file".to_string(),
+                    text: "Absolute path to the per-file diff file on disk.".to_string(),
+                    command: None,
+                    present: false,
+                },
+                FieldDocumentation {
+                    name: "commits[].analysis.file_diffs[].byte_len".to_string(),
+                    text: "Byte length of the per-file diff content.".to_string(),
+                    command: None,
                     present: false,
                 },
                 FieldDocumentation {
@@ -612,6 +643,7 @@ mod tests {
                         },
                         diff_summary: diff_summary.to_string(),
                         diff_file: "/tmp/test.diff".to_string(),
+                        file_diffs: Vec::new(),
                     },
                     diff_content: diff_content.to_string(),
                 },
@@ -944,6 +976,7 @@ mod tests {
                 },
                 diff_summary: String::new(),
                 diff_file: String::new(),
+                file_diffs: Vec::new(),
             },
         }
     }
@@ -1064,6 +1097,7 @@ mod tests {
                         },
                         diff_summary: "file.rs | 1 +".to_string(),
                         diff_file: diff_path.to_string_lossy().to_string(),
+                        file_diffs: Vec::new(),
                     },
                 }
             })

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,7 +7,7 @@ pub mod remote;
 pub mod repository;
 
 pub use amendment::AmendmentHandler;
-pub use commit::{CommitAnalysis, CommitAnalysisForAI, CommitInfo, CommitInfoForAI};
+pub use commit::{CommitAnalysis, CommitAnalysisForAI, CommitInfo, CommitInfoForAI, FileDiffRef};
 pub use diff_split::{split_by_file, split_file_by_hunk, FileDiff, HunkDiff};
 pub use remote::RemoteInfo;
 pub use repository::GitRepository;


### PR DESCRIPTION
## Description

This PR implements per-file diff storage alongside the existing flat commit diff file (Issue #232). When a commit's diff is written to disk, it is now also split by file and each per-file chunk is written to a numbered file under a commit-specific subdirectory (`<diffs_dir>/<commit_hash>/<index>.diff`). A new `FileDiffRef` struct tracks the repository-relative path, absolute disk path, and byte length for each per-file diff.

This enables AI assistants and other consumers to analyze individual file changes within a commit without needing to load the entire flat diff into memory, which is especially valuable for large commits with many changed files.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #232

## Changes Made

**Core Changes (`src/git/commit.rs`):**
- Added `FileDiffRef` struct with `path`, `diff_file`, and `byte_len` fields, used to reference individual per-file diffs on disk
- Added `file_diffs: Vec<FileDiffRef>` field to `CommitAnalysis`, serialized with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so it is omitted when empty and backward-compatible when deserializing older data
- Updated `write_diff_to_file` to return `(String, Vec<FileDiffRef>)` instead of just `String`; after writing the flat diff, it splits the content by file via `split_by_file`, creates `<diffs_dir>/<commit_hash>/` directory, writes each per-file chunk as `<index:04>.diff`, and builds the `FileDiffRef` list
- Updated `CommitAnalysis::analyze` to destructure the new return value and populate `file_diffs` in the constructed struct

**Public API (`src/git.rs`):**
- Exported `FileDiffRef` from the `git` module's public API alongside the existing `CommitAnalysis`, `CommitAnalysisForAI`, `CommitInfo`, and `CommitInfoForAI` exports

**Data Layer (`src/data.rs`):**
- Registered presence detection for `commits[].analysis.file_diffs`, `commits[].analysis.file_diffs[].path`, `commits[].analysis.file_diffs[].diff_file`, and `commits[].analysis.file_diffs[].byte_len` field names in `RepositoryView`
- Added `FieldDocumentation` entries for all four new fields describing their purpose and content for AI assistants

**Test Fixture Updates:**
- Added `file_diffs: Vec::new()` to all `CommitAnalysis` struct literals in test fixtures across `src/claude/batch.rs`, `src/claude/client.rs`, `src/claude/context/patterns.rs`, `src/cli/git/check.rs`, `src/cli/git/twiddle.rs`, and `src/data.rs` to satisfy the new required field

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

**New Tests Added (`src/git/commit.rs`):**
- `file_diffs_default_empty_on_deserialize`: verifies that `file_diffs` defaults to an empty `Vec` when deserializing YAML that omits the field
- `file_diffs_omitted_when_empty_on_serialize`: verifies that serializing a `CommitAnalysis` with an empty `file_diffs` does not include the `file_diffs` key in the YAML output
- `file_diffs_included_when_populated`: verifies that a populated `file_diffs` vec is correctly serialized, including `path`, `diff_file`, and `byte_len` values

### Test Commands
```bash
# Core test suite
cargo test

# Run git/commit-specific tests
cargo test --lib git::commit

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [x] Performance impact
- [x] Architecture changes
- [x] Error handling
- [ ] User experience
- [x] Backward compatibility

The key areas for review are:
- `src/git/commit.rs` — `FileDiffRef` struct definition, `write_diff_to_file` return type change, per-file write loop, and directory creation logic
- `src/data.rs` — presence detection registration and field documentation for new `file_diffs` fields
- Serde attributes (`default`, `skip_serializing_if`) ensuring backward compatibility with existing serialized data

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [ ] No performance impact
- [ ] Performance improvement (describe below)
- [x] Potential performance impact (describe below)

Each commit analysis now creates a subdirectory under `<diffs_dir>/<commit_hash>/` and writes one file per changed file in the commit. For commits touching many files, this adds proportional I/O at analysis time. However, per-file diffs are only written once per commit and are small (median ~400 bytes in this commit's own diffs), so the overhead is expected to be minimal in practice. The trade-off is that consumers can now read individual file diffs selectively without loading the full flat diff.

## Security Considerations
- [x] No security implications

## Breaking Changes

None. The `file_diffs` field uses `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so:
- Existing serialized `CommitAnalysis` YAML without `file_diffs` deserializes cleanly with an empty vec
- New serialized output omits `file_diffs` when empty, remaining identical to the previous format for commits with no per-file diffs

## Deployment Notes
- [x] No special deployment requirements

The per-file diff files are written to the AI scratch directory (controlled by `AI_SCRATCH` environment variable), the same location used by the existing flat diff files. No configuration changes are required.

## Additional Notes

**Future Enhancements:**
- Consumers (e.g., Claude batch/client context builders) can be updated to use `file_diffs` for targeted per-file analysis instead of loading the full flat diff
- The `byte_len` field enables consumers to prioritize or skip large diffs based on size before loading content

**Known Limitations:**
- Per-file diff directories are not cleaned up automatically; cleanup follows the same lifecycle as the existing flat diff files in the AI scratch directory

**Alternatives Considered:**
- Embedding per-file diff content directly in `CommitAnalysis` was rejected to avoid large memory footprints for commits with many or large changed files; the file-reference approach keeps the struct lightweight