### PR TITLE
fix(atlassian): allow empty attribute values in wiki markup parser

### DIFF
--- a/src/atlassian/attrs.rs
+++ b/src/atlassian/attrs.rs
@@ -121,8 +121,8 @@ fn parse_inner(inner: &str) -> Option<Attrs> {
         rest = rest[key_end..].trim_start();
 
         if rest.starts_with('=') {
-            // Key-value pair
-            rest = rest[1..].trim_start();
+            // Key-value pair (no trim after '=' so empty values like key= are detected)
+            rest = &rest[1..];
             let (value, remaining) = parse_value(rest)?;
             attrs.map.insert(key.to_string(), value);
             rest = remaining.trim_start();
@@ -146,9 +146,6 @@ fn parse_value(text: &str) -> Option<(String, &str)> {
         let end = text
             .find(|c: char| c.is_whitespace() || c == '}')
             .unwrap_or(text.len());
-        if end == 0 {
-            return None;
-        }
         Some((text[..end].to_string(), &text[end..]))
     }
 }
@@ -273,6 +270,30 @@ mod tests {
         let (_, attrs) = parse_attrs("{title=\"Click to expand\"}", 0).unwrap();
         let rendered = attrs.render();
         assert_eq!(rendered, "{title=\"Click to expand\"}");
+    }
+
+    #[test]
+    fn empty_value() {
+        // Issue #363: accessLevel= (empty value) should parse as empty string
+        let (end, attrs) = parse_attrs("{id=abc accessLevel=}", 0).unwrap();
+        assert_eq!(end, 21);
+        assert_eq!(attrs.get("id"), Some("abc"));
+        assert_eq!(attrs.get("accessLevel"), Some(""));
+    }
+
+    #[test]
+    fn empty_value_mid_attrs() {
+        let (_, attrs) = parse_attrs("{a= b=value}", 0).unwrap();
+        assert_eq!(attrs.get("a"), Some(""));
+        assert_eq!(attrs.get("b"), Some("value"));
+    }
+
+    #[test]
+    fn empty_value_render_round_trip() {
+        let (_, original) = parse_attrs("{id=abc accessLevel=}", 0).unwrap();
+        let rendered = original.render();
+        let (_, reparsed) = parse_attrs(&rendered, 0).unwrap();
+        assert_eq!(original, reparsed);
     }
 
     #[test]

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -4207,6 +4207,24 @@ mod tests {
     }
 
     #[test]
+    fn mention_with_empty_access_level_round_trips() {
+        // Issue #363: accessLevel="" produces accessLevel= which failed to parse
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"mention","attrs":{"id":"61921b41c15977006af2b1d1","text":"@Javier Inchausti","accessLevel":""}}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let mention = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(
+            mention.node_type, "mention",
+            "mention with empty accessLevel was not parsed as mention, got: {}",
+            mention.node_type
+        );
+    }
+
+    #[test]
     fn span_with_color() {
         let doc = markdown_to_adf("This is :span[red text]{color=#ff5630}.").unwrap();
         let content = doc.content[0].content.as_ref().unwrap();


### PR DESCRIPTION
## Description

Fixes a bug in the Atlassian wiki markup attribute parser where attribute values with empty strings (e.g., `accessLevel=`) would fail to parse. This caused mention nodes with an empty `accessLevel` attribute to be silently dropped during ADF-to-markdown round-trips, resulting in data loss when converting Atlassian Document Format content.

The root cause was a two-part issue in `src/atlassian/attrs.rs`: an early-return guard that rejected zero-length unquoted values, and a whitespace trim after the `=` sign that prevented empty values from being correctly detected before the next key or closing brace.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #363

## Changes Made

**Core Changes:**
- Removed early-return guard in `parse_value()` (`src/atlassian/attrs.rs`) that returned `None` when an unquoted value had zero length, now allowing empty strings as valid attribute values
- Changed `rest = rest[1..].trim_start()` to `rest = &rest[1..]` after the `=` sign in `parse_inner()` so that whitespace is not consumed before detecting an empty value, preserving the correct parse boundary

**Testing:**
- Added `empty_value` unit test in `src/atlassian/attrs.rs` verifying `{id=abc accessLevel=}` parses `accessLevel` as an empty string
- Added `empty_value_mid_attrs` unit test verifying an empty value in the middle of an attribute list (`{a= b=value}`) is handled correctly
- Added `empty_value_render_round_trip` unit test verifying that attrs with empty values survive a render-then-reparse cycle unchanged
- Added `mention_with_empty_access_level_round_trips` integration test in `src/atlassian/convert.rs` verifying that an ADF mention node with `accessLevel: ""` survives a full ADF→markdown→ADF round-trip and is still recognised as a `mention` node

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (normal key=value attrs unaffected)
- [x] Tested error/edge cases (empty value at end, empty value mid-attrs)
- [x] Backward compatibility verified (existing non-empty attr parsing unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new attr-parser tests
cargo test --lib atlassian::attrs

# Run only the mention round-trip integration test
cargo test --lib atlassian::convert::tests::mention_with_empty_access_level_round_trips

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — specifically the `parse_value` and `parse_inner` functions in `src/atlassian/attrs.rs` where the whitespace-trimming and early-return logic was changed
- [x] Backward compatibility — ensure existing attribute parsing with non-empty values remains unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Treating a zero-length unquoted value as a parse error and falling back to treating the key as a boolean flag was considered, but this would not preserve the original ADF intent of an explicitly empty `accessLevel` attribute, and would still break the round-trip.