### PR TITLE
feat(atlassian,cli): add JIRA issue attachment download commands

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -252,6 +252,21 @@ pub struct JiraLinkType {
     pub outward: String,
 }
 
+/// A JIRA issue attachment.
+#[derive(Debug, Clone)]
+pub struct JiraAttachment {
+    /// Attachment ID.
+    pub id: String,
+    /// File name.
+    pub filename: String,
+    /// MIME type (e.g., "image/png", "application/pdf").
+    pub mime_type: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Download URL.
+    pub content_url: String,
+}
+
 /// A JIRA workflow transition.
 #[derive(Debug, Clone)]
 pub struct JiraTransition {
@@ -410,6 +425,27 @@ struct JiraLinkTypeEntry {
     name: String,
     inward: String,
     outward: String,
+}
+
+#[derive(Deserialize)]
+struct JiraAttachmentIssueResponse {
+    fields: JiraAttachmentFields,
+}
+
+#[derive(Deserialize)]
+struct JiraAttachmentFields {
+    #[serde(default)]
+    attachment: Vec<JiraAttachmentEntry>,
+}
+
+#[derive(Deserialize)]
+struct JiraAttachmentEntry {
+    id: String,
+    filename: String,
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    size: u64,
+    content: String,
 }
 
 #[derive(Deserialize)]
@@ -1764,6 +1800,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_bytes_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/file.bin"))
+            .and(wiremock::matchers::header("Accept", "*/*"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(b"binary content"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let data = client
+            .get_bytes(&format!("{}/file.bin", server.uri()))
+            .await
+            .unwrap();
+        assert_eq!(&data[..], b"binary content");
+    }
+
+    #[tokio::test]
+    async fn get_bytes_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/missing.bin"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .get_bytes(&format!("{}/missing.bin", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn get_attachments_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "fields": {
+                        "attachment": [
+                            {"id": "1", "filename": "screenshot.png", "mimeType": "image/png", "size": 12345, "content": "https://org.atlassian.net/attachment/1"},
+                            {"id": "2", "filename": "report.pdf", "mimeType": "application/pdf", "size": 99999, "content": "https://org.atlassian.net/attachment/2"}
+                        ]
+                    }
+                }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let attachments = client.get_attachments("PROJ-1").await.unwrap();
+
+        assert_eq!(attachments.len(), 2);
+        assert_eq!(attachments[0].filename, "screenshot.png");
+        assert_eq!(attachments[0].mime_type, "image/png");
+        assert_eq!(attachments[0].size, 12345);
+        assert_eq!(attachments[1].filename, "report.pdf");
+    }
+
+    #[tokio::test]
+    async fn get_attachments_empty() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"fields": {"attachment": []}})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let attachments = client.get_attachments("PROJ-1").await.unwrap();
+        assert!(attachments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_attachments_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/NOPE-1"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_attachments("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
     async fn get_changelog_success() {
         let server = wiremock::MockServer::start().await;
 
@@ -2224,6 +2359,30 @@ impl AtlassianClient {
             .send()
             .await
             .context("Failed to send POST request to Atlassian API")
+    }
+
+    /// Sends an authenticated GET request and returns raw bytes.
+    pub async fn get_bytes(&self, url: &str) -> Result<Vec<u8>> {
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "*/*")
+            .send()
+            .await
+            .context("Failed to send GET request for binary download")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .context("Failed to read response bytes")?;
+        Ok(bytes.to_vec())
     }
 
     /// Sends an authenticated DELETE request and returns the raw response.
@@ -2860,6 +3019,40 @@ impl AtlassianClient {
             return Err(AtlassianError::ApiRequestFailed { status, body }.into());
         }
         Ok(())
+    }
+
+    /// Gets attachment metadata for a JIRA issue.
+    pub async fn get_attachments(&self, key: &str) -> Result<Vec<JiraAttachment>> {
+        let url = format!(
+            "{}/rest/api/3/issue/{}?fields=attachment",
+            self.instance_url, key
+        );
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: JiraAttachmentIssueResponse = response
+            .json()
+            .await
+            .context("Failed to parse attachment response")?;
+
+        Ok(resp
+            .fields
+            .attachment
+            .into_iter()
+            .map(|a| JiraAttachment {
+                id: a.id,
+                filename: a.filename,
+                mime_type: a.mime_type,
+                size: a.size,
+                content_url: a.content,
+            })
+            .collect())
     }
 
     /// Gets the changelog for a JIRA issue.

