### PR TITLE
feat(atlassian,cli): add jira issue link list command

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -256,6 +256,21 @@ pub struct JiraLinkType {
     pub outward: String,
 }
 
+/// A link on a JIRA issue.
+#[derive(Debug, Clone)]
+pub struct JiraIssueLink {
+    /// Link ID (used for removal).
+    pub id: String,
+    /// Link type name.
+    pub link_type: String,
+    /// Direction: "inward" or "outward".
+    pub direction: String,
+    /// The linked issue key.
+    pub linked_issue_key: String,
+    /// The linked issue summary.
+    pub linked_issue_summary: String,
+}
+
 /// A JIRA issue attachment.
 #[derive(Debug, Clone)]
 pub struct JiraAttachment {
@@ -436,6 +451,44 @@ struct AgileSprintEntry {
     #[serde(rename = "endDate")]
     end_date: Option<String>,
     goal: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinksResponse {
+    fields: JiraIssueLinksFields,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinksFields {
+    #[serde(default)]
+    issuelinks: Vec<JiraIssueLinkEntry>,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinkEntry {
+    id: String,
+    #[serde(rename = "type")]
+    link_type: JiraIssueLinkType,
+    #[serde(rename = "inwardIssue")]
+    inward_issue: Option<JiraIssueLinkIssue>,
+    #[serde(rename = "outwardIssue")]
+    outward_issue: Option<JiraIssueLinkIssue>,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinkType {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinkIssue {
+    key: String,
+    fields: Option<JiraIssueLinkIssueFields>,
+}
+
+#[derive(Deserialize)]
+struct JiraIssueLinkIssueFields {
+    summary: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1863,6 +1916,83 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn get_issue_links_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "fields": {
+                        "issuelinks": [
+                            {
+                                "id": "100",
+                                "type": {"name": "Blocks"},
+                                "outwardIssue": {"key": "PROJ-2", "fields": {"summary": "Blocked issue"}}
+                            },
+                            {
+                                "id": "101",
+                                "type": {"name": "Relates"},
+                                "inwardIssue": {"key": "PROJ-3", "fields": {"summary": "Related issue"}}
+                            }
+                        ]
+                    }
+                }),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let links = client.get_issue_links("PROJ-1").await.unwrap();
+
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].id, "100");
+        assert_eq!(links[0].link_type, "Blocks");
+        assert_eq!(links[0].direction, "outward");
+        assert_eq!(links[0].linked_issue_key, "PROJ-2");
+        assert_eq!(links[0].linked_issue_summary, "Blocked issue");
+        assert_eq!(links[1].id, "101");
+        assert_eq!(links[1].direction, "inward");
+        assert_eq!(links[1].linked_issue_key, "PROJ-3");
+    }
+
+    #[tokio::test]
+    async fn get_issue_links_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"fields": {"issuelinks": []}})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let links = client.get_issue_links("PROJ-1").await.unwrap();
+        assert!(links.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_issue_links_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/NOPE-1"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_issue_links("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
     }
 
     #[tokio::test]
@@ -3382,6 +3512,54 @@ impl AtlassianClient {
         }
 
         Ok(())
+    }
+
+    /// Lists links on a JIRA issue.
+    pub async fn get_issue_links(&self, key: &str) -> Result<Vec<JiraIssueLink>> {
+        let url = format!(
+            "{}/rest/api/3/issue/{}?fields=issuelinks",
+            self.instance_url, key
+        );
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: JiraIssueLinksResponse = response
+            .json()
+            .await
+            .context("Failed to parse issue links response")?;
+
+        let mut links = Vec::new();
+        for entry in resp.fields.issuelinks {
+            if let Some(inward) = entry.inward_issue {
+                links.push(JiraIssueLink {
+                    id: entry.id.clone(),
+                    link_type: entry.link_type.name.clone(),
+                    direction: "inward".to_string(),
+                    linked_issue_key: inward.key,
+                    linked_issue_summary: inward.fields.and_then(|f| f.summary).unwrap_or_default(),
+                });
+            }
+            if let Some(outward) = entry.outward_issue {
+                links.push(JiraIssueLink {
+                    id: entry.id,
+                    link_type: entry.link_type.name,
+                    direction: "outward".to_string(),
+                    linked_issue_key: outward.key,
+                    linked_issue_summary: outward
+                        .fields
+                        .and_then(|f| f.summary)
+                        .unwrap_or_default(),
+                });
+            }
+        }
+
+        Ok(links)
     }
 
     /// Lists available issue link types.

