### PR TITLE
fix(atlassian): render bare URL links as text with link mark instead of inlineCard

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1219,10 +1219,13 @@ fn parse_inline(text: &str) -> Vec<AdfNode> {
             '[' => {
                 if let Some((end, link_text, href)) = try_parse_link(text, i) {
                     flush_plain(text, plain_start, i, &mut nodes);
-                    // When text == href, emit an inlineCard (smart link) so that
-                    // JIRA renders it as a resolved card rather than a plain link.
                     if link_text == href {
-                        nodes.push(AdfNode::inline_card(href));
+                        // Bare URL link [url](url): emit as text with link mark,
+                        // not via parse_inline which would produce an inlineCard.
+                        nodes.push(AdfNode::text_with_marks(
+                            link_text,
+                            vec![AdfMark::link(href)],
+                        ));
                     } else {
                         let inner = parse_inline(link_text);
                         for mut node in inner {
@@ -3572,12 +3575,16 @@ mod tests {
     }
 
     #[test]
-    fn self_link_still_becomes_inline_card() {
-        // [url](url) — text equals url, still produces inlineCard (Tier 1 bare URL)
+    fn self_link_becomes_link_mark_not_inline_card() {
+        // Issue #378: [url](url) should produce a link mark, not inlineCard.
+        // inlineCard is only for :card[url] directives and bare URLs.
         let doc = markdown_to_adf("[https://example.com](https://example.com)").unwrap();
         let node = &doc.content[0].content.as_ref().unwrap()[0];
-        assert_eq!(node.node_type, "inlineCard");
-        assert_eq!(node.attrs.as_ref().unwrap()["url"], "https://example.com");
+        assert_eq!(node.node_type, "text");
+        assert_eq!(node.text.as_deref(), Some("https://example.com"));
+        let mark = &node.marks.as_ref().unwrap()[0];
+        assert_eq!(mark.mark_type, "link");
+        assert_eq!(mark.attrs.as_ref().unwrap()["href"], "https://example.com");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes Issue #378 where markdown links of the form `[url](url)` (where the link text equals the URL) were being converted to ADF `inlineCard` nodes instead of plain text nodes with a `link` mark. This caused JIRA to render these links as smart/resolved cards rather than as simple clickable hyperlinks.

The root cause was that the `parse_inline` function in `src/atlassian/convert.rs` had logic to detect "self-links" (where `link_text == href`) and emit them as `inlineCard` nodes. While smart cards may be desirable in some contexts, bare URL markdown links `[url](url)` should render as plain hyperlinks. True `inlineCard` nodes should only be produced by explicit `:card[url]` directives or raw bare URLs (not wrapped in markdown link syntax).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #378

## Changes Made

**Core Changes:**
- Modified `parse_inline` in `src/atlassian/convert.rs` to emit `AdfNode::text_with_marks(link_text, vec![AdfMark::link(href)])` instead of `AdfNode::inline_card(href)` when a markdown link has `link_text == href`
- Reserved `inlineCard` emission exclusively for `:card[url]` directives and true bare URLs (not markdown link syntax)

**Testing:**
- Renamed test `self_link_still_becomes_inline_card` to `self_link_becomes_link_mark_not_inline_card` to reflect the corrected expected behavior
- Updated test assertions to verify the output is a `text` node with a `link` mark (with `href` attribute) rather than an `inlineCard` node with a `url` attribute

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (existing test updated to assert correct behavior)

**Manual Testing:**
- [x] Tested happy path scenarios — `[https://example.com](https://example.com)` now renders as a clickable hyperlink in JIRA
- [x] Backward compatibility verified — `:card[url]` directives and raw bare URLs continue to produce `inlineCard` nodes as expected

### Test Commands
```bash
# Core test suite
cargo test

# Run only the relevant Atlassian conversion tests
cargo test --test '*' atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — confirm that `:card[url]` and raw bare URL handling still produce `inlineCard` nodes
- [x] Error handling — verify that regular `[text](url)` links (where text ≠ url) are unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `inlineCard` for self-links was considered but rejected because markdown authors who write `[url](url)` expect a hyperlink, not a JIRA smart card. Smart card rendering via `inlineCard` remains available through the explicit `:card[url]` directive for users who want that behavior.