### PR TITLE
feat(atlassian,cli): add --output flag for json/yaml output to atlassian commands

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use base64::Engine;
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::error::AtlassianError;
@@ -28,7 +28,7 @@ pub struct AtlassianClient {
 }
 
 /// JIRA issue data returned from the REST API.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraIssue {
     /// Issue key (e.g., "PROJ-123").
     pub key: String,
@@ -72,7 +72,7 @@ pub struct JiraUser {
 }
 
 /// Result from creating a JIRA issue via the REST API.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraCreatedIssue {
     /// Issue key (e.g., "PROJ-124").
     pub key: String,
@@ -83,7 +83,7 @@ pub struct JiraCreatedIssue {
 }
 
 /// Result from a JIRA JQL search.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraSearchResult {
     /// Matching issues.
     pub issues: Vec<JiraIssue>,
@@ -93,7 +93,7 @@ pub struct JiraSearchResult {
 }
 
 /// A Confluence search result.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConfluenceSearchResult {
     /// Page ID.
     pub id: String,
@@ -104,7 +104,7 @@ pub struct ConfluenceSearchResult {
 }
 
 /// Result from a Confluence CQL search.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConfluenceSearchResults {
     /// Matching pages.
     pub results: Vec<ConfluenceSearchResult>,
@@ -113,7 +113,7 @@ pub struct ConfluenceSearchResults {
 }
 
 /// A JIRA issue comment.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraComment {
     /// Comment ID.
     pub id: String,
@@ -126,7 +126,7 @@ pub struct JiraComment {
 }
 
 /// A JIRA project.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraProject {
     /// Project ID.
     pub id: String,
@@ -141,7 +141,7 @@ pub struct JiraProject {
 }
 
 /// Result from listing JIRA projects.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraProjectList {
     /// Projects returned.
     pub projects: Vec<JiraProject>,
@@ -150,7 +150,7 @@ pub struct JiraProjectList {
 }
 
 /// A JIRA field definition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraField {
     /// Field ID (e.g., "summary", "customfield_10001").
     pub id: String,
@@ -163,7 +163,7 @@ pub struct JiraField {
 }
 
 /// An option value for a JIRA custom field.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraFieldOption {
     /// Option ID.
     pub id: String,
@@ -172,7 +172,7 @@ pub struct JiraFieldOption {
 }
 
 /// A JIRA agile board.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AgileBoard {
     /// Board ID.
     pub id: u64,
@@ -185,7 +185,7 @@ pub struct AgileBoard {
 }
 
 /// Result from listing agile boards.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AgileBoardList {
     /// Boards returned.
     pub boards: Vec<AgileBoard>,
@@ -194,7 +194,7 @@ pub struct AgileBoardList {
 }
 
 /// A JIRA agile sprint.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AgileSprint {
     /// Sprint ID.
     pub id: u64,
@@ -211,7 +211,7 @@ pub struct AgileSprint {
 }
 
 /// Result from listing agile sprints.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AgileSprintList {
     /// Sprints returned.
     pub sprints: Vec<AgileSprint>,
@@ -220,7 +220,7 @@ pub struct AgileSprintList {
 }
 
 /// A JIRA issue changelog entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraChangelogEntry {
     /// Entry ID.
     pub id: String,
@@ -233,7 +233,7 @@ pub struct JiraChangelogEntry {
 }
 
 /// A single field change in a changelog entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraChangelogItem {
     /// Field name that changed.
     pub field: String,
@@ -244,7 +244,7 @@ pub struct JiraChangelogItem {
 }
 
 /// A JIRA issue link type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraLinkType {
     /// Link type ID.
     pub id: String,
@@ -257,7 +257,7 @@ pub struct JiraLinkType {
 }
 
 /// A link on a JIRA issue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraIssueLink {
     /// Link ID (used for removal).
     pub id: String,
@@ -272,7 +272,7 @@ pub struct JiraIssueLink {
 }
 
 /// A JIRA issue attachment.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraAttachment {
     /// Attachment ID.
     pub id: String,
@@ -287,7 +287,7 @@ pub struct JiraAttachment {
 }
 
 /// A JIRA workflow transition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JiraTransition {
     /// Transition ID.
     pub id: String,

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -52,7 +52,7 @@ impl ConfluenceCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::atlassian::format::ContentFormat;
+    use crate::cli::atlassian::format::{ContentFormat, OutputFormat};
 
     #[test]
     fn confluence_subcommands_read_variant() {
@@ -98,6 +98,7 @@ mod tests {
                 space: None,
                 title: None,
                 limit: 25,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Search(_)));