--- a/src/cli/atlassian/jira/link.rs
+++ b/src/cli/atlassian/jira/link.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use crate::atlassian::client::JiraLinkType;
+use crate::atlassian::client::{JiraIssueLink, JiraLinkType};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA issue links.
@@ -17,6 +17,8 @@ pub struct LinkCommand {
 /// Link subcommands.
 #[derive(Subcommand)]
 pub enum LinkSubcommands {
+    /// Lists links on a JIRA issue.
+    List(ListLinksCommand),
     /// Lists available issue link types.
     Types(TypesCommand),
     /// Creates a link between two issues.
@@ -31,11 +33,29 @@ impl LinkCommand {
     /// Executes the link command.
     pub async fn execute(self) -> Result<()> {
         match self.command {
+            LinkSubcommands::List(cmd) => cmd.execute().await,
             LinkSubcommands::Types(cmd) => cmd.execute().await,
             LinkSubcommands::Create(cmd) => cmd.execute().await,
             LinkSubcommands::Remove(cmd) => cmd.execute().await,
             LinkSubcommands::Epic(cmd) => cmd.execute().await,
         }
+    }
+}
+
+/// Lists links on a JIRA issue.
+#[derive(Parser)]
+pub struct ListLinksCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
+}
+
+impl ListLinksCommand {
+    /// Fetches and displays issue links.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let links = client.get_issue_links(&self.key).await?;
+        print_issue_links(&self.key, &links);
+        Ok(())
     }
 }
 
@@ -135,7 +155,53 @@ fn format_link_direction(type_name: &str) -> &str {
     }
 }
 
-/// Prints link types as a formatted table.
+/// Prints issue links as a formatted table.
+fn print_issue_links(key: &str, links: &[JiraIssueLink]) {
+    if links.is_empty() {
+        println!("{key}: no links.");
+        return;
+    }
+
+    let id_width = links.iter().map(|l| l.id.len()).max().unwrap_or(2).max(2);
+    let type_width = links
+        .iter()
+        .map(|l| l.link_type.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let dir_width = 7; // "outward" is the longest
+    let key_width = links
+        .iter()
+        .map(|l| l.linked_issue_key.len())
+        .max()
+        .unwrap_or(3)
+        .max(3);
+
+    println!(
+        "{:<id_width$}  {:<type_width$}  {:<dir_width$}  {:<key_width$}  SUMMARY",
+        "ID", "TYPE", "DIR", "KEY"
+    );
+    let summary_sep = "-".repeat(7);
+    println!(
+        "{:<id_width$}  {:<type_width$}  {:<dir_width$}  {:<key_width$}  {summary_sep}",
+        "-".repeat(id_width),
+        "-".repeat(type_width),
+        "-".repeat(dir_width),
+        "-".repeat(key_width),
+    );
+
+    for link in links {
+        println!(
+            "{:<id_width$}  {:<type_width$}  {:<dir_width$}  {:<key_width$}  {}",
+            link.id,
+            link.link_type,
+            link.direction,
+            link.linked_issue_key,
+            link.linked_issue_summary
+        );
+    }
+}
+
 fn print_link_types(types: &[JiraLinkType]) {
     if types.is_empty() {
         println!("No link types found.");
@@ -224,7 +290,49 @@ mod tests {
         print_link_types(&types);
     }
 
+    // ── print_issue_links ───────────────────────────────────────────
+
+    fn sample_link(
+        id: &str,
+        link_type: &str,
+        direction: &str,
+        key: &str,
+        summary: &str,
+    ) -> JiraIssueLink {
+        JiraIssueLink {
+            id: id.to_string(),
+            link_type: link_type.to_string(),
+            direction: direction.to_string(),
+            linked_issue_key: key.to_string(),
+            linked_issue_summary: summary.to_string(),
+        }
+    }
+
+    #[test]
+    fn print_issue_links_empty() {
+        print_issue_links("PROJ-1", &[]);
+    }
+
+    #[test]
+    fn print_issue_links_with_data() {
+        let links = vec![
+            sample_link("100", "Blocks", "outward", "PROJ-2", "Blocked issue"),
+            sample_link("101", "Relates", "inward", "PROJ-3", "Related issue"),
+        ];
+        print_issue_links("PROJ-1", &links);
+    }
+
     // ── dispatch ───────────────────────────────────────────────────
+
+    #[test]
+    fn link_command_list_variant() {
+        let cmd = LinkCommand {
+            command: LinkSubcommands::List(ListLinksCommand {
+                key: "PROJ-1".to_string(),
+            }),
+        };
+        assert!(matches!(cmd.command, LinkSubcommands::List(_)));
+    }
 
     #[test]
     fn link_command_types_variant() {

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -635,6 +635,7 @@ Manages JIRA issue links
 Usage: link <COMMAND>
 
 Commands:
+  list    Lists links on a JIRA issue
   types   Lists available issue link types
   create  Creates a link between two issues
   remove  Removes an issue link by ID
@@ -672,6 +673,21 @@ Options:
       --epic <EPIC>    Epic issue key
       --issue <ISSUE>  Issue key to link to the epic
   -h, --help           Print help
+
+
+================================================================================
+
+omni-dev atlassian jira link list - Lists links on a JIRA issue
+
+Lists links on a JIRA issue
+
+Usage: list <KEY>
+
+Arguments:
+  <KEY>  JIRA issue key (e.g., PROJ-123)
+
+Options:
+  -h, --help  Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements the `omni-dev atlassian jira link list` subcommand (Issue #320), which fetches and displays all links on a given JIRA issue in a formatted table. Users can now quickly inspect all issue relationships (blocks, relates to, etc.) for any JIRA issue directly from the CLI, showing the link ID, type, direction, linked issue key, and summary.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #320

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `JiraIssueLink` public struct with fields: `id`, `link_type`, `direction`, `linked_issue_key`, and `linked_issue_summary`
- Added private deserialization structs: `JiraIssueLinksResponse`, `JiraIssueLinksFields`, `JiraIssueLinkEntry`, `JiraIssueLinkType`, `JiraIssueLinkIssue`, `JiraIssueLinkIssueFields`
- Implemented `get_issue_links(&self, key: &str) -> Result<Vec<JiraIssueLink>>` on `AtlassianClient`, querying `GET /rest/api/3/issue/{key}?fields=issuelinks` and mapping both inward and outward issue entries into the unified `JiraIssueLink` struct

**CLI Changes (`src/cli/atlassian/jira/link.rs`):**
- Added `ListLinksCommand` struct (parsed via `clap`) accepting a JIRA issue key argument
- Added `List(ListLinksCommand)` variant to `LinkSubcommands` enum, wired into `LinkCommand::execute()`
- Added `print_issue_links(key, links)` formatting helper that renders a dynamic-width table with columns: ID, TYPE, DIR, KEY, SUMMARY; handles the empty case gracefully

**Testing:**
- Added unit tests in `src/atlassian/client.rs`: `get_issue_links_success` (two-link response with both inward and outward), `get_issue_links_empty` (empty issuelinks array), `get_issue_links_api_error` (404 error propagation)
- Added unit tests in `src/cli/atlassian/jira/link.rs`: `print_issue_links_empty`, `print_issue_links_with_data`, `link_command_list_variant` (dispatch coverage)

**Snapshot Update (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include the new `list` subcommand entry under `omni-dev atlassian jira link` and its full help text

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`get_issue_links` success, empty, and error cases)
- [x] Integration tests updated (help output snapshot updated)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (404 API error, empty link list)
- [x] Backward compatibility verified (existing `types`, `create`, `remove` subcommands unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only atlassian/link-related tests
cargo test get_issue_links
cargo test print_issue_links
cargo test link_command_list_variant

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual CLI usage (requires configured Atlassian credentials)
omni-dev atlassian jira link list PROJ-123
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `get_issue_links` checks HTTP status before deserializing and returns a typed `AtlassianError::ApiRequestFailed` on non-2xx responses
- [x] Architecture changes — both inward and outward issue references within a single `JiraIssueLinkEntry` are expanded into separate `JiraIssueLink` rows, which may produce two rows per link entry when both sides are populated (though the JIRA API typically populates only one side per entry)
- [x] Backward compatibility — new `List` variant is prepended to `LinkSubcommands`; existing subcommands are unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — single additional HTTP request made only when the `link list` subcommand is invoked; no changes to existing code paths

## Security Considerations

- [x] No security implications — uses the same authenticated `AtlassianClient` HTTP client as all other Atlassian commands; no new credentials or permissions required

## Breaking Changes

None. This is a purely additive change. All existing `atlassian jira link` subcommands (`types`, `create`, `remove`) continue to work identically.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Could add `--json` or `--output` flags for machine-readable output of issue links
- Could support filtering links by type or direction

**Known Limitations:**
- If a `JiraIssueLinkEntry` from the API contains both `inwardIssue` and `outwardIssue` (which is non-standard), it will produce two rows in the output table. In practice the JIRA API always populates exactly one side per entry.