### PR TITLE
test(atlassian): add test coverage for get_field_contexts 404 error response

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -2243,6 +2243,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_field_contexts_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/field/nonexistent/context",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_field_contexts("nonexistent").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
     async fn get_field_contexts_empty() {
         let server = wiremock::MockServer::start().await;
 


### PR DESCRIPTION
## Description

This PR improves test coverage for the Atlassian client's `get_field_contexts` API method by adding a test case that verifies correct HTTP 404 error propagation. The change addresses Issue #319, which identified gaps in field options context coverage for API error handling paths.

Previously, only the happy path (successful responses and empty results) was tested for `get_field_contexts`. This PR ensures the client correctly surfaces HTTP error responses to callers, which is critical for robust error handling in production usage.

## Type of Change

- [x] Test coverage improvement

## Related Issue

Fixes #319

## Changes Made

**Testing:**
- Added `get_field_contexts_api_error` async test in `src/atlassian/client.rs`
- Test uses `wiremock` to mock `GET /rest/api/3/field/nonexistent/context` returning HTTP 404
- Asserts that the resulting error message contains `"404"`, confirming proper error propagation from the Atlassian client

**Documentation:**
- No documentation changes required; this is a test-only change

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added (not applicable)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested error/edge cases (404 HTTP error propagation verified via mock server)
- [x] Backward compatibility verified (test-only change, no production code modified)

### Test Commands
```bash
# Core test suite
cargo test

# Run Atlassian client tests specifically
cargo test --test '*' atlassian::client

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — verify the assertion `err.to_string().contains("404")` is the appropriate way to confirm error propagation in this client

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Context:**
- The new test `get_field_contexts_api_error` is inserted immediately before the existing `get_field_contexts_empty` test in `src/atlassian/client.rs`, maintaining logical grouping of tests for this API method.
- This is a purely additive test-only change with zero impact on production code paths.