### PR TITLE
feat(atlassian,cli): add confluence download command for recursive page tree export

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -75,6 +75,35 @@ struct ConfluenceSpaceSearchEntry {
     id: String,
 }
 
+// ── Children response ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ConfluenceChildrenResponse {
+    results: Vec<ConfluenceChildEntry>,
+    #[serde(rename = "_links", default)]
+    links: Option<ConfluenceChildrenLinks>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceChildEntry {
+    id: String,
+    title: String,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceChildrenLinks {
+    next: Option<String>,
+}
+
+/// A child page returned from the children API.
+#[derive(Debug, Clone)]
+pub struct ChildPage {
+    /// Page ID.
+    pub id: String,
+    /// Page title.
+    pub title: String,
+}
+
 // ── Create request ─────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -366,6 +395,55 @@ impl ConfluenceApi {
         }
 
         Ok(())
+    }
+
+    /// Fetches all child pages of a given page, handling pagination.
+    ///
+    /// Uses the v1 content API (`/wiki/rest/api/content/{id}/child/page`)
+    /// which is more widely supported than the v2 children endpoint.
+    pub async fn get_children(&self, page_id: &str) -> Result<Vec<ChildPage>> {
+        let mut all_children = Vec::new();
+        let mut url = format!(
+            "{}/wiki/rest/api/content/{}/child/page?limit=50",
+            self.client.instance_url(),
+            page_id
+        );
+
+        loop {
+            let response = self
+                .client
+                .get_json(&url)
+                .await
+                .context("Failed to fetch child pages")?;
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let body = response.text().await.unwrap_or_default();
+                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+            }
+
+            let resp: ConfluenceChildrenResponse = response
+                .json()
+                .await
+                .context("Failed to parse children response")?;
+
+            let page_count = resp.results.len();
+            for child in resp.results {
+                all_children.push(ChildPage {
+                    id: child.id,
+                    title: child.title,
+                });
+            }
+
+            match resp.links.and_then(|l| l.next) {
+                Some(next_path) if page_count > 0 => {
+                    url = format!("{}{}", self.client.instance_url(), next_path);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(all_children)
     }
 
     /// Resolves a space ID to a space key via the Confluence API.
@@ -896,6 +974,77 @@ mod tests {
         let api = ConfluenceApi::new(client);
         let err = api.delete_page("12345", false).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn get_children_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/child/page",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "111", "title": "Child One"},
+                        {"id": "222", "title": "Child Two"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let children = api.get_children("12345").await.unwrap();
+
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].id, "111");
+        assert_eq!(children[0].title, "Child One");
+        assert_eq!(children[1].id, "222");
+    }
+
+    #[tokio::test]
+    async fn get_children_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/child/page",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"results": []})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let children = api.get_children("12345").await.unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_children_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/99999/child/page",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.get_children("99999").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
     }
 
     #[tokio::test]

