### PR TITLE
feat(atlassian,cli): add JIRA sprint management commands

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -189,6 +189,32 @@ pub struct AgileBoardList {
     pub total: u32,
 }
 
+/// A JIRA agile sprint.
+#[derive(Debug, Clone)]
+pub struct AgileSprint {
+    /// Sprint ID.
+    pub id: u64,
+    /// Sprint name.
+    pub name: String,
+    /// Sprint state (e.g., "active", "future", "closed").
+    pub state: String,
+    /// Sprint start date (ISO 8601).
+    pub start_date: Option<String>,
+    /// Sprint end date (ISO 8601).
+    pub end_date: Option<String>,
+    /// Sprint goal.
+    pub goal: Option<String>,
+}
+
+/// Result from listing agile sprints.
+#[derive(Debug, Clone)]
+pub struct AgileSprintList {
+    /// Sprints returned.
+    pub sprints: Vec<AgileSprint>,
+    /// Total number of sprints.
+    pub total: u32,
+}
+
 /// A JIRA workflow transition.
 #[derive(Debug, Clone)]
 pub struct JiraTransition {
@@ -314,6 +340,25 @@ struct AgileIssueListResponse {
     issues: Vec<JiraIssueResponse>,
     #[serde(default)]
     total: u32,
+}
+
+#[derive(Deserialize)]
+struct AgileSprintListResponse {
+    values: Vec<AgileSprintEntry>,
+    #[serde(default)]
+    total: u32,
+}
+
+#[derive(Deserialize)]
+struct AgileSprintEntry {
+    id: u64,
+    name: String,
+    state: String,
+    #[serde(rename = "startDate")]
+    start_date: Option<String>,
+    #[serde(rename = "endDate")]
+    end_date: Option<String>,
+    goal: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1374,6 +1419,162 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_sprints_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/board/1/sprint"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "values": [
+                        {"id": 10, "name": "Sprint 1", "state": "closed", "startDate": "2026-03-01", "endDate": "2026-03-14", "goal": "MVP"},
+                        {"id": 11, "name": "Sprint 2", "state": "active", "startDate": "2026-03-15", "endDate": "2026-03-28"}
+                    ],
+                    "total": 2
+                }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_sprints(1, None, 50).await.unwrap();
+
+        assert_eq!(result.total, 2);
+        assert_eq!(result.sprints.len(), 2);
+        assert_eq!(result.sprints[0].id, 10);
+        assert_eq!(result.sprints[0].name, "Sprint 1");
+        assert_eq!(result.sprints[0].state, "closed");
+        assert_eq!(result.sprints[0].goal.as_deref(), Some("MVP"));
+        assert!(result.sprints[1].goal.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_sprints_with_state_filter() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/board/1/sprint"))
+            .and(wiremock::matchers::query_param("state", "active"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "values": [{"id": 11, "name": "Sprint 2", "state": "active"}],
+                    "total": 1
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_sprints(1, Some("active"), 50).await.unwrap();
+        assert_eq!(result.sprints.len(), 1);
+        assert_eq!(result.sprints[0].state, "active");
+    }
+
+    #[tokio::test]
+    async fn get_sprints_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/board/999/sprint"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_sprints(999, None, 50).await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn get_sprint_issues_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/sprint/10/issue"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "issues": [{
+                        "key": "PROJ-1",
+                        "fields": {
+                            "summary": "Sprint issue",
+                            "description": null,
+                            "status": {"name": "In Progress"},
+                            "issuetype": {"name": "Story"},
+                            "assignee": {"displayName": "Alice"},
+                            "priority": null,
+                            "labels": []
+                        }
+                    }],
+                    "total": 1
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_sprint_issues(10, None, 50).await.unwrap();
+
+        assert_eq!(result.total, 1);
+        assert_eq!(result.issues[0].key, "PROJ-1");
+        assert_eq!(result.issues[0].assignee.as_deref(), Some("Alice"));
+    }
+
+    #[tokio::test]
+    async fn get_sprint_issues_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/sprint/999/issue"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_sprint_issues(999, None, 50).await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn add_issues_to_sprint_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/sprint/10/issue"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.add_issues_to_sprint(10, &["PROJ-1", "PROJ-2"]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_issues_to_sprint_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/agile/1.0/sprint/999/issue"))
+            .respond_with(wiremock::ResponseTemplate::new(400).set_body_string("Bad Request"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .add_issues_to_sprint(999, &["NOPE-1"])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
     async fn get_fields_success() {
         let server = wiremock::MockServer::start().await;
 
@@ -2193,6 +2394,126 @@ impl AtlassianClient {
             issues,
             total: resp.total,
         })
+    }
+
+    /// Lists sprints for an agile board.
+    pub async fn get_sprints(
+        &self,
+        board_id: u64,
+        state: Option<&str>,
+        max_results: u32,
+    ) -> Result<AgileSprintList> {
+        let mut url = format!(
+            "{}/rest/agile/1.0/board/{}/sprint?maxResults={}",
+            self.instance_url, board_id, max_results
+        );
+        if let Some(s) = state {
+            url.push_str(&format!("&state={s}"));
+        }
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: AgileSprintListResponse = response
+            .json()
+            .await
+            .context("Failed to parse sprint list response")?;
+
+        let sprints = resp
+            .values
+            .into_iter()
+            .map(|s| AgileSprint {
+                id: s.id,
+                name: s.name,
+                state: s.state,
+                start_date: s.start_date,
+                end_date: s.end_date,
+                goal: s.goal,
+            })
+            .collect();
+
+        Ok(AgileSprintList {
+            sprints,
+            total: resp.total,
+        })
+    }
+
+    /// Lists issues in an agile sprint.
+    pub async fn get_sprint_issues(
+        &self,
+        sprint_id: u64,
+        jql: Option<&str>,
+        max_results: u32,
+    ) -> Result<JiraSearchResult> {
+        let base = format!(
+            "{}/rest/agile/1.0/sprint/{}/issue",
+            self.instance_url, sprint_id
+        );
+        let mut params: Vec<(&str, String)> = vec![("maxResults", max_results.to_string())];
+        if let Some(jql_str) = jql {
+            params.push(("jql", jql_str.to_string()));
+        }
+        let url =
+            reqwest::Url::parse_with_params(&base, params.iter().map(|(k, v)| (*k, v.as_str())))
+                .context("Failed to build sprint issues URL")?;
+
+        let response = self.get_json(url.as_str()).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: AgileIssueListResponse = response
+            .json()
+            .await
+            .context("Failed to parse sprint issues response")?;
+
+        let issues = resp
+            .issues
+            .into_iter()
+            .map(|r| JiraIssue {
+                key: r.key,
+                summary: r.fields.summary.unwrap_or_default(),
+                description_adf: r.fields.description,
+                status: r.fields.status.and_then(|s| s.name),
+                issue_type: r.fields.issuetype.and_then(|t| t.name),
+                assignee: r.fields.assignee.and_then(|a| a.display_name),
+                priority: r.fields.priority.and_then(|p| p.name),
+                labels: r.fields.labels,
+            })
+            .collect();
+
+        Ok(JiraSearchResult {
+            issues,
+            total: resp.total,
+        })
+    }
+
+    /// Adds issues to an agile sprint.
+    pub async fn add_issues_to_sprint(&self, sprint_id: u64, issue_keys: &[&str]) -> Result<()> {
+        let url = format!(
+            "{}/rest/agile/1.0/sprint/{}/issue",
+            self.instance_url, sprint_id
+        );
+
+        let body = serde_json::json!({ "issues": issue_keys });
+
+        let response = self.post_json(&url, &body).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
     }
 
     /// Lists all JIRA field definitions.

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod field;
 pub(crate) mod project;
 pub(crate) mod read;
 pub(crate) mod search;
+pub(crate) mod sprint;
 pub(crate) mod transition;
 pub(crate) mod write;
 
@@ -48,6 +49,8 @@ pub enum JiraSubcommands {
     Field(field::FieldCommand),
     /// Manages JIRA agile boards.
     Board(board::BoardCommand),
+    /// Manages JIRA agile sprints.
+    Sprint(sprint::SprintCommand),
 }
 
 impl JiraCommand {
@@ -65,6 +68,7 @@ impl JiraCommand {
             JiraSubcommands::Project(cmd) => cmd.execute().await,
             JiraSubcommands::Field(cmd) => cmd.execute().await,
             JiraSubcommands::Board(cmd) => cmd.execute().await,
+            JiraSubcommands::Sprint(cmd) => cmd.execute().await,
         }
     }
 }
@@ -208,5 +212,19 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Board(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_sprint_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Sprint(sprint::SprintCommand {
+                command: sprint::SprintSubcommands::List(sprint::ListCommand {
+                    board_id: 1,
+                    state: None,
+                    max_results: 50,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Sprint(_)));
     }
 }

--- a/src/cli/atlassian/jira/sprint.rs
+++ b/src/cli/atlassian/jira/sprint.rs
@@ -1,0 +1,472 @@
+//! CLI commands for JIRA agile sprints.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::client::{AgileSprintList, JiraSearchResult};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages JIRA agile sprints.
+#[derive(Parser)]
+pub struct SprintCommand {
+    /// The sprint subcommand to execute.
+    #[command(subcommand)]
+    pub command: SprintSubcommands,
+}
+
+/// Sprint subcommands.
+#[derive(Subcommand)]
+pub enum SprintSubcommands {
+    /// Lists sprints for a board.
+    List(ListCommand),
+    /// Lists issues in a sprint.
+    Issues(IssuesCommand),
+    /// Adds issues to a sprint.
+    Add(AddCommand),
+}
+
+impl SprintCommand {
+    /// Executes the sprint command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            SprintSubcommands::List(cmd) => cmd.execute().await,
+            SprintSubcommands::Issues(cmd) => cmd.execute().await,
+            SprintSubcommands::Add(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists sprints for a board.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Board ID.
+    #[arg(long)]
+    pub board_id: u64,
+
+    /// Filter by sprint state (active, future, closed).
+    #[arg(long)]
+    pub state: Option<String>,
+
+    /// Maximum number of results (default: 50).
+    #[arg(long, default_value_t = 50)]
+    pub max_results: u32,
+}
+
+impl ListCommand {
+    /// Fetches and displays sprints.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let result = client
+            .get_sprints(self.board_id, self.state.as_deref(), self.max_results)
+            .await?;
+        print_sprints(&result);
+        Ok(())
+    }
+}
+
+/// Lists issues in a sprint.
+#[derive(Parser)]
+pub struct IssuesCommand {
+    /// Sprint ID.
+    #[arg(long)]
+    pub sprint_id: u64,
+
+    /// JQL filter for issues.
+    #[arg(long)]
+    pub jql: Option<String>,
+
+    /// Maximum number of results (default: 50).
+    #[arg(long, default_value_t = 50)]
+    pub max_results: u32,
+}
+
+impl IssuesCommand {
+    /// Fetches and displays sprint issues.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let result = client
+            .get_sprint_issues(self.sprint_id, self.jql.as_deref(), self.max_results)
+            .await?;
+        print_sprint_issues(&result);
+        Ok(())
+    }
+}
+
+/// Adds issues to a sprint.
+#[derive(Parser)]
+pub struct AddCommand {
+    /// Sprint ID.
+    #[arg(long)]
+    pub sprint_id: u64,
+
+    /// Comma-separated issue keys (e.g., "PROJ-1,PROJ-2").
+    #[arg(long)]
+    pub issues: String,
+}
+
+impl AddCommand {
+    /// Parses issue keys and adds them to the sprint.
+    pub async fn execute(self) -> Result<()> {
+        let keys = parse_issue_keys(&self.issues);
+        if keys.is_empty() {
+            anyhow::bail!("No issue keys provided. Use --issues KEY1,KEY2,...");
+        }
+
+        let (client, _instance_url) = create_client()?;
+        let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+        client
+            .add_issues_to_sprint(self.sprint_id, &key_refs)
+            .await?;
+
+        println!(
+            "Added {} issue(s) to sprint {}.",
+            keys.len(),
+            self.sprint_id
+        );
+        Ok(())
+    }
+}
+
+/// Parses a comma-separated list of issue keys.
+fn parse_issue_keys(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Prints sprints as a formatted table.
+fn print_sprints(result: &AgileSprintList) {
+    if result.sprints.is_empty() {
+        println!("No sprints found.");
+        return;
+    }
+
+    let id_width = result
+        .sprints
+        .iter()
+        .map(|s| s.id.to_string().len())
+        .max()
+        .unwrap_or(2)
+        .max(2);
+    let state_width = result
+        .sprints
+        .iter()
+        .map(|s| s.state.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+
+    println!(
+        "{:<id_width$}  {:<state_width$}  START       END         NAME",
+        "ID", "STATE"
+    );
+    let name_sep = "-".repeat(4);
+    println!(
+        "{:<id_width$}  {:<state_width$}  ----------  ----------  {name_sep}",
+        "-".repeat(id_width),
+        "-".repeat(state_width),
+    );
+
+    for sprint in &result.sprints {
+        let start = format_date(sprint.start_date.as_deref());
+        let end = format_date(sprint.end_date.as_deref());
+        println!(
+            "{:<id_width$}  {:<state_width$}  {:<10}  {:<10}  {}",
+            sprint.id, sprint.state, start, end, sprint.name
+        );
+    }
+
+    if result.total > result.sprints.len() as u32 {
+        println!(
+            "\nShowing {} of {} sprints.",
+            result.sprints.len(),
+            result.total
+        );
+    }
+}
+
+/// Formats an ISO date string to just the date portion, or "-" if absent.
+fn format_date(date: Option<&str>) -> &str {
+    match date {
+        Some(d) if d.len() >= 10 => &d[..10],
+        Some(d) => d,
+        None => "-",
+    }
+}
+
+/// Prints sprint issues as a formatted table.
+fn print_sprint_issues(result: &JiraSearchResult) {
+    if result.issues.is_empty() {
+        println!("No issues found.");
+        return;
+    }
+
+    let key_width = result
+        .issues
+        .iter()
+        .map(|i| i.key.len())
+        .max()
+        .unwrap_or(3)
+        .max(3);
+    let status_width = result
+        .issues
+        .iter()
+        .filter_map(|i| i.status.as_ref().map(String::len))
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let assignee_width = result
+        .issues
+        .iter()
+        .filter_map(|i| i.assignee.as_ref().map(String::len))
+        .max()
+        .unwrap_or(8)
+        .max(8);
+
+    let summary_sep = "-".repeat(7);
+    println!(
+        "{:<key_width$}  {:<status_width$}  {:<assignee_width$}  SUMMARY",
+        "KEY", "STATUS", "ASSIGNEE"
+    );
+    println!(
+        "{:<key_width$}  {:<status_width$}  {:<assignee_width$}  {summary_sep}",
+        "-".repeat(key_width),
+        "-".repeat(status_width),
+        "-".repeat(assignee_width),
+    );
+
+    for issue in &result.issues {
+        let status = issue.status.as_deref().unwrap_or("-");
+        let assignee = issue.assignee.as_deref().unwrap_or("-");
+        println!(
+            "{:<key_width$}  {:<status_width$}  {:<assignee_width$}  {}",
+            issue.key, status, assignee, issue.summary
+        );
+    }
+
+    if result.total > result.issues.len() as u32 {
+        println!(
+            "\nShowing {} of {} issues.",
+            result.issues.len(),
+            result.total
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::{AgileSprint, JiraIssue};
+
+    fn sample_sprint(
+        id: u64,
+        name: &str,
+        state: &str,
+        start: Option<&str>,
+        end: Option<&str>,
+        goal: Option<&str>,
+    ) -> AgileSprint {
+        AgileSprint {
+            id,
+            name: name.to_string(),
+            state: state.to_string(),
+            start_date: start.map(String::from),
+            end_date: end.map(String::from),
+            goal: goal.map(String::from),
+        }
+    }
+
+    fn sample_issue(
+        key: &str,
+        summary: &str,
+        status: Option<&str>,
+        assignee: Option<&str>,
+    ) -> JiraIssue {
+        JiraIssue {
+            key: key.to_string(),
+            summary: summary.to_string(),
+            description_adf: None,
+            status: status.map(String::from),
+            issue_type: None,
+            assignee: assignee.map(String::from),
+            priority: None,
+            labels: vec![],
+        }
+    }
+
+    // ── parse_issue_keys ───────────────────────────────────────────
+
+    #[test]
+    fn parse_keys_basic() {
+        let keys = parse_issue_keys("PROJ-1,PROJ-2,PROJ-3");
+        assert_eq!(keys, vec!["PROJ-1", "PROJ-2", "PROJ-3"]);
+    }
+
+    #[test]
+    fn parse_keys_with_whitespace() {
+        let keys = parse_issue_keys("PROJ-1, PROJ-2 , PROJ-3");
+        assert_eq!(keys, vec!["PROJ-1", "PROJ-2", "PROJ-3"]);
+    }
+
+    #[test]
+    fn parse_keys_single() {
+        let keys = parse_issue_keys("PROJ-1");
+        assert_eq!(keys, vec!["PROJ-1"]);
+    }
+
+    #[test]
+    fn parse_keys_empty() {
+        let keys = parse_issue_keys("");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn parse_keys_trailing_comma() {
+        let keys = parse_issue_keys("PROJ-1,PROJ-2,");
+        assert_eq!(keys, vec!["PROJ-1", "PROJ-2"]);
+    }
+
+    // ── format_date ────────────────────────────────────────────────
+
+    #[test]
+    fn format_date_full_iso() {
+        assert_eq!(format_date(Some("2026-03-15T10:00:00.000Z")), "2026-03-15");
+    }
+
+    #[test]
+    fn format_date_just_date() {
+        assert_eq!(format_date(Some("2026-03-15")), "2026-03-15");
+    }
+
+    #[test]
+    fn format_date_short() {
+        assert_eq!(format_date(Some("2026")), "2026");
+    }
+
+    #[test]
+    fn format_date_none() {
+        assert_eq!(format_date(None), "-");
+    }
+
+    // ── print_sprints ──────────────────────────────────────────────
+
+    #[test]
+    fn print_sprints_empty() {
+        let result = AgileSprintList {
+            sprints: vec![],
+            total: 0,
+        };
+        print_sprints(&result);
+    }
+
+    #[test]
+    fn print_sprints_with_data() {
+        let result = AgileSprintList {
+            sprints: vec![
+                sample_sprint(
+                    10,
+                    "Sprint 1",
+                    "closed",
+                    Some("2026-03-01"),
+                    Some("2026-03-14"),
+                    Some("MVP"),
+                ),
+                sample_sprint(11, "Sprint 2", "active", Some("2026-03-15"), None, None),
+            ],
+            total: 2,
+        };
+        print_sprints(&result);
+    }
+
+    #[test]
+    fn print_sprints_with_pagination() {
+        let result = AgileSprintList {
+            sprints: vec![sample_sprint(10, "Sprint 1", "active", None, None, None)],
+            total: 50,
+        };
+        print_sprints(&result);
+    }
+
+    // ── print_sprint_issues ────────────────────────────────────────
+
+    #[test]
+    fn print_sprint_issues_empty() {
+        let result = JiraSearchResult {
+            issues: vec![],
+            total: 0,
+        };
+        print_sprint_issues(&result);
+    }
+
+    #[test]
+    fn print_sprint_issues_with_data() {
+        let result = JiraSearchResult {
+            issues: vec![
+                sample_issue("PROJ-1", "Fix login", Some("Open"), Some("Alice")),
+                sample_issue("PROJ-2", "Add feature", None, None),
+            ],
+            total: 2,
+        };
+        print_sprint_issues(&result);
+    }
+
+    #[test]
+    fn print_sprint_issues_with_pagination() {
+        let result = JiraSearchResult {
+            issues: vec![sample_issue("PROJ-1", "Issue", Some("Open"), None)],
+            total: 100,
+        };
+        print_sprint_issues(&result);
+    }
+
+    // ── dispatch ───────────────────────────────────────────────────
+
+    #[test]
+    fn sprint_command_list_variant() {
+        let cmd = SprintCommand {
+            command: SprintSubcommands::List(ListCommand {
+                board_id: 1,
+                state: None,
+                max_results: 50,
+            }),
+        };
+        assert!(matches!(cmd.command, SprintSubcommands::List(_)));
+    }
+
+    #[test]
+    fn sprint_command_issues_variant() {
+        let cmd = SprintCommand {
+            command: SprintSubcommands::Issues(IssuesCommand {
+                sprint_id: 10,
+                jql: None,
+                max_results: 50,
+            }),
+        };
+        assert!(matches!(cmd.command, SprintSubcommands::Issues(_)));
+    }
+
+    #[test]
+    fn sprint_command_add_variant() {
+        let cmd = SprintCommand {
+            command: SprintSubcommands::Add(AddCommand {
+                sprint_id: 10,
+                issues: "PROJ-1,PROJ-2".to_string(),
+            }),
+        };
+        assert!(matches!(cmd.command, SprintSubcommands::Add(_)));
+    }
+
+    #[test]
+    fn list_command_with_state() {
+        let cmd = ListCommand {
+            board_id: 1,
+            state: Some("active".to_string()),
+            max_results: 25,
+        };
+        assert_eq!(cmd.state.as_deref(), Some("active"));
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -364,6 +364,7 @@ Commands:
   project     Lists JIRA projects
   field       Manages JIRA field definitions and options
   board       Manages JIRA agile boards
+  sprint      Manages JIRA agile sprints
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -620,6 +621,68 @@ Options:
       --project <PROJECT>          Filter by project key
       --assignee <ASSIGNEE>        Filter by assignee (display name or email)
       --status <STATUS>            Filter by status name
+      --max-results <MAX_RESULTS>  Maximum number of results (default: 50) [default: 50]
+  -h, --help                       Print help
+
+
+================================================================================
+
+omni-dev atlassian jira sprint - Manages JIRA agile sprints
+
+Manages JIRA agile sprints
+
+Usage: sprint <COMMAND>
+
+Commands:
+  list    Lists sprints for a board
+  issues  Lists issues in a sprint
+  add     Adds issues to a sprint
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira sprint add - Adds issues to a sprint
+
+Adds issues to a sprint
+
+Usage: add --sprint-id <SPRINT_ID> --issues <ISSUES>
+
+Options:
+      --sprint-id <SPRINT_ID>  Sprint ID
+      --issues <ISSUES>        Comma-separated issue keys (e.g., "PROJ-1,PROJ-2")
+  -h, --help                   Print help
+
+
+================================================================================
+
+omni-dev atlassian jira sprint issues - Lists issues in a sprint
+
+Lists issues in a sprint
+
+Usage: issues [OPTIONS] --sprint-id <SPRINT_ID>
+
+Options:
+      --sprint-id <SPRINT_ID>      Sprint ID
+      --jql <JQL>                  JQL filter for issues
+      --max-results <MAX_RESULTS>  Maximum number of results (default: 50) [default: 50]
+  -h, --help                       Print help
+
+
+================================================================================
+
+omni-dev atlassian jira sprint list - Lists sprints for a board
+
+Lists sprints for a board
+
+Usage: list [OPTIONS] --board-id <BOARD_ID>
+
+Options:
+      --board-id <BOARD_ID>        Board ID
+      --state <STATE>              Filter by sprint state (active, future, closed)
       --max-results <MAX_RESULTS>  Maximum number of results (default: 50) [default: 50]
   -h, --help                       Print help
 


### PR DESCRIPTION
## Description

This PR implements JIRA agile sprint management commands under the `atlassian jira sprint` subcommand. Users can now list sprints for a board, view issues in a sprint, and add issues to a sprint directly from the CLI. This closes the feature gap between board management (already supported) and sprint-level operations, enabling full agile workflow management through omni-dev.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #306

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `AgileSprint` struct with fields: `id`, `name`, `state`, `start_date`, `end_date`, `goal`
- Added `AgileSprintList` struct wrapping a `Vec<AgileSprint>` with a `total` count
- Added private deserialization types `AgileSprintListResponse` and `AgileSprintEntry` for JIRA API responses
- Implemented `get_sprints(board_id, state, max_results)` calling `GET /rest/agile/1.0/board/{id}/sprint` with optional state filter
- Implemented `get_sprint_issues(sprint_id, jql, max_results)` calling `GET /rest/agile/1.0/sprint/{id}/issue` with optional JQL filtering
- Implemented `add_issues_to_sprint(sprint_id, issue_keys)` calling `POST /rest/agile/1.0/sprint/{id}/issue` for bulk issue assignment

**CLI Sprint Module (`src/cli/atlassian/jira/sprint.rs` — new file):**
- Added `SprintCommand` with three subcommands: `List`, `Issues`, `Add`
- `ListCommand`: accepts `--board-id`, `--state` (optional filter: active/future/closed), `--max-results`
- `IssuesCommand`: accepts `--sprint-id`, `--jql` (optional JQL filter), `--max-results`
- `AddCommand`: accepts `--sprint-id`, `--issues` (comma-separated issue keys, e.g., `PROJ-1,PROJ-2`)
- Implemented `print_sprints()` with dynamic column-width formatted table output and pagination hints
- Implemented `print_sprint_issues()` with dynamic column-width table showing key, status, assignee, and summary
- Implemented `parse_issue_keys()` helper for splitting/trimming comma-separated key lists
- Implemented `format_date()` helper that truncates ISO 8601 timestamps to date-only display

**JIRA CLI Module (`src/cli/atlassian/jira/mod.rs`):**
- Registered `sprint` as a new public module
- Added `Sprint(sprint::SprintCommand)` variant to `JiraSubcommands` enum
- Wired dispatch in `JiraCommand::execute()` for the new sprint variant
- Added unit test `jira_subcommands_sprint_variant` verifying enum dispatch

**Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include `sprint` in the `jira` subcommand listing
- Added full help text for `sprint`, `sprint list`, `sprint issues`, and `sprint add`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Unit Tests Added in `src/atlassian/client.rs`:**
- `get_sprints_success` — verifies successful response parsing with full and partial sprint data
- `get_sprints_with_state_filter` — verifies `state` query param is passed correctly
- `get_sprints_api_error` — verifies 404 errors are surfaced with status code
- `get_sprint_issues_success` — verifies sprint issue list parsing including assignee
- `get_sprint_issues_api_error` — verifies 404 error handling
- `add_issues_to_sprint_success` — verifies 204 No Content success response
- `add_issues_to_sprint_api_error` — verifies 400 error handling

**Unit Tests Added in `src/cli/atlassian/jira/sprint.rs`:**
- `parse_keys_basic`, `parse_keys_with_whitespace`, `parse_keys_single`, `parse_keys_empty`, `parse_keys_trailing_comma` — full coverage of the key parser
- `format_date_full_iso`, `format_date_just_date`, `format_date_short`, `format_date_none` — all branches of date formatting
- `print_sprints_empty`, `print_sprints_with_data`, `print_sprints_with_pagination` — output rendering for sprints
- `print_sprint_issues_empty`, `print_sprint_issues_with_data`, `print_sprint_issues_with_pagination` — output rendering for issues
- `sprint_command_list_variant`, `sprint_command_issues_variant`, `sprint_command_add_variant` — enum dispatch verification
- `list_command_with_state` — verifies state filter is threaded through correctly

**Unit Test Added in `src/cli/atlassian/jira/mod.rs`:**
- `jira_subcommands_sprint_variant` — verifies `Sprint` variant is correctly matched in parent enum

### Test Commands

```bash
# Run all tests
cargo test

# Run only sprint-related tests
cargo test sprint

# Run only Atlassian client tests
cargo test --test '*' -- atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — all three client methods check HTTP status and return structured errors with status code and body
- [x] Architecture changes — sprint module follows the same pattern as the existing `board` module for consistency
- [x] Backward compatibility — purely additive; no existing commands or APIs are modified

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications — sprint operations use the same authenticated `AtlassianClient` as all other JIRA commands; no new credential handling introduced

## Breaking Changes

None. This is a purely additive feature. All existing `atlassian jira` subcommands are unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Support pagination (`--start-at`) for boards with many sprints
- Add `sprint view <sprint-id>` command to show sprint metadata in detail
- Consider adding `--output json` flag for machine-readable output

**Known Limitations:**
- `--max-results` defaults to 50; there is no automatic pagination yet — large boards may require multiple calls with `--start-at` once that flag is added