### PR TITLE
fix(atlassian): preserve link mark with textColor/bg/subsup spans

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2847,7 +2847,23 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
                 attr_parts.push(kind.to_string());
             }
         }
-        output.push_str(&format!(":span[{inner}]{{{}}}", attr_parts.join(" ")));
+        let span = format!(":span[{inner}]{{{}}}", attr_parts.join(" "));
+        // If there's also a link mark, wrap the span in a link
+        if let Some(link_mark) = has_link {
+            let href = link_mark
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("href"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            output.push('[');
+            output.push_str(&span);
+            output.push_str("](");
+            output.push_str(href);
+            output.push(')');
+        } else {
+            output.push_str(&span);
+        }
     } else if has_underline || !annotations.is_empty() {
         let mut attr_parts = Vec::new();
         if has_underline {
@@ -5040,6 +5056,127 @@ mod tests {
         let doc = markdown_to_adf(md).unwrap();
         let result = adf_to_markdown(&doc).unwrap();
         assert!(result.contains(":span[red text]{color=#ff5630}"));
+    }
+
+    #[test]
+    fn text_color_and_link_marks_both_preserved() {
+        // Issue #405: text with both textColor and link marks loses link on round-trip
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"red link","marks":[
+            {"type":"link","attrs":{"href":"https://example.com"}},
+            {"type":"textColor","attrs":{"color":"#ff0000"}}
+          ]}
+        ]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains(":span[red link]{color=#ff0000}"),
+            "JFM should contain span with color, got: {md}"
+        );
+        assert!(
+            md.contains("](https://example.com)"),
+            "JFM should contain link href, got: {md}"
+        );
+        // Full round-trip: both marks survive
+        let rt = markdown_to_adf(&md).unwrap();
+        let text_node = &rt.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "textColor"),
+            "should have textColor mark, got: {:?}",
+            marks.iter().map(|m| &m.mark_type).collect::<Vec<_>>()
+        );
+        assert!(
+            marks.iter().any(|m| m.mark_type == "link"),
+            "should have link mark, got: {:?}",
+            marks.iter().map(|m| &m.mark_type).collect::<Vec<_>>()
+        );
+        // Verify attribute values survive
+        let link_mark = marks.iter().find(|m| m.mark_type == "link").unwrap();
+        assert_eq!(
+            link_mark.attrs.as_ref().unwrap()["href"],
+            "https://example.com"
+        );
+        let color_mark = marks.iter().find(|m| m.mark_type == "textColor").unwrap();
+        assert_eq!(color_mark.attrs.as_ref().unwrap()["color"], "#ff0000");
+    }
+
+    #[test]
+    fn bg_color_and_link_marks_both_preserved() {
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"highlighted link","marks":[
+            {"type":"link","attrs":{"href":"https://example.com"}},
+            {"type":"backgroundColor","attrs":{"color":"#ffff00"}}
+          ]}
+        ]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("bg=#ffff00"), "should have bg color: {md}");
+        assert!(
+            md.contains("](https://example.com)"),
+            "should have link: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let text_node = &rt.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(marks.iter().any(|m| m.mark_type == "backgroundColor"));
+        assert!(marks.iter().any(|m| m.mark_type == "link"));
+    }
+
+    #[test]
+    fn text_color_link_and_strong_rendering() {
+        // Verify textColor + link + strong renders all three formatting elements
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"bold red link","marks":[
+            {"type":"strong"},
+            {"type":"link","attrs":{"href":"https://example.com"}},
+            {"type":"textColor","attrs":{"color":"#ff0000"}}
+          ]}
+        ]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("**bold red link**"), "should have bold: {md}");
+        assert!(md.contains("color=#ff0000"), "should have color: {md}");
+        assert!(
+            md.contains("](https://example.com)"),
+            "should have link: {md}"
+        );
+    }
+
+    #[test]
+    fn subsup_and_link_marks_both_preserved() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"note","marks":[
+            {"type":"link","attrs":{"href":"https://example.com"}},
+            {"type":"subsup","attrs":{"type":"sup"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("sup"), "should have sup: {md}");
+        assert!(
+            md.contains("](https://example.com)"),
+            "should have link: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let text_node = &rt.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(marks.iter().any(|m| m.mark_type == "subsup"));
+        assert!(marks.iter().any(|m| m.mark_type == "link"));
+    }
+
+    #[test]
+    fn text_color_without_link_unchanged() {
+        // Regression guard: textColor without link should still work
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"just red","marks":[
+            {"type":"textColor","attrs":{"color":"#ff0000"}}
+          ]}
+        ]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains(":span[just red]{color=#ff0000}"), "md: {md}");
+        assert!(!md.contains("](http"), "should NOT have link syntax: {md}");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes issue #405 where ADF text nodes containing both a span-producing mark (textColor, backgroundColor, or subsup) and a link mark would silently drop the hyperlink during ADF-to-markdown conversion.

The `needs_span` branch in `render_marked_text` was rendering `:span[text]{color=...}` correctly but ignoring any co-occurring link mark. This meant that on round-trip conversion, the hyperlink was lost entirely. The fix wraps the rendered span in markdown link syntax `[:span[text]{color=...}](href)` when a link mark is also present — matching the same pattern already used for the annotation+link fix introduced in #390.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #405

## Changes Made

**Core Changes:**
- Modified `render_marked_text` in `src/atlassian/convert.rs` to detect a co-occurring link mark when rendering a `:span[...]` directive
- When a link mark is present alongside a span-producing mark (textColor, backgroundColor, subsup, etc.), the span is now wrapped in markdown link syntax: `[:span[text]{attrs}](href)`
- The fix applies uniformly to all span-producing mark types, not just textColor

**Testing:**
- Added `text_color_and_link_marks_both_preserved` — full round-trip test verifying textColor + link marks both survive, with attribute value verification
- Added `bg_color_and_link_marks_both_preserved` — backgroundColor + link combination round-trip test
- Added `text_color_link_and_strong_rendering` — triple mark rendering check (textColor + link + strong)
- Added `subsup_and_link_marks_both_preserved` — subsup + link round-trip test
- Added `text_color_without_link_unchanged` — regression guard ensuring standalone textColor renders unchanged without link syntax

## Testing

**Automated Testing:**
- [x] All existing tests pass (1497 tests pass, clippy clean)
- [x] New tests added for all affected mark combinations
- [x] Round-trip tests verify both ADF→markdown and markdown→ADF directions

**Manual Testing:**
- [x] Tested happy path scenarios (each mark combination individually)
- [x] Tested error/edge cases (textColor without link is unaffected)
- [x] Backward compatibility verified — standalone span marks render identically to before

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run only the new regression tests
cargo test text_color_and_link
cargo test bg_color_and_link
cargo test text_color_link_and_strong
cargo test subsup_and_link
cargo test text_color_without_link
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the fix is conditional; spans without a link mark follow the original code path unchanged
- [x] Error handling — `href` extraction from mark attrs uses `unwrap_or("")` to degrade gracefully if attrs are malformed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The fix is purely additive — text nodes with only span-producing marks (no link) continue to render identically to before.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Applying the fix in the markdown parser (markdown→ADF direction) rather than the renderer — rejected because the renderer is where information is lost; fixing it at the source is cleaner and consistent with how the annotation+link case was resolved in #390.