### PR TITLE
fix(atlassian): add blank-line separation between block children in containers

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1612,6 +1612,16 @@ pub fn adf_to_markdown(doc: &AdfDocument) -> Result<String> {
     Ok(output)
 }
 
+/// Renders a sequence of block nodes with blank-line separators between them.
+fn render_block_children(children: &[AdfNode], output: &mut String) {
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
+            output.push('\n');
+        }
+        render_block_node(child, output);
+    }
+}
+
 /// Renders a block-level ADF node to markdown.
 fn render_block_node(node: &AdfNode, output: &mut String) {
     match node.node_type.as_str() {
@@ -1803,9 +1813,7 @@ fn render_block_node(node: &AdfNode, output: &mut String) {
             }
             output.push_str(&format!(":::panel{{{}}}\n", attr_parts.join(" ")));
             if let Some(ref content) = node.content {
-                for child in content {
-                    render_block_node(child, output);
-                }
+                render_block_children(content, output);
             }
             output.push_str(":::\n");
         }
@@ -1826,9 +1834,7 @@ fn render_block_node(node: &AdfNode, output: &mut String) {
                 output.push_str(&format!(":::{directive_name}\n"));
             }
             if let Some(ref content) = node.content {
-                for child in content {
-                    render_block_node(child, output);
-                }
+                render_block_children(content, output);
             }
             output.push_str(":::\n");
         }
@@ -1845,9 +1851,7 @@ fn render_block_node(node: &AdfNode, output: &mut String) {
                             .unwrap_or(50.0);
                         output.push_str(&format!(":::column{{width={width}}}\n"));
                         if let Some(ref col_content) = child.content {
-                            for block in col_content {
-                                render_block_node(block, output);
-                            }
+                            render_block_children(col_content, output);
                         }
                         output.push_str(":::\n");
                     }
@@ -1877,9 +1881,7 @@ fn render_block_node(node: &AdfNode, output: &mut String) {
                     .unwrap_or("");
                 output.push_str(&format!(":::extension{{type={ext_type} key={ext_key}}}\n"));
                 if let Some(ref content) = node.content {
-                    for child in content {
-                        render_block_node(child, output);
-                    }
+                    render_block_children(content, output);
                 }
                 output.push_str(":::\n");
             }
@@ -5037,6 +5039,73 @@ mod tests {
     fn cell_contains_hard_break_empty() {
         let para = AdfNode::paragraph(vec![]);
         assert!(!cell_contains_hard_break(&para));
+    }
+
+    // ── Multi-paragraph container tests ──────────────────────────
+
+    #[test]
+    fn multi_paragraph_panel_roundtrips() {
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode {
+                node_type: "panel".to_string(),
+                attrs: Some(serde_json::json!({"panelType": "info"})),
+                content: Some(vec![
+                    AdfNode::paragraph(vec![AdfNode::text("First paragraph.")]),
+                    AdfNode::paragraph(vec![AdfNode::text("Second paragraph.")]),
+                ]),
+                text: None,
+                marks: None,
+            }],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        // Should have blank line between paragraphs inside the panel
+        assert!(
+            md.contains("First paragraph.\n\nSecond paragraph."),
+            "Panel should have blank line between paragraphs, got:\n{md}"
+        );
+
+        // Round-trip should preserve two separate paragraphs
+        let roundtripped = markdown_to_adf(&md).unwrap();
+        assert_eq!(roundtripped.content.len(), 1);
+        assert_eq!(roundtripped.content[0].node_type, "panel");
+        let panel_content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            panel_content.len(),
+            2,
+            "Panel should have 2 paragraphs after round-trip, got {}",
+            panel_content.len()
+        );
+    }
+
+    #[test]
+    fn multi_paragraph_expand_roundtrips() {
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode {
+                node_type: "expand".to_string(),
+                attrs: Some(serde_json::json!({"title": "Details"})),
+                content: Some(vec![
+                    AdfNode::paragraph(vec![AdfNode::text("Para one.")]),
+                    AdfNode::paragraph(vec![AdfNode::text("Para two.")]),
+                ]),
+                text: None,
+                marks: None,
+            }],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&md).unwrap();
+        let expand_content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            expand_content.len(),
+            2,
+            "Expand should have 2 paragraphs after round-trip, got {}",
+            expand_content.len()
+        );
     }
 
     // ── Nested container directive tests ───────────────────────────


### PR DESCRIPTION
## Description

This PR fixes a markdown rendering bug where multiple paragraphs inside ADF container elements (panels, expands, columns, extensions) were rendered without the blank-line separator required to preserve paragraph boundaries on round-trip conversion.

Without a blank line between sibling block nodes, two consecutive paragraphs collapse into a single paragraph when the markdown is parsed back to ADF. This means content like:

```
:::panel{type=info}
First paragraph.
Second paragraph.
:::
```

would round-trip back as a single merged paragraph rather than two distinct paragraphs. The fix introduces a `render_block_children` helper that inserts a `\n` separator between sibling block nodes, restoring correct paragraph boundaries in all container directive types.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Relates to #344

## Changes Made

**Core Changes:**
- Added `render_block_children` helper function in `src/atlassian/convert.rs` that iterates over a slice of `AdfNode` block children and inserts a blank line (`\n`) between each sibling before delegating to `render_block_node`
- Replaced inline `for child in content { render_block_node(...) }` loops in panel, expand, column, and extension rendering paths with calls to the new `render_block_children` helper

**Testing:**
- Added `multi_paragraph_panel_roundtrips` test asserting that a panel containing two paragraphs renders with a blank line between them and that a full ADF → markdown → ADF round-trip preserves two separate paragraph nodes
- Added `multi_paragraph_expand_roundtrips` test asserting the same invariant for expand nodes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new round-trip tests
cargo test multi_paragraph_panel_roundtrips
cargo test multi_paragraph_expand_roundtrips

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the only observable change is the addition of blank lines between block siblings inside container directives; existing single-paragraph containers are unaffected since the separator is only inserted when `i > 0`
- [x] Error handling — the helper delegates entirely to the existing `render_block_node` so error handling behaviour is unchanged

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Inserting the blank line inside `render_block_node` as a trailing newline was considered but rejected because it would affect all rendering contexts, not just multi-child containers, and would require callers to trim trailing whitespace.
- The `render_block_children` approach is minimal and surgical: it only affects the inter-sibling gap and leaves all other rendering logic untouched.