### PR TITLE
fix(atlassian,cli): auto-discover field context when fetching jira field options

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -517,6 +517,16 @@ struct JiraFieldSchema {
 }
 
 #[derive(Deserialize)]
+struct JiraFieldContextsResponse {
+    values: Vec<JiraFieldContextEntry>,
+}
+
+#[derive(Deserialize)]
+struct JiraFieldContextEntry {
+    id: String,
+}
+
+#[derive(Deserialize)]
 struct JiraFieldOptionsResponse {
     values: Vec<JiraFieldOptionEntry>,
 }
@@ -2206,12 +2216,127 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_field_options_success() {
+    async fn get_field_contexts_success() {
         let server = wiremock::MockServer::start().await;
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path(
-                "/rest/api/3/field/customfield_10001/context/default/option",
+                "/rest/api/3/field/customfield_10001/context",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"values": [{"id": "12345"}, {"id": "67890"}]}),
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let contexts = client
+            .get_field_contexts("customfield_10001")
+            .await
+            .unwrap();
+
+        assert_eq!(contexts.len(), 2);
+        assert_eq!(contexts[0], "12345");
+    }
+
+    #[tokio::test]
+    async fn get_field_contexts_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/customfield_99999/context",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"values": []})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let contexts = client
+            .get_field_contexts("customfield_99999")
+            .await
+            .unwrap();
+        assert!(contexts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_field_options_auto_discovers_context() {
+        let server = wiremock::MockServer::start().await;
+
+        // Context discovery
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/customfield_10001/context",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"values": [{"id": "12345"}]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Options for discovered context
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/customfield_10001/context/12345/option",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"values": [{"id": "1", "value": "High"}]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let options = client
+            .get_field_options("customfield_10001", None)
+            .await
+            .unwrap();
+
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0].value, "High");
+    }
+
+    #[tokio::test]
+    async fn get_field_options_no_context_errors() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/customfield_99999/context",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"values": []})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .get_field_options("customfield_99999", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("No contexts found"));
+    }
+
+    #[tokio::test]
+    async fn get_field_options_with_explicit_context() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/customfield_10001/context/12345/option",
             ))
             .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
                 serde_json::json!({"values": [
@@ -2226,7 +2351,7 @@ mod tests {
 
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let options = client
-            .get_field_options("customfield_10001", None)
+            .get_field_options("customfield_10001", Some("12345"))
             .await
             .unwrap();
 
@@ -2268,7 +2393,7 @@ mod tests {
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path(
-                "/rest/api/3/field/nonexistent/context/default/option",
+                "/rest/api/3/field/nonexistent/context/99999/option",
             ))
             .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
             .expect(1)
@@ -2277,7 +2402,7 @@ mod tests {
 
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let err = client
-            .get_field_options("nonexistent", None)
+            .get_field_options("nonexistent", Some("99999"))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("404"));
@@ -3430,12 +3555,49 @@ impl AtlassianClient {
     }
 
     /// Lists options for a JIRA custom field.
+    /// Lists contexts for a JIRA custom field.
+    pub async fn get_field_contexts(&self, field_id: &str) -> Result<Vec<String>> {
+        let url = format!(
+            "{}/rest/api/3/field/{}/context",
+            self.instance_url, field_id
+        );
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: JiraFieldContextsResponse = response
+            .json()
+            .await
+            .context("Failed to parse field contexts response")?;
+
+        Ok(resp.values.into_iter().map(|c| c.id).collect())
+    }
+
+    /// Lists options for a JIRA custom field.
+    ///
+    /// When `context_id` is `None`, auto-discovers the first context for the field.
     pub async fn get_field_options(
         &self,
         field_id: &str,
         context_id: Option<&str>,
     ) -> Result<Vec<JiraFieldOption>> {
-        let ctx = context_id.unwrap_or("default");
+        let ctx = if let Some(id) = context_id {
+            id.to_string()
+        } else {
+            let contexts = self.get_field_contexts(field_id).await?;
+            contexts.into_iter().next().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No contexts found for field \"{field_id}\". \
+                     Use --context-id to specify one explicitly."
+                )
+            })?
+        };
+
         let url = format!(
             "{}/rest/api/3/field/{}/context/{}/option",
             self.instance_url, field_id, ctx

--- a/src/cli/atlassian/jira/field.rs
+++ b/src/cli/atlassian/jira/field.rs
@@ -59,7 +59,7 @@ pub struct OptionsCommand {
     #[arg(long)]
     pub field_id: String,
 
-    /// Context ID (defaults to "default").
+    /// Context ID (auto-discovered if omitted).
     #[arg(long)]
     pub context_id: Option<String>,
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -622,7 +622,7 @@ Usage: options [OPTIONS] --field-id <FIELD_ID>
 
 Options:
       --field-id <FIELD_ID>      Field ID (e.g., "customfield_10001")
-      --context-id <CONTEXT_ID>  Context ID (defaults to "default")
+      --context-id <CONTEXT_ID>  Context ID (auto-discovered if omitted)
   -h, --help                     Print help
 
 


### PR DESCRIPTION
## Description

Fixes Issue #319 where fetching Jira field options required users to know and specify the internal context ID. Previously, the code hardcoded `"default"` as a fallback when no `--context-id` was provided. In practice, Jira instances rarely use `"default"` as a context ID, causing silent failures or incorrect behavior.

This PR replaces the hardcoded `"default"` context fallback with automatic context discovery via the Jira API. When no `--context-id` is provided, the client now queries `GET /rest/api/3/field/{id}/context` to retrieve available context IDs and uses the first one found. If no contexts exist, a clear error message is returned guiding the user to specify one explicitly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #319

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `get_field_contexts` method that calls `GET /rest/api/3/field/{id}/context` to retrieve available context IDs for a custom field
- Added `JiraFieldContextsResponse` and `JiraFieldContextEntry` deserialization structs to support the new API response format
- Updated `get_field_options` to auto-discover the first available context when `context_id` is `None`, instead of falling back to the hardcoded string `"default"`
- Added a clear error message when no contexts are found: `"No contexts found for field \"...\". Use --context-id to specify one explicitly."`

**CLI Changes (`src/cli/atlassian/jira/field.rs`):**
- Updated `--context-id` argument help text from `"Context ID (defaults to \"default\")"` to `"Context ID (auto-discovered if omitted)"` to accurately reflect the new behavior

**Testing (`src/atlassian/client.rs` tests):**
- Added `get_field_contexts_success` test: verifies successful context list retrieval from the Jira API
- Added `get_field_contexts_empty` test: verifies an empty context list is handled correctly
- Added `get_field_options_auto_discovers_context` test: end-to-end verification that options are fetched using a dynamically discovered context ID
- Added `get_field_options_no_context_errors` test: verifies a clear error is returned when no contexts exist and no explicit context is provided
- Added `get_field_options_with_explicit_context` test: verifies that providing an explicit `--context-id` bypasses auto-discovery and calls the expected endpoint directly
- Updated existing tests that previously used `None` (which relied on the old `"default"` fallback) to pass an explicit context ID instead

**Snapshot Updates (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated snapshot to reflect new `--context-id` help text

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (5 new unit tests covering success, empty, auto-discovery, explicit context, and error cases)
- [x] Integration tests updated (help output snapshot updated to reflect new CLI text)

**Manual Testing:**
- [x] Tested happy path scenarios (auto-discovery finds and uses first context)
- [x] Tested error/edge cases (no contexts available returns descriptive error)
- [x] Backward compatibility verified (explicit `--context-id` still works as before)

### Test Commands
```bash
# Core test suite
cargo test

# Run Atlassian client tests specifically
cargo test atlassian::client

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the new error message for missing contexts should be clear and actionable
- [x] Backward compatibility — existing callers passing an explicit `context_id: Some("...")` are unaffected; behavior only changes when `None` is passed
- [x] Architecture changes — the new `get_field_contexts` method is a standalone public API method and can be reused independently

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Potential performance impact — when `--context-id` is omitted, an additional API call to `GET /rest/api/3/field/{id}/context` is made before fetching options. This is a single lightweight GET request and is only incurred when auto-discovery is needed. Users who provide an explicit `--context-id` incur no additional overhead.

## Security Considerations

- [x] No security implications — this change only affects how context IDs are resolved; no authentication, authorization, or sensitive data handling is modified.

## Breaking Changes

None. The change in behavior only affects the `None` context ID code path, which previously used the hardcoded string `"default"`. Since `"default"` is not a valid context ID in standard Jira installations, the previous behavior was effectively broken for most users. Callers that pass an explicit `context_id` are completely unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `"default"` as the fallback and requiring users to always specify `--context-id`: rejected because it creates a poor UX and requires internal Jira knowledge that most users don't have.
- Fetching all contexts and letting users select interactively: deferred as a future enhancement; auto-selecting the first context covers the common case where fields have exactly one context.

**Known Limitations:**
- When a field has multiple contexts, auto-discovery always picks the first one returned by the API. Users with multi-context fields should use `--context-id` to specify the desired context explicitly.