### PR TITLE
fix(atlassian): preserve emoji shortName without colons on round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1613,8 +1613,12 @@ fn try_parse_emoji_shortcode(text: &str, i: usize) -> Option<(usize, &str)> {
 /// trailing `{id="..." text="..."}` attributes to preserve round-trip fidelity.
 fn parse_emoji_with_attrs(text: &str, shortcode_end: usize, short_name: &str) -> (usize, AdfNode) {
     if let Some((attr_end, attrs)) = parse_attrs(text, shortcode_end) {
-        let colon_name = format!(":{short_name}:");
-        let mut emoji_attrs = serde_json::json!({"shortName": colon_name});
+        // Use the explicit shortName attr if provided (preserves original form),
+        // otherwise fall back to colon-wrapped name.
+        let resolved_name = attrs
+            .get("shortName")
+            .map_or_else(|| format!(":{short_name}:"), str::to_string);
+        let mut emoji_attrs = serde_json::json!({"shortName": resolved_name});
         if let Some(id) = attrs.get("id") {
             emoji_attrs["id"] = serde_json::Value::String(id.to_string());
         }
@@ -2441,23 +2445,25 @@ fn render_inline_node(node: &AdfNode, output: &mut String) {
                     output.push_str(name);
                     output.push(':');
 
-                    // Preserve id and text attrs for round-trip fidelity.
+                    // Preserve id, text, and shortName attrs for round-trip fidelity.
                     let id = attrs.get("id").and_then(serde_json::Value::as_str);
                     let text = attrs.get("text").and_then(serde_json::Value::as_str);
-                    if id.is_some() || text.is_some() {
-                        let mut parts = Vec::new();
-                        if let Some(id) = id {
-                            let escaped = id.replace('\\', "\\\\").replace('"', "\\\"");
-                            parts.push(format!("id=\"{escaped}\""));
-                        }
-                        if let Some(text) = text {
-                            let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
-                            parts.push(format!("text=\"{escaped}\""));
-                        }
-                        output.push('{');
-                        output.push_str(&parts.join(" "));
-                        output.push('}');
+                    // Always emit attrs so shortName is preserved exactly.
+                    let mut parts = Vec::new();
+                    // Emit the original shortName so to-adf can restore it exactly.
+                    let escaped_sn = short_name.replace('\\', "\\\\").replace('"', "\\\"");
+                    parts.push(format!("shortName=\"{escaped_sn}\""));
+                    if let Some(id) = id {
+                        let escaped = id.replace('\\', "\\\\").replace('"', "\\\"");
+                        parts.push(format!("id=\"{escaped}\""));
                     }
+                    if let Some(text) = text {
+                        let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+                        parts.push(format!("text=\"{escaped}\""));
+                    }
+                    output.push('{');
+                    output.push_str(&parts.join(" "));
+                    output.push('}');
                 }
             }
         }
@@ -3543,6 +3549,24 @@ mod tests {
         );
         assert_eq!(attrs["id"], "atlassian-cross_mark");
         assert_eq!(attrs["text"], "❌");
+    }
+
+    #[test]
+    fn emoji_shortname_without_colons_preserved() {
+        // Issue #379: shortName without colons should not gain colons
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"emoji","attrs":{"shortName":"white_check_mark","id":"2705","text":"✅"}}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let emoji = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let attrs = emoji.attrs.as_ref().unwrap();
+        assert_eq!(
+            attrs["shortName"], "white_check_mark",
+            "shortName without colons should stay without colons, got: {}",
+            attrs["shortName"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes a regression (issue #379) where emoji `shortName` values stored without colon wrapping (e.g. `white_check_mark`) were incorrectly gaining colons during ADF-to-markdown-to-ADF round-trip conversion. After the fix, the original `shortName` form is preserved exactly through the full round-trip.

**Root Cause:** In `parse_emoji_with_attrs`, the code was unconditionally wrapping the short name in colons (`:{short_name}:`) when building the `shortName` attribute, ignoring any explicit `shortName` already present in the parsed inline attributes. On the render side, the `shortName` attribute was not being emitted into the markdown inline attribute block, so the original form could not be recovered.

**Solution:** When converting markdown back to ADF, use the explicit `shortName` attribute from the parsed inline attrs if present, falling back to colon-wrapping only when no attr is available. When rendering ADF to markdown, always emit a `shortName` attribute in the inline attribute block so the original form is preserved for round-trip fidelity.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #379

## Changes Made

**Core Changes:**
- `parse_emoji_with_attrs` in `src/atlassian/convert.rs`: When inline attrs contain an explicit `shortName`, use it directly instead of always wrapping in colons. This preserves the original form (with or without colons) when converting back to ADF.
- `render_inline_node` in `src/atlassian/convert.rs`: Changed attr emission from conditional (only when `id` or `text` present) to unconditional, and added `shortName` as the first emitted attribute. This ensures the original `shortName` value is always written into the markdown representation so round-tripping restores it exactly.

**Testing:**
- Added regression test `emoji_shortname_without_colons_preserved` in `src/atlassian/convert.rs` that verifies an ADF emoji node with `shortName: "white_check_mark"` (no colons) survives a full `adf_to_markdown` → `markdown_to_adf` round-trip with the `shortName` unchanged.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression test added specifically for issue #379
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (emoji with colon-wrapped shortName still works)
- [x] Tested error/edge cases (emoji with no colons in shortName now preserved)
- [x] Backward compatibility verified (existing emoji handling unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test emoji_shortname_without_colons_preserved

# Run all atlassian conversion tests
cargo test --lib atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the change to always emit `shortName` in inline attrs means markdown output will now always include `{shortName="..."}` on emoji nodes that previously only emitted attrs when `id` or `text` were present. Reviewers should confirm this does not break any existing markdown consumers or snapshot tests.
- [x] Error handling — the fallback path (`format!(":{short_name}:")`) is preserved for cases where no explicit `shortName` attr is provided, maintaining existing behaviour for those code paths.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

No breaking changes. The fix is purely additive in terms of what is emitted in the inline attribute block (`shortName` is now always included), but this is strictly more information and is handled gracefully by the existing parser.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Normalising all `shortName` values to the colon-wrapped form at ingestion time was considered, but rejected because it would silently mutate data that Atlassian APIs may return in a specific form, and would make lossless round-tripping impossible for content originally using the unwrapped form.