### PR TITLE
fix(atlassian): include expand/nestedExpand localId in directive attrs

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -442,12 +442,16 @@ impl<'a> MarkdownParser<'a> {
             "expand" => {
                 let title = d.attrs.as_ref().and_then(|a| a.get("title"));
                 let inner_blocks = MarkdownParser::new(&inner_text).parse_blocks()?;
-                AdfNode::expand(title, inner_blocks)
+                let mut node = AdfNode::expand(title, inner_blocks);
+                pass_through_local_id(&d.attrs, &mut node);
+                node
             }
             "nested-expand" => {
                 let title = d.attrs.as_ref().and_then(|a| a.get("title"));
                 let inner_blocks = MarkdownParser::new(&inner_text).parse_blocks()?;
-                AdfNode::nested_expand(title, inner_blocks)
+                let mut node = AdfNode::nested_expand(title, inner_blocks);
+                pass_through_local_id(&d.attrs, &mut node);
+                node
             }
             "layout" => {
                 // Parse inner content looking for :::column sub-containers
@@ -2051,15 +2055,25 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
             } else {
                 "expand"
             };
-            let title = node
+            let mut attr_parts = Vec::new();
+            if let Some(t) = node
                 .attrs
                 .as_ref()
                 .and_then(|a| a.get("title"))
-                .and_then(serde_json::Value::as_str);
-            if let Some(t) = title {
-                output.push_str(&format!(":::{directive_name}{{title=\"{t}\"}}\n"));
-            } else {
+                .and_then(serde_json::Value::as_str)
+            {
+                attr_parts.push(format!("title=\"{t}\""));
+            }
+            if let Some(ref attrs) = node.attrs {
+                maybe_push_local_id(attrs, &mut attr_parts, opts);
+            }
+            if attr_parts.is_empty() {
                 output.push_str(&format!(":::{directive_name}\n"));
+            } else {
+                output.push_str(&format!(
+                    ":::{directive_name}{{{}}}\n",
+                    attr_parts.join(" ")
+                ));
             }
             if let Some(ref content) = node.content {
                 render_block_children(content, output, opts);
@@ -2168,8 +2182,11 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
             }
         }
     }
