### PR TITLE
fix(atlassian): preserve colon delimiters in emoji shortName attributes

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1543,7 +1543,8 @@ fn try_parse_emoji_shortcode(text: &str, i: usize) -> Option<(usize, &str)> {
 /// trailing `{id="..." text="..."}` attributes to preserve round-trip fidelity.
 fn parse_emoji_with_attrs(text: &str, shortcode_end: usize, short_name: &str) -> (usize, AdfNode) {
     if let Some((attr_end, attrs)) = parse_attrs(text, shortcode_end) {
-        let mut emoji_attrs = serde_json::json!({"shortName": short_name});
+        let colon_name = format!(":{short_name}:");
+        let mut emoji_attrs = serde_json::json!({"shortName": colon_name});
         if let Some(id) = attrs.get("id") {
             emoji_attrs["id"] = serde_json::Value::String(id.to_string());
         }
@@ -1561,7 +1562,7 @@ fn parse_emoji_with_attrs(text: &str, shortcode_end: usize, short_name: &str) ->
             },
         )
     } else {
-        (shortcode_end, AdfNode::emoji(short_name))
+        (shortcode_end, AdfNode::emoji(&format!(":{short_name}:")))
     }
 }
 
@@ -3341,7 +3342,7 @@ mod tests {
         let content = doc.content[0].content.as_ref().unwrap();
         assert_eq!(content[0].text.as_deref(), Some("Hello "));
         assert_eq!(content[1].node_type, "emoji");
-        assert_eq!(content[1].attrs.as_ref().unwrap()["shortName"], "wave");
+        assert_eq!(content[1].attrs.as_ref().unwrap()["shortName"], ":wave:");
         assert_eq!(content[2].text.as_deref(), Some(" world"));
     }
 
@@ -3408,7 +3409,7 @@ mod tests {
         let round_tripped = markdown_to_adf(&md).unwrap();
         let emoji = &round_tripped.content[0].content.as_ref().unwrap()[0];
         let attrs = emoji.attrs.as_ref().unwrap();
-        assert_eq!(attrs["shortName"], "check_mark");
+        assert_eq!(attrs["shortName"], ":check_mark:");
         assert_eq!(attrs["id"], "2705");
         assert_eq!(attrs["text"], "✅");
     }
@@ -3418,9 +3419,31 @@ mod tests {
         let md = "Hello :wave: world\n";
         let doc = markdown_to_adf(md).unwrap();
         let emoji = &doc.content[0].content.as_ref().unwrap()[1];
-        assert_eq!(emoji.attrs.as_ref().unwrap()["shortName"], "wave");
+        assert_eq!(emoji.attrs.as_ref().unwrap()["shortName"], ":wave:");
         // No id or text attrs when not provided
         assert!(emoji.attrs.as_ref().unwrap().get("id").is_none());
+    }
+
+    #[test]
+    fn emoji_shortname_preserves_colons_round_trip() {
+        // Issue #362: emoji shortName colons stripped during round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"emoji","attrs":{"shortName":":cross_mark:","id":"atlassian-cross_mark","text":"❌"}}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+
+        // ADF → markdown → ADF round-trip
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let emoji = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let attrs = emoji.attrs.as_ref().unwrap();
+        assert_eq!(
+            attrs["shortName"], ":cross_mark:",
+            "shortName should preserve colons, got: {}",
+            attrs["shortName"]
+        );
+        assert_eq!(attrs["id"], "atlassian-cross_mark");
+        assert_eq!(attrs["text"], "❌");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes a round-trip fidelity bug (Issue #362) in the Atlassian ADF ↔ markdown conversion pipeline where emoji `shortName` values were being stored without their surrounding colons. When an ADF document containing an emoji node (e.g., `{"shortName": ":cross_mark:"}`) was converted to markdown and back, the resulting `shortName` would lose its colon delimiters (becoming `cross_mark` instead of `:cross_mark:`), causing mismatches and broken round-trips.

The fix ensures that colon wrapping is applied consistently in `parse_emoji_with_attrs` for both the attrs-present and attrs-absent code paths when constructing `shortName` values from parsed shortcodes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #362

## Changes Made

**Core Changes:**
- In `src/atlassian/convert.rs`, updated `parse_emoji_with_attrs` to wrap parsed emoji shortcodes in colons when constructing `shortName` values: `format!(":{short_name}:")` is now applied in both the attrs-present branch (previously set `shortName` to the raw `short_name` string) and the attrs-absent branch (previously passed `short_name` directly to `AdfNode::emoji`)

**Testing:**
- Updated existing test `emoji_markdown_basic` to assert that `shortName` is `":wave:"` (with colons) instead of `"wave"`
- Updated existing test for the attrs-present round-trip path to assert `shortName` is `":check_mark:"` instead of `"check_mark"`
- Updated existing test `emoji_shortname_no_attrs` to assert `shortName` is `":wave:"` instead of `"wave"`
- Added new regression test `emoji_shortname_preserves_colons_round_trip` that performs a full ADF → markdown → ADF round-trip using the `:cross_mark:` emoji from Issue #362, asserting that `shortName`, `id`, and `text` attributes are preserved correctly

## Testing

**Automated Testing:**
- [x] All existing tests pass (updated assertions to reflect correct colon-wrapped behavior)
- [x] New tests added for new functionality — `emoji_shortname_preserves_colons_round_trip` regression test added

**Manual Testing:**
- [x] Tested happy path scenarios (emoji with and without explicit `id`/`text` attrs)
- [x] Tested edge cases (emoji shortcodes parsed from markdown with no attrs block)
- [x] Backward compatibility verified — the fix corrects previously incorrect behavior; ADF documents that relied on uncolon-wrapped shortNames were already non-compliant with the ADF spec

### Test Commands
```bash
# Core test suite
cargo test

# Run only the Atlassian conversion tests
cargo test atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — consumers of `shortName` values should now receive the colon-wrapped form as per ADF spec
- [x] Error handling — both branches in `parse_emoji_with_attrs` are covered by the fix

The key change is in `src/atlassian/convert.rs` at the `parse_emoji_with_attrs` function (~line 1543 and ~line 1562). Both the `if let Some((attr_end, attrs))` (attrs-present) and `else` (attrs-absent) branches now format `shortName` as `:{short_name}:`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

This fix corrects previously incorrect behavior. Any code that compared `shortName` values without colons (e.g., `"wave"` instead of `":wave:"`) will need to be updated to use the colon-wrapped form. However, this matches the ADF specification for emoji `shortName` fields, so the old behavior was a defect, not a feature.

**Backward Compatibility:**
- ADF documents generated by this library will now produce `shortName` values that correctly include surrounding colons, matching the Atlassian ADF schema expectation.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Stripping colons at the ADF output serialization layer rather than at parse time — rejected because it would leave internal representations inconsistent and make the bug harder to trace across the pipeline.