### PR TITLE
fix(atlassian): preserve link marks when annotation or other span marks are also present

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2662,7 +2662,23 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
                 }
             }
         }
-        output.push_str(&format!("[{inner}]{{{}}}", attr_parts.join(" ")));
+        let bracketed = format!("[{inner}]{{{}}}", attr_parts.join(" "));
+        // If there's also a link mark, wrap the bracketed span in a link
+        if let Some(link_mark) = has_link {
+            let href = link_mark
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("href"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            output.push('[');
+            output.push_str(&bracketed);
+            output.push_str("](");
+            output.push_str(href);
+            output.push(')');
+        } else {
+            output.push_str(&bracketed);
+        }
     } else if let Some(link_mark) = has_link {
         let href = link_mark
             .attrs
@@ -4243,6 +4259,94 @@ mod tests {
         assert!(
             marks.iter().any(|m| m.mark_type == "annotation"),
             "should have annotation mark"
+        );
+    }
+
+    #[test]
+    fn annotation_and_link_marks_both_preserved() {
+        // Issue #390: text with both annotation and link marks loses link on round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"HANGUL-8","marks":[
+            {"type":"annotation","attrs":{"annotationType":"inlineComment","id":"5ca7425e-34cd-48d3-b4eb-9873ac8b20e0"}},
+            {"type":"link","attrs":{"href":"https://zendesk.atlassian.net/browse/HANGUL-8"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        // Should contain both annotation attrs and link syntax
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id, got: {md}"
+        );
+        assert!(
+            md.contains("](https://"),
+            "JFM should contain link href, got: {md}"
+        );
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "should have annotation mark, got: {:?}",
+            marks.iter().map(|m| &m.mark_type).collect::<Vec<_>>()
+        );
+        assert!(
+            marks.iter().any(|m| m.mark_type == "link"),
+            "should have link mark, got: {:?}",
+            marks.iter().map(|m| &m.mark_type).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn underline_and_link_marks_both_preserved() {
+        // Underline + link should also coexist
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![AdfNode::text_with_marks(
+                "click here",
+                vec![AdfMark::underline(), AdfMark::link("https://example.com")],
+            )])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("underline"), "should have underline attr: {md}");
+        assert!(
+            md.contains("](https://example.com)"),
+            "should have link: {md}"
+        );
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(marks.iter().any(|m| m.mark_type == "underline"));
+        assert!(marks.iter().any(|m| m.mark_type == "link"));
+    }
+
+    #[test]
+    fn annotation_link_and_bold_all_preserved() {
+        // All three marks should coexist
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"important","marks":[
+            {"type":"annotation","attrs":{"annotationType":"inlineComment","id":"abc"}},
+            {"type":"link","attrs":{"href":"https://example.com"}},
+            {"type":"strong"}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "should have annotation"
+        );
+        assert!(
+            marks.iter().any(|m| m.mark_type == "link"),
+            "should have link"
+        );
+        assert!(
+            marks.iter().any(|m| m.mark_type == "strong"),
+            "should have strong"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes Issue #390 where text nodes carrying both an annotation (inline comment) mark and a link mark would lose the link during ADF-to-Markdown conversion. The `render_marked_text` function built a bracketed span (`[text]{attrs}`) for non-link marks but discarded any co-present link mark in that branch. The fix detects a link mark alongside other span-producing marks and wraps the bracketed span in Markdown link syntax (`[[text]{attrs}](href)`), so both marks survive a round-trip through JFM.

The same fix applies to any combination of span-producing marks (underline, annotation, code, etc.) paired with a link mark, not just the annotation+link case.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #390

## Changes Made

**Core Changes:**
- Modified `render_marked_text` in `src/atlassian/convert.rs` to detect a co-present `link` mark when rendering a bracketed span for other marks
- When a link mark is present alongside span marks, wraps the resulting `[text]{attrs}` span in Markdown link syntax `[[text]{attrs}](href)` instead of emitting the bare span and silently dropping the link

**Testing:**
- Added `annotation_and_link_marks_both_preserved` test: round-trips a text node with both `annotation` and `link` marks and asserts both survive
- Added `underline_and_link_marks_both_preserved` test: round-trips a text node with both `underline` and `link` marks and asserts both survive
- Added `annotation_link_and_bold_all_preserved` test: round-trips a text node with `annotation`, `link`, and `strong` marks and asserts all three survive
- Reformatted multi-argument `assert!` calls to match rustfmt style (separate style commit)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (3 regression tests covering the reported issue and related combinations)

**Manual Testing:**
- [x] Tested happy path scenarios (annotation+link, underline+link, annotation+link+bold)
- [x] Tested error/edge cases (missing href, empty attrs)
- [x] Backward compatibility verified — existing mark rendering paths are unchanged

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test annotation_and_link_marks_both_preserved
cargo test underline_and_link_marks_both_preserved
cargo test annotation_link_and_bold_all_preserved

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `unwrap_or("")` is used when `href` is absent; reviewers should confirm this is the desired fallback behaviour
- [x] Backward compatibility — the `else` branch is unchanged, so text with only span marks (no link) follows the original code path

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The fix is purely additive — the new code path is only entered when a link mark is present alongside other span marks. All existing rendering paths are unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Pre-processing the mark list to separate link marks from span marks before entering `render_marked_text`. Rejected in favour of the in-place detection approach, which keeps the fix localised to the exact line that was dropping the link.