### PR TITLE
fix(atlassian): preserve trailing space in pipe table cells

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -803,7 +803,7 @@ impl<'a> MarkdownParser<'a> {
             .iter()
             .enumerate()
             .map(|(col_idx, cell)| {
-                let (cell_text, cell_attrs) = extract_cell_attrs(cell.trim());
+                let (cell_text, cell_attrs) = extract_cell_attrs(cell);
                 let mut para = AdfNode::paragraph(parse_inline(&cell_text));
                 apply_column_alignment(&mut para, alignments.get(col_idx).copied().flatten());
                 if let Some(attrs) = cell_attrs {
@@ -833,7 +833,7 @@ impl<'a> MarkdownParser<'a> {
                 .iter()
                 .enumerate()
                 .map(|(col_idx, cell)| {
-                    let (cell_text, cell_attrs) = extract_cell_attrs(cell.trim());
+                    let (cell_text, cell_attrs) = extract_cell_attrs(cell);
                     let mut para = AdfNode::paragraph(parse_inline(&cell_text));
                     apply_column_alignment(&mut para, alignments.get(col_idx).copied().flatten());
                     if let Some(attrs) = cell_attrs {
@@ -1073,7 +1073,16 @@ fn parse_table_row(line: &str) -> Vec<String> {
     let trimmed = trimmed.strip_prefix('|').unwrap_or(trimmed);
     let trimmed = trimmed.strip_suffix('|').unwrap_or(trimmed);
 
-    trimmed.split('|').map(|s| s.trim().to_string()).collect()
+    trimmed
+        .split('|')
+        .map(|s| {
+            // Strip exactly one leading and one trailing space (pipe table padding).
+            // Preserve any additional whitespace as significant content.
+            let s = s.strip_prefix(' ').unwrap_or(s);
+            let s = s.strip_suffix(' ').unwrap_or(s);
+            s.to_string()
+        })
+        .collect()
 }
 
 /// Parses column alignments from a GFM table separator row.
@@ -1108,12 +1117,12 @@ fn apply_column_alignment(para: &mut AdfNode, alignment: Option<&str>) {
 /// Extracts `{attrs}` prefix from a pipe table cell text.
 /// Returns `(remaining_text, Option<adf_attrs_json>)`.
 fn extract_cell_attrs(cell_text: &str) -> (String, Option<serde_json::Value>) {
-    let trimmed = cell_text.trim();
+    let trimmed = cell_text.trim_start();
     if !trimmed.starts_with('{') {
         return (cell_text.to_string(), None);
     }
     if let Some((end_pos, attrs)) = parse_attrs(trimmed, 0) {
-        let remaining = trimmed[end_pos..].trim().to_string();
+        let remaining = trimmed[end_pos..].trim_start().to_string();
         let adf_attrs = build_cell_attrs(&attrs);
         if adf_attrs == serde_json::json!({}) {
             (cell_text.to_string(), None)
@@ -4640,6 +4649,33 @@ mod tests {
         let cell = &rows[1].content.as_ref().unwrap()[0];
         let attrs = cell.attrs.as_ref().unwrap();
         assert_eq!(attrs["colspan"], 2);
+    }
+
+    #[test]
+    fn trailing_space_after_mention_in_table_cell_preserved() {
+        // Issue #372: trailing space after mention in table cell was dropped
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{},"content":[{"type":"paragraph","content":[
+          {"type":"mention","attrs":{"id":"aaa","text":"@Rob"}},
+          {"type":"text","text":" "}
+        ]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let cell = &round_tripped.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let para = &cell.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+        assert!(
+            inlines.len() >= 2,
+            "expected mention + text(' ') nodes, got {} nodes: {:?}",
+            inlines.len(),
+            inlines.iter().map(|n| &n.node_type).collect::<Vec<_>>()
+        );
+        assert_eq!(inlines[0].node_type, "mention");
+        assert_eq!(inlines[1].node_type, "text");
+        assert_eq!(inlines[1].text.as_deref(), Some(" "));
     }
 
     // ── Column alignment tests ─────────────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes issue #372 where trailing spaces after inline elements (such as mentions) in pipe table cells were being silently dropped during ADF → markdown → ADF round-trip conversion.

The root cause was that `parse_table_row` used `trim()` on each cell, which stripped both leading and trailing whitespace indiscriminately. Pipe table syntax uses exactly one space of padding on each side of a cell's content (`| content |`), and the old code stripped all surrounding whitespace—including intentional trailing spaces that are significant inline content (e.g., a space text node following a `@mention` used for formatting separation).

The fix changes cell parsing to strip exactly one leading space and one trailing space per cell (the pipe table padding), preserving any additional whitespace as meaningful content. Corresponding adjustments were made to `extract_cell_attrs` to avoid double-stripping on the trailing side.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #372

## Changes Made

**Core Changes:**
- Changed `parse_table_row` in `src/atlassian/convert.rs` to strip exactly one leading and one trailing space per cell using `strip_prefix(' ')` / `strip_suffix(' ')` instead of `trim()`, preserving significant whitespace content
- Removed `.trim()` call on the cell string before passing to `extract_cell_attrs` in both the header-row and body-row cell mapping loops, deferring whitespace handling to `parse_table_row`
- Updated `extract_cell_attrs` to use `trim_start()` instead of `trim()` when looking for a leading `{attrs}` prefix, and `trim_start()` instead of `trim()` after stripping the attrs block — so trailing spaces within cell content are no longer discarded

**Testing:**
- Added regression test `trailing_space_after_mention_in_table_cell_preserved` that constructs an ADF document with a table cell containing a `mention` node followed by a `text` node containing a single space `" "`, converts it through a full ADF → markdown → ADF round-trip, and asserts that both the mention and the trailing space text node survive intact

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — regression test for issue #372 added directly in `src/atlassian/convert.rs` (mod tests)

**Manual Testing:**
- [x] Tested happy path scenarios — table cells with normal content continue to parse correctly
- [x] Tested error/edge cases — cells with no padding spaces still handled gracefully via `unwrap_or(s)` fallback
- [x] Backward compatibility verified — the change only affects cells that had trailing spaces after inline elements, which were previously incorrectly dropped

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test trailing_space_after_mention_in_table_cell_preserved

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — confirm the one-space strip correctly handles cells with no padding, partial padding, and multi-space content
- [x] Error handling — `strip_prefix`/`strip_suffix` with `unwrap_or` ensures cells without exactly one space of padding are handled gracefully

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the change replaces one `trim()` call with two `strip_prefix`/`strip_suffix` calls, which is equivalent in complexity

## Security Considerations

- [x] No security implications — this is a whitespace parsing fix in an internal markdown conversion function

## Breaking Changes

None. This is a bug fix that restores correct behavior. Any content that was previously losing trailing spaces in table cells will now round-trip correctly. No migration is required.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using `trim_end()` only on the cell content in `parse_table_row` (keeping `trim_start()`) — rejected because both leading and trailing padding spaces should be stripped exactly once per the GFM pipe table spec
- Stripping the padding in `extract_cell_attrs` instead of `parse_table_row` — rejected because `parse_table_row` is the correct place to handle cell boundary normalization, keeping `extract_cell_attrs` focused solely on the `{attrs}` prefix concern