### PR TITLE
docs(docs,atlassian): rename jfm to atlassian, expand command reference, and relocate JFM spec

### DIFF
--- a/docs/specs/jfm.md
+++ b/docs/specs/jfm.md
@@ -4,42 +4,7 @@
 
 JFM provides bidirectional conversion between Markdown and Atlassian Document
 Format (ADF), enabling JIRA Cloud issues and Confluence Cloud pages to be
-read, edited, and updated as local markdown files. It integrates with the
-JIRA Cloud REST API v3 and Confluence Cloud REST API v2 for fetching and
-pushing content.
-
-## Architecture
-
-```
-┌──────────────┐     ┌───────────────┐     ┌──────────────────┐
-│  CLI Layer   │────▶│  JFM Library  │────▶│  JIRA Cloud API  │
-│  (cli/jfm/)  │     │  (src/jfm/)   │     │  REST API v3     │
-└──────────────┘     └───────┬───────┘     └──────────────────┘
-                             │
-                    ┌────────┼────────┐
-                    │        │        │
-              ┌─────┴──┐ ┌──┴───┐ ┌──┴──────────────────┐
-              │Document│ │ MD ↔ │ │ Confluence Cloud API │
-              │ Parser │ │  ADF │ │   REST API v2        │
-              └────────┘ └──────┘ └─────────────────────┘
-```
-
-### Module Structure
-
-| Module           | File                | Purpose                                      |
-|------------------|---------------------|----------------------------------------------|
-| `adf`            | `adf.rs`            | ADF type definitions and node constructors    |
-| `api`            | `api.rs`            | `AtlassianApi` trait, `ContentItem`, `ContentMetadata` |
-| `attrs`          | `attrs.rs`          | Pandoc-style attribute parsing (`{key=val}`)  |
-| `auth`           | `auth.rs`           | Credential load/save from settings file       |
-| `client`         | `client.rs`         | Shared Atlassian HTTP transport (Basic Auth)  |
-| `confluence_api` | `confluence_api.rs` | Confluence REST API v2 implementation         |
-| `convert`        | `convert.rs`        | Bidirectional Markdown ↔ ADF conversion       |
-| `directive`      | `directive.rs`      | Generic directive parsing (inline/leaf/container) |
-| `document`       | `document.rs`       | JFM document format (frontmatter + body)      |
-| `error`          | `error.rs`          | Error types for the JFM subsystem             |
-| `jira_api`       | `jira_api.rs`       | JIRA REST API v3 implementation               |
-| `target`         | `target.rs`         | Target resolution (auto-detect JIRA/Confluence)|
+read, edited, and updated as local markdown files.
 
 ## JFM Document Format
 
@@ -89,7 +54,8 @@ Page body content here.
 |--------------|----------|------------------------------------------|
 | `type`       | Yes      | Always `"jira"`                          |
 | `instance`   | Yes      | Atlassian Cloud instance URL             |
-| `key`        | Yes      | JIRA issue key (e.g., `PROJ-123`)        |
+| `key`        | No       | JIRA issue key (e.g., `PROJ-123`). Absent when creating a new issue. |
+| `project`    | No       | Project key (e.g., `PROJ`). Used for issue creation when `key` is absent. |
 | `summary`    | Yes      | Issue title/summary                      |
 | `status`     | No       | Issue status (read-only from JIRA)       |
 | `issue_type` | No       | Issue type (Bug, Story, Task, etc.)      |
@@ -103,7 +69,7 @@ Page body content here.
 |--------------|----------|------------------------------------------|
 | `type`       | Yes      | Always `"confluence"`                    |
 | `instance`   | Yes      | Atlassian Cloud instance URL             |
-| `page_id`    | Yes      | Confluence page ID                       |
+| `page_id`    | No       | Confluence page ID. Absent when creating a new page. |
 | `title`      | Yes      | Page title                               |
 | `space_key`  | Yes      | Space key (e.g., `ENG`)                  |
 | `status`     | No       | Page status (`"current"` or `"draft"`)   |
