### PR TITLE
feat(claude,git,data): implement split dispatch for large diffs

### DIFF
--- a/src/claude/diff_pack.rs
+++ b/src/claude/diff_pack.rs
@@ -7,9 +7,6 @@
 //! hunk that still exceeds capacity gets its own chunk; the dispatch layer
 //! is responsible for treating that as a hard error.
 
-// Building block for the dispatch layer (#192); no callers yet.
-#![allow(dead_code)]
-
 use std::fs;
 
 use anyhow::{Context, Result};
@@ -43,6 +40,7 @@ pub(crate) struct DiffChunk {
 #[derive(Debug)]
 pub(crate) struct CommitDiffPlan {
     /// SHA-1 hash of the commit these chunks belong to.
+    #[allow(dead_code)] // Structural metadata; useful in Debug output
     pub commit_hash: String,
     /// Ordered list of chunks, each fitting within the token budget.
     pub chunks: Vec<DiffChunk>,

--- a/src/claude/test_utils.rs
+++ b/src/claude/test_utils.rs
@@ -41,6 +41,14 @@ impl ConfigurableMockAiClient {
             },
         }
     }
+
+    /// Returns a new mock client with a custom context window size.
+    ///
+    /// Useful for testing split-dispatch behaviour with a small budget.
+    pub(crate) fn with_context_length(mut self, max_context_length: usize) -> Self {
+        self.metadata.max_context_length = max_context_length;
+        self
+    }
 }
 
 impl AiClient for ConfigurableMockAiClient {


### PR DESCRIPTION
## Description

When a single commit's diff exceeds the AI model's token budget, the previous behavior would fall back to progressive diff reduction, potentially losing important context. This PR implements a split dispatch strategy specifically for single-commit views: the diff is partitioned into file-level chunks, one AI request is dispatched per chunk to collect partial amendments, and a dedicated reduce pass merges those partial amendments into a single cohesive result.

This ensures that large commits (e.g., those touching many large files) receive accurate, complete commit message proposals without silently truncating diff content. Multi-commit views retain the existing progressive diff reduction behavior.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #235

## Changes Made

**Core Changes (`src/claude/client.rs`):**
- Added `try_full_diff_budget` helper to probe whether the full diff fits the token budget before deciding on a dispatch path
- Added `generate_amendment_split` to orchestrate per-chunk AI requests using `pack_file_diffs`, collecting partial `Amendment` results for each file chunk
- Added `merge_amendment_chunks` reduce pass driven by `AMENDMENT_CHUNK_MERGE_SYSTEM_PROMPT` to synthesize partial chunk amendments into one cohesive message
- Wired split dispatch into both `generate_amendments_with_options` and `generate_contextual_amendments_with_options` for single-commit views; multi-commit views continue using progressive diff reduction via the `if repo_view.commits.len() == 1` branch

**Data Layer (`src/data.rs`):**
- Added `RepositoryViewForAI::single_commit_view_for_ai` to produce a minimal, prompt-sized view for per-chunk dispatch — strips `versions`, `remotes`, `pr_template`, and `branch_prs` while preserving `branch_info` for scope context

**Git Layer (`src/git/commit.rs`):**
- Added `CommitInfoForAI::from_commit_info_partial` to build a partial commit view containing only specified file diffs, with deduplication for hunk-split files that appear multiple times in the same chunk

**Prompts (`src/claude/prompts.rs`):**
- Added `AMENDMENT_CHUNK_MERGE_SYSTEM_PROMPT` with instructions for synthesizing partial chunk amendments into a single conventional commit message
- Added `generate_chunk_merge_user_prompt` to construct the reduce-pass user prompt, including original message, full `diff --stat` summary, and all partial chunk amendments

**Diff Pack (`src/claude/diff_pack.rs`):**
- Removed `#![allow(dead_code)]` from the module now that `pack_file_diffs` has active callers
- Moved `#[allow(dead_code)]` to the `commit_hash` field only, which is retained for `Debug` output

**Test Utilities (`src/claude/test_utils.rs`):**
- Added `ConfigurableMockAiClient::with_context_length` builder to constrain the mock token budget, enabling testing of split dispatch with a small context window

**Testing:**
- Added integration tests in `src/claude/client.rs`: `generate_amendments_split_dispatch` (happy path with 3 AI responses: 2 chunks + 1 merge), `generate_amendments_split_chunk_failure` (error propagation when a chunk fails), `generate_amendments_no_split_when_fits` (single-request path when diff is within budget)
- Added unit tests for `CommitInfoForAI::from_commit_info_partial` in `src/git/commit.rs`: subset loading, path deduplication for hunk-split files, and metadata preservation
- Added unit tests for `RepositoryViewForAI::single_commit_view_for_ai` in `src/data.rs`: metadata stripping and `branch_info` preservation
- Added unit tests for `AMENDMENT_CHUNK_MERGE_SYSTEM_PROMPT` and `generate_chunk_merge_user_prompt` in `src/claude/prompts.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (split dispatch succeeds, merge pass produces single amendment)
- [x] Tested error/edge cases (chunk failure propagates correctly, no split when diff fits budget)
- [x] Backward compatibility verified (multi-commit views unaffected, single-commit views within budget use single request)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run split-dispatch specific tests
cargo test generate_amendments_split
cargo test from_commit_info_partial
cargo test single_commit_view_for_ai
cargo test chunk_merge
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the dispatch decision point in `generate_amendments_with_options` and `generate_contextual_amendments_with_options` (the `if repo_view.commits.len() == 1` branch)
- [x] Error handling — chunk failure propagation in `generate_amendment_split` and the reduce pass in `merge_amendment_chunks`
- [x] Performance impact — each oversized single-commit diff now triggers N+1 AI requests (N chunks + 1 merge pass) instead of 1 truncated request; this is intentional

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Potential performance impact (describe below)

For single-commit views whose diff exceeds the token budget, split dispatch issues N+1 AI requests (one per file chunk plus one merge pass) rather than one request with a truncated diff. This is an intentional trade-off: completeness over latency. Commits within the token budget continue to use a single request with no overhead. Multi-commit views are entirely unaffected.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. Split dispatch is fully transparent to callers — the public API of `generate_amendments_with_options` and `generate_contextual_amendments_with_options` is unchanged. The behavior change only affects single-commit views with diffs too large for the token budget.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Contextual split dispatch for multi-commit views (currently only single-commit views use split dispatch; multi-commit split dispatch could be added if needed)
- Configurable chunk sizing strategy beyond the current token-budget-based packing
- Parallel chunk dispatch to reduce latency for large commits (deferred to avoid complexity)

**Known Limitations:**
- If a single file's diff exceeds the per-chunk token budget, `pack_file_diffs` treats it as its own chunk and the dispatch layer will receive an oversized request; this is treated as a hard error by the existing infrastructure

**Alternatives Considered:**
- Extending progressive diff reduction to single-commit views — rejected because it silently loses file-level diff detail rather than processing all changes
- Parallelising chunk requests — deferred to avoid complexity; sequential dispatch is sufficient for correctness