--- a/src/cli/atlassian/confluence/search.rs
+++ b/src/cli/atlassian/confluence/search.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::atlassian::client::ConfluenceSearchResults;
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Searches Confluence pages using CQL.
@@ -24,6 +25,10 @@ pub struct SearchCommand {
     /// Maximum number of results, 0 for unlimited (default: 25).
     #[arg(long, default_value_t = 25)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl SearchCommand {
@@ -33,6 +38,9 @@ impl SearchCommand {
         let (client, _instance_url) = create_client()?;
 
         let result = client.search_confluence(&cql, self.limit).await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_search_results(&result);
 
         Ok(())
@@ -136,6 +144,7 @@ mod tests {
             space: None,
             title: None,
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.build_cql().unwrap(), "space = ENG ORDER BY title");
     }
@@ -147,6 +156,7 @@ mod tests {
             space: Some("ENG".to_string()),
             title: None,
             limit: 25,
+            output: OutputFormat::Table,
         };
         let cql = cmd.build_cql().unwrap();
         assert!(cql.contains("type = \"page\""));
@@ -160,6 +170,7 @@ mod tests {
             space: None,
             title: Some("architecture".to_string()),
             limit: 25,
+            output: OutputFormat::Table,
         };
         let cql = cmd.build_cql().unwrap();
         assert!(cql.contains("title ~ \"architecture\""));
@@ -172,6 +183,7 @@ mod tests {
             space: Some("ENG".to_string()),
             title: Some("auth".to_string()),
             limit: 10,
+            output: OutputFormat::Table,
         };
         let cql = cmd.build_cql().unwrap();
         assert!(cql.contains("type = \"page\""));
@@ -187,6 +199,7 @@ mod tests {
             space: None,
             title: None,
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert!(cmd.build_cql().is_err());
     }
@@ -198,6 +211,7 @@ mod tests {
             space: Some("ENG".to_string()),
             title: Some("ignored".to_string()),
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.build_cql().unwrap(), "title = \"override\"");
     }