--- a/src/cli/atlassian/jira/attachment.rs
+++ b/src/cli/atlassian/jira/attachment.rs
@@ -1,0 +1,335 @@
+//! CLI commands for JIRA issue attachments.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::client::JiraAttachment;
+use crate::cli::atlassian::helpers::create_client;
+
+/// Image MIME types for filtering.
+const IMAGE_MIME_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/svg+xml",
+    "image/webp",
+];
+
+/// Manages JIRA issue attachments.
+#[derive(Parser)]
+pub struct AttachmentCommand {
+    /// The attachment subcommand to execute.
+    #[command(subcommand)]
+    pub command: AttachmentSubcommands,
+}
+
+/// Attachment subcommands.
+#[derive(Subcommand)]
+pub enum AttachmentSubcommands {
+    /// Downloads all attachments (or filtered by pattern).
+    Download(DownloadCommand),
+    /// Downloads only image attachments.
+    Images(ImagesCommand),
+}
+
+impl AttachmentCommand {
+    /// Executes the attachment command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            AttachmentSubcommands::Download(cmd) => cmd.execute().await,
+            AttachmentSubcommands::Images(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Downloads all attachments for an issue.
+#[derive(Parser)]
+pub struct DownloadCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    #[arg(long)]
+    pub key: String,
+
+    /// Output directory (defaults to current directory).
+    #[arg(long, default_value = ".")]
+    pub output_dir: String,
+
+    /// Filter filenames by substring (case-insensitive).
+    #[arg(long)]
+    pub filter: Option<String>,
+}
+
+impl DownloadCommand {
+    /// Fetches attachment metadata and downloads matching files.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let attachments = client.get_attachments(&self.key).await?;
+        let filtered = filter_attachments(&attachments, self.filter.as_deref());
+
+        if filtered.is_empty() {
+            println!("No attachments found.");
+            return Ok(());
+        }
+
+        ensure_dir(&self.output_dir)?;
+
+        for attachment in &filtered {
+            download_file(&client, attachment, &self.output_dir).await?;
+        }
+
+        println!(
+            "Downloaded {} file(s) to {}.",
+            filtered.len(),
+            self.output_dir
+        );
+        Ok(())
+    }
+}
+
+/// Downloads only image attachments for an issue.
+#[derive(Parser)]
+pub struct ImagesCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    #[arg(long)]
+    pub key: String,
+
+    /// Output directory (defaults to current directory).
+    #[arg(long, default_value = ".")]
+    pub output_dir: String,
+}
+
+impl ImagesCommand {
+    /// Fetches attachment metadata and downloads image files.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let attachments = client.get_attachments(&self.key).await?;
+        let images = filter_images(&attachments);
+
+        if images.is_empty() {
+            println!("No image attachments found.");
+            return Ok(());
+        }
+
+        ensure_dir(&self.output_dir)?;
+
+        for attachment in &images {
+            download_file(&client, attachment, &self.output_dir).await?;
+        }
+
+        println!(
+            "Downloaded {} image(s) to {}.",
+            images.len(),
+            self.output_dir
+        );
+        Ok(())
+    }
+}
+
+/// Filters attachments by a case-insensitive substring match on filename.
+fn filter_attachments<'a>(
+    attachments: &'a [JiraAttachment],
+    filter: Option<&str>,
+) -> Vec<&'a JiraAttachment> {
+    match filter {
+        Some(pattern) => {
+            let pattern_lower = pattern.to_lowercase();
+            attachments
+                .iter()
+                .filter(|a| a.filename.to_lowercase().contains(&pattern_lower))
+                .collect()
+        }
+        None => attachments.iter().collect(),
+    }
+}
+
+/// Filters attachments to only images by MIME type.
+fn filter_images(attachments: &[JiraAttachment]) -> Vec<&JiraAttachment> {
+    attachments
+        .iter()
+        .filter(|a| IMAGE_MIME_TYPES.contains(&a.mime_type.as_str()))
+        .collect()
+}
+
+/// Creates the output directory if it doesn't exist.
+fn ensure_dir(dir: &str) -> Result<()> {
+    if !Path::new(dir).exists() {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create output directory: {dir}"))?;
+    }
+    Ok(())
+}
+
+/// Downloads a single attachment to the output directory.
+async fn download_file(
+    client: &crate::atlassian::client::AtlassianClient,
+    attachment: &JiraAttachment,
+    output_dir: &str,
+) -> Result<()> {
+    eprintln!(
+        "Downloading {} ({})...",
+        attachment.filename,
+        format_size(attachment.size)
+    );
+    let data = client.get_bytes(&attachment.content_url).await?;
+    let path = Path::new(output_dir).join(&attachment.filename);
+    fs::write(&path, &data).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Formats a file size for display.
+fn format_size(size: u64) -> String {
+    if size < 1024 {
+        format!("{size} B")
+    } else if size < 1024 * 1024 {
+        format!("{:.1} KB", size as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", size as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn sample_attachment(id: &str, filename: &str, mime_type: &str, size: u64) -> JiraAttachment {
+        JiraAttachment {
+            id: id.to_string(),
+            filename: filename.to_string(),
+            mime_type: mime_type.to_string(),
+            size,
+            content_url: format!("https://org.atlassian.net/attachment/{id}"),
+        }
+    }
+
+    // ── filter_attachments ─────────────────────────────────────────
+
+    #[test]
+    fn filter_no_pattern_returns_all() {
+        let attachments = vec![
+            sample_attachment("1", "file.txt", "text/plain", 100),
+            sample_attachment("2", "image.png", "image/png", 200),
+        ];
+        let result = filter_attachments(&attachments, None);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn filter_by_pattern() {
+        let attachments = vec![
+            sample_attachment("1", "screenshot.png", "image/png", 100),
+            sample_attachment("2", "report.pdf", "application/pdf", 200),
+            sample_attachment("3", "Screenshot_2.png", "image/png", 300),
+        ];
+        let result = filter_attachments(&attachments, Some("screenshot"));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn filter_no_match() {
+        let attachments = vec![sample_attachment("1", "file.txt", "text/plain", 100)];
+        let result = filter_attachments(&attachments, Some("nonexistent"));
+        assert!(result.is_empty());
+    }
+
+    // ── filter_images ──────────────────────────────────────────────
+
+    #[test]
+    fn filter_images_mixed() {
+        let attachments = vec![
+            sample_attachment("1", "photo.png", "image/png", 100),
+            sample_attachment("2", "doc.pdf", "application/pdf", 200),
+            sample_attachment("3", "icon.gif", "image/gif", 50),
+            sample_attachment("4", "page.svg", "image/svg+xml", 75),
+            sample_attachment("5", "hero.webp", "image/webp", 150),
+            sample_attachment("6", "photo.jpg", "image/jpeg", 300),
+        ];
+        let result = filter_images(&attachments);
+        assert_eq!(result.len(), 5);
+    }
+
+    #[test]
+    fn filter_images_none() {
+        let attachments = vec![
+            sample_attachment("1", "doc.pdf", "application/pdf", 200),
+            sample_attachment("2", "data.json", "application/json", 100),
+        ];
+        let result = filter_images(&attachments);
+        assert!(result.is_empty());
+    }
+
+    // ── format_size ────────────────────────────────────────────────
+
+    #[test]
+    fn format_size_bytes() {
+        assert_eq!(format_size(500), "500 B");
+    }
+
+    #[test]
+    fn format_size_kilobytes() {
+        assert_eq!(format_size(2048), "2.0 KB");
+    }
+
+    #[test]
+    fn format_size_megabytes() {
+        assert_eq!(format_size(5_242_880), "5.0 MB");
+    }
+
+    #[test]
+    fn format_size_zero() {
+        assert_eq!(format_size(0), "0 B");
+    }
+
+    // ── ensure_dir ─────────────────────────────────────────────────
+
+    #[test]
+    fn ensure_dir_creates_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let new_dir = temp.path().join("subdir");
+        ensure_dir(new_dir.to_str().unwrap()).unwrap();
+        assert!(new_dir.exists());
+    }
+
+    #[test]
+    fn ensure_dir_existing_is_ok() {
+        let temp = tempfile::tempdir().unwrap();
+        ensure_dir(temp.path().to_str().unwrap()).unwrap();
+    }
+
+    // ── dispatch ───────────────────────────────────────────────────
+
+    #[test]
+    fn attachment_command_download_variant() {
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Download(DownloadCommand {
+                key: "PROJ-1".to_string(),
+                output_dir: ".".to_string(),
+                filter: None,
+            }),
+        };
+        assert!(matches!(cmd.command, AttachmentSubcommands::Download(_)));
+    }
+
+    #[test]
+    fn attachment_command_images_variant() {
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Images(ImagesCommand {
+                key: "PROJ-1".to_string(),
+                output_dir: ".".to_string(),
+            }),
+        };
+        assert!(matches!(cmd.command, AttachmentSubcommands::Images(_)));
+    }
+
+    #[test]
+    fn download_command_with_filter() {
+        let cmd = DownloadCommand {
+            key: "PROJ-1".to_string(),
+            output_dir: "/tmp/out".to_string(),
+            filter: Some("screenshot".to_string()),
+        };
+        assert_eq!(cmd.filter.as_deref(), Some("screenshot"));
+    }
+}

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -1,5 +1,6 @@
 //! JIRA CLI subcommands.
 
+pub(crate) mod attachment;
 pub(crate) mod board;
 pub(crate) mod changelog;
 pub(crate) mod comment;
@@ -57,6 +58,8 @@ pub enum JiraSubcommands {
     Link(link::LinkCommand),
     /// Shows change history for JIRA issues.
     Changelog(changelog::ChangelogCommand),
+    /// Downloads JIRA issue attachments.
+    Attachment(attachment::AttachmentCommand),
 }
 
 impl JiraCommand {
@@ -77,6 +80,7 @@ impl JiraCommand {
             JiraSubcommands::Sprint(cmd) => cmd.execute().await,
             JiraSubcommands::Link(cmd) => cmd.execute().await,
             JiraSubcommands::Changelog(cmd) => cmd.execute().await,
+            JiraSubcommands::Attachment(cmd) => cmd.execute().await,
         }
     }
 }