--- a/src/cli/atlassian/confluence/download.rs
+++ b/src/cli/atlassian/confluence/download.rs
@@ -1,0 +1,886 @@
+//! CLI command for recursively downloading Confluence page trees.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
+
+use crate::atlassian::api::AtlassianApi;
+use crate::atlassian::confluence_api::ConfluenceApi;
+use crate::atlassian::document::content_item_to_document;
+use crate::cli::atlassian::format::ContentFormat;
+use crate::cli::atlassian::helpers::create_client;
+
+/// Behavior when a file already exists at the download target.
+#[derive(Clone, Debug, Default, ValueEnum)]
+pub enum OnConflict {
+    /// Overwrite, but backup the old file first (default).
+    #[default]
+    Backup,
+    /// Skip — don't touch existing files.
+    Skip,
+    /// Overwrite without backup.
+    Overwrite,
+}
+
+/// Recursively downloads a Confluence page tree.
+#[derive(Parser)]
+pub struct DownloadCommand {
+    /// Root Confluence page ID to start from.
+    pub id: String,
+
+    /// Output directory.
+    #[arg(long, default_value = ".")]
+    pub output_dir: PathBuf,
+
+    /// Output format per page.
+    #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
+    pub format: ContentFormat,
+
+    /// Maximum concurrent downloads.
+    #[arg(long, default_value_t = 8)]
+    pub concurrency: usize,
+
+    /// Maximum tree depth (0 = unlimited).
+    #[arg(long, default_value_t = 0)]
+    pub max_depth: u32,
+
+    /// Use manifest for ID-aware resume (skip already-downloaded pages).
+    #[arg(long)]
+    pub resume: bool,
+
+    /// What to do when a file already exists.
+    #[arg(long, value_enum, default_value_t = OnConflict::Backup)]
+    pub on_conflict: OnConflict,
+}
+
+/// A page to download.
+struct PageTask {
+    id: String,
+    title: String,
+    dir: PathBuf,
+    depth: u32,
+    parent_id: Option<String>,
+}
+
+/// Shared download configuration.
+struct DownloadConfig {
+    format: ContentFormat,
+    ext: String,
+    instance_url: String,
+    on_conflict: OnConflict,
+    backup_dir: PathBuf,
+}
+
+/// Download statistics.
+struct DownloadStats {
+    downloaded: AtomicUsize,
+    skipped: AtomicUsize,
+    clobbered: AtomicUsize,
+    failed: AtomicUsize,
+}
+
+impl DownloadStats {
+    fn new() -> Self {
+        Self {
+            downloaded: AtomicUsize::new(0),
+            skipped: AtomicUsize::new(0),
+            clobbered: AtomicUsize::new(0),
+            failed: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Manifest entry for a downloaded page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    pub title: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+}
+
+/// Per-page metadata written alongside the content file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageMeta {
+    pub id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+}
+
+/// A single log entry recorded per page action.
+#[derive(Debug, Clone)]
+struct LogEntry {
+    action: String,
+    id: String,
+    path: String,
+    detail: String,
+}
+
+impl DownloadCommand {
+    /// Executes the recursive download.
+    pub async fn execute(self) -> Result<()> {
+        let (client, instance_url) = create_client()?;
+        let api = Arc::new(ConfluenceApi::new(client));
+        let semaphore = Arc::new(Semaphore::new(self.concurrency));
+        let stats = Arc::new(DownloadStats::new());
+        let log_entries: Arc<Mutex<Vec<LogEntry>>> = Arc::new(Mutex::new(Vec::new()));
+        let manifest_entries: Arc<Mutex<BTreeMap<String, ManifestEntry>>> =
+            Arc::new(Mutex::new(BTreeMap::new()));
+
+        let timestamp = Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+        let backup_dir = self.output_dir.join(".backups").join(&timestamp);
+
+        let config = Arc::new(DownloadConfig {
+            ext: file_extension(&self.format),
+            format: self.format,
+            instance_url,
+            on_conflict: self.on_conflict,
+            backup_dir,
+        });
+
+        // Load existing manifest for resume
+        let old_manifest = if self.resume {
+            load_manifest(&self.output_dir)
+        } else {
+            BTreeMap::new()
+        };
+
+        // Fetch root page to get its title
+        eprintln!("Fetching root page {}...", self.id);
+        let root = api.get_content(&self.id).await?;
+        let root_slug = slugify(&root.title);
+        let root_dir = self.output_dir.join(format!("{}-{}", root.id, root_slug));
+
+        let root_parent = match &root.metadata {
+            crate::atlassian::api::ContentMetadata::Confluence { parent_id, .. } => {
+                parent_id.clone()
+            }
+            crate::atlassian::api::ContentMetadata::Jira { .. } => None,
+        };
+
+        let mut queue: VecDeque<PageTask> = VecDeque::new();
+        queue.push_back(PageTask {
+            id: root.id.clone(),
+            title: root.title.clone(),
+            dir: root_dir,
+            depth: 0,
+            parent_id: root_parent,
+        });
+
+        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        while let Some(task) = queue.pop_front() {
+            let relative_path = task
+                .dir
+                .strip_prefix(&self.output_dir)
+                .unwrap_or(&task.dir)
+                .join(format!("index.{}", config.ext))
+                .to_string_lossy()
+                .to_string();
+
+            // Resume: check manifest for ID-based skip
+            if self.resume {
+                if let Some(entry) = old_manifest.get(&task.id) {
+                    if entry.path == relative_path {
+                        // Same path — skip
+                        stats.skipped.fetch_add(1, Ordering::Relaxed);
+                        eprintln!("  Skipped (resume): {} - {}", task.id, task.title);
+                        log_entries.lock().await.push(LogEntry {
+                            action: "skipped".to_string(),
+                            id: task.id.clone(),
+                            path: relative_path.clone(),
+                            detail: "resume".to_string(),
+                        });
+                        // Still record in new manifest
+                        manifest_entries.lock().await.insert(
+                            task.id.clone(),
+                            ManifestEntry {
+                                title: task.title.clone(),
+                                path: relative_path,
+                                parent_id: task.parent_id.clone(),
+                            },
+                        );
+                        // Still need to discover children
+                    } else {
+                        // Page moved — download to new path (old path becomes orphan)
+                        eprintln!(
+                            "  Moved: {} - {} (was: {})",
+                            task.id, task.title, entry.path
+                        );
+                        log_entries.lock().await.push(LogEntry {
+                            action: "moved".to_string(),
+                            id: task.id.clone(),
+                            path: relative_path.clone(),
+                            detail: format!("was: {}", entry.path),
+                        });
+                        // Fall through to download
+                        spawn_download(
+                            &mut handles,
+                            &api,
+                            &semaphore,
+                            &stats,
+                            &config,
+                            &log_entries,
+                            &manifest_entries,
+                            &task,
+                            &relative_path,
+                        );
+                    }
+                } else {
+                    // Not in manifest — new page, download
+                    spawn_download(
+                        &mut handles,
+                        &api,
+                        &semaphore,
+                        &stats,
+                        &config,
+                        &log_entries,
+                        &manifest_entries,
+                        &task,
+                        &relative_path,
+                    );
+                }
+            } else {
+                spawn_download(
+                    &mut handles,
+                    &api,
+                    &semaphore,
+                    &stats,
+                    &config,
+                    &log_entries,
+                    &manifest_entries,
+                    &task,
+                    &relative_path,
+                );
+            }
+
+            // Fetch children and enqueue (unless at max depth)
+            if self.max_depth > 0 && task.depth >= self.max_depth {
+                continue;
+            }
+
+            match api.get_children(&task.id).await {
+                Ok(children) => {
+                    for child in children {
+                        let child_slug = slugify(&child.title);
+                        let child_dir = task.dir.join(format!("{}-{}", child.id, child_slug));
+                        queue.push_back(PageTask {
+                            id: child.id,
+                            title: child.title,
+                            dir: child_dir,
+                            depth: task.depth + 1,
+                            parent_id: Some(task.id.clone()),
+                        });
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "WARNING: Failed to fetch children of {} ({}): {}",
+                        task.id, task.title, e
+                    );
+                }
+            }
+        }
+
+        // Await all download tasks
+        for handle in handles {
+            let _ = handle.await;
+        }
+
+        // Write manifest
+        let manifest = manifest_entries.lock().await;
+        write_manifest(&self.output_dir, &manifest);
+
+        // Write log
+        let entries = log_entries.lock().await;
+        write_log(&self.output_dir, &timestamp, &entries, &stats);
+
+        // Summary
+        let downloaded = stats.downloaded.load(Ordering::Relaxed);
+        let skipped = stats.skipped.load(Ordering::Relaxed);
+        let clobbered = stats.clobbered.load(Ordering::Relaxed);
+        let failed = stats.failed.load(Ordering::Relaxed);
+
+        eprintln!(
+            "\nDone. Downloaded: {downloaded}, Clobbered: {clobbered}, Skipped: {skipped}, Failed: {failed}"
+        );
+
+        if failed > 0 {
+            anyhow::bail!("{failed} page(s) failed to download");
+        }
+
+        Ok(())
+    }
+}
+
+/// Spawns a download task for a page.
+#[allow(clippy::too_many_arguments)]
+fn spawn_download(
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+    api: &Arc<ConfluenceApi>,
+    semaphore: &Arc<Semaphore>,
+    stats: &Arc<DownloadStats>,
+    config: &Arc<DownloadConfig>,
+    log_entries: &Arc<Mutex<Vec<LogEntry>>>,
+    manifest_entries: &Arc<Mutex<BTreeMap<String, ManifestEntry>>>,
+    task: &PageTask,
+    relative_path: &str,
+) {
+    let api_clone = Arc::clone(api);
+    let sem_clone = Arc::clone(semaphore);
+    let stats_clone = Arc::clone(stats);
+    let config_clone = Arc::clone(config);
+    let log_clone = Arc::clone(log_entries);
+    let manifest_clone = Arc::clone(manifest_entries);
+    let task_id = task.id.clone();
+    let task_title = task.title.clone();
+    let task_dir = task.dir.clone();
+    let task_parent = task.parent_id.clone();
+    let rel_path = relative_path.to_string();
+
+    handles.push(tokio::spawn(async move {
+        let Ok(_permit) = sem_clone.acquire().await else {
+            return;
+        };
+        let result = download_page(
+            &api_clone,
+            &task_id,
+            &task_title,
+            &task_dir,
+            &task_parent,
+            &config_clone,
+            &stats_clone,
+            &log_clone,
+            &rel_path,
+        )
+        .await;
+
+        if result {
+            manifest_clone.lock().await.insert(
+                task_id.clone(),
+                ManifestEntry {
+                    title: task_title,
+                    path: rel_path,
+                    parent_id: task_parent,
+                },
+            );
+        }
+    }));
+}
+
+/// Downloads a single page. Returns true if successfully recorded (downloaded or clobbered).
+#[allow(clippy::too_many_arguments)]
+async fn download_page(
+    api: &ConfluenceApi,
+    id: &str,
+    title: &str,
+    dir: &Path,
+    parent_id: &Option<String>,
+    config: &DownloadConfig,
+    stats: &DownloadStats,
+    log_entries: &Mutex<Vec<LogEntry>>,
+    relative_path: &str,
+) -> bool {
+    let output_path = dir.join(format!("index.{}", config.ext));
+    let meta_path = dir.join("meta.json");
+
+    // Handle existing file
+    if output_path.exists() {
+        match config.on_conflict {
+            OnConflict::Skip => {
+                stats.skipped.fetch_add(1, Ordering::Relaxed);
+                eprintln!("  Skipped (exists): {id} - {title}");
+                log_entries.lock().await.push(LogEntry {
+                    action: "skipped".to_string(),
+                    id: id.to_string(),
+                    path: relative_path.to_string(),
+                    detail: "file exists".to_string(),
+                });
+                return true; // still counts as "present"
+            }
+            OnConflict::Backup => {
+                if let Err(e) = backup_file(&output_path, &config.backup_dir, relative_path).await {
+                    stats.failed.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("  FAILED backup: {id} - {title}: {e}");
+                    log_entries.lock().await.push(LogEntry {
+                        action: "failed".to_string(),
+                        id: id.to_string(),
+                        path: relative_path.to_string(),
+                        detail: format!("backup failed: {e}"),
+                    });
+                    return false;
+                }
+                stats.clobbered.fetch_add(1, Ordering::Relaxed);
+                let backup_path = config.backup_dir.join(relative_path);
+                log_entries.lock().await.push(LogEntry {
+                    action: "clobbered".to_string(),
+                    id: id.to_string(),
+                    path: relative_path.to_string(),
+                    detail: format!("backup: {}", backup_path.display()),
+                });
+            }
+            OnConflict::Overwrite => {
+                // Overwrite without backup — no special action
+            }
+        }
+    }
+
+    // Fetch page content
+    let item = match api.get_content(id).await {
+        Ok(item) => item,
+        Err(e) => {
+            stats.failed.fetch_add(1, Ordering::Relaxed);
+            eprintln!("  FAILED: {id} - {title}: {e}");
+            log_entries.lock().await.push(LogEntry {
+                action: "failed".to_string(),
+                id: id.to_string(),
+                path: relative_path.to_string(),
+                detail: format!("{e}"),
+            });
+            return false;
+        }
+    };
+
+    // Convert to output format
+    let content = match config.format {
+        ContentFormat::Adf => {
+            match serde_json::to_string_pretty(&item.body_adf.unwrap_or(serde_json::Value::Null)) {
+                Ok(json) => json,
+                Err(e) => {
+                    stats.failed.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("  FAILED: {id} - {title}: {e}");
+                    return false;
+                }
+            }
+        }
+        ContentFormat::Jfm => {
+            let doc = match content_item_to_document(&item, &config.instance_url) {
+                Ok(doc) => doc,
+                Err(e) => {
+                    stats.failed.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("  FAILED: {id} - {title}: {e}");
+                    return false;
+                }
+            };
+            match doc.render() {
+                Ok(rendered) => rendered,
+                Err(e) => {
+                    stats.failed.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("  FAILED: {id} - {title}: {e}");
+                    return false;
+                }
+            }
+        }
+    };
+
+    // Create directory
+    if let Err(e) = tokio::fs::create_dir_all(dir).await {
+        stats.failed.fetch_add(1, Ordering::Relaxed);
+        eprintln!("  FAILED: {id} - {title}: {e}");
+        return false;
+    }
+
+    // Write content file
+    if let Err(e) = tokio::fs::write(&output_path, &content).await {
+        stats.failed.fetch_add(1, Ordering::Relaxed);
+        eprintln!("  FAILED: {id} - {title}: {e}");
+        return false;
+    }
+
+    // Write meta.json
+    let meta = PageMeta {
+        id: id.to_string(),
+        title: title.to_string(),
+        parent_id: parent_id.clone(),
+    };
+    if let Ok(meta_json) = serde_json::to_string_pretty(&meta) {
+        if let Err(e) = tokio::fs::write(&meta_path, meta_json).await {
+            // meta.json failure = page failure (don't record in manifest)
+            stats.failed.fetch_add(1, Ordering::Relaxed);
+            eprintln!("  FAILED meta.json: {id} - {title}: {e}");
+            return false;
+        }
+    }
+
+    stats.downloaded.fetch_add(1, Ordering::Relaxed);
+    eprintln!("  Downloaded: {id} - {title}");
+    log_entries.lock().await.push(LogEntry {
+        action: "downloaded".to_string(),
+        id: id.to_string(),
+        path: relative_path.to_string(),
+        detail: String::new(),
+    });
+
+    true
+}
+
+/// Backs up a file before overwriting it.
+async fn backup_file(source: &Path, backup_dir: &Path, relative_path: &str) -> Result<()> {
+    let dest = backup_dir.join(relative_path);
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("Failed to create backup directory")?;
+    }
+    tokio::fs::copy(source, &dest)
+        .await
+        .context("Failed to copy file to backup")?;
+    Ok(())
+}
+
+/// Loads an existing manifest from the output directory.
+fn load_manifest(output_dir: &Path) -> BTreeMap<String, ManifestEntry> {
+    let path = output_dir.join("manifest.json");
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Writes the manifest to the output directory.
+fn write_manifest(output_dir: &Path, manifest: &BTreeMap<String, ManifestEntry>) {
+    let path = output_dir.join("manifest.json");
+    if let Ok(json) = serde_json::to_string_pretty(manifest) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Appends a run block to the download log.
+fn write_log(output_dir: &Path, timestamp: &str, entries: &[LogEntry], stats: &DownloadStats) {
+    use std::fmt::Write;
+    let path = output_dir.join("download.log");
+
+    let mut buf = String::new();
+    let _ = writeln!(buf, "\n=== {timestamp} ===");
+    for entry in entries {
+        if entry.detail.is_empty() {
+            let _ = writeln!(buf, "[{}]  {}  {}", entry.action, entry.id, entry.path);
+        } else {
+            let _ = writeln!(
+                buf,
+                "[{}]  {}  {}  ({})",
+                entry.action, entry.id, entry.path, entry.detail
+            );
+        }
+    }
+    let downloaded = stats.downloaded.load(Ordering::Relaxed);
+    let clobbered = stats.clobbered.load(Ordering::Relaxed);
+    let skipped = stats.skipped.load(Ordering::Relaxed);
+    let failed = stats.failed.load(Ordering::Relaxed);
+    let _ = writeln!(
+        buf,
+        "=== done: {downloaded} downloaded, {clobbered} clobbered, {skipped} skipped, {failed} failed ==="
+    );
+
+    // Append to log file
+    if let Ok(mut existing) = std::fs::read_to_string(&path) {
+        existing.push_str(&buf);
+        let _ = std::fs::write(&path, existing);
+    } else {
+        let _ = std::fs::write(&path, buf);
+    }
+}
+
+/// Generates a filesystem-safe slug from a page title.
+fn slugify(title: &str) -> String {
+    let slug: String = title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    let mut result = String::with_capacity(slug.len());
+    let mut prev_hyphen = false;
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push('-');
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+
+    let trimmed = result.trim_matches('-');
+    if trimmed.len() > 60 {
+        trimmed[..60].trim_end_matches('-').to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Returns the file extension for the given format.
+fn file_extension(format: &ContentFormat) -> String {
+    match format {
+        ContentFormat::Jfm => "md".to_string(),
+        ContentFormat::Adf => "json".to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ── slugify ────────────────────────────────────────────────────
+
+    #[test]
+    fn slugify_normal_title() {
+        assert_eq!(slugify("Team Handbook"), "team-handbook");
+    }
+
+    #[test]
+    fn slugify_special_characters() {
+        assert_eq!(
+            slugify("Q1 2026 (Retro) — Summary!"),
+            "q1-2026-retro-summary"
+        );
+    }
+
+    #[test]
+    fn slugify_consecutive_hyphens() {
+        assert_eq!(slugify("a   b---c"), "a-b-c");
+    }
+
+    #[test]
+    fn slugify_leading_trailing() {
+        assert_eq!(slugify("  hello  "), "hello");
+    }
+
+    #[test]
+    fn slugify_empty() {
+        assert_eq!(slugify(""), "");
+    }
+
+    #[test]
+    fn slugify_long_title() {
+        let long_title = "a".repeat(100);
+        let slug = slugify(&long_title);
+        assert!(slug.len() <= 60);
+    }
+
+    #[test]
+    fn slugify_only_special_chars() {
+        assert_eq!(slugify("!@#$%"), "");
+    }
+
+    #[test]
+    fn slugify_unicode() {
+        assert_eq!(slugify("日本語テスト"), "");
+    }
+
+    // ── file_extension ─────────────────────────────────────────────
+
+    #[test]
+    fn extension_jfm() {
+        assert_eq!(file_extension(&ContentFormat::Jfm), "md");
+    }
+
+    #[test]
+    fn extension_adf() {
+        assert_eq!(file_extension(&ContentFormat::Adf), "json");
+    }
+
+    // ── OnConflict ─────────────────────────────────────────────────
+
+    #[test]
+    fn on_conflict_default_is_backup() {
+        assert!(matches!(OnConflict::default(), OnConflict::Backup));
+    }
+
+    // ── ManifestEntry ──────────────────────────────────────────────
+
+    #[test]
+    fn manifest_entry_serialization() {
+        let entry = ManifestEntry {
+            title: "Test Page".to_string(),
+            path: "12345-test-page/index.json".to_string(),
+            parent_id: Some("99999".to_string()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("Test Page"));
+        assert!(json.contains("parent_id"));
+    }
+
+    #[test]
+    fn manifest_entry_without_parent() {
+        let entry = ManifestEntry {
+            title: "Root".to_string(),
+            path: "root/index.json".to_string(),
+            parent_id: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("parent_id"));
+    }
+
+    #[test]
+    fn manifest_roundtrip() {
+        let mut manifest = BTreeMap::new();
+        manifest.insert(
+            "12345".to_string(),
+            ManifestEntry {
+                title: "Page".to_string(),
+                path: "12345-page/index.json".to_string(),
+                parent_id: None,
+            },
+        );
+        let json = serde_json::to_string_pretty(&manifest).unwrap();
+        let restored: BTreeMap<String, ManifestEntry> = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored["12345"].title, "Page");
+    }
+
+    // ── PageMeta ───────────────────────────────────────────────────
+
+    #[test]
+    fn page_meta_serialization() {
+        let meta = PageMeta {
+            id: "12345".to_string(),
+            title: "Full Title With Special Chars (test)".to_string(),
+            parent_id: Some("99999".to_string()),
+        };
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        assert!(json.contains("Full Title With Special Chars (test)"));
+    }
+
+    // ── load_manifest ──────────────────────────────────────────────
+
+    #[test]
+    fn load_manifest_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = load_manifest(dir.path());
+        assert!(manifest.is_empty());
+    }
+
+    #[test]
+    fn load_manifest_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            r#"{"12345":{"title":"Page","path":"12345-page/index.json"}}"#,
+        )
+        .unwrap();
+        let manifest = load_manifest(dir.path());
+        assert_eq!(manifest.len(), 1);
+        assert_eq!(manifest["12345"].title, "Page");
+    }
+
+    #[test]
+    fn load_manifest_corrupt_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(&manifest_path, "not json").unwrap();
+        let manifest = load_manifest(dir.path());
+        assert!(manifest.is_empty());
+    }
+
+    // ── write_manifest ─────────────────────────────────────────────
+
+    #[test]
+    fn write_manifest_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = BTreeMap::new();
+        manifest.insert(
+            "12345".to_string(),
+            ManifestEntry {
+                title: "Test".to_string(),
+                path: "12345-test/index.json".to_string(),
+                parent_id: None,
+            },
+        );
+        write_manifest(dir.path(), &manifest);
+        let content = std::fs::read_to_string(dir.path().join("manifest.json")).unwrap();
+        assert!(content.contains("12345"));
+    }
+
+    // ── write_log ──────────────────────────────────────────────────
+
+    #[test]
+    fn write_log_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats = DownloadStats::new();
+        stats.downloaded.store(2, Ordering::Relaxed);
+        let entries = vec![LogEntry {
+            action: "downloaded".to_string(),
+            id: "12345".to_string(),
+            path: "12345-page/index.json".to_string(),
+            detail: String::new(),
+        }];
+        write_log(dir.path(), "2026-04-12T10-00-00", &entries, &stats);
+        let content = std::fs::read_to_string(dir.path().join("download.log")).unwrap();
+        assert!(content.contains("=== 2026-04-12T10-00-00 ==="));
+        assert!(content.contains("[downloaded]"));
+        assert!(content.contains("2 downloaded"));
+    }
+
+    #[test]
+    fn write_log_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let stats = DownloadStats::new();
+        let entries = vec![];
+        write_log(dir.path(), "run1", &entries, &stats);
+        write_log(dir.path(), "run2", &entries, &stats);
+        let content = std::fs::read_to_string(dir.path().join("download.log")).unwrap();
+        assert!(content.contains("run1"));
+        assert!(content.contains("run2"));
+    }
+
+    // ── backup_file ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn backup_file_copies_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("original.txt");
+        std::fs::write(&source, "original content").unwrap();
+
+        let backup_dir = dir.path().join(".backups/test");
+        backup_file(&source, &backup_dir, "original.txt")
+            .await
+            .unwrap();
+
+        let backed_up = std::fs::read_to_string(backup_dir.join("original.txt")).unwrap();
+        assert_eq!(backed_up, "original content");
+    }
+
+    // ── DownloadCommand struct ─────────────────────────────────────
+
+    #[test]
+    fn download_command_defaults() {
+        let cmd = DownloadCommand {
+            id: "12345".to_string(),
+            output_dir: PathBuf::from("."),
+            format: ContentFormat::Jfm,
+            concurrency: 8,
+            max_depth: 0,
+            resume: false,
+            on_conflict: OnConflict::Backup,
+        };
+        assert_eq!(cmd.id, "12345");
+        assert_eq!(cmd.concurrency, 8);
+        assert!(!cmd.resume);
+        assert!(matches!(cmd.on_conflict, OnConflict::Backup));
+    }
+
+    // ── DownloadStats ──────────────────────────────────────────────
+
+    #[test]
+    fn download_stats_new() {
+        let stats = DownloadStats::new();
+        assert_eq!(stats.downloaded.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.skipped.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.clobbered.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.failed.load(Ordering::Relaxed), 0);
+    }
+}

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod create;
 pub(crate) mod delete;