@@ -252,6 +266,7 @@ mod tests {
             space: None,
             title: None,
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert!(cmd.cql.is_none());
         assert_eq!(cmd.limit, 25);

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -1,8 +1,10 @@
-//! Shared output format type for Atlassian CLI commands.
+//! Shared format types for Atlassian CLI commands.
 
+use anyhow::{Context, Result};
 use clap::ValueEnum;
+use serde::Serialize;
 
-/// Output/input format for Atlassian content.
+/// Output/input format for Atlassian content (read/write/create commands).
 #[derive(Clone, Debug, Default, ValueEnum)]
 pub enum ContentFormat {
     /// JFM markdown with YAML frontmatter.
@@ -10,6 +12,41 @@ pub enum ContentFormat {
     Jfm,
     /// Raw Atlassian Document Format JSON.
     Adf,
+}
+
+/// Display format for list/table commands.
+#[derive(Clone, Debug, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable table.
+    #[default]
+    Table,
+    /// JSON.
+    Json,
+    /// YAML.
+    Yaml,
+}
+
+/// Serializes data in the requested output format.
+/// Returns `Ok(true)` if data was printed (json/yaml), `Ok(false)` if the
+/// caller should handle table output.
+pub fn output_as<T: Serialize>(data: &T, format: &OutputFormat) -> Result<bool> {
+    match format {
+        OutputFormat::Table => Ok(false),
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(data).context("Failed to serialize as JSON")?
+            );
+            Ok(true)
+        }
+        OutputFormat::Yaml => {
+            print!(
+                "{}",
+                serde_yaml::to_string(data).context("Failed to serialize as YAML")?
+            );
+            Ok(true)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -45,5 +82,42 @@ mod tests {
         let format = ContentFormat::Adf;
         let cloned = format.clone();
         assert!(matches!(cloned, ContentFormat::Adf));
+    }
+
+    // ── OutputFormat ───────────────────────────────────────────────
+
+    #[test]
+    fn output_default_is_table() {
+        assert!(matches!(OutputFormat::default(), OutputFormat::Table));
+    }
+
+    #[test]
+    fn output_json_variant() {
+        assert!(matches!(OutputFormat::Json, OutputFormat::Json));
+    }
+
+    #[test]
+    fn output_yaml_variant() {
+        assert!(matches!(OutputFormat::Yaml, OutputFormat::Yaml));
+    }
+
+    // ── output_as ──────────────────────────────────────────────────
+
+    #[test]
+    fn output_as_table_returns_false() {
+        let data = vec![1, 2, 3];
+        assert!(!output_as(&data, &OutputFormat::Table).unwrap());
+    }
+
+    #[test]
+    fn output_as_json_returns_true() {
+        let data = vec![1, 2, 3];
+        assert!(output_as(&data, &OutputFormat::Json).unwrap());
+    }
+
+    #[test]
+    fn output_as_yaml_returns_true() {
+        let data = vec![1, 2, 3];
+        assert!(output_as(&data, &OutputFormat::Yaml).unwrap());
     }
 }

--- a/src/cli/atlassian/jira/board.rs
+++ b/src/cli/atlassian/jira/board.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::client::{AgileBoardList, JiraSearchResult};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA agile boards.
@@ -47,6 +48,10 @@ pub struct ListCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListCommand {
@@ -56,6 +61,9 @@ impl ListCommand {
         let result = client
             .get_boards(self.project.as_deref(), self.r#type.as_deref(), self.limit)
             .await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_boards(&result);
         Ok(())
     }
@@ -75,6 +83,10 @@ pub struct IssuesCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl IssuesCommand {
@@ -84,6 +96,9 @@ impl IssuesCommand {
         let result = client
             .get_board_issues(self.board_id, self.jql.as_deref(), self.limit)
             .await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_board_issues(&result);
         Ok(())
     }
@@ -312,6 +327,7 @@ mod tests {
                 project: None,
                 r#type: None,
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, BoardSubcommands::List(_)));
@@ -324,6 +340,7 @@ mod tests {
                 board_id: 1,
                 jql: None,
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, BoardSubcommands::Issues(_)));
@@ -335,6 +352,7 @@ mod tests {
             project: Some("PROJ".to_string()),
             r#type: Some("scrum".to_string()),
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.project.as_deref(), Some("PROJ"));
         assert_eq!(cmd.r#type.as_deref(), Some("scrum"));
@@ -346,6 +364,7 @@ mod tests {
             board_id: 42,
             jql: Some("status = Open".to_string()),
             limit: 10,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.board_id, 42);
         assert_eq!(cmd.jql.as_deref(), Some("status = Open"));

--- a/src/cli/atlassian/jira/changelog.rs
+++ b/src/cli/atlassian/jira/changelog.rs
@@ -3,7 +3,10 @@
 use anyhow::Result;
 use clap::Parser;
 
+use serde::Serialize;
+
 use crate::atlassian::client::{JiraChangelogEntry, JiraChangelogItem};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Shows change history for one or more JIRA issues.
@@ -15,6 +18,10 @@ pub struct ChangelogCommand {
     /// Maximum number of changelog entries per issue (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ChangelogCommand {
@@ -27,16 +34,35 @@ impl ChangelogCommand {
 
         let (client, _instance_url) = create_client()?;
 
-        for (i, key) in keys.iter().enumerate() {
+        let mut all_changelogs: Vec<IssueChangelog> = Vec::new();
+        for key in &keys {
+            let entries = client.get_changelog(key, self.limit).await?;
+            all_changelogs.push(IssueChangelog {
+                key: key.clone(),
+                entries,
+            });
+        }
+
+        if output_as(&all_changelogs, &self.output)? {
+            return Ok(());
+        }
+
+        for (i, changelog) in all_changelogs.iter().enumerate() {
             if i > 0 {
                 println!();
             }
-            let entries = client.get_changelog(key, self.limit).await?;
-            print_changelog(key, &entries);
+            print_changelog(&changelog.key, &changelog.entries);
         }
 
         Ok(())
     }
+}
+
+/// Collected changelog for a single issue, used for json/yaml serialization.
+#[derive(Serialize)]
+struct IssueChangelog {
+    key: String,
+    entries: Vec<JiraChangelogEntry>,
 }
 
 /// Parses a comma-separated list of issue keys.
@@ -219,6 +245,7 @@ mod tests {
         let cmd = ChangelogCommand {
             keys: "PROJ-1,PROJ-2".to_string(),
             limit: 50,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.keys, "PROJ-1,PROJ-2");
         assert_eq!(cmd.limit, 50);

--- a/src/cli/atlassian/jira/comment.rs
+++ b/src/cli/atlassian/jira/comment.rs
@@ -7,7 +7,7 @@ use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::client::JiraComment;
 use crate::atlassian::convert::{adf_to_markdown, markdown_to_adf};
 use crate::atlassian::document::JfmDocument;
-use crate::cli::atlassian::format::ContentFormat;
+use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
 use crate::cli::atlassian::helpers::{create_client, read_input};
 
 /// Manages comments on a JIRA issue.
@@ -42,6 +42,10 @@ impl CommentCommand {
 pub struct ListCommand {
     /// JIRA issue key (e.g., PROJ-123).
     pub key: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListCommand {
@@ -49,6 +53,9 @@ impl ListCommand {
     pub async fn execute(self) -> Result<()> {
         let (client, _instance_url) = create_client()?;
         let comments = client.get_comments(&self.key).await?;
+        if output_as(&comments, &self.output)? {
+            return Ok(());
+        }
         print_comments(&comments);
         Ok(())
     }
@@ -342,6 +349,7 @@ mod tests {
         let cmd = CommentCommand {
             command: CommentSubcommands::List(ListCommand {
                 key: "PROJ-1".to_string(),
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, CommentSubcommands::List(_)));

--- a/src/cli/atlassian/jira/field.rs
+++ b/src/cli/atlassian/jira/field.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::client::{JiraField, JiraFieldOption};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA field definitions and options.
@@ -39,6 +40,10 @@ pub struct ListCommand {
     /// Filter fields by name (case-insensitive substring match).
     #[arg(long)]
     pub search: Option<String>,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListCommand {
@@ -47,6 +52,9 @@ impl ListCommand {
         let (client, _instance_url) = create_client()?;
         let fields = client.get_fields().await?;
         let filtered = filter_fields(&fields, self.search.as_deref());
+        if output_as(&filtered, &self.output)? {
+            return Ok(());
+        }
         print_fields(&filtered);
         Ok(())
     }
@@ -62,6 +70,10 @@ pub struct OptionsCommand {
     /// Context ID (auto-discovered if omitted).
     #[arg(long)]
     pub context_id: Option<String>,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl OptionsCommand {
@@ -71,6 +83,9 @@ impl OptionsCommand {
         let options = client
             .get_field_options(&self.field_id, self.context_id.as_deref())
             .await?;
+        if output_as(&options, &self.output)? {
+            return Ok(());
+        }
         print_options(&options);
         Ok(())
     }
@@ -243,7 +258,10 @@ mod tests {
     #[test]
     fn field_command_list_variant() {
         let cmd = FieldCommand {
-            command: FieldSubcommands::List(ListCommand { search: None }),
+            command: FieldSubcommands::List(ListCommand {
+                search: None,
+                output: OutputFormat::Table,
+            }),
         };
         assert!(matches!(cmd.command, FieldSubcommands::List(_)));
     }
@@ -254,6 +272,7 @@ mod tests {
             command: FieldSubcommands::Options(OptionsCommand {
                 field_id: "customfield_10001".to_string(),
                 context_id: None,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, FieldSubcommands::Options(_)));
@@ -263,6 +282,7 @@ mod tests {
     fn list_command_with_search() {
         let cmd = ListCommand {
             search: Some("story".to_string()),
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.search.as_deref(), Some("story"));
     }
@@ -272,6 +292,7 @@ mod tests {
         let cmd = OptionsCommand {
             field_id: "customfield_10001".to_string(),
             context_id: Some("12345".to_string()),
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.context_id.as_deref(), Some("12345"));
     }

--- a/src/cli/atlassian/jira/link.rs
+++ b/src/cli/atlassian/jira/link.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::client::{JiraIssueLink, JiraLinkType};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA issue links.
@@ -47,6 +48,10 @@ impl LinkCommand {
 pub struct ListLinksCommand {
     /// JIRA issue key (e.g., PROJ-123).
     pub key: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListLinksCommand {
@@ -54,6 +59,9 @@ impl ListLinksCommand {
     pub async fn execute(self) -> Result<()> {
         let (client, _instance_url) = create_client()?;
         let links = client.get_issue_links(&self.key).await?;
+        if output_as(&links, &self.output)? {
+            return Ok(());
+        }
         print_issue_links(&self.key, &links);
         Ok(())
     }
@@ -61,13 +69,20 @@ impl ListLinksCommand {
 
 /// Lists available issue link types.
 #[derive(Parser)]
-pub struct TypesCommand;
+pub struct TypesCommand {
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
 
 impl TypesCommand {
     /// Fetches and displays link types.
     pub async fn execute(self) -> Result<()> {
         let (client, _instance_url) = create_client()?;
         let types = client.get_link_types().await?;
+        if output_as(&types, &self.output)? {
+            return Ok(());
+        }
         print_link_types(&types);
         Ok(())
     }
@@ -329,6 +344,7 @@ mod tests {
         let cmd = LinkCommand {
             command: LinkSubcommands::List(ListLinksCommand {
                 key: "PROJ-1".to_string(),
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, LinkSubcommands::List(_)));
@@ -337,7 +353,9 @@ mod tests {
     #[test]
     fn link_command_types_variant() {
         let cmd = LinkCommand {
-            command: LinkSubcommands::Types(TypesCommand),
+            command: LinkSubcommands::Types(TypesCommand {
+                output: OutputFormat::Table,
+            }),
         };
         assert!(matches!(cmd.command, LinkSubcommands::Types(_)));
     }

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -88,7 +88,7 @@ impl JiraCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::atlassian::format::ContentFormat;
+    use crate::cli::atlassian::format::{ContentFormat, OutputFormat};
 
     #[test]
     fn jira_subcommands_read_variant() {
@@ -150,6 +150,7 @@ mod tests {
                 assignee: None,
                 status: None,
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Search(_)));
@@ -162,6 +163,7 @@ mod tests {
                 key: "PROJ-1".to_string(),
                 transition: Some("Done".to_string()),
                 list: false,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Transition(_)));
@@ -173,6 +175,7 @@ mod tests {
             command: JiraSubcommands::Comment(comment::CommentCommand {
                 command: comment::CommentSubcommands::List(comment::ListCommand {
                     key: "PROJ-1".to_string(),
+                    output: OutputFormat::Table,
                 }),
             }),
         };
@@ -194,7 +197,10 @@ mod tests {
     fn jira_subcommands_project_variant() {
         let cmd = JiraCommand {
             command: JiraSubcommands::Project(project::ProjectCommand {
-                command: project::ProjectSubcommands::List(project::ListCommand { limit: 50 }),
+                command: project::ProjectSubcommands::List(project::ListCommand {
+                    limit: 50,
+                    output: OutputFormat::Table,
+                }),
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Project(_)));
@@ -204,7 +210,10 @@ mod tests {
     fn jira_subcommands_field_variant() {
         let cmd = JiraCommand {
             command: JiraSubcommands::Field(field::FieldCommand {
-                command: field::FieldSubcommands::List(field::ListCommand { search: None }),
+                command: field::FieldSubcommands::List(field::ListCommand {
+                    search: None,
+                    output: OutputFormat::Table,
+                }),
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Field(_)));
@@ -218,6 +227,7 @@ mod tests {
                     project: None,
                     r#type: None,
                     limit: 50,
+                    output: OutputFormat::Table,
                 }),
             }),
         };
@@ -232,6 +242,7 @@ mod tests {
                     board_id: 1,
                     state: None,
                     limit: 50,
+                    output: OutputFormat::Table,
                 }),
             }),
         };
@@ -242,7 +253,9 @@ mod tests {
     fn jira_subcommands_link_variant() {
         let cmd = JiraCommand {
             command: JiraSubcommands::Link(link::LinkCommand {
-                command: link::LinkSubcommands::Types(link::TypesCommand),
+                command: link::LinkSubcommands::Types(link::TypesCommand {
+                    output: OutputFormat::Table,
+                }),
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Link(_)));
@@ -254,6 +267,7 @@ mod tests {
             command: JiraSubcommands::Changelog(changelog::ChangelogCommand {
                 keys: "PROJ-1".to_string(),
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Changelog(_)));

--- a/src/cli/atlassian/jira/project.rs
+++ b/src/cli/atlassian/jira/project.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::client::JiraProjectList;
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA projects.
@@ -36,6 +37,10 @@ pub struct ListCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListCommand {
@@ -43,6 +48,9 @@ impl ListCommand {
     pub async fn execute(self) -> Result<()> {
         let (client, _instance_url) = create_client()?;
         let result = client.get_projects(self.limit).await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_projects(&result);
         Ok(())
     }
@@ -179,14 +187,20 @@ mod tests {
     #[test]
     fn project_command_list_variant() {
         let cmd = ProjectCommand {
-            command: ProjectSubcommands::List(ListCommand { limit: 50 }),
+            command: ProjectSubcommands::List(ListCommand {
+                limit: 50,
+                output: OutputFormat::Table,
+            }),
         };
         assert!(matches!(cmd.command, ProjectSubcommands::List(_)));
     }
 
     #[test]
     fn list_command_defaults() {
-        let cmd = ListCommand { limit: 50 };
+        let cmd = ListCommand {
+            limit: 50,
+            output: OutputFormat::Table,
+        };
         assert_eq!(cmd.limit, 50);
     }
 }

--- a/src/cli/atlassian/jira/search.rs
+++ b/src/cli/atlassian/jira/search.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::atlassian::client::JiraSearchResult;
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Searches JIRA issues using JQL.
@@ -28,6 +29,10 @@ pub struct SearchCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl SearchCommand {
@@ -37,6 +42,9 @@ impl SearchCommand {
         let (client, _instance_url) = create_client()?;
 
         let result = client.search_issues(&jql, self.limit).await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_search_results(&result);
 
         Ok(())
@@ -167,6 +175,7 @@ mod tests {
             assignee: None,
             status: None,
             limit: 50,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.build_jql().unwrap(), "project = PROJ ORDER BY created");
     }
@@ -179,6 +188,7 @@ mod tests {
             assignee: None,
             status: None,
             limit: 50,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.build_jql().unwrap(), "project = \"PROJ\"");
     }
@@ -191,6 +201,7 @@ mod tests {
             assignee: Some("alice".to_string()),
             status: Some("Open".to_string()),
             limit: 25,
+            output: OutputFormat::Table,
         };
         let jql = cmd.build_jql().unwrap();
         assert!(jql.contains("project = \"PROJ\""));
@@ -207,6 +218,7 @@ mod tests {
             assignee: None,
             status: None,
             limit: 50,
+            output: OutputFormat::Table,
         };
         assert!(cmd.build_jql().is_err());
     }
@@ -219,6 +231,7 @@ mod tests {
             assignee: Some("alice".to_string()),
             status: None,
             limit: 50,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.build_jql().unwrap(), "assignee = bob");
     }

--- a/src/cli/atlassian/jira/sprint.rs
+++ b/src/cli/atlassian/jira/sprint.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::client::{AgileSprintList, JiraSearchResult};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Manages JIRA agile sprints.
@@ -50,6 +51,10 @@ pub struct ListCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl ListCommand {
@@ -59,6 +64,9 @@ impl ListCommand {
         let result = client
             .get_sprints(self.board_id, self.state.as_deref(), self.limit)
             .await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_sprints(&result);
         Ok(())
     }
@@ -78,6 +86,10 @@ pub struct IssuesCommand {
     /// Maximum number of results, 0 for unlimited (default: 50).
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl IssuesCommand {
@@ -87,6 +99,9 @@ impl IssuesCommand {
         let result = client
             .get_sprint_issues(self.sprint_id, self.jql.as_deref(), self.limit)
             .await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
         print_sprint_issues(&result);
         Ok(())
     }
@@ -432,6 +447,7 @@ mod tests {
                 board_id: 1,
                 state: None,
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, SprintSubcommands::List(_)));
@@ -444,6 +460,7 @@ mod tests {
                 sprint_id: 10,
                 jql: None,
                 limit: 50,
+                output: OutputFormat::Table,
             }),
         };
         assert!(matches!(cmd.command, SprintSubcommands::Issues(_)));
@@ -466,6 +483,7 @@ mod tests {
             board_id: 1,
             state: Some("active".to_string()),
             limit: 25,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.state.as_deref(), Some("active"));
     }

--- a/src/cli/atlassian/jira/transition.rs
+++ b/src/cli/atlassian/jira/transition.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::atlassian::client::JiraTransition;
+use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Lists or executes workflow transitions on a JIRA issue.
@@ -18,6 +19,10 @@ pub struct TransitionCommand {
     /// Lists available transitions (same as omitting the transition argument).
     #[arg(long)]
     pub list: bool,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
 }
 
 impl TransitionCommand {
@@ -27,6 +32,9 @@ impl TransitionCommand {
         let transitions = client.get_transitions(&self.key).await?;
 
         let Some(target) = self.transition.as_deref().filter(|_| !self.list) else {
+            if output_as(&transitions, &self.output)? {
+                return Ok(());
+            }
             print_transitions(&transitions);
             return Ok(());
         };
@@ -228,6 +236,7 @@ mod tests {
             key: "PROJ-1".to_string(),
             transition: None,
             list: true,
+            output: OutputFormat::Table,
         };
         assert!(cmd.list);
         assert!(cmd.transition.is_none());
@@ -239,6 +248,7 @@ mod tests {
             key: "PROJ-1".to_string(),
             transition: Some("Done".to_string()),
             list: false,
+            output: OutputFormat::Table,
         };
         assert_eq!(cmd.transition.as_deref(), Some("Done"));
     }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -271,11 +271,12 @@ Searches Confluence pages using CQL
 Usage: search [OPTIONS]
 
 Options:
-      --cql <CQL>      Raw CQL query string (e.g., "space = ENG AND title ~ 'architecture'")
-      --space <SPACE>  Filter by space key
-      --title <TITLE>  Filter by title (substring match)
-      --limit <LIMIT>  Maximum number of results, 0 for unlimited (default: 25) [default: 25]
-  -h, --help           Print help
+      --cql <CQL>        Raw CQL query string (e.g., "space = ENG AND title ~ 'architecture'")
+      --space <SPACE>    Filter by space key
+      --title <TITLE>    Filter by title (substring match)
+      --limit <LIMIT>    Maximum number of results, 0 for unlimited (default: 25) [default: 25]
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -454,7 +455,8 @@ Options:
       --board-id <BOARD_ID>  Board ID
       --jql <JQL>            JQL filter for issues
       --limit <LIMIT>        Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help                 Print help
+  -o, --output <OUTPUT>      Output format [default: table] [possible values: table, json, yaml]
+  -h, --help                 Print help (see more with '--help')
 
 
 ================================================================================
@@ -469,7 +471,8 @@ Options:
       --project <PROJECT>  Filter by project key
       --type <TYPE>        Filter by board type (scrum or kanban)
       --limit <LIMIT>      Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help               Print help
+  -o, --output <OUTPUT>    Output format [default: table] [possible values: table, json, yaml]
+  -h, --help               Print help (see more with '--help')
 
 
 ================================================================================
@@ -484,8 +487,9 @@ Arguments:
   <KEYS>  Issue keys, comma-separated (e.g., PROJ-1 or PROJ-1,PROJ-2)
 
 Options:
-      --limit <LIMIT>  Maximum number of changelog entries per issue (default: 50) [default: 50]
-  -h, --help           Print help
+      --limit <LIMIT>    Maximum number of changelog entries per issue (default: 50) [default: 50]
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -528,13 +532,14 @@ omni-dev atlassian jira comment list - Lists comments on a JIRA issue
 
 Lists comments on a JIRA issue
 
-Usage: list <KEY>
+Usage: list [OPTIONS] <KEY>
 
 Arguments:
   <KEY>  JIRA issue key (e.g., PROJ-123)
 
 Options:
-  -h, --help  Print help
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -615,7 +620,8 @@ Usage: list [OPTIONS]
 
 Options:
       --search <SEARCH>  Filter fields by name (case-insensitive substring match)
-  -h, --help             Print help
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -629,7 +635,8 @@ Usage: options [OPTIONS] --field-id <FIELD_ID>
 Options:
       --field-id <FIELD_ID>      Field ID (e.g., "customfield_10001")
       --context-id <CONTEXT_ID>  Context ID (auto-discovered if omitted)
-  -h, --help                     Print help
+  -o, --output <OUTPUT>          Output format [default: table] [possible values: table, json, yaml]
+  -h, --help                     Print help (see more with '--help')
 
 
 ================================================================================
@@ -687,13 +694,14 @@ omni-dev atlassian jira link list - Lists links on a JIRA issue
 
 Lists links on a JIRA issue
 
-Usage: list <KEY>
+Usage: list [OPTIONS] <KEY>
 
 Arguments:
   <KEY>  JIRA issue key (e.g., PROJ-123)
 
 Options:
-  -h, --help  Print help
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -715,10 +723,11 @@ omni-dev atlassian jira link types - Lists available issue link types
 
 Lists available issue link types
 
-Usage: types
+Usage: types [OPTIONS]
 
 Options:
-  -h, --help  Print help
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -746,8 +755,9 @@ Lists all accessible JIRA projects
 Usage: list [OPTIONS]
 
 Options:
-      --limit <LIMIT>  Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help           Print help
+      --limit <LIMIT>    Maximum number of results, 0 for unlimited (default: 50) [default: 50]
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -781,7 +791,8 @@ Options:
       --assignee <ASSIGNEE>  Filter by assignee (display name or email)
       --status <STATUS>      Filter by status name
       --limit <LIMIT>        Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help                 Print help
+  -o, --output <OUTPUT>      Output format [default: table] [possible values: table, json, yaml]
+  -h, --help                 Print help (see more with '--help')
 
 
 ================================================================================
@@ -828,7 +839,8 @@ Options:
       --sprint-id <SPRINT_ID>  Sprint ID
       --jql <JQL>              JQL filter for issues
       --limit <LIMIT>          Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help                   Print help
+  -o, --output <OUTPUT>        Output format [default: table] [possible values: table, json, yaml]
+  -h, --help                   Print help (see more with '--help')
 
 
 ================================================================================
@@ -843,7 +855,8 @@ Options:
       --board-id <BOARD_ID>  Board ID
       --state <STATE>        Filter by sprint state (active, future, closed)
       --limit <LIMIT>        Maximum number of results, 0 for unlimited (default: 50) [default: 50]
-  -h, --help                 Print help
+  -o, --output <OUTPUT>      Output format [default: table] [possible values: table, json, yaml]
+  -h, --help                 Print help (see more with '--help')
 
 
 ================================================================================
@@ -859,8 +872,9 @@ Arguments:
   [TRANSITION]  Transition name or ID to execute. Omit to list available transitions
 
 Options:
-      --list  Lists available transitions (same as omitting the transition argument)
-  -h, --help  Print help
+      --list             Lists available transitions (same as omitting the transition argument)
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR adds machine-readable output support to all Atlassian list/search/query CLI commands. Users can now request JSON or YAML output instead of the default human-readable table format using the `--output` / `-o` flag. This enables scripting, automation pipelines, and integration with other tools that consume structured data from Atlassian resources.

The implementation introduces a shared `OutputFormat` enum and `output_as` helper in `format.rs`, then derives `Serialize` on all relevant Atlassian client structs so they can be serialised via `serde_json` / `serde_yaml`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #334

## Changes Made

**Core Changes:**
- Added `OutputFormat` enum (`Table`, `Json`, `Yaml`) with `#[derive(Clone, Debug, Default, ValueEnum)]` to `src/cli/atlassian/format.rs`
- Added `output_as<T: Serialize>(data: &T, format: &OutputFormat) -> Result<bool>` helper that serialises via `serde_json::to_string_pretty` or `serde_yaml::to_string`, returning `true` when structured output was printed so callers can skip table rendering
- Derived `Serialize` on all Atlassian client structs in `src/atlassian/client.rs`: `JiraIssue`, `JiraCreatedIssue`, `JiraSearchResult`, `ConfluenceSearchResult`, `ConfluenceSearchResults`, `JiraComment`, `JiraProject`, `JiraProjectList`, `JiraField`, `JiraFieldOption`, `AgileBoard`, `AgileBoardList`, `AgileSprint`, `AgileSprintList`, `JiraChangelogEntry`, `JiraChangelogItem`, `JiraLinkType`, `JiraIssueLink`, `JiraAttachment`, `JiraTransition`
- Added `-o`/`--output` flag (default: `table`) to the following commands:
  - `confluence search`
  - `jira search`
  - `jira transition` (list mode)
  - `jira comment list`
  - `jira link list` and `jira link types`
  - `jira field list` and `jira field options`
  - `jira project list`
  - `jira board list` and `jira board issues`
  - `jira sprint list` and `jira sprint issues`
  - `jira changelog`
- Refactored `jira changelog` execution to collect all issue changelogs into a `Vec<IssueChangelog>` before printing, enabling a single serialised block for json/yaml output while preserving the existing per-issue table rendering
- Introduced local `IssueChangelog` struct (with `#[derive(Serialize)]`) in `src/cli/atlassian/jira/changelog.rs` to wrap key + entries for structured output

**Testing:**
- Added unit tests for `OutputFormat` variants (`output_default_is_table`, `output_json_variant`, `output_yaml_variant`) in `format.rs`
- Added unit tests for `output_as` helper (`output_as_table_returns_false`, `output_as_json_returns_true`, `output_as_yaml_returns_true`)
- Updated all existing unit tests across `board.rs`, `changelog.rs`, `comment.rs`, `confluence/mod.rs`, `confluence/search.rs`, `field.rs`, `jira/mod.rs`, `link.rs`, `project.rs`, `search.rs`, `sprint.rs`, `transition.rs` to include the new `output: OutputFormat::Table` field
- Updated integration snapshot `tests/snapshots/integration_test__help_all_output.snap` to reflect `-o`/`--output` option in help text for all affected commands

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for `OutputFormat` variants and `output_as` return values
- [x] Integration snapshot tests updated to reflect new CLI flags

**Manual Testing:**
- [x] Tested happy path scenarios (table output unchanged, json/yaml output produces valid structured data)
- [x] Tested error/edge cases (invalid output format value rejected by clap)
- [x] Backward compatibility verified (default remains `table`, existing behaviour unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run format-specific tests
cargo test atlassian::format

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify CLI help output matches snapshot
cargo test integration_test__help_all_output

# Example: get board list as JSON
omni-dev atlassian jira board list --output json

# Example: get Confluence search results as YAML
omni-dev atlassian confluence search --cql "space = ENG" --output yaml
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes — `output_as` short-circuits before table rendering; callers must handle the `bool` return correctly
- [x] Error handling — `output_as` propagates serialisation errors via `anyhow::Context`
- [ ] User experience
- [x] Backward compatibility — default output format is `table`, preserving existing behaviour

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The changelog command now collects all results before printing, but this was already the logical boundary for structured output and has negligible overhead for typical changelog sizes.

## Security Considerations
- [x] No security implications

Output is serialised from data already returned by the Atlassian REST API; no additional data is exposed beyond what the table view already showed.

## Breaking Changes

None. The `--output` flag defaults to `table`, so all existing commands behave identically without the flag. The only observable change in existing behaviour is the slight reformatting of help text alignment due to the addition of the new option column.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional output formats (e.g., `csv`) could be added to `OutputFormat` without changing any command implementations
- The `output_as` helper could be moved to a shared crate-level utility if other non-Atlassian commands need the same pattern

**Alternatives Considered:**
- A global `--output` flag on the top-level `atlassian` subcommand was considered but rejected in favour of per-command flags to allow commands that do not produce list output (e.g., `create`, `update`) to remain unaffected