-    if let Some(ref attrs) = node.attrs {
-        maybe_push_local_id(attrs, &mut parts, opts);
+    // Skip localId for node types that already include it in their directive attrs
+    if !matches!(node.node_type.as_str(), "expand" | "nestedExpand") {
+        if let Some(ref attrs) = node.attrs {
+            maybe_push_local_id(attrs, &mut parts, opts);
+        }
     }
     if !parts.is_empty() {
         output.push_str(&format!("{{{}}}\n", parts.join(" ")));
@@ -6901,6 +6918,148 @@ mod tests {
             col_content.iter().any(|n| n.node_type == "expand"),
             "Column should contain an expand node, got: {:?}",
             col_content.iter().map(|n| &n.node_type).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn expand_localid_in_directive_attrs() {
+        // Issue #412: localId should be in directive attrs, not trailing text
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"expand","attrs":{"localId":"exp-001","title":"Details"},"content":[
+            {"type":"paragraph","content":[{"type":"text","text":"body"}]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("localId=exp-001"),
+            "should contain localId: {md}"
+        );
+        assert!(
+            md.contains(":::expand{"),
+            "should have expand directive with attrs: {md}"
+        );
+        assert!(
+            !md.contains(":::\n{localId="),
+            "localId should NOT be trailing: {md}"
+        );
+    }
+
+    #[test]
+    fn expand_localid_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"expand","attrs":{"localId":"exp-001","title":"Details"},"content":[
+            {"type":"paragraph","content":[{"type":"text","text":"body"}]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let expand = &rt.content[0];
+        assert_eq!(expand.node_type, "expand");
+        assert_eq!(
+            expand.attrs.as_ref().unwrap()["localId"],
+            "exp-001",
+            "expand localId should survive round-trip"
+        );
+        assert_eq!(
+            expand.attrs.as_ref().unwrap()["title"],
+            "Details",
+            "expand title should survive round-trip"
+        );
+    }
+
+    #[test]
+    fn nested_expand_localid_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"nestedExpand","attrs":{"localId":"ne-001","title":"S"},"content":[
+            {"type":"paragraph","content":[{"type":"text","text":"content"}]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains(":::nested-expand{"),
+            "should have directive: {md}"
+        );
+        assert!(md.contains("localId=ne-001"), "should have localId: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let ne = &rt.content[0];
+        assert_eq!(ne.node_type, "nestedExpand");
+        assert_eq!(ne.attrs.as_ref().unwrap()["localId"], "ne-001");
+    }
+
+    #[test]
+    fn nested_expand_localid_followed_by_content() {
+        // Issue #412 reproducer: localId must not leak into following paragraph
+        let adf_json = "{\
+            \"version\":1,\"type\":\"doc\",\"content\":[\
+              {\"type\":\"nestedExpand\",\"attrs\":{\"localId\":\"exp-001\",\"title\":\"S\"},\"content\":[\
+                {\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"\\u00a0\"}]}\
+              ]},\
+              {\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"after\"}]}\
+            ]}";
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        // nestedExpand should have localId
+        let ne = &rt.content[0];
+        assert_eq!(ne.node_type, "nestedExpand");
+        assert_eq!(
+            ne.attrs.as_ref().unwrap()["localId"],
+            "exp-001",
+            "nestedExpand should preserve localId"
+        );
+        // Following paragraph should contain "after", not "{localId=...}"
+        let para = &rt.content[1];
+        assert_eq!(para.node_type, "paragraph");
+        let text = para.content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap_or("");
+        assert!(
+            !text.contains("localId"),
+            "following paragraph should not contain localId: {text}"
+        );
+        assert!(
+            text.contains("after"),
+            "following paragraph should contain 'after': {text}"
+        );
+    }
+
+    #[test]
+    fn expand_localid_without_title() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"expand","attrs":{"localId":"exp-002"},"content":[
+            {"type":"paragraph","content":[{"type":"text","text":"no title"}]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains(":::expand{localId=exp-002}"),
+            "should have localId without title: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        assert_eq!(rt.content[0].attrs.as_ref().unwrap()["localId"], "exp-002");
+    }
+
+    #[test]
+    fn expand_localid_stripped() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"expand","attrs":{"localId":"exp-001","title":"X"},"content":[
+            {"type":"paragraph","content":[{"type":"text","text":"body"}]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let opts = RenderOptions {
+            strip_local_ids: true,
+        };
+        let md = adf_to_markdown_with_options(&doc, &opts).unwrap();
+        assert!(!md.contains("localId"), "localId should be stripped: {md}");
+        assert!(
+            md.contains(":::expand{title=\"X\"}"),
+            "title should remain: {md}"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes issue #412 where `localId` on `expand` and `nestedExpand` ADF nodes was being rendered as trailing text after the closing `:::` fence (e.g., `:::\n{localId=exp-001}`) instead of being included inside the directive attribute block (e.g., `:::expand{title="Details" localId=exp-001}`).

The root cause was that the generic block-attrs post-processing path appended `localId` as a trailing `{...}` block after the directive fence, which would then get absorbed into adjacent content nodes when more block-level nodes followed. The fix moves `localId` directly into the directive opening fence for `expand` and `nestedExpand`, matching the same approach used for `title`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #412

## Changes Made

**Core Changes:**
- Modified `render_block_node` in `src/atlassian/convert.rs` to collect `attr_parts` (title + localId) and join them into a single `:::expand{...}` attribute block rather than emitting them separately
- Added `pass_through_local_id` call in the `"expand"` and `"nested-expand"` directive parsing branches so that `localId` from directive attrs is propagated back into the ADF node when parsing markdown → ADF
- Added guard in the generic trailing `localId` post-processing path to skip `expand` and `nestedExpand` node types, preventing double-emission of `localId`

**Testing:**
- Added six regression tests in `src/atlassian/convert.rs`:
  - `expand_localid_in_directive_attrs` — verifies `localId` appears in the opening fence, not as trailing text
  - `expand_localid_roundtrip` — full ADF→MD→ADF round-trip with both `title` and `localId`
  - `nested_expand_localid_roundtrip` — same for `nestedExpand`
  - `nested_expand_localid_followed_by_content` — exact reproducer from #412; verifies `localId` does not leak into the following paragraph's text content
  - `expand_localid_without_title` — `localId`-only (no title), renders as `:::expand{localId=exp-002}`
  - `expand_localid_stripped` — verifies `--strip-local-ids` still removes `localId` while keeping `title`

## Testing

**Automated Testing:**
- [x] All existing tests pass (1498 tests confirmed passing)
- [x] New tests added for new functionality (6 regression tests)
- [x] Integration tests updated/added (round-trip tests cover parser + renderer)

**Manual Testing:**
- [x] Tested happy path scenarios (expand with title + localId)
- [x] Tested error/edge cases (expand without title, nestedExpand followed by paragraph, strip_local_ids flag)
- [x] Backward compatibility verified (no change to expand/nestedExpand nodes without localId)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test expand_localid
cargo test nested_expand_localid

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — expand/nestedExpand nodes without `localId` should be unaffected
- [x] Error handling — `localId` must not appear in adjacent paragraph content after round-trip

The key logic change is in `render_block_node` around line 2055 of `src/atlassian/convert.rs`: instead of a single conditional `if let Some(t) = title { ... } else { ... }`, we now build a `Vec<String>` of attribute parts (`title` and optionally `localId`) and format them together. The guard `!matches!(node.node_type.as_str(), "expand" | "nestedExpand")` on the generic `maybe_push_local_id` path at line ~2182 is critical to prevent duplication.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a bug fix — output for `expand`/`nestedExpand` nodes that previously had incorrect trailing `{localId=...}` text will now correctly include `localId` inside the directive attribute block. Consumers that were working around the broken output may need to update, but the new output is the correct and intended format.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Fixing the generic trailing `{...}` post-processor to correctly attach to the preceding directive fence rather than leaking as a separate block — rejected because it would be more fragile and wouldn't address the root cause of `localId` needing to be part of the directive's attribute syntax.