### PR TITLE
fix(atlassian): trim trailing spaces in render_inline_content for round-trip fidelity

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2361,11 +2361,17 @@ fn render_media(node: &AdfNode, parent_attrs: Option<&serde_json::Value>, output
 }
 
 /// Renders inline content (text nodes with marks) from a block node's children.
+/// Trailing spaces (not newlines) are trimmed to ensure round-trip fidelity
+/// in pipe tables, where cell content is trimmed during parsing.
 fn render_inline_content(node: &AdfNode, output: &mut String) {
     if let Some(ref content) = node.content {
         for child in content {
             render_inline_node(child, output);
         }
+    }
+    // Trim trailing spaces (but not newlines — those are from hardBreak).
+    while output.ends_with(' ') {
+        output.pop();
     }
 }
 
@@ -5379,6 +5385,77 @@ mod tests {
     fn cell_contains_hard_break_empty() {
         let para = AdfNode::paragraph(vec![]);
         assert!(!cell_contains_hard_break(&para));
+    }
+
+    // ── Trailing whitespace trimming tests ───────────────────────
+
+    #[test]
+    fn trailing_space_text_node_trimmed_in_roundtrip() {
+        // mention + " " + mention + " " → the trailing " " should not survive round-trip
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![
+                AdfNode::mention("abc", "@Rob"),
+                AdfNode::text(" "),
+                AdfNode::mention("def", "@Alice"),
+                AdfNode::text(" "),
+            ])],
+        };
+        let md = adf_to_markdown(&adf).unwrap();
+        // Trailing space should be stripped
+        assert!(
+            !md.trim_end_matches('\n').ends_with(' '),
+            "Rendered markdown should not have trailing space: {:?}",
+            md
+        );
+        // Round-trip should preserve inter-mention space but not trailing
+        let rt = markdown_to_adf(&md).unwrap();
+        let para = &rt.content[0];
+        let nodes = para.content.as_ref().unwrap();
+        // Should have: mention, text(" "), mention — no trailing text(" ")
+        assert_eq!(nodes.len(), 3, "Expected 3 nodes, got {nodes:?}");
+        assert_eq!(nodes[0].node_type, "mention");
+        assert_eq!(nodes[1].node_type, "text");
+        assert_eq!(nodes[1].text.as_deref(), Some(" "));
+        assert_eq!(nodes[2].node_type, "mention");
+    }
+
+    #[test]
+    fn trailing_space_trimmed_in_pipe_table_cell() {
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::table(vec![AdfNode::table_row(vec![
+                AdfNode::table_cell(vec![AdfNode::paragraph(vec![
+                    AdfNode::mention("abc", "@Rob"),
+                    AdfNode::text(" "),
+                    AdfNode::mention("def", "@Alice"),
+                    AdfNode::text(" "),
+                ])]),
+            ])])],
+        };
+        let md = adf_to_markdown(&adf).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let para = &cell.content.as_ref().unwrap()[0];
+        let nodes = para.content.as_ref().unwrap();
+        // Inter-mention space preserved, trailing space dropped
+        assert!(
+            nodes.iter().any(|n| n.node_type == "mention"),
+            "Should have mentions"
+        );
+        assert!(
+            nodes
+                .iter()
+                .filter(|n| n.node_type == "text" && n.text.as_deref() == Some(" "))
+                .count()
+                >= 1,
+            "Should have at least one space between mentions"
+        );
     }
 
     // ── Multi-paragraph container tests ──────────────────────────


### PR DESCRIPTION
## Description

This PR fixes a round-trip fidelity issue in the ADF → markdown → ADF conversion pipeline. When inline content (e.g., a mention node followed by a trailing space text node) was rendered to markdown, the trailing space survived into the output string. During the reverse parse, pipe table cell parsers strip trailing whitespace from cell content, causing the reconstructed ADF structure to differ from the original — breaking round-trip equality.

The fix adds a trailing-space trim loop at the end of `render_inline_content` that removes any spaces appended after the last inline node, while deliberately preserving newlines produced by `hardBreak` nodes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #346

## Changes Made

**Core Changes:**
- Added a trailing-space trim loop in `render_inline_content` (`src/atlassian/convert.rs`) that pops trailing `' '` characters from the output buffer after all child nodes have been rendered
- Added a doc comment to `render_inline_content` explaining the round-trip motivation and the deliberate preservation of newlines

**Testing:**
- Added `trailing_space_text_node_trimmed_in_roundtrip` test: verifies that a paragraph containing `mention + " " + mention + " "` produces markdown without a trailing space and that the round-trip ADF has exactly 3 nodes (mention, space text, mention) with no trailing text node
- Added `trailing_space_trimmed_in_pipe_table_cell` test: verifies the same trailing-space pattern inside a pipe table cell is dropped during round-trip while the inter-mention space is preserved

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios (mention + space + mention paragraphs)
- [x] Tested edge cases (trailing space inside pipe table cells, hardBreak nodes not affected)
- [x] Backward compatibility verified (inter-node spaces are preserved; only trailing spaces are trimmed)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new trailing-space tests
cargo test trailing_space

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the trim only removes spaces at the very end of the output buffer; spaces between inline nodes (e.g., between two mentions) are unaffected
- [x] The deliberate choice to use `while output.ends_with(' ')` rather than `trim_end()` to preserve newlines from `hardBreak` nodes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using `output.trim_end_matches(' ')` (returns a `&str` slice) was considered but would also require a re-allocation and does not mutate in place; the `while ends_with / pop` loop is idiomatic for in-place `String` mutation and avoids allocating a new string.
- Trimming inside each individual inline node renderer was considered but would have incorrectly removed intentional spaces between nodes.