@@ -255,5 +259,19 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Changelog(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_attachment_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Attachment(attachment::AttachmentCommand {
+                command: attachment::AttachmentSubcommands::Download(attachment::DownloadCommand {
+                    key: "PROJ-1".to_string(),
+                    output_dir: ".".to_string(),
+                    filter: None,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Attachment(_)));
     }
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -367,10 +367,57 @@ Commands:
   sprint      Manages JIRA agile sprints
   link        Manages JIRA issue links
   changelog   Shows change history for JIRA issues
+  attachment  Downloads JIRA issue attachments
   help        Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira attachment - Downloads JIRA issue attachments
+
+Downloads JIRA issue attachments
+
+Usage: attachment <COMMAND>
+
+Commands:
+  download  Downloads all attachments (or filtered by pattern)
+  images    Downloads only image attachments
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira attachment download - Downloads all attachments (or filtered by pattern)
+
+Downloads all attachments (or filtered by pattern)
+
+Usage: download [OPTIONS] --key <KEY>
+
+Options:
+      --key <KEY>                JIRA issue key (e.g., PROJ-123)
+      --output-dir <OUTPUT_DIR>  Output directory (defaults to current directory) [default: .]
+      --filter <FILTER>          Filter filenames by substring (case-insensitive)
+  -h, --help                     Print help
+
+
+================================================================================
+
+omni-dev atlassian jira attachment images - Downloads only image attachments
+
+Downloads only image attachments
+
+Usage: images [OPTIONS] --key <KEY>
+
+Options:
+      --key <KEY>                JIRA issue key (e.g., PROJ-123)
+      --output-dir <OUTPUT_DIR>  Output directory (defaults to current directory) [default: .]
+  -h, --help                     Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR adds attachment retrieval and download functionality for JIRA issues via new CLI subcommands. Users can now download all attachments for a given JIRA issue key or filter to images only, directly from the command line. The implementation adds both the Atlassian client-level API methods and the corresponding CLI surface.

This work is part of the Issue 308 JIRA changelog feature branch and extends the existing `omni-dev atlassian jira` command tree with a new `attachment` subcommand.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Relates to #308

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `JiraAttachment` public struct with fields: `id`, `filename`, `mime_type`, `size`, `content_url`
- Added private deserialization types: `JiraAttachmentIssueResponse`, `JiraAttachmentFields`, `JiraAttachmentEntry`
- Added `get_attachments(key: &str)` method that fetches attachment metadata via `/rest/api/3/issue/{key}?fields=attachment`
- Added `get_bytes(url: &str)` method for authenticated binary downloads returning `Vec<u8>`

**New CLI Module (`src/cli/atlassian/jira/attachment.rs`):**
- Added `AttachmentCommand` with `AttachmentSubcommands` enum (`Download`, `Images`)
- Added `DownloadCommand` with `--key`, `--output-dir`, and `--filter` CLI options; downloads all attachments with optional case-insensitive filename substring filtering
- Added `ImagesCommand` with `--key` and `--output-dir` options; downloads only image attachments (PNG, JPEG, GIF, SVG, WebP)
- Added `filter_attachments()` helper for pattern-based filtering
- Added `filter_images()` helper filtering by MIME type against a known image type list
- Added `ensure_dir()` helper that creates the output directory if it doesn't exist
- Added `format_size()` helper for human-readable file size display (B/KB/MB)
- Added `download_file()` async helper that downloads and writes a single attachment

**JIRA Module Registration (`src/cli/atlassian/jira/mod.rs`):**
- Registered `attachment` as a new `pub(crate)` module
- Added `Attachment(attachment::AttachmentCommand)` variant to `JiraSubcommands` enum
- Wired up dispatch in `JiraCommand::execute` for the new variant

**Snapshot Update (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include `attachment` subcommand listing under `omni-dev atlassian jira`
- Added help output sections for `attachment`, `attachment download`, and `attachment images` subcommands

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Unit Tests added in `src/cli/atlassian/jira/attachment.rs`:**
- `filter_no_pattern_returns_all` — verifies all attachments returned when no filter is set
- `filter_by_pattern` — verifies case-insensitive substring matching (e.g., "screenshot" matches "Screenshot_2.png")
- `filter_no_match` — verifies empty result when filter matches nothing
- `filter_images_mixed` — verifies correct extraction of image MIME types from a mixed attachment list
- `filter_images_none` — verifies empty result when no image attachments are present
- `format_size_bytes`, `format_size_kilobytes`, `format_size_megabytes`, `format_size_zero` — verifies human-readable size formatting
- `ensure_dir_creates_directory` — verifies directory creation using `tempfile`
- `ensure_dir_existing_is_ok` — verifies no error when directory already exists
- `attachment_command_download_variant` — verifies correct enum dispatch for Download subcommand
- `attachment_command_images_variant` — verifies correct enum dispatch for Images subcommand
- `download_command_with_filter` — verifies filter option is correctly stored

**Unit Tests added in `src/atlassian/client.rs`:**
- `get_bytes_success` — verifies binary content download returns correct bytes using wiremock
- `get_bytes_api_error` — verifies 404 error propagation for binary downloads
- `get_attachments_success` — verifies correct deserialization of attachment metadata (2 attachments)
- `get_attachments_empty` — verifies handling of issue with no attachments
- `get_attachments_api_error` — verifies 404 error propagation for attachment metadata fetch

**Integration Test added in `src/cli/atlassian/jira/mod.rs`:**
- `jira_subcommands_attachment_variant` — verifies `Attachment` variant is correctly handled in `JiraSubcommands`

### Test Commands
```bash
# Core test suite
cargo test

# Run attachment-specific tests
cargo test attachment

# Run client-level attachment tests
cargo test get_bytes
cargo test get_attachments

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `get_bytes` and `get_attachments` both check response status and surface API errors with status code and body
- [x] Security implications — all download requests use the existing `auth_header` from `AtlassianClient`; no credentials are exposed in filenames or logs
- [x] Backward compatibility — purely additive change; no existing commands or APIs were modified

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact — downloads are performed sequentially per attachment; no buffering or streaming changes to the core HTTP client

## Security Considerations
- [x] No security implications beyond existing auth — all HTTP requests use the existing authenticated client; binary content is written directly to disk without execution

## Breaking Changes

None. This PR is purely additive: new CLI subcommands, new client methods, and new types. No existing commands, APIs, or data structures were modified.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Support for uploading attachments to JIRA issues
- Parallel/concurrent download support for issues with many attachments
- Progress bar display for large file downloads

**Known Limitations:**
- Downloads are sequential; large attachment sets may be slow
- The `--filter` option on `download` matches substrings only; regex support is not included

**Alternatives Considered:**
- Streaming downloads to disk (vs. buffering full response in memory): opted for simplicity given typical attachment sizes; can be revisited if large file support is needed