### PR TITLE
fix(atlassian): ensure blank lines between consecutive block nodes in table cells

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2153,9 +2153,7 @@ fn render_directive_table(node: &AdfNode, rows: &[AdfNode], output: &mut String)
                 output.push_str(&format!(":::{directive_name}{{{cell_attr_str}}}\n"));
             }
             if let Some(ref content) = cell.content {
-                for block in content {
-                    render_block_node(block, output);
-                }
+                render_block_children(content, output);
             }
             output.push_str(":::\n");
         }
@@ -5448,6 +5446,168 @@ mod tests {
             "Expand should have 2 paragraphs after round-trip, got {}",
             expand_content.len()
         );
+    }
+
+    #[test]
+    fn consecutive_nested_expands_in_table_cell_roundtrip() {
+        let cell_content = vec![
+            AdfNode {
+                node_type: "nestedExpand".to_string(),
+                attrs: Some(serde_json::json!({"title": "First"})),
+                content: Some(vec![AdfNode::paragraph(vec![AdfNode::text("item 1")])]),
+                text: None,
+                marks: None,
+            },
+            AdfNode {
+                node_type: "nestedExpand".to_string(),
+                attrs: Some(serde_json::json!({"title": "Second"})),
+                content: Some(vec![AdfNode::paragraph(vec![AdfNode::text("item 2")])]),
+                text: None,
+                marks: None,
+            },
+        ];
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::table(vec![AdfNode::table_row(vec![
+                AdfNode::table_cell(cell_content),
+            ])])],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        assert!(
+            md.contains(":::\n\n:::nested-expand"),
+            "Should have blank line between consecutive nested-expands in cell, got:\n{md}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let cell_nodes = cell.content.as_ref().unwrap();
+        let expand_count = cell_nodes
+            .iter()
+            .filter(|n| n.node_type == "nestedExpand")
+            .count();
+        assert_eq!(
+            expand_count, 2,
+            "Both nested-expands should survive round-trip, got {expand_count}"
+        );
+    }
+
+    #[test]
+    fn multi_paragraph_in_table_cell_roundtrip() {
+        // Two paragraphs inside a directive table cell should survive round-trip
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::table(vec![AdfNode::table_row(vec![
+                AdfNode::table_cell(vec![
+                    AdfNode::paragraph(vec![AdfNode::text("Para one.")]),
+                    AdfNode::paragraph(vec![AdfNode::text("Para two.")]),
+                ]),
+            ])])],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        assert!(
+            md.contains("Para one.\n\nPara two."),
+            "Should have blank line between paragraphs in cell, got:\n{md}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let para_count = cell
+            .content
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|n| n.node_type == "paragraph")
+            .count();
+        assert_eq!(para_count, 2, "Both paragraphs should survive round-trip");
+    }
+
+    #[test]
+    fn panel_inside_table_cell_roundtrip() {
+        // A panel inside a directive table cell
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::table(vec![AdfNode::table_row(vec![
+                AdfNode::table_cell(vec![
+                    AdfNode::paragraph(vec![AdfNode::text("Before panel.")]),
+                    AdfNode {
+                        node_type: "panel".to_string(),
+                        attrs: Some(serde_json::json!({"panelType": "info"})),
+                        content: Some(vec![AdfNode::paragraph(vec![AdfNode::text(
+                            "Panel content",
+                        )])]),
+                        text: None,
+                        marks: None,
+                    },
+                ]),
+            ])])],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        assert!(
+            md.contains(":::panel"),
+            "Should contain panel directive, got:\n{md}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let has_panel = cell
+            .content
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|n| n.node_type == "panel");
+        assert!(has_panel, "Panel should survive round-trip in table cell");
+    }
+
+    #[test]
+    fn three_consecutive_expands_in_table_cell() {
+        let make_expand = |title: &str| AdfNode {
+            node_type: "nestedExpand".to_string(),
+            attrs: Some(serde_json::json!({"title": title})),
+            content: Some(vec![AdfNode::paragraph(vec![AdfNode::text("content")])]),
+            text: None,
+            marks: None,
+        };
+        let adf = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::table(vec![AdfNode::table_row(vec![
+                AdfNode::table_cell(vec![
+                    make_expand("First"),
+                    make_expand("Second"),
+                    make_expand("Third"),
+                ]),
+            ])])],
+        };
+
+        let md = adf_to_markdown(&adf).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let expand_count = cell
+            .content
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|n| n.node_type == "nestedExpand")
+            .count();
+        assert_eq!(expand_count, 3, "All 3 expands should survive round-trip");
     }
 
     // ── Nested container directive tests ───────────────────────────


### PR DESCRIPTION
## Description

Fixes a bug where consecutive block-level nodes (e.g. nested expands, paragraphs, panels) inside directive table cells were rendered without blank line separators. This caused them to merge during round-trip parsing — for example, two `nestedExpand` blocks would collapse into one after an ADF → Markdown → ADF conversion cycle.

The root cause was that `render_directive_table` manually iterated over cell content using a bare `for block in content` loop, bypassing the `render_block_children` helper which already handles inter-block blank line insertion consistently throughout the rest of the renderer. The fix is a one-line change replacing the manual loop with a call to `render_block_children`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #357

## Changes Made

**Core Changes:**
- Replaced the manual `for block in content { render_block_node(block, output); }` loop in `render_directive_table` with a call to the existing `render_block_children(content, output)` helper, ensuring blank lines are consistently inserted between consecutive block-level nodes in table cells.

**Testing:**
- Added test `consecutive_nested_expands_in_table_cell_roundtrip`: verifies that two consecutive `nestedExpand` nodes in a table cell are separated by a blank line in Markdown output and both survive round-trip conversion.
- Added test `multi_paragraph_in_table_cell_roundtrip`: verifies that two paragraphs in a table cell produce a blank line separator (`Para one.\n\nPara two.`) and both survive round-trip conversion.
- Added test `panel_inside_table_cell_roundtrip`: verifies that a `panel` block inside a table cell renders the `:::panel` directive correctly and survives round-trip conversion.
- Added test `three_consecutive_expands_in_table_cell`: verifies that three consecutive `nestedExpand` nodes all survive round-trip conversion through Markdown.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test consecutive_nested_expands_in_table_cell_roundtrip
cargo test multi_paragraph_in_table_cell_roundtrip
cargo test panel_inside_table_cell_roundtrip
cargo test three_consecutive_expands_in_table_cell

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility

The change in `render_directive_table` is a single 3-line substitution in `src/atlassian/convert.rs`. The `render_block_children` helper is already used throughout the renderer for all other container node types, so this aligns table cell rendering with the established pattern. No other behavior is affected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The fix produces correct Markdown output that was previously malformed — existing content that was not affected by the bug is rendered identically.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Inserting blank lines manually inside the existing `for` loop rather than delegating to `render_block_children`. This was rejected because it would duplicate logic already maintained centrally in `render_block_children`, increasing the risk of future drift.