### PR TITLE
fix(atlassian): add annotation mark support to ADF/markdown conversion

### DIFF
--- a/src/atlassian/adf.rs
+++ b/src/atlassian/adf.rs
@@ -674,6 +674,15 @@ impl AdfMark {
         }
     }
 
+    /// Creates an annotation mark (inline comment highlight).
+    #[must_use]
+    pub fn annotation(id: &str, annotation_type: &str) -> Self {
+        Self {
+            mark_type: "annotation".to_string(),
+            attrs: Some(serde_json::json!({"id": id, "annotationType": annotation_type})),
+        }
+    }
+
     /// Creates a text color mark.
     #[must_use]
     pub fn text_color(color: &str) -> Self {

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1396,6 +1396,10 @@ fn try_parse_bracketed_span(text: &str, i: usize) -> Option<(usize, Vec<AdfNode>
     if attrs.has_flag("underline") {
         marks.push(AdfMark::underline());
     }
+    if let Some(ann_id) = attrs.get("annotation-id") {
+        let ann_type = attrs.get("annotation-type").unwrap_or("inlineComment");
+        marks.push(AdfMark::annotation(ann_id, ann_type));
+    }
 
     if marks.is_empty() {
         return None; // no recognized marks
@@ -2519,6 +2523,10 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
     let bg_color = marks.iter().find(|m| m.mark_type == "backgroundColor");
     let subsup = marks.iter().find(|m| m.mark_type == "subsup");
     let has_underline = marks.iter().any(|m| m.mark_type == "underline");
+    let annotations: Vec<&AdfMark> = marks
+        .iter()
+        .filter(|m| m.mark_type == "annotation")
+        .collect();
 
     let needs_span = text_color.is_some() || bg_color.is_some() || subsup.is_some();
 
@@ -2556,8 +2564,26 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
             }
         }
         output.push_str(&format!(":span[{inner}]{{{}}}", attr_parts.join(" ")));
-    } else if has_underline {
-        output.push_str(&format!("[{inner}]{{underline}}"));
+    } else if has_underline || !annotations.is_empty() {
+        let mut attr_parts = Vec::new();
+        if has_underline {
+            attr_parts.push("underline".to_string());
+        }
+        for ann in &annotations {
+            if let Some(ref attrs) = ann.attrs {
+                if let Some(id) = attrs.get("id").and_then(serde_json::Value::as_str) {
+                    let escaped = id.replace('\\', "\\\\").replace('"', "\\\"");
+                    attr_parts.push(format!("annotation-id=\"{escaped}\""));
+                }
+                if let Some(at) = attrs
+                    .get("annotationType")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    attr_parts.push(format!("annotation-type={at}"));
+                }
+            }
+        }
+        output.push_str(&format!("[{inner}]{{{}}}", attr_parts.join(" ")));
     } else if let Some(link_mark) = has_link {
         let href = link_mark
             .attrs
@@ -4036,6 +4062,63 @@ mod tests {
         let doc = markdown_to_adf(md).unwrap();
         let result = adf_to_markdown(&doc).unwrap();
         assert!(result.contains("[underlined text]{underline}"));
+    }
+
+    #[test]
+    fn annotation_mark_round_trip() {
+        // Issue #364: annotation marks were silently dropped
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"highlighted text","marks":[
+            {"type":"annotation","attrs":{"id":"abc123","annotationType":"inlineComment"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(text_node.text.as_deref(), Some("highlighted text"));
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        let ann = marks
+            .iter()
+            .find(|m| m.mark_type == "annotation")
+            .expect("should have annotation mark");
+        let attrs = ann.attrs.as_ref().unwrap();
+        assert_eq!(attrs["id"], "abc123");
+        assert_eq!(attrs["annotationType"], "inlineComment");
+    }
+
+    #[test]
+    fn annotation_mark_with_bold() {
+        // Annotation + bold should both survive round-trip
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![AdfNode::text_with_marks(
+                "bold comment",
+                vec![
+                    AdfMark::strong(),
+                    AdfMark::annotation("def456", "inlineComment"),
+                ],
+            )])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "strong"),
+            "should have strong mark"
+        );
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "should have annotation mark"
+        );
     }
 
     // ── Inline directive tests (Tier 4) ───────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes Issue #364 where annotation marks (inline comments) were silently dropped during ADF-to-markdown and markdown-to-ADF conversion. Previously, any text node in an ADF document carrying an `annotation` mark would lose that mark entirely when converted to Jira Flavored Markdown (JFM) and back, breaking round-trip fidelity for documents containing Jira inline comments.

The fix adds full support for annotation marks in both directions of the conversion pipeline, including correct handling of annotation marks combined with other formatting such as bold and underline.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #364

## Changes Made

**Core Changes:**
- Added `AdfMark::annotation(id, annotation_type)` constructor in `src/atlassian/adf.rs` that creates an annotation mark with `id` and `annotationType` attributes
- Updated `try_parse_bracketed_span` in `src/atlassian/convert.rs` to parse `annotation-id` and `annotation-type` bracketed span attributes during markdown-to-ADF conversion, defaulting `annotation-type` to `"inlineComment"` when not specified
- Updated `render_marked_text` in `src/atlassian/convert.rs` to emit annotation marks as bracketed span attributes (`annotation-id="..."` and `annotation-type=...`) during ADF-to-markdown conversion
- Refactored the `has_underline || !annotations.is_empty()` branch in `render_marked_text` to support combined annotation + underline rendering as a single bracketed span with multiple attributes

**Testing:**
- Added `annotation_mark_round_trip` test that verifies a full ADF → markdown → ADF round-trip for a text node with an `annotation` mark, asserting both `id` and `annotationType` are preserved
- Added `annotation_mark_with_bold` test that verifies annotation marks survive alongside `strong` formatting in a round-trip, ensuring combined mark scenarios are handled correctly

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (pure annotation mark round-trip)
- [x] Tested edge cases (annotation + bold, annotation + underline combined)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified (no changes to existing mark rendering behaviour)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new annotation mark tests
cargo test annotation_mark

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `annotation-type` gracefully defaults to `"inlineComment"` when absent during parsing
- [x] Backward compatibility — existing underline-only bracketed span rendering is preserved; the branch condition was widened, not replaced

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. Annotation marks were previously silently dropped, so the new behaviour (preserving them) is strictly additive. Existing documents without annotation marks are unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider supporting multiple annotation marks on a single text node (currently the renderer iterates all annotations, but the parser only captures the first `annotation-id` attribute encountered)

**Known Limitations:**
- The markdown representation uses `annotation-id="..."` and `annotation-type=...` as bracketed span attributes, which is a JFM-specific convention and may not round-trip correctly with non-Jira markdown renderers

**Alternatives Considered:**
- Representing annotations as HTML comments was considered but rejected as it would not survive markdown-to-ADF parsing