### PR TITLE
fix(atlassian): preserve ADF mark ordering in bracketed span conversion

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1442,9 +1442,13 @@ fn try_parse_bracketed_span(text: &str, i: usize) -> Option<(usize, Vec<AdfNode>
     let result: Vec<AdfNode> = inner
         .into_iter()
         .map(|mut node| {
-            for mark in &marks {
-                add_mark(&mut node, mark.clone());
+            // Prepend bracket marks before inner marks to preserve original
+            // ADF mark ordering (e.g., [underline, strong] not [strong, underline]).
+            let mut combined = marks.clone();
+            if let Some(ref existing) = node.marks {
+                combined.extend(existing.iter().cloned());
             }
+            node.marks = Some(combined);
             node
         })
         .collect();
@@ -4100,6 +4104,30 @@ mod tests {
         let doc = markdown_to_adf(md).unwrap();
         let result = adf_to_markdown(&doc).unwrap();
         assert!(result.contains("[underlined text]{underline}"));
+    }
+
+    #[test]
+    fn mark_ordering_underline_strong_preserved() {
+        // Issue #383: mark ordering was non-deterministic
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"bold and underlined","marks":[{"type":"underline"},{"type":"strong"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["underline", "strong"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a bug where ADF marks on bracketed spans were appended after inner node marks instead of prepended, causing non-deterministic mark ordering during round-trip conversion. For example, a node with `[underline, strong]` marks would round-trip as `[strong, underline]`, breaking ordering expectations.

The root cause was in `try_parse_bracketed_span` where bracket-level marks were added to inner nodes using `add_mark`, which appended them after any existing marks. The fix changes this to prepend bracket marks before the inner node's existing marks, preserving the original ADF mark ordering through the markdown round-trip.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #383

## Changes Made

**Core Changes:**
- Changed mark application in `try_parse_bracketed_span` (`src/atlassian/convert.rs`) to prepend bracket-level marks before existing inner node marks, rather than appending via `add_mark`
- The new logic constructs a `combined` vec starting with the bracket marks, then extends with any existing node marks, and assigns the result to `node.marks`

**Testing:**
- Added regression test `mark_ordering_underline_strong_preserved` in `src/atlassian/convert.rs` that:
  - Creates an ADF document with a text node carrying `[underline, strong]` marks
  - Round-trips it through `adf_to_markdown` → `markdown_to_adf`
  - Asserts the resulting mark order is `["underline", "strong"]` (original order preserved)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression test added for Issue #383 (`mark_ordering_underline_strong_preserved`)

**Manual Testing:**
- [x] Tested round-trip conversion of nodes with multiple marks
- [x] Verified `[underline, strong]` ordering is preserved through markdown conversion
- [x] Backward compatibility verified — no change to nodes with a single mark or no marks

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test mark_ordering_underline_strong_preserved

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the change in `try_parse_bracketed_span` affects all bracketed span mark application; verify single-mark and no-mark nodes are unaffected
- [x] Error handling — `node.marks` is now directly assigned rather than being mutated via `add_mark`; confirm this is equivalent for all cases

The key change in `src/atlassian/convert.rs` (around line 1442):

```rust
// Before: marks appended after inner node marks
for mark in &marks {
    add_mark(&mut node, mark.clone());
}

// After: bracket marks prepended before inner node marks
let mut combined = marks.clone();
if let Some(ref existing) = node.marks {
    combined.extend(existing.iter().cloned());
}
node.marks = Some(combined);
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Continuing to use `add_mark` with a sort/reorder step post-application — rejected as more complex and fragile compared to simply building the combined vec in the correct order upfront.