### PR TITLE
fix(atlassian): preserve table cell attrs in ADF-markdown roundtrip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -935,7 +935,7 @@ fn build_cell_attrs(attrs: &crate::atlassian::attrs::Attrs) -> serde_json::Value
     if let Some(colwidth) = attrs.get("colwidth") {
         let widths: Vec<serde_json::Value> = colwidth
             .split(',')
-            .filter_map(|s| s.trim().parse::<u32>().ok())
+            .filter_map(|s| s.trim().parse::<f64>().ok())
             .map(|n| serde_json::json!(n))
             .collect();
         if !widths.is_empty() {
@@ -2143,14 +2143,10 @@ fn build_cell_attrs_string(cell: &AdfNode) -> String {
     };
     let mut parts = Vec::new();
     if let Some(colspan) = attrs.get("colspan").and_then(serde_json::Value::as_u64) {
-        if colspan > 1 {
-            parts.push(format!("colspan={colspan}"));
-        }
+        parts.push(format!("colspan={colspan}"));
     }
     if let Some(rowspan) = attrs.get("rowspan").and_then(serde_json::Value::as_u64) {
-        if rowspan > 1 {
-            parts.push(format!("rowspan={rowspan}"));
-        }
+        parts.push(format!("rowspan={rowspan}"));
     }
     if let Some(bg) = attrs.get("background").and_then(serde_json::Value::as_str) {
         if needs_attr_quoting(bg) {
@@ -2165,8 +2161,9 @@ fn build_cell_attrs_string(cell: &AdfNode) -> String {
             .iter()
             .filter_map(serde_json::Value::as_f64)
             .map(|n| {
+                // Always format as float to preserve Confluence's representation
                 if n.fract() == 0.0 {
-                    (n as u64).to_string()
+                    format!("{n:.1}")
                 } else {
                     n.to_string()
                 }
@@ -4772,7 +4769,10 @@ mod tests {
             .as_ref()
             .unwrap()[0];
         let colwidth = cell.attrs.as_ref().unwrap()["colwidth"].as_array().unwrap();
-        assert_eq!(colwidth, &[serde_json::json!(100), serde_json::json!(200)]);
+        assert_eq!(
+            colwidth,
+            &[serde_json::json!(100.0), serde_json::json!(200.0)]
+        );
     }
 
     #[test]
@@ -4804,12 +4804,12 @@ mod tests {
         let doc: crate::atlassian::adf::AdfDocument = serde_json::from_value(adf_doc).unwrap();
         let md = adf_to_markdown(&doc).unwrap();
         assert!(
-            md.contains("colwidth=157"),
-            "expected colwidth=157 in markdown, got: {md}"
+            md.contains("colwidth=157.0"),
+            "expected colwidth=157.0 in markdown, got: {md}"
         );
         assert!(
-            md.contains("colwidth=863"),
-            "expected colwidth=863 in markdown, got: {md}"
+            md.contains("colwidth=863.0"),
+            "expected colwidth=863.0 in markdown, got: {md}"
         );
         // Round-trip back to ADF
         let doc2 = markdown_to_adf(&md).unwrap();
@@ -4820,14 +4820,49 @@ mod tests {
             header1.attrs.as_ref().unwrap()["colwidth"]
                 .as_array()
                 .unwrap(),
-            &[serde_json::json!(157)]
+            &[serde_json::json!(157.0)]
         );
         assert_eq!(
             header2.attrs.as_ref().unwrap()["colwidth"]
                 .as_array()
                 .unwrap(),
-            &[serde_json::json!(863)]
+            &[serde_json::json!(863.0)]
         );
+    }
+
+    #[test]
+    fn colwidth_float_preserved_in_roundtrip() {
+        // Issue #369: colwidth 254.0 was coerced to integer 254
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[{"type":"tableRow","content":[{"type":"tableHeader","attrs":{"colwidth":[254.0,416.0]},"content":[{"type":"paragraph","content":[]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let cell = &round_tripped.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let colwidth = cell.attrs.as_ref().unwrap()["colwidth"].as_array().unwrap();
+        assert_eq!(
+            colwidth,
+            &[serde_json::json!(254.0), serde_json::json!(416.0)],
+            "colwidth should preserve float values"
+        );
+    }
+
+    #[test]
+    fn default_rowspan_colspan_preserved_in_roundtrip() {
+        // Issue #369: rowspan=1 and colspan=1 were elided
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{"rowspan":1,"colspan":1},"content":[{"type":"paragraph","content":[{"type":"text","text":"cell"}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let cell = &round_tripped.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let attrs = cell.attrs.as_ref().unwrap();
+        assert_eq!(attrs["rowspan"], 1, "rowspan=1 should be preserved");
+        assert_eq!(attrs["colspan"], 1, "colspan=1 should be preserved");
     }
 
     // ── Nested list tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes issue #369 where table cell attributes were incorrectly coerced or silently dropped during ADF-to-markdown-to-ADF roundtrip conversion. Specifically:

1. **Colwidth float coercion**: `colwidth` values like `254.0` were being parsed as integers and serialized back as `254`, causing a type mismatch on the return parse step.
2. **Default colspan/rowspan elision**: `colspan=1` and `rowspan=1` (the default values) were conditionally omitted from the markdown representation, meaning they were lost on roundtrip, breaking fidelity with the original ADF document.

The fix ensures that colwidth values are parsed as `f64` and always formatted with decimal notation (e.g. `157.0`), and that `colspan`/`rowspan` attributes are always emitted regardless of their value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #369

## Changes Made

**Core Changes (`src/atlassian/convert.rs`):**
- Changed colwidth parsing in `build_cell_attrs` from `parse::<u32>()` to `parse::<f64>()` so float values are preserved in the ADF attribute map
- Changed colwidth formatting in `build_cell_attrs_string` to always emit whole-number floats as `"{n:.1}"` (e.g. `157.0`) instead of truncating to integer strings, ensuring the markdown-to-ADF parser reconstructs them as `f64` values
- Removed the `if colspan > 1` and `if rowspan > 1` guards in `build_cell_attrs_string` so that default values `colspan=1` and `rowspan=1` are always included in the markdown cell attribute string and survive roundtrip

**Testing:**
- Updated existing `colwidth_roundtrip` test assertions to expect `serde_json::json!(100.0)` / `serde_json::json!(200.0)` and `colwidth=157.0` / `colwidth=863.0` in markdown
- Added new test `colwidth_float_preserved_in_roundtrip` covering issue #369 where `colwidth=[254.0, 416.0]` was being coerced to integers on roundtrip
- Added new test `default_rowspan_colspan_preserved_in_roundtrip` verifying that `rowspan=1` and `colspan=1` are not elided during conversion

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`colwidth_float_preserved_in_roundtrip`, `default_rowspan_colspan_preserved_in_roundtrip`)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (colwidth roundtrip with float and integer values)
- [x] Tested edge cases (default colspan/rowspan values of 1)
- [x] Backward compatibility verified (no functional change for non-default span values)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the affected atlassian conversion tests
cargo test --lib atlassian::convert

# Run the specific regression tests for issue #369
cargo test colwidth_float_preserved_in_roundtrip
cargo test default_rowspan_colspan_preserved_in_roundtrip

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — colwidth values that were previously integers in stored markdown (e.g. `colwidth=157`) will now be written as `colwidth=157.0`; existing stored markdown with integer colwidth values must still parse correctly on read
- [x] Error handling — the `filter_map` on `parse::<f64>()` gracefully drops malformed values as before

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (`// Always format as float to preserve Confluence's representation`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

The markdown serialization format for `colwidth` changes from integer notation (`colwidth=157`) to float notation (`colwidth=157.0`). The markdown-to-ADF parser must accept both forms. This is an internal serialization detail and does not affect the public ADF schema or API surface.

**Backward Compatibility:**
- Existing markdown with integer-format colwidths (`colwidth=157`) will continue to round-trip correctly because `parse::<f64>()` accepts both `"157"` and `"157.0"`.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `u32` parsing and storing colwidths as integers in the ADF value: rejected because Confluence ADF uses JSON numbers which can be floats, and coercing to integers silently changes the schema type.
- Only emitting `colspan`/`rowspan` when non-default: the current approach (always emit) was chosen to guarantee roundtrip fidelity at the cost of slightly more verbose markdown cell attribute strings.