### PR TITLE
fix(atlassian): preserve hardBreak nodes in markdown roundtrip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1273,6 +1273,21 @@ fn parse_inline(text: &str) -> Vec<AdfNode> {
                 }
                 chars.next();
             }
+            ' ' if text[i..].starts_with("  \n") => {
+                // Trailing-space line break → hardBreak node.
+                // Flush preceding text (without the trailing spaces).
+                flush_plain(text, plain_start, i, &mut nodes);
+                nodes.push(AdfNode::hard_break());
+                // Skip past all spaces and the newline
+                while chars.peek().is_some_and(|&(_, c)| c == ' ') {
+                    chars.next();
+                }
+                // Skip the newline
+                if chars.peek().is_some_and(|&(_, c)| c == '\n') {
+                    chars.next();
+                }
+                plain_start = chars.peek().map_or(text.len(), |&(idx, _)| idx);
+            }
             '!' if text[i..].starts_with("![") => {
                 // Inline image — skip the ! and let [ handle it next iteration
                 // (Images at block level are handled by try_image; inline images
@@ -5298,6 +5313,28 @@ mod tests {
             "Should have exactly 1 row, got {}",
             rows.len()
         );
+    }
+
+    #[test]
+    fn hardbreak_in_paragraph_roundtrips() {
+        // Issue #373: hardBreak absorbed into preceding text node
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"line one"},
+          {"type":"hardBreak"},
+          {"type":"text","text":"line two"}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        let types: Vec<&str> = inlines.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["text", "hardBreak", "text"],
+            "hardBreak should be preserved, got: {types:?}"
+        );
+        assert_eq!(inlines[0].text.as_deref(), Some("line one"));
+        assert_eq!(inlines[2].text.as_deref(), Some("line two"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes issue #373 where `hardBreak` ADF nodes were being lost during the ADF→markdown→ADF roundtrip conversion. When converting ADF to markdown, `hardBreak` nodes are rendered as two trailing spaces followed by a newline (standard CommonMark line break syntax). However, the markdown parser's `parse_inline` function was not recognizing this pattern, causing the trailing spaces and newline to be absorbed into the preceding text node rather than being re-emitted as a `hardBreak` node on the return trip.

The fix adds trailing-space line break detection in `parse_inline`, correctly flushing preceding plain text and emitting a `hardBreak` node when a line ends with two or more spaces followed by a newline.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #373

## Changes Made

**Core Changes:**
- Added `' ' if text[i..].starts_with("  \n")` pattern arm in `parse_inline` in `src/atlassian/convert.rs` to detect trailing-space line breaks (CommonMark hard line break syntax)
- Flush any accumulated plain text (without the trailing spaces) before emitting the `hardBreak` node
- Skip all trailing space characters and the subsequent newline character after emitting the break node
- Reset `plain_start` to the next character position after the newline

**Testing:**
- Added `hardbreak_in_paragraph_roundtrips` regression test in `src/atlassian/convert.rs` that verifies a paragraph containing `text → hardBreak → text` ADF nodes roundtrips correctly through ADF→markdown→ADF conversion
- Test asserts node types are `["text", "hardBreak", "text"]` and verifies text content of each node

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`hardbreak_in_paragraph_roundtrips`)
- [x] Regression test directly exercises the reported failure scenario from issue #373

**Manual Testing:**
- [x] Tested happy path scenarios (paragraph with single hardBreak between two text nodes)
- [x] Tested edge cases (multiple consecutive trailing spaces before newline)
- [x] Backward compatibility verified (existing table and inline parsing tests unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression test
cargo test hardbreak_in_paragraph_roundtrips

# Run all atlassian conversion tests
cargo test --lib atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `plain_start` is correctly reset after consuming the trailing spaces and newline
- [x] Backward compatibility — the new match arm is inserted before the `'!'` image handler and after existing character handlers; no existing patterns are affected

The key logic to review is in `src/atlassian/convert.rs` around line 1267, in the `parse_inline` function's character-matching loop. The new arm matches a space character only when the remainder of the input starts with `"  \n"` (two spaces plus newline), which is the CommonMark hard line break representation used by `adf_to_markdown`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

The new match arm is a simple string prefix check (`starts_with("  \n")`) that only triggers on space characters followed by two spaces and a newline. This is O(1) and adds negligible overhead to inline parsing.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely corrective fix restoring expected roundtrip behaviour for documents containing `hardBreak` nodes. Documents that did not contain `hardBreak` nodes are unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using a regex-based approach for trailing-space detection — rejected in favour of the existing character-by-character iterator pattern already used throughout `parse_inline`, keeping the code consistent and avoiding a regex dependency in this hot path.