### PR TITLE
fix(atlassian): preserve style and localId attrs on status nodes

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1430,7 +1430,19 @@ fn try_dispatch_inline_directive(text: &str, pos: usize) -> Option<(AdfNode, usi
                 .as_ref()
                 .and_then(|a| a.get("color"))
                 .unwrap_or("neutral");
-            AdfNode::status(content, color)
+            let mut node = AdfNode::status(content, color);
+            // Pass through style and localId if present
+            if let Some(ref attrs) = d.attrs {
+                if let Some(ref mut node_attrs) = node.attrs {
+                    if let Some(style) = attrs.get("style") {
+                        node_attrs["style"] = serde_json::Value::String(style.to_string());
+                    }
+                    if let Some(local_id) = attrs.get("localId") {
+                        node_attrs["localId"] = serde_json::Value::String(local_id.to_string());
+                    }
+                }
+            }
+            node
         }
         "date" => {
             // Convert ISO 8601 date to epoch milliseconds for ADF
@@ -2382,7 +2394,16 @@ fn render_inline_node(node: &AdfNode, output: &mut String) {
                     .get("color")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("neutral");
-                output.push_str(&format!(":status[{text}]{{color={color}}}"));
+                let mut attr_parts = vec![format!("color={color}")];
+                if let Some(style) = attrs.get("style").and_then(serde_json::Value::as_str) {
+                    attr_parts.push(format!("style={style}"));
+                }
+                if let Some(local_id) = attrs.get("localId").and_then(serde_json::Value::as_str) {
+                    if local_id != "00000000-0000-0000-0000-000000000000" {
+                        attr_parts.push(format!("localId={local_id}"));
+                    }
+                }
+                output.push_str(&format!(":status[{text}]{{{}}}", attr_parts.join(" ")));
             }
         }
         "date" => {
@@ -4023,6 +4044,59 @@ mod tests {
         let doc = markdown_to_adf(md).unwrap();
         let result = adf_to_markdown(&doc).unwrap();
         assert!(result.contains(":status[In Progress]{color=blue}"));
+    }
+
+    #[test]
+    fn status_with_style_and_localid_roundtrips() {
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![{
+                let mut node = AdfNode::status("open", "green");
+                node.attrs.as_mut().unwrap()["style"] =
+                    serde_json::Value::String("bold".to_string());
+                node.attrs.as_mut().unwrap()["localId"] =
+                    serde_json::Value::String("d2205ca5-84b9-4950-a730-bfe550fc146b".to_string());
+                node
+            }])],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        assert!(
+            md.contains("style=bold"),
+            "Markdown should contain style attr: {md}"
+        );
+        assert!(
+            md.contains("localId=d2205ca5"),
+            "Markdown should contain localId attr: {md}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let status = &rt.content[0].content.as_ref().unwrap()[0];
+        let attrs = status.attrs.as_ref().unwrap();
+        assert_eq!(attrs["text"], "open");
+        assert_eq!(attrs["color"], "green");
+        assert_eq!(attrs["style"], "bold");
+        assert_eq!(
+            attrs["localId"], "d2205ca5-84b9-4950-a730-bfe550fc146b",
+            "localId should be preserved, got: {}",
+            attrs["localId"]
+        );
+    }
+
+    #[test]
+    fn status_without_style_still_works() {
+        let md = ":status[Done]{color=green}\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let status = &doc.content[0].content.as_ref().unwrap()[0];
+        let attrs = status.attrs.as_ref().unwrap();
+        assert_eq!(attrs["text"], "Done");
+        assert_eq!(attrs["color"], "green");
+        // No style attr — should not be present
+        assert!(
+            attrs.get("style").is_none() || attrs["style"].is_null(),
+            "style should not be set when not provided"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a data loss issue where `style` and `localId` attributes on Atlassian Document Format (ADF) status nodes were silently dropped during round-trip conversion between ADF and Markdown. When converting ADF → Markdown → ADF, these optional attributes were not being passed through, causing information loss for styled or uniquely-identified status nodes.

The fix extends the `:status[]{}` directive handling in `src/atlassian/convert.rs` to preserve both `style` and `localId` attributes across the full conversion pipeline, with a special case to suppress the nil UUID (`00000000-0000-0000-0000-000000000000`) for `localId` to avoid unnecessary noise in the Markdown output.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #346

## Changes Made

**Core Changes:**
- Updated `try_dispatch_inline_directive` in `src/atlassian/convert.rs` to pass through `style` and `localId` from directive attributes into the ADF status node during Markdown-to-ADF conversion
- Updated `render_inline_node` in `src/atlassian/convert.rs` to include `style` and `localId` in the `:status[]{}` directive output during ADF-to-Markdown conversion
- Added nil UUID guard: `localId` with value `00000000-0000-0000-0000-000000000000` is intentionally omitted from Markdown output to reduce noise

**Testing:**
- Added `status_with_style_and_localid_roundtrips` test to verify full round-trip preservation of `style` and `localId` attributes
- Added `status_without_style_still_works` test to confirm status nodes without optional attributes continue to work correctly

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

**Test Coverage:**
- Two new unit tests covering the added functionality in `src/atlassian/convert.rs`

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new tests
cargo test status_with_style_and_localid_roundtrips
cargo test status_without_style_still_works

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — status nodes without `style` or `localId` must continue to work identically
- [x] Error handling — nil UUID suppression logic in `render_inline_node`

The key logic changes are both in `src/atlassian/convert.rs`:

1. **Markdown → ADF** (`try_dispatch_inline_directive`, around line 1430): After creating the status node, optionally inject `style` and `localId` from the parsed directive attributes into the node's attrs map.

2. **ADF → Markdown** (`render_inline_node`, around line 2394): Build the attribute string dynamically, appending `style` and `localId` when present. The nil UUID for `localId` is skipped to keep output clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The change is fully backward compatible — existing status directives without `style` or `localId` continue to render and parse identically to before.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Considered always emitting `localId` including the nil UUID, but this would add noise to Markdown output for status nodes that don't have a meaningful identifier. Suppressing the nil UUID keeps the output clean while still preserving real identifiers.