### PR TITLE
fix(atlassian): update JIRA search endpoint and handle missing total field

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -310,6 +310,7 @@ struct JiraAssigneeField {
 #[derive(Deserialize)]
 struct JiraSearchResponse {
     issues: Vec<JiraIssueResponse>,
+    #[serde(default)]
     total: u32,
 }
 
@@ -935,7 +936,7 @@ mod tests {
         });
 
         wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/rest/api/3/search"))
+            .and(wiremock::matchers::path("/rest/api/3/search/jql"))
             .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&search_json))
             .expect(1)
             .mount(&server)
@@ -954,11 +955,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_issues_without_total() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/search/jql"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "issues": [{
+                        "key": "PROJ-1",
+                        "fields": {
+                            "summary": "Test",
+                            "description": null,
+                            "status": null,
+                            "issuetype": null,
+                            "assignee": null,
+                            "priority": null,
+                            "labels": []
+                        }
+                    }]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.search_issues("project = PROJ", 50).await.unwrap();
+
+        assert_eq!(result.issues.len(), 1);
+        // total falls back to issues count when not in response
+        assert_eq!(result.total, 1);
+    }
+
+    #[tokio::test]
     async fn search_issues_empty_results() {
         let server = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/rest/api/3/search"))
+            .and(wiremock::matchers::path("/rest/api/3/search/jql"))
             .respond_with(
                 wiremock::ResponseTemplate::new(200)
                     .set_body_json(serde_json::json!({"issues": [], "total": 0})),
@@ -979,7 +1014,7 @@ mod tests {
         let server = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/rest/api/3/search"))
+            .and(wiremock::matchers::path("/rest/api/3/search/jql"))
             .respond_with(wiremock::ResponseTemplate::new(400).set_body_string("Invalid JQL query"))
             .expect(1)
             .mount(&server)
@@ -2634,7 +2669,7 @@ impl AtlassianClient {
 
     /// Searches JIRA issues using JQL.
     pub async fn search_issues(&self, jql: &str, max_results: u32) -> Result<JiraSearchResult> {
-        let url = format!("{}/rest/api/3/search", self.instance_url);
+        let url = format!("{}/rest/api/3/search/jql", self.instance_url);
 
         let body = serde_json::json!({
             "jql": jql,
@@ -2658,7 +2693,7 @@ impl AtlassianClient {
             .await
             .context("Failed to parse JIRA search response")?;
 
-        let issues = search_response
+        let issues: Vec<JiraIssue> = search_response
             .issues
             .into_iter()
             .map(|r| JiraIssue {
@@ -2673,10 +2708,13 @@ impl AtlassianClient {
             })
             .collect();
 
-        Ok(JiraSearchResult {
-            issues,
-            total: search_response.total,
-        })
+        let total = if search_response.total > 0 {
+            search_response.total
+        } else {
+            issues.len() as u32
+        };
+
+        Ok(JiraSearchResult { issues, total })
     }
 
     /// Searches Confluence pages using CQL.


### PR DESCRIPTION
## Description

This PR fixes the JIRA search API integration in `src/atlassian/client.rs` to address two issues discovered with the JIRA REST API (Issue #317):

1. **Wrong search endpoint**: The `search_issues` method was calling `/rest/api/3/search` but JIRA's JQL-specific endpoint is `/rest/api/3/search/jql`. Using the incorrect endpoint caused search requests to fail or behave unexpectedly.

2. **Missing `total` field handling**: Some JIRA API responses omit the `total` field from the search response body. Without `#[serde(default)]`, deserialization would fail entirely when this field was absent. The fix adds a sensible fallback: when `total` is zero or missing from the response, it falls back to `issues.len()` as the total count.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #317

## Changes Made

**Core Changes:**
- Changed `search_issues` URL from `/rest/api/3/search` to `/rest/api/3/search/jql` to use the correct JQL search endpoint
- Added `#[serde(default)]` to the `total` field in `JiraSearchResponse` struct to gracefully handle responses that omit the field
- Added fallback logic: when `search_response.total` is zero (indicating absent or explicitly zero), total is derived from `issues.len() as u32`
- Added explicit type annotation `Vec<JiraIssue>` to the `issues` binding for clarity after the collect

**Testing:**
- Added `search_issues_without_total` async test covering the case where the API response omits the `total` field — verifies that `result.total` correctly falls back to `issues.len()`
- Updated `search_issues_empty_results` test to expect `/rest/api/3/search/jql` endpoint path
- Updated `search_issues_bad_request` test to expect `/rest/api/3/search/jql` endpoint path
- Updated existing `search_issues` happy-path test to expect `/rest/api/3/search/jql` endpoint path

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`search_issues_without_total`)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested error/edge cases (missing `total` field in response)
- [x] Backward compatibility verified (fallback logic is non-breaking)

### Test Commands

```bash
# Core test suite
cargo test

# Run only atlassian client tests
cargo test --lib atlassian::client

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — specifically the `total` fallback logic: when `total == 0` we assume it was absent and fall back to `issues.len()`. This is correct for the missing-field case but note that a legitimate empty result set (zero issues) will also result in `total = 0` via the fallback, which is still accurate.
- [x] Backward compatibility — existing callers of `search_issues` are unaffected; the method signature and return type are unchanged.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The `search_issues` method signature and `JiraSearchResult` return type are unchanged. The endpoint correction and total fallback are transparent to callers.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The fallback logic uses `total == 0` as a proxy for "total was absent from the response." This means a genuine response with `total: 0` (empty result set) will also go through the fallback path, but since the fallback computes `issues.len()` which would also be `0` in that case, the result is still correct.

**Alternatives Considered:**
- Using `Option<u32>` for the `total` field instead of `#[serde(default)]` was considered, but `serde(default)` is simpler and keeps the rest of the code working with a `u32` directly without unwrapping.