### PR TITLE
fix(atlassian,cli): add --purge flag and improve 404 error message for confluence delete

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -344,14 +344,24 @@ impl ConfluenceApi {
     }
 
     /// Deletes a Confluence page.
-    pub async fn delete_page(&self, id: &str) -> Result<()> {
-        let url = format!("{}/wiki/api/v2/pages/{}", self.client.instance_url(), id);
+    pub async fn delete_page(&self, id: &str, purge: bool) -> Result<()> {
+        let mut url = format!("{}/wiki/api/v2/pages/{}", self.client.instance_url(), id);
+        if purge {
+            url.push_str("?purge=true");
+        }
 
         let response = self.client.delete(&url).await?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
             let body = response.text().await.unwrap_or_default();
+            if status == 404 {
+                anyhow::bail!(
+                    "Page {id} not found or insufficient permissions. \
+                     Confluence returns 404 when the API user lacks space-level delete permission. \
+                     Check Space Settings > Permissions."
+                );
+            }
             return Err(AtlassianError::ApiRequestFailed { status, body }.into());
         }
 
@@ -830,12 +840,30 @@ mod tests {
 
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let api = ConfluenceApi::new(client);
-        let result = api.delete_page("12345").await;
+        let result = api.delete_page("12345", false).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn delete_page_not_found() {
+    async fn delete_page_with_purge() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::query_param("purge", "true"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = api.delete_page("12345", true).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_page_not_found_hints_permissions() {
         let server = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("DELETE"))
@@ -847,8 +875,10 @@ mod tests {
 
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let api = ConfluenceApi::new(client);
-        let err = api.delete_page("99999").await.unwrap_err();
-        assert!(err.to_string().contains("404"));
+        let err = api.delete_page("99999", false).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found or insufficient permissions"));
+        assert!(msg.contains("Space Settings"));
     }
 
     #[tokio::test]
@@ -864,7 +894,7 @@ mod tests {
 
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let api = ConfluenceApi::new(client);
-        let err = api.delete_page("12345").await.unwrap_err();
+        let err = api.delete_page("12345", false).await.unwrap_err();
         assert!(err.to_string().contains("403"));
     }
 

--- a/src/cli/atlassian/confluence/delete.rs
+++ b/src/cli/atlassian/confluence/delete.rs
@@ -18,6 +18,10 @@ pub struct DeleteCommand {
     /// Skips the confirmation prompt.
     #[arg(long)]
     pub force: bool,
+
+    /// Permanently purges the page instead of moving to trash (requires space admin).
+    #[arg(long)]
+    pub purge: bool,
 }
 
 impl DeleteCommand {
@@ -35,7 +39,7 @@ impl DeleteCommand {
             }
         }
 
-        api.delete_page(&self.id).await?;
+        api.delete_page(&self.id, self.purge).await?;
         println!("Deleted page {} from {}.", self.id, instance_url);
 
         Ok(())
@@ -70,9 +74,11 @@ mod tests {
         let cmd = DeleteCommand {
             id: "12345".to_string(),
             force: false,
+            purge: false,
         };
         assert_eq!(cmd.id, "12345");
         assert!(!cmd.force);
+        assert!(!cmd.purge);
     }
 
     #[test]
@@ -80,8 +86,19 @@ mod tests {
         let cmd = DeleteCommand {
             id: "12345".to_string(),
             force: true,
+            purge: false,
         };
         assert!(cmd.force);
+    }
+
+    #[test]
+    fn delete_command_purge_mode() {
+        let cmd = DeleteCommand {
+            id: "12345".to_string(),
+            force: true,
+            purge: true,
+        };
+        assert!(cmd.purge);
     }
 
     // ── format_delete_prompt ───────────────────────────────────────

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -124,6 +124,7 @@ mod tests {
             command: ConfluenceSubcommands::Delete(delete::DeleteCommand {
                 id: "12345".to_string(),
                 force: true,
+                purge: false,
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Delete(_)));

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -226,6 +226,7 @@ Arguments:
 
 Options:
       --force  Skips the confirmation prompt
+      --purge  Permanently purges the page instead of moving to trash (requires space admin)
   -h, --help   Print help
 
 


### PR DESCRIPTION
## Description

This PR fixes Issue #318 by improving the Confluence delete command in two ways:

1. **Adds a `--purge` flag** that permanently deletes pages instead of moving them to trash. When `--purge` is passed, the API request appends `?purge=true` to the DELETE URL, which bypasses the Confluence trash and permanently removes the page. This operation requires space admin privileges.

2. **Improves the 404 error message** to surface actionable guidance. Previously, a 404 response from the Confluence API only surfaced the raw status code, leaving users confused. The underlying cause is that Confluence returns 404 (not 403) when the API user lacks space-level delete permission — a Confluence API quirk that is non-obvious and difficult to diagnose. The new error message explains this behaviour and directs users to check Space Settings > Permissions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #318

## Changes Made

**Core Changes:**
- Added `purge: bool` field to `DeleteCommand` struct in `src/cli/atlassian/confluence/delete.rs` with `--purge` CLI flag and doc comment
- Updated `delete_page` API method signature in `src/atlassian/confluence_api.rs` to accept a `purge: bool` parameter
- Appended `?purge=true` query parameter to the DELETE request URL when `purge` is `true`
- Added specific 404 handling in `delete_page` that returns a descriptive `anyhow::bail!` message explaining the permission issue and directing users to Space Settings > Permissions
- Updated call site in `DeleteCommand::run` to pass `self.purge` through to the API layer
- Updated existing struct literal tests in `src/cli/atlassian/confluence/mod.rs` to include the new `purge` field

**Testing:**
- Added `delete_page_with_purge` integration test in `confluence_api.rs` that uses `wiremock` to assert the `purge=true` query param is included in the DELETE request
- Renamed `delete_page_not_found` test to `delete_page_not_found_hints_permissions` and updated assertions to verify the error message contains `"not found or insufficient permissions"` and `"Space Settings"` instead of just `"404"`
- Added `delete_command_purge_mode` unit test in `delete.rs` verifying the `purge` flag is set correctly
- Updated existing `delete_command_default` and `delete_command_force` tests to include the new `purge: false` field

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run Confluence-specific tests
cargo test confluence

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the 404 branch in `confluence_api.rs` is the primary fix for Issue #318; verify the message is clear and accurate
- [x] User experience — the `--purge` flag should only be exercised by users with space admin privileges; the CLI help text communicates this constraint
- [x] Backward compatibility — all existing call sites of `delete_page` have been updated to pass `false` for `purge`, preserving existing behaviour

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

The `--purge` flag is gated behind Confluence's own space admin permission check server-side; no additional client-side guards are required.

## Breaking Changes

None. The `purge: bool` parameter added to `delete_page` is an internal API change; all existing callers have been updated. The CLI interface is purely additive — the `--purge` flag is optional and defaults to `false`.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The `--purge` operation requires the API user to have space admin privileges in Confluence. If that privilege is absent, Confluence will likely return a 403, which surfaces the raw status code as before.

**Alternatives Considered:**
- Returning the raw 404 body text alongside the status code was considered, but the Confluence API body for this case is typically uninformative JSON, so a crafted human-readable message was preferred.