### PR TITLE
docs(specs): add annotation mark documentation to JFM spec

### DIFF
--- a/docs/specs/jfm.md
+++ b/docs/specs/jfm.md
@@ -154,6 +154,7 @@ ADF v1.
 | `underline`   | Bracketed span: `[text]{underline}`         |
 | `textColor`   | Bracketed span: `[text]{color=#hex}`        |
 | `subsup`      | Mark for subscript/superscript              |
+| `annotation`  | Bracketed span: `[text]{annotation-id=... annotation-type=...}` |
 
 ### Unsupported Node Handling
 
@@ -263,7 +264,7 @@ Inline content within paragraphs is parsed for:
 - Bold, italic, code, strikethrough
 - Links and bare URLs
 - Inline directives (status, date, mention, emoji)
-- Bracketed spans with attributes (`[text]{color=red}`)
+- Bracketed spans with attributes (`[text]{color=red}`, `[text]{annotation-id=...}`)
 
 ### ADF to Markdown
 
@@ -281,6 +282,32 @@ Block-level attributes can follow a block on a separate line:
 ```
 
 Supported attributes: `align`, `indent`, `breakout`.
+
+### Inline Attribute Marks
+
+Bracketed spans `[text]{attrs}` represent inline marks that have no native
+markdown syntax. Multiple attributes can be combined in a single span.
+
+#### Underline
+
+```markdown
+[underlined text]{underline}
+```
+
+#### Annotation (Inline Comments)
+
+Confluence inline comments attach an `annotation` mark to highlighted text.
+The mark links the text span to a comment thread stored in Confluence's
+comment system. JFM preserves these marks for round-trip fidelity:
+
+```markdown
+[highlighted text]{annotation-id="abc123" annotation-type=inlineComment}
+```
+
+- `annotation-id`: the annotation identifier (required)
+- `annotation-type`: the annotation type, typically `inlineComment` (required)
+- Annotations can coexist with other marks (bold, italic, etc.):
+  `[**bold comment**]{annotation-id="abc123" annotation-type=inlineComment}`
 
 ## Authentication
 


### PR DESCRIPTION
## Description

This PR adds documentation for the `annotation` inline mark to the JFM (Jira Flavored Markdown) specification. The `annotation` mark represents Confluence inline comments, which attach comment threads to highlighted text spans. This documentation fills a gap in the spec by covering how these marks are represented in JFM syntax and how they interact with other marks for round-trip fidelity.

## Type of Change

- [x] Documentation update

## Related Issue

No specific issue linked.

## Changes Made

**Documentation (`docs/specs/jfm.md`):**
- Added `annotation` entry to the inline marks table with its bracketed span syntax (`[text]{annotation-id=... annotation-type=...}`)
- Updated the inline content parsing section to include `[text]{annotation-id=...}` as an example of bracketed spans with attributes
- Added a new **Inline Attribute Marks** subsection documenting:
  - General explanation of how bracketed spans `[text]{attrs}` represent inline marks without native markdown syntax
  - Documented the `underline` mark with example
  - Documented the `annotation` mark in detail:
    - Explains the purpose (Confluence inline comments attached to highlighted text)
    - Documents required attributes: `annotation-id` and `annotation-type`
    - Provides a concrete usage example: `[highlighted text]{annotation-id="abc123" annotation-type=inlineComment}`
    - Notes that annotations can coexist with other marks (e.g., bold, italic)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change)

**Manual Testing:**
- [x] Reviewed documentation for accuracy and completeness
- [x] Verified examples are syntactically correct per the JFM spec

## Review Focus Areas

**Please pay special attention to:**
- [ ] Backward compatibility — the annotation mark spec should be consistent with existing round-trip behavior

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive documentation change describing existing behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional inline marks (e.g., `subsup` for subscript/superscript) could be similarly documented in the Inline Attribute Marks section with their own examples.

**Known Limitations:**
- The spec currently documents `annotation-type` as typically `inlineComment` but does not enumerate other possible values; this may warrant a follow-up if other types are discovered.