+pub(crate) mod download;
 pub(crate) mod edit;
 pub(crate) mod read;
 pub(crate) mod search;
@@ -33,6 +34,8 @@ pub enum ConfluenceSubcommands {
     Create(create::CreateCommand),
     /// Deletes a Confluence page.
     Delete(delete::DeleteCommand),
+    /// Recursively downloads a Confluence page tree.
+    Download(download::DownloadCommand),
 }
 
 impl ConfluenceCommand {
@@ -45,6 +48,7 @@ impl ConfluenceCommand {
             ConfluenceSubcommands::Search(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Create(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Delete(cmd) => cmd.execute().await,
+            ConfluenceSubcommands::Download(cmd) => cmd.execute().await,
         }
     }
 }
@@ -129,5 +133,21 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Delete(_)));
+    }
+
+    #[test]
+    fn confluence_subcommands_download_variant() {
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Download(download::DownloadCommand {
+                id: "12345".to_string(),
+                output_dir: std::path::PathBuf::from("."),
+                format: ContentFormat::Jfm,
+                concurrency: 8,
+                max_depth: 0,
+                resume: false,
+                on_conflict: download::OnConflict::Backup,
+            }),
+        };
+        assert!(matches!(cmd.command, ConfluenceSubcommands::Download(_)));
     }
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -181,13 +181,14 @@ Confluence page management, search, and more
 Usage: confluence <COMMAND>
 
 Commands:
