### PR TITLE
fix(atlassian): fix content after directive table block being silently dropped

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -356,11 +356,10 @@ impl<'a> MarkdownParser<'a> {
             let current = self.current_line();
             if try_parse_container_open(current).is_some() {
                 depth += 1;
-            } else if is_container_close(current, colon_count) {
-                if depth == 0 {
-                    self.advance(); // past closing fence
-                    break;
-                }
+            } else if depth == 0 && is_container_close(current, colon_count) {
+                self.advance(); // past closing fence
+                break;
+            } else if depth > 0 && is_container_close(current, 3) {
                 depth -= 1;
             }
             inner_lines.push(current.to_string());
@@ -5263,6 +5262,125 @@ mod tests {
                 .iter()
                 .map(|n| &n.node_type)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn content_after_directive_table_is_preserved() {
+        // Issue #361: content after a ::::table block was silently dropped
+        let md = "\
+## Before table
+
+::::table{layout=default}
+:::tr
+:::th{}
+Cell
+:::
+:::
+::::
+
+## After table
+
+Paragraph after.";
+        let adf = markdown_to_adf(md).unwrap();
+        let types: Vec<&str> = adf.content.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["heading", "table", "heading", "paragraph"],
+            "Content after table was dropped: got {types:?}"
+        );
+    }
+
+    #[test]
+    fn paragraph_after_directive_table_is_preserved() {
+        // Issue #361: minimal reproducer — paragraph after table
+        let md = "\
+::::table{layout=default}
+:::tr
+:::th{}
+Header
+:::
+:::
+::::
+
+Just a paragraph.";
+        let adf = markdown_to_adf(md).unwrap();
+        let types: Vec<&str> = adf.content.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["table", "paragraph"],
+            "Paragraph after table was dropped: got {types:?}"
+        );
+    }
+
+    #[test]
+    fn extension_after_directive_table_is_preserved() {
+        // Issue #361: extension after table
+        let md = "\
+::::table{layout=default}
+:::tr
+:::th{}
+Header
+:::
+:::
+::::
+
+::extension{type=com.atlassian.confluence.macro.core key=toc}";
+        let adf = markdown_to_adf(md).unwrap();
+        let types: Vec<&str> = adf.content.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["table", "extension"],
+            "Extension after table was dropped: got {types:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_blocks_after_directive_table() {
+        // Issue #361: multiple blocks after table, including another table
+        let md = "\
+## Heading 1
+
+::::table{layout=default}
+:::tr
+:::td{}
+A
+:::
+:::td{}
+B
+:::
+:::
+::::
+
+## Heading 2
+
+Some text.
+
+---
+
+::::table{layout=default}
+:::tr
+:::th{}
+C
+:::
+:::
+::::
+
+## Heading 3";
+        let adf = markdown_to_adf(md).unwrap();
+        let types: Vec<&str> = adf.content.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec![
+                "heading",
+                "table",
+                "heading",
+                "paragraph",
+                "rule",
+                "table",
+                "heading"
+            ],
+            "Content after tables was dropped: got {types:?}"
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes a bug (Issue #361) where any content appearing after a `::::table` directive block in Markdown was silently dropped during conversion to ADF (Atlassian Document Format). The root cause was incorrect depth tracking logic in the container fence parser within `src/atlassian/convert.rs`.

The original code decremented the depth counter even when closing a nested container at depth 0, which caused the outer container's closing fence to be consumed incorrectly, leaving the parser in a state where it skipped all subsequent content. The fix separates the depth-0 and depth>0 cases into distinct branches so the outer fence is correctly detected and the parser advances past it, allowing subsequent blocks to be processed normally.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #361

## Changes Made

**Core Changes:**
- Fixed container fence parsing logic in `src/atlassian/convert.rs` (`MarkdownParser`) to correctly handle the closing fence at depth 0 versus nested depth > 0
- Separated the single `else if is_container_close` branch into two distinct branches: one for `depth == 0` (break out of the container) and one for `depth > 0` (decrement depth for nested containers)

**Testing:**
- Added `content_after_directive_table_is_preserved` test: verifies heading and paragraph after a table are not dropped
- Added `paragraph_after_directive_table_is_preserved` test: minimal reproducer — paragraph immediately after a table block
- Added `extension_after_directive_table_is_preserved` test: verifies an extension node after a table is not dropped
- Added `multiple_blocks_after_directive_table` test: complex scenario with multiple tables, headings, paragraphs, and a rule, verifying all nodes are present in order

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (4 regression tests covering Issue #361 scenarios)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (content before and after table preserved)
- [x] Tested edge cases (multiple tables, extensions, rules after table)
- [x] Backward compatibility verified (nested container depth tracking still correct)

**Test Coverage:**
- New tests cover the exact failure scenarios from Issue #361 with assertions on ADF node type order

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test content_after_directive_table
cargo test paragraph_after_directive_table
cargo test extension_after_directive_table
cargo test multiple_blocks_after_directive_table

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the two-branch fix in `MarkdownParser` around lines 356–365 in `src/atlassian/convert.rs` is the core of the fix and warrants careful review
- [x] Backward compatibility — nested container depth tracking (`depth > 0` branch uses colon count of 3 rather than the outer fence's colon count; confirm this is correct for all valid nesting patterns)

The key change is:

**Before:**
```rust
} else if is_container_close(current, colon_count) {
    if depth == 0 {
        self.advance(); // past closing fence
        break;
    }
    depth -= 1;
}
```

**After:**
```rust
} else if depth == 0 && is_container_close(current, colon_count) {
    self.advance(); // past closing fence
    break;
} else if depth > 0 && is_container_close(current, 3) {
    depth -= 1;
}
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a purely corrective fix. Previously dropped content will now appear in the ADF output, which is the correct and expected behavior.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping a single `else if` branch with an inner `if depth == 0` check (original structure) — rejected because it always falls through to `depth -= 1` when depth > 0 regardless of colon count, which may not be semantically correct for deeply nested containers using different fence lengths.