@@ -276,11 +242,9 @@ Attributes follow Pandoc-style `{key=value flag}` syntax:
 - Keys: alphanumeric, hyphens, underscores
 - Values: unquoted (stop at whitespace/`}`) or quoted (single/double)
 - Flags: bare words treated as boolean true
-- Round-trip safe: `parse → render → parse` preserves structure
+- Round-trip safe: `parse -> render -> parse` preserves structure
 
-## Markdown ↔ ADF Conversion
-
-### Markdown to ADF
+## Markdown to ADF Conversion
 
 The converter uses a line-oriented parser that processes blocks in order:
 
@@ -318,119 +282,23 @@ Block-level attributes can follow a block on a separate line:
 
 Supported attributes: `align`, `indent`, `breakout`.
 
-## Atlassian Cloud API Integration
-
-### Authentication
+## Authentication
 
 - **Method**: HTTP Basic Auth (base64-encoded `email:api_token`)
-- **Credential storage**: `~/.omni-dev/settings.json` in the `env` map
+- **Credential sources** (checked in order):
+  1. Environment variables
+  2. `~/.omni-dev/settings.json` `env` map
 - **Required keys**:
   - `ATLASSIAN_INSTANCE_URL`
   - `ATLASSIAN_EMAIL`
   - `ATLASSIAN_API_TOKEN`
 - Same credentials serve both JIRA and Confluence (same Atlassian instance)
 
-### Client Architecture
-
-The `AtlassianClient` struct provides shared HTTP transport (auth headers,
-timeouts). Backend-specific logic is in `JiraApi` and `ConfluenceApi`, both
-implementing the `AtlassianApi` trait. Auto-detection in `target.rs`
-selects the correct backend based on the identifier pattern.
-
-### JIRA API Endpoints
-
-| Operation       | Method | Endpoint                         |
-|-----------------|--------|----------------------------------|
-| Fetch issue     | GET    | `/rest/api/3/issue/{key}`        |
-| Update issue    | PUT    | `/rest/api/3/issue/{key}`        |
-| Verify auth     | GET    | `/rest/api/3/myself`             |
-
-### Confluence API Endpoints
-
-| Operation       | Method | Endpoint                                            |
-|-----------------|--------|-----------------------------------------------------|
-| Fetch page      | GET    | `/wiki/api/v2/pages/{id}?body-format=atlas_doc_format` |
-| Update page     | PUT    | `/wiki/api/v2/pages/{id}`                           |
-| Fetch space     | GET    | `/wiki/api/v2/spaces/{id}`                          |
-
-### Confluence Update Details
-
-- Page updates require an incremented `version.number`
-- Current version is fetched before writing (optimistic locking)
-- ADF is sent as a JSON string in `body.value` with
-  `body.representation = "atlas_doc_format"`
-
-### Configuration
-
-- HTTP timeout: 30 seconds
-- Content-Type: `application/json`
-- Instance URL: HTTPS, trailing slash normalized
-
 ## Error Types
 
 | Error                  | Cause                                        |
 |------------------------|----------------------------------------------|
-| `CredentialsNotFound`  | No credentials in `~/.omni-dev/settings.json`|
-| `ApiRequestFailed`     | HTTP error from JIRA (includes status + body)|
+| `CredentialsNotFound`  | No credentials configured                    |
+| `ApiRequestFailed`     | HTTP error from API (includes status + body) |
 | `InvalidDocument`      | JFM parse error (bad YAML, missing delimiters)|
 | `ConversionError`      | ADF conversion failure                       |