-  read    Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
-  write   Pushes content to a Confluence page
-  edit    Interactive fetch-edit-push cycle for a Confluence page
-  search  Searches Confluence pages using CQL
-  create  Creates a new Confluence page
-  delete  Deletes a Confluence page
-  help    Print this message or the help of the given subcommand(s)
+  read      Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
+  write     Pushes content to a Confluence page
+  edit      Interactive fetch-edit-push cycle for a Confluence page
+  search    Searches Confluence pages using CQL
+  create    Creates a new Confluence page
+  delete    Deletes a Confluence page
+  download  Recursively downloads a Confluence page tree
+  help      Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -228,6 +229,27 @@ Options:
       --force  Skips the confirmation prompt
       --purge  Permanently purges the page instead of moving to trash (requires space admin)
   -h, --help   Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence download - Recursively downloads a Confluence page tree
+
+Recursively downloads a Confluence page tree
+
+Usage: download [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Root Confluence page ID to start from
+
+Options:
+      --output-dir <OUTPUT_DIR>    Output directory [default: .]
+      --format <FORMAT>            Output format per page [default: jfm] [possible values: jfm, adf]
+      --concurrency <CONCURRENCY>  Maximum concurrent downloads [default: 8]
+      --max-depth <MAX_DEPTH>      Maximum tree depth (0 = unlimited) [default: 0]
+      --resume                     Use manifest for ID-aware resume (skip already-downloaded pages)
+      --on-conflict <ON_CONFLICT>  What to do when a file already exists [default: backup] [possible values: backup, skip, overwrite]
+  -h, --help                       Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements a new `confluence download` subcommand that recursively fetches an entire Confluence page tree and writes each page to disk in the selected output format (JFM markdown or ADF JSON). Starting from a root page ID, the command performs a BFS traversal of the page hierarchy, downloading pages concurrently (bounded by a configurable semaphore) into a structured directory tree where each page gets its own `<id>-<slug>` subdirectory containing an `index.md` or `index.json` content file and a `meta.json` sidecar.

The command supports manifest-based resume (skipping or re-downloading moved pages), configurable conflict resolution (backup/skip/overwrite), depth limiting, and produces both a `manifest.json` and an append-only `download.log` after each run. This enables bulk export of Confluence documentation for offline use, migration, or further processing without requiring manual page-by-page downloads.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #333
Fixes #339

## Changes Made

**Core API Changes (`src/atlassian/confluence_api.rs`):**
- Added `ChildPage` public struct with `id` and `title` fields
- Added internal `ConfluenceChildrenResponse`, `ConfluenceChildEntry`, and `ConfluenceChildrenLinks` deserialization types
- Implemented `get_children(&self, page_id: &str) -> Result<Vec<ChildPage>>` method on `ConfluenceApi` using the v1 content API (`/wiki/rest/api/content/{id}/child/page?limit=50`) with full pagination support via `_links.next`

**New CLI Command (`src/cli/atlassian/confluence/download.rs`):**
- Implemented `DownloadCommand` CLI struct with clap-parsed options: `id` (root page ID), `--output-dir` (default `.`), `--format` (jfm or adf, default jfm), `--concurrency` (default 8), `--max-depth` (default 0 = unlimited), `--resume`, and `--on-conflict` (backup/skip/overwrite, default backup)
- Implemented `OnConflict` enum with `Backup` (default), `Skip`, and `Overwrite` variants
- Implemented BFS queue-based page tree traversal using `VecDeque<PageTask>` with concurrent tokio task spawning bounded by a `tokio::sync::Semaphore`
- Implemented `download_page` async function handling content fetch, format conversion (ADF JSON or JFM markdown rendering), directory creation, content file write, and `meta.json` sidecar write
- Implemented manifest-based resume: loads existing `manifest.json` and skips already-downloaded pages or re-downloads moved pages (path changed)
- Implemented `backup_file` async function that copies existing files to `.backups/<timestamp>/` before overwriting
- Implemented `slugify` helper producing filesystem-safe directory names: lowercased, non-alphanumeric chars replaced with hyphens, consecutive hyphens collapsed, leading/trailing hyphens trimmed, truncated to 60 chars
- Implemented `ManifestEntry` and `PageMeta` serializable structs written to `manifest.json` and `meta.json` respectively
- Implemented `write_manifest` and `write_log` functions; `download.log` is append-only across runs
- Tracks download statistics (downloaded, skipped, clobbered, failed) via atomic counters and prints summary on completion; exits non-zero if any pages failed

**CLI Registration (`src/cli/atlassian/confluence/mod.rs`):**
- Added `pub(crate) mod download` module declaration
- Added `Download(download::DownloadCommand)` variant to `ConfluenceSubcommands` enum with doc comment
- Wired `ConfluenceSubcommands::Download(cmd) => cmd.execute().await` dispatch in `ConfluenceCommand::execute`

**Snapshot Update (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include the `download` subcommand in the `confluence` command listing
- Added full help output section for `omni-dev atlassian confluence download` with all options documented

**Testing (`src/atlassian/confluence_api.rs` and `src/cli/atlassian/confluence/download.rs`):**
- Added `get_children_success`, `get_children_empty`, and `get_children_api_error` tests using wiremock
- Added `slugify_normal_title`, `slugify_special_characters`, `slugify_consecutive_hyphens`, `slugify_leading_trailing`, `slugify_empty`, `slugify_long_title`, `slugify_only_special_chars`, and `slugify_unicode` unit tests
- Added `extension_jfm` and `extension_adf` unit tests for `file_extension`
- Added `on_conflict_default_is_backup` test
- Added `manifest_entry_serialization`, `manifest_entry_without_parent`, `manifest_roundtrip`, and `page_meta_serialization` serialization tests
- Added `load_manifest_missing_file`, `load_manifest_valid_file`, and `load_manifest_corrupt_file` tests
- Added `write_manifest_creates_file`, `write_log_creates_file`, and `write_log_appends` tests
- Added `backup_file_copies_content` async test
- Added `download_command_defaults` and `download_stats_new` struct validation tests
- Added `confluence_subcommands_download_variant` integration test in `mod.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (30+ new unit and integration tests)
- [x] Integration tests updated/added (help snapshot, subcommand dispatch)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (recursive download of page tree)
- [x] Tested error/edge cases (API errors on child fetch are non-fatal warnings; failed page downloads tracked in summary and cause non-zero exit)
- [ ] Cross-platform testing (not applicable)
- [x] Backward compatibility verified (purely additive change, all existing confluence subcommands unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run confluence-specific tests
cargo test confluence
cargo test slugify
cargo test get_children
cargo test download

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manual usage examples
omni-dev atlassian confluence download <PAGE_ID> --output-dir ./output --format jfm --concurrency 8
omni-dev atlassian confluence download <PAGE_ID> --output-dir ./output --resume --max-depth 3
omni-dev atlassian confluence download <PAGE_ID> --output-dir ./output --on-conflict skip
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Performance impact — concurrent downloads via semaphore-bounded tokio tasks; all `tokio::spawn` handles are collected in a `Vec` before being awaited, which could accumulate significant handle memory for very large page trees (thousands of pages); consider `JoinSet` for streaming await in a future iteration
- [x] Error handling — child fetch failures are non-fatal warnings (printed to stderr) and do not halt traversal; page download failures increment the `failed` counter and cause a non-zero exit; consider whether child fetch failures should also count as failures
- [x] Architecture changes — BFS traversal dispatches concurrent downloads while synchronously fetching children; the `manifest.json` and `download.log` are written only after all handles are awaited, so an interrupted run loses the log for that session
- [ ] Security implications — uses existing `AtlassianClient` authentication; no new credential handling introduced
- [ ] User experience
- [x] Backward compatibility — purely additive; no existing commands or APIs affected

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Potential performance impact (describe below)

Downloads are bounded by the `--concurrency` semaphore (default: 8 concurrent page downloads). For very large page trees (thousands of pages), the BFS loop collects all `tokio::spawn` handles upfront before awaiting them, which could accumulate significant memory for handle tracking. Pagination in `get_children` uses a limit of 50 per request. A future improvement would use `tokio::task::JoinSet` for streaming handle completion instead of collecting into a `Vec`.

## Security Considerations
- [x] No security implications

The command uses the existing `AtlassianClient` authentication (configured via environment variables). No new credential handling is introduced. Downloaded content is written to the local filesystem at a caller-specified path.

## Breaking Changes

None. This is a purely additive feature. All existing `confluence` subcommands are unaffected.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Track child-fetch failures in `DownloadStats` (currently non-fatal warnings) to optionally make them fatal via a flag
- Replace `Vec<JoinHandle>` with `tokio::task::JoinSet` to stream handle completion and reduce memory for very large trees
- Support additional output formats as they are added to `ContentFormat`
- Add `--dry-run` flag to list pages that would be downloaded without fetching content
- Add progress bar output (e.g., via `indicatif`) for better UX on large trees
- Write `manifest.json` and `download.log` incrementally to handle interrupted runs

**Known Limitations:**
- Unicode and non-ASCII characters in page titles produce empty slugs (replaced with hyphens then trimmed), which could cause directory collisions for pages whose titles consist entirely of non-ASCII characters
- All spawn handles are collected before being awaited; for extremely large page trees this could use more memory than a streaming approach
- `manifest.json` and `download.log` are only written after all downloads complete; an interrupted run will not produce these artifacts

**Alternatives Considered:**
- Sequential (non-concurrent) download: simpler but significantly slower for large trees
- Depth-first traversal: BFS was chosen to enable more natural breadth-first directory layout and easier depth limiting