### PR TITLE
fix(atlassian): preserve localId attribute on table nodes during roundtrip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -424,6 +424,9 @@ impl<'a> MarkdownParser<'a> {
                             table_attrs["width"] = serde_json::json!(w);
                         }
                     }
+                    if let Some(local_id) = attrs.get("localId") {
+                        table_attrs["localId"] = serde_json::Value::String(local_id.to_string());
+                    }
                 }
                 if table_attrs == serde_json::json!({}) {
                     AdfNode::table(rows)
@@ -869,6 +872,9 @@ impl<'a> MarkdownParser<'a> {
                         if let Ok(w) = tw.parse::<f64>() {
                             table_attrs["width"] = serde_json::json!(w);
                         }
+                    }
+                    if let Some(local_id) = attrs.get("localId") {
+                        table_attrs["localId"] = serde_json::Value::String(local_id.to_string());
                     }
                     if table_attrs != serde_json::json!({}) {
                         table.attrs = Some(table_attrs);
@@ -2101,6 +2107,9 @@ fn render_directive_table(node: &AdfNode, rows: &[AdfNode], output: &mut String)
             };
             attr_parts.push(format!("width={tw_str}"));
         }
+        if let Some(local_id) = attrs.get("localId").and_then(serde_json::Value::as_str) {
+            attr_parts.push(format!("localId={local_id}"));
+        }
     }
     if attr_parts.is_empty() {
         output.push_str("::::table\n");
@@ -2231,6 +2240,9 @@ fn render_table_level_attrs(node: &AdfNode, output: &mut String) {
                 tw.to_string()
             };
             parts.push(format!("width={tw_str}"));
+        }
+        if let Some(local_id) = attrs.get("localId").and_then(serde_json::Value::as_str) {
+            parts.push(format!("localId={local_id}"));
         }
         if !parts.is_empty() {
             output.push_str(&format!("{{{}}}\n", parts.join(" ")));
@@ -4902,6 +4914,24 @@ mod tests {
     }
 
     // ── Nested list tests ──────────────────────────────────────────────
+
+    #[test]
+    fn table_localid_preserved_in_roundtrip() {
+        // Issue #374: localId on table nodes was dropped
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default","localId":"7afd4550-e66c-4b12-875f-a91c6c7b62c7"},"content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{},"content":[{"type":"paragraph","content":[{"type":"text","text":"cell"}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("localId="),
+            "JFM should contain localId, got: {md}"
+        );
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let attrs = round_tripped.content[0].attrs.as_ref().unwrap();
+        assert_eq!(
+            attrs["localId"], "7afd4550-e66c-4b12-875f-a91c6c7b62c7",
+            "localId should be preserved"
+        );
+    }
 
     #[test]
     fn nested_bullet_list_roundtrip() {


### PR DESCRIPTION
## Description

This PR fixes issue #374 where the `localId` attribute on ADF (Atlassian Document Format) table nodes was silently dropped during markdown conversion and roundtrip operations. When a table with a `localId` attribute was converted from ADF to markdown and back to ADF, the `localId` value was lost entirely. This fix ensures the attribute is preserved through the full conversion pipeline.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #374

## Changes Made

**Core Changes:**
- Added `localId` parsing in `MarkdownParser` table attribute handler (line ~424 in `src/atlassian/convert.rs`) so that `localId` is read from directive attributes and stored in the ADF table node's attrs during ADF→markdown→ADF conversion
- Added a second `localId` parsing site in the second `MarkdownParser` table attribute handler (line ~873) covering the alternative parsing path used for inline table attribute directives
- Added `localId` rendering in `render_directive_table` so that when an ADF table node with a `localId` is serialized to markdown, the `localId=<value>` token is included in the directive attributes
- Added `localId` rendering in `render_table_level_attrs` so the attribute is also emitted when rendering table-level attribute blocks

**Testing:**
- Added regression test `table_localid_preserved_in_roundtrip` in `src/atlassian/convert.rs` that verifies a table with a `localId` attribute survives a full ADF→markdown→ADF roundtrip with the exact UUID value intact

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — `table_localid_preserved_in_roundtrip` regression test added

**Manual Testing:**
- [x] Tested happy path scenarios — ADF table with `localId` roundtrips correctly
- [x] Backward compatibility verified — tables without `localId` are unaffected

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test table_localid_preserved_in_roundtrip

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — existing tables without `localId` must continue to work identically
- [x] Error handling — `localId` is treated as optional; missing values are safely skipped

The fix is applied symmetrically across all four relevant code paths in `src/atlassian/convert.rs`:
1. `MarkdownParser` first table attr handler (~line 424) — parses `localId` from ADF attrs into `table_attrs`
2. `MarkdownParser` second table attr handler (~line 873) — parses `localId` from inline directive attrs into the node
3. `render_directive_table` (~line 2107) — emits `localId=<value>` into `::::table` directive syntax
4. `render_table_level_attrs` (~line 2241) — emits `localId=<value>` into `{...}` attribute block syntax

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix — it preserves data that was previously being silently discarded. All existing behaviour for tables without `localId` is unchanged.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Root Cause:** The `localId` field was present in the ADF schema for table nodes but was never included in the attribute serialization or deserialization logic in `convert.rs`. Every other table attribute (`width`, `layout`, `isNumberColumnEnabled`) was handled; `localId` was simply overlooked.

**Alternatives Considered:** An alternative approach would have been to generically pass through all unknown ADF table attributes. However, the explicit per-attribute approach is consistent with how all other table attributes are handled in this file and is safer for forward compatibility.