-
-## Target Auto-Detection
-
-The `<ID>` argument is auto-detected based on pattern:
-
-| Pattern                    | Target     | Example      |
-|----------------------------|------------|--------------|
-| `[A-Z][A-Z0-9]+-\d+`      | JIRA       | `PROJ-123`   |
-| `^\d+$`                    | Confluence | `12345`      |
-| Other                      | Error      | `My Page`    |
-
-Explicit flags `--jira` and `--confluence` override auto-detection.
-
-## CLI Commands
-
-| Command                            | Purpose                              |
-|------------------------------------|--------------------------------------|
-| `omni-dev jfm auth login`         | Configure Atlassian credentials      |
-| `omni-dev jfm auth status`        | Verify authentication                |
-| `omni-dev jfm read <ID>`          | Fetch content as JFM markdown        |
-| `omni-dev jfm write <ID> [FILE]`  | Push JFM markdown to JIRA/Confluence |
-| `omni-dev jfm edit <ID>`          | Interactive fetch-edit-push cycle    |
-| `omni-dev jfm convert to-adf`     | Convert markdown to ADF JSON         |
-| `omni-dev jfm convert from-adf`   | Convert ADF JSON to markdown         |
-
-All read/write/edit commands accept `--jira` or `--confluence` flags to
-override auto-detection.
-
-See the [User Guide](../user-guide.md) for detailed command usage and
-examples.
-
-## Data Flow
-
-### Read
-
-```
-resolve_target(ID) → create_api_for_target() → api.get_content()
-→ ContentItem → content_item_to_document() → render() → stdout/file
-```
-
-### Write
-
-```
-file/stdin → JfmDocument::parse() → markdown_to_adf()
-→ resolve_target(ID) → create_api_for_target() → api.update_content()
-```
-
-### Edit
-
-```
-resolve_target(ID) → api.get_content() → JFM doc → temp file
-→ [edit loop: show/edit/accept/quit] → api.update_content() if changed
-```
-
-### Convert (local, no auth)
-
-```
-markdown → markdown_to_adf() → ADF JSON    (to-adf)
-ADF JSON → adf_to_markdown() → markdown    (from-adf)
-```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,7 +8,7 @@ intelligence.
 1. [Getting Started](#getting-started)
 2. [Core Concepts](#core-concepts)
 3. [Command Reference](#command-reference)
-4. [JIRA and Confluence Integration (JFM)](#jfm---jira-and-confluence-integration)
+4. [Atlassian Integration](#atlassian---jira-and-confluence-integration)
 5. [Contextual Intelligence](#contextual-intelligence)
 6. [Workflows](#workflows)
 7. [Advanced Usage](#advanced-usage)
@@ -246,54 +246,61 @@ description: |
   error handling for edge cases.
 ```
 
-### `jfm` - JIRA and Confluence Integration
+### `atlassian` - JIRA and Confluence Integration
 
-Read, edit, and update JIRA issues and Confluence pages as local markdown
-files using JFM (JIRA-Flavored Markdown). JFM converts between markdown
-and Atlassian Document Format (ADF), so you can work with Atlassian
-content in your editor.
+Read, edit, and manage JIRA issues and Confluence pages from the command line.
+Content is represented as JFM (JIRA-Flavored Markdown) with YAML frontmatter,
+enabling round-trip editing between your editor and Atlassian Cloud.
 
-See the [JFM Specification](plan/jfm.md) for full technical details.
+See the [JFM Specification](plan/jfm.md) for full technical details on the
+markdown format.
 
 #### Authentication Setup
 
-Before using JFM, configure your Atlassian Cloud credentials:
+Configure your Atlassian Cloud credentials:
 
 ```bash
 # Interactive credential setup (prompts for instance URL, email, API token)
-omni-dev jfm auth login
+omni-dev atlassian auth login
 
-# Verify credentials work (makes API call)
-omni-dev jfm auth status
+# Verify credentials work
+omni-dev atlassian auth status
 ```
 
-Credentials are stored in `~/.omni-dev/settings.json`. You need:
-- Your Atlassian Cloud instance URL (e.g., `https://myorg.atlassian.net`)
-- Your email address
-- An API token (generate at https://id.atlassian.com/manage-profile/security/api-tokens)
-
-#### Reading Content
-
-Fetch a JIRA issue or Confluence page as a JFM markdown document:
+Credentials are stored in `~/.omni-dev/settings.json`. You can also use
+environment variables:
 
 ```bash
-# JIRA issue (auto-detected from key pattern)
-omni-dev jfm read PROJ-123
-omni-dev jfm read PROJ-123 -o issue.md
-
-# Confluence page (auto-detected from numeric ID)
-omni-dev jfm read 12345
-omni-dev jfm read 12345 -o page.md
-
-# Explicit target override
-omni-dev jfm read 12345 --jira        # force JIRA interpretation
-omni-dev jfm read PROJ-123 --confluence  # force Confluence
-
-# Get raw ADF JSON (useful for debugging)
-omni-dev jfm read PROJ-123 --raw
+export ATLASSIAN_INSTANCE_URL=https://myorg.atlassian.net
+export ATLASSIAN_EMAIL=you@example.com
+export ATLASSIAN_API_TOKEN=your-token
 ```
 
-JIRA output:
+Environment variables take precedence over the settings file.
+
+#### JIRA: Reading and Writing Issues
+
+```bash
+# Read an issue as JFM markdown
+omni-dev atlassian jira read PROJ-123
+omni-dev atlassian jira read PROJ-123 -o issue.md
+omni-dev atlassian jira read PROJ-123 --format adf   # raw ADF JSON
+
+# Write changes back (prompts for confirmation)
+omni-dev atlassian jira write PROJ-123 issue.md
+omni-dev atlassian jira write PROJ-123 issue.md --force
+omni-dev atlassian jira write PROJ-123 issue.md --dry-run
+
+# Interactive edit: fetch -> $EDITOR -> push
+omni-dev atlassian jira edit PROJ-123
+```
+
+The edit command opens an interactive loop:
+1. Fetches the issue and writes JFM to a temp file
+2. Prompts: `[A]ccept, [S]how, [E]dit, or [Q]uit?`
+3. On accept, converts back to ADF and pushes changes
+
+JFM output example:
 
 ```markdown
 ---
@@ -304,18 +311,203 @@ summary: Implement user authentication
 status: In Progress
 issue_type: Story
 assignee: Alice Smith
-priority: High
 labels:
   - backend
-  - auth
 ---
-
-## Description
 
 This story covers the implementation of OAuth2-based authentication...
 ```
 
-Confluence output:
+#### JIRA: Search
+
+Search issues using JQL or convenience flags:
+
+```bash
+# Raw JQL
+omni-dev atlassian jira search --jql "project = PROJ AND status = Open"
+
+# Convenience flags (combined with AND)
+omni-dev atlassian jira search --project PROJ --status "In Progress"
+omni-dev atlassian jira search --assignee alice --limit 100
+
+# Fetch all results (auto-paginates)
+omni-dev atlassian jira search --jql "project = PROJ" --limit 0
+```
+
+Output is a formatted table: `KEY | STATUS | ASSIGNEE | SUMMARY`.
+
+#### JIRA: Create Issues
+
+Create issues from JFM markdown or CLI flags:
+
+```bash
+# From JFM file (project, type, summary from frontmatter)
+omni-dev atlassian jira create issue.md
+
+# From CLI flags
+omni-dev atlassian jira create issue.md --project PROJ --type Bug --summary "Fix login"
+
+# From ADF JSON (all metadata via flags)
+omni-dev atlassian jira create body.json --format adf --project PROJ --summary "Title"
+
+# Preview without creating
+omni-dev atlassian jira create issue.md --dry-run
+```
+
+Prints the created issue key (e.g., `PROJ-124`) to stdout.
+
+#### JIRA: Transitions
+
+List and execute workflow transitions:
+
+```bash
+# List available transitions
+omni-dev atlassian jira transition PROJ-123
+
+# Execute a transition by name (case-insensitive)
+omni-dev atlassian jira transition PROJ-123 "In Progress"
+
+# Execute by ID
+omni-dev atlassian jira transition PROJ-123 21
+```
+
+#### JIRA: Comments
+
+```bash
+# List comments on an issue
+omni-dev atlassian jira comment list PROJ-123
+
+# Add a comment from a file
+omni-dev atlassian jira comment add PROJ-123 comment.md
+
+# Add from stdin
+echo "This is a comment" | omni-dev atlassian jira comment add PROJ-123
+
+# Add ADF JSON comment
+omni-dev atlassian jira comment add PROJ-123 body.json --format adf
+```
+
+#### JIRA: Delete Issues
+
+```bash
+# Delete with confirmation prompt
+omni-dev atlassian jira delete PROJ-123
+
+# Skip confirmation
+omni-dev atlassian jira delete PROJ-123 --force
+```
+
+#### JIRA: Projects
+
+```bash
+# List all accessible projects
+omni-dev atlassian jira project list
+omni-dev atlassian jira project list --limit 100
+```
+
+#### JIRA: Fields
+
+```bash
+# List all field definitions
+omni-dev atlassian jira field list
+
+# Search by name
+omni-dev atlassian jira field list --search "story"
+
+# Show options for a custom field (auto-discovers context)
+omni-dev atlassian jira field options --field-id customfield_10001
+
+# Specify context explicitly
+omni-dev atlassian jira field options --field-id customfield_10001 --context-id 12345
+```
+
+#### JIRA: Agile Boards
+
+```bash
+# List boards
+omni-dev atlassian jira board list
+omni-dev atlassian jira board list --project PROJ --type scrum
+
+# List issues on a board
+omni-dev atlassian jira board issues --board-id 1
+omni-dev atlassian jira board issues --board-id 1 --jql "status = Open"
+```
+
+#### JIRA: Sprints
+
+```bash
+# List sprints for a board
+omni-dev atlassian jira sprint list --board-id 1
+omni-dev atlassian jira sprint list --board-id 1 --state active
+
+# List issues in a sprint
+omni-dev atlassian jira sprint issues --sprint-id 10
+
+# Add issues to a sprint
+omni-dev atlassian jira sprint add --sprint-id 10 --issues PROJ-1,PROJ-2,PROJ-3
+```
+
+#### JIRA: Issue Links
+
+```bash
+# List links on an issue (shows link IDs)
+omni-dev atlassian jira link list PROJ-123
+
+# List available link types
+omni-dev atlassian jira link types
+
+# Create a link
+omni-dev atlassian jira link create --type Blocks --inward PROJ-1 --outward PROJ-2
+
+# Remove a link by ID (get IDs from `link list`)
+omni-dev atlassian jira link remove --link-id 12345
+
+# Link an issue to an epic
+omni-dev atlassian jira link epic --epic EPIC-1 --issue PROJ-2
+```
+
+#### JIRA: Changelog
+
+View change history for one or more issues:
+
+```bash
+omni-dev atlassian jira changelog --keys PROJ-1
+omni-dev atlassian jira changelog --keys PROJ-1,PROJ-2 --limit 100
+```
+
+#### JIRA: Attachments
+
+```bash
+# Download all attachments
+omni-dev atlassian jira attachment download --key PROJ-123
+omni-dev atlassian jira attachment download --key PROJ-123 --output-dir ./files
+
+# Filter by filename
+omni-dev atlassian jira attachment download --key PROJ-123 --filter screenshot
+
+# Download only images (png, jpeg, gif, svg, webp)
+omni-dev atlassian jira attachment images --key PROJ-123
+omni-dev atlassian jira attachment images --key PROJ-123 --output-dir ./images
+```
+
+#### Confluence: Reading and Writing Pages
+
+```bash
+# Read a page as JFM markdown
+omni-dev atlassian confluence read 12345
+omni-dev atlassian confluence read 12345 -o page.md
+omni-dev atlassian confluence read 12345 --format adf
+
+# Write changes back
+omni-dev atlassian confluence write 12345 page.md
+omni-dev atlassian confluence write 12345 page.md --force
+omni-dev atlassian confluence write 12345 page.md --dry-run
+
+# Interactive edit
+omni-dev atlassian confluence edit 12345
+```
+
+Confluence JFM output example:
 
 ```markdown
 ---
@@ -333,63 +525,79 @@ version: 7
 Page body content here...
 ```
 
-#### Writing Changes
+#### Confluence: Search
 
-Push a JFM markdown file back to JIRA or Confluence:
-
-```bash
-# Update from file (prompts for confirmation)
-omni-dev jfm write PROJ-123 issue.md
-omni-dev jfm write 12345 page.md
-
-# Skip confirmation prompt
-omni-dev jfm write PROJ-123 issue.md --force
-
-# Preview what would be sent without updating
-omni-dev jfm write PROJ-123 issue.md --dry-run
-
-# Read from stdin
-cat issue.md | omni-dev jfm write PROJ-123
-```
-
-The write command updates the content body (converted to ADF) and
-optionally the title if it changed in the frontmatter. For Confluence,
-the page version is automatically incremented.
-
-#### Interactive Editing
-
-Fetch content, edit in your editor, and push changes in one command:
+Search pages using CQL or convenience flags:
 
 ```bash
-omni-dev jfm edit PROJ-123
-omni-dev jfm edit 12345
-omni-dev jfm edit 12345 --confluence
+# Raw CQL
+omni-dev atlassian confluence search --cql "space = ENG AND title ~ 'auth'"
+
+# Convenience flags
+omni-dev atlassian confluence search --space ENG
+omni-dev atlassian confluence search --title architecture
+omni-dev atlassian confluence search --space ENG --title auth --limit 100
 ```
 
-This opens an interactive loop:
-1. Fetches the content and writes it to a temp file
-2. Prompts with: `[A]ccept, [S]how, [E]dit, or [Q]uit?`
-   - **Edit** - Opens the temp file in your editor (`$EDITOR` or `$OMNI_DEV_EDITOR`)
-   - **Show** - Prints the current file content
-   - **Accept** - Pushes changes (only if content changed)
-   - **Quit** - Cancels without updating
+#### Confluence: Create Pages
+
+```bash
+# From JFM file
+omni-dev atlassian confluence create page.md
+
+# From CLI flags
+omni-dev atlassian confluence create page.md --space ENG --title "New Page"
+
+# With parent page
+omni-dev atlassian confluence create page.md --space ENG --title "Child" --parent 12345
+
+# Preview
+omni-dev atlassian confluence create page.md --dry-run
+```
+
+#### Confluence: Delete Pages
+
+```bash
+# Delete (moves to trash, prompts for confirmation)
+omni-dev atlassian confluence delete 12345
+
+# Skip confirmation
+omni-dev atlassian confluence delete 12345 --force
+
+# Permanently purge (requires space admin)
+omni-dev atlassian confluence delete 12345 --force --purge
+```
 
 #### Offline Format Conversion
 
-Convert between markdown and ADF locally without credentials:
+Convert between JFM markdown and ADF JSON locally without credentials:
 
 ```bash
-# Convert markdown to ADF JSON
-omni-dev jfm convert to-adf issue.md
+# Markdown to ADF JSON
+omni-dev atlassian convert to-adf issue.md
+omni-dev atlassian convert to-adf issue.md --compact
 
-# Compact JSON output
-omni-dev jfm convert to-adf issue.md --compact
-
-# Convert ADF JSON back to markdown
-omni-dev jfm convert from-adf issue.json
+# ADF JSON to markdown
+omni-dev atlassian convert from-adf issue.json
 
 # Pipe for inspection
-cat issue.md | omni-dev jfm convert to-adf | jq .
+cat issue.md | omni-dev atlassian convert to-adf | jq .
+```
+
+#### Auto-Pagination
+
+All commands that query paginated endpoints auto-paginate transparently.
+Use `--limit` to control how many results are fetched:
+
+```bash
+# Default: up to 50 results
+omni-dev atlassian jira search --project PROJ
+
+# Fetch more
+omni-dev atlassian jira search --project PROJ --limit 200
+
+# Fetch all (no limit)
+omni-dev atlassian jira search --project PROJ --limit 0
 ```
 
 #### JFM Markdown Syntax

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -252,7 +252,7 @@ Read, edit, and manage JIRA issues and Confluence pages from the command line.
 Content is represented as JFM (JIRA-Flavored Markdown) with YAML frontmatter,
 enabling round-trip editing between your editor and Atlassian Cloud.
 
-See the [JFM Specification](plan/jfm.md) for full technical details on the
+See the [JFM Specification](specs/jfm.md) for full technical details on the
 markdown format.
 
 #### Authentication Setup


### PR DESCRIPTION
## Description

This PR updates the omni-dev user guide and JFM specification to reflect the renamed `atlassian` command (previously `jfm`) and substantially expands the Atlassian integration documentation with accurate CLI examples for all subcommands. It also relocates the JFM specification from `docs/plan/jfm.md` to `docs/specs/jfm.md` and revises its content to remove implementation-internal details.

The existing documentation referred to the old `jfm` command name and covered only basic `read`/`write`/`edit` operations. This update aligns all documentation with the current `atlassian` command structure, adds environment variable authentication as an alternative to the settings file, and provides comprehensive coverage of every JIRA and Confluence subcommand. The spec relocation removes architecture diagrams and implementation internals (module structure, API endpoint tables, client architecture, data flow diagrams) that belong in code comments rather than user-facing documentation.

## Type of Change
- [x] Documentation update

## Related Issue
N/A

## Changes Made

**User Guide (`docs/user-guide.md`):**
- Rename TOC entry from `JIRA and Confluence Integration (JFM)` to `Atlassian Integration`
- Rename section heading from `### jfm` to `### atlassian`
- Update all command examples from `omni-dev jfm` to `omni-dev atlassian`
- Add environment variable authentication (`ATLASSIAN_INSTANCE_URL`, `ATLASSIAN_EMAIL`, `ATLASSIAN_API_TOKEN`) as an alternative to the settings file
- Revise introductory description to reflect round-trip editing capability via JFM with YAML frontmatter
- Restructure JIRA and Confluence coverage into dedicated subsections with `read`, `write`, and `edit` subcommand patterns documented
- Add JIRA sections: search (JQL + convenience flags), create issues, transitions, comments, delete, projects, fields (including custom field options), agile boards, sprints, issue links, changelog, and attachments (download + images)
- Add Confluence sections: reading/writing pages, search (CQL + convenience flags), create pages (with parent support), and delete pages (including `--purge`)
- Add auto-pagination section explaining `--limit` flag behaviour (default 50, configurable, `0` = fetch all)
- Update offline format conversion examples to use `atlassian convert`
- Update JFM Specification link from `plan/jfm.md` to `specs/jfm.md`
- Net change: +281 lines, -73 lines

**JFM Specification (relocated `docs/plan/jfm.md` → `docs/specs/jfm.md`):**
- Delete `docs/plan/jfm.md` and create `docs/specs/jfm.md` with revised content
- Remove architecture diagram and module structure table (implementation internals)
- Remove CLI commands table and data flow diagrams
- Remove JIRA/Confluence API endpoint tables and client architecture details
- Update JIRA frontmatter: mark `key` as optional (absent when creating new issues), add `project` field for issue creation
- Update Confluence frontmatter: mark `page_id` as optional (absent when creating new pages)
- Simplify authentication section to list environment variables as first credential source (checked before settings file)
- Simplify error types table with generalized descriptions not tied to implementation internals

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change, no new tests required)

**Manual Testing:**
- [x] Reviewed all new command examples for accuracy against the current CLI interface
- [x] Verified all section headings and TOC links are consistent
- [x] Confirmed JFM spec link in user guide resolves to the new `specs/jfm.md` path

### Test Commands
```bash
# No code changes; documentation review only
cargo test
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — ensure all command examples are correct and section structure is logical for new users learning the atlassian subcommands
- [x] Backward compatibility — the documentation now uses the `atlassian` command throughout; verify this matches the actual binary command name

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a documentation-only update. No code behaviour changes.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The JFM Markdown Syntax section in `user-guide.md` (below the changed area) was not modified in this PR and may still reference older patterns; a follow-up review is recommended
- Screenshots or a recorded demo of the interactive edit loop (`jira edit`, `confluence edit`) would improve the editing sections
- Consider adding a migration callout for users who were referencing the old `jfm` command name in scripts or tooling if the binary rename was recent

**Known Limitations:**
- The `docs/plan/` directory may still contain other planning documents that reference the old `jfm.md` path; these are not addressed in this PR