### PR TITLE
fix(atlassian): preserve original timestamp attribute in date round-trips

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1657,7 +1657,11 @@ fn try_dispatch_inline_directive(text: &str, pos: usize) -> Option<(AdfNode, usi
             node
         }
         "date" => {
-            let timestamp = iso_date_to_epoch_ms(content);
+            let timestamp = d
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("timestamp"))
+                .map_or_else(|| iso_date_to_epoch_ms(content), ToString::to_string);
             let mut node = AdfNode::date(&timestamp);
             pass_through_local_id(&d.attrs, &mut node);
             node
@@ -2893,13 +2897,9 @@ fn render_inline_node(node: &AdfNode, output: &mut String, opts: &RenderOptions)
                 if let Some(timestamp) = attrs.get("timestamp").and_then(serde_json::Value::as_str)
                 {
                     let display = epoch_ms_to_iso_date(timestamp);
-                    let mut attr_parts = Vec::new();
+                    let mut attr_parts = vec![format!("timestamp={timestamp}")];
                     maybe_push_local_id(attrs, &mut attr_parts, opts);
-                    if attr_parts.is_empty() {
-                        output.push_str(&format!(":date[{display}]"));
-                    } else {
-                        output.push_str(&format!(":date[{display}]{{{}}}", attr_parts.join(" ")));
-                    }
+                    output.push_str(&format!(":date[{display}]{{{}}}", attr_parts.join(" ")));
                 }
             }
         }
@@ -5631,14 +5631,14 @@ mod tests {
 
     #[test]
     fn adf_date_to_markdown() {
-        // ADF dates use epoch ms; renderer converts back to ISO
+        // ADF dates use epoch ms; renderer converts back to ISO with timestamp attr
         let doc = AdfDocument {
             version: 1,
             doc_type: "doc".to_string(),
             content: vec![AdfNode::paragraph(vec![AdfNode::date("1776211200000")])],
         };
         let md = adf_to_markdown(&doc).unwrap();
-        assert!(md.contains(":date[2026-04-15]"));
+        assert!(md.contains(":date[2026-04-15]{timestamp=1776211200000}"));
     }
 
     #[test]
@@ -5650,7 +5650,7 @@ mod tests {
             content: vec![AdfNode::paragraph(vec![AdfNode::date("2026-04-15")])],
         };
         let md = adf_to_markdown(&doc).unwrap();
-        assert!(md.contains(":date[2026-04-15]"));
+        assert!(md.contains(":date[2026-04-15]{timestamp=2026-04-15}"));
     }
 
     #[test]
@@ -5662,6 +5662,27 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_date_non_midnight_timestamp() {
+        // Issue #409: non-midnight timestamps must survive round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"date","attrs":{"timestamp":"1700000000000"}}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        // JFM should include the original timestamp
+        assert!(
+            md.contains("timestamp=1700000000000"),
+            "JFM should preserve original timestamp: {md}"
+        );
+        // Round-trip back to ADF
+        let doc2 = markdown_to_adf(&md).unwrap();
+        let content = doc2.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].attrs.as_ref().unwrap()["timestamp"],
+            "1700000000000",
+            "Round-trip must preserve original non-midnight timestamp"
+        );
+    }
+
+    #[test]
     fn date_epoch_ms_passthrough() {
         // If JFM date is already epoch ms, pass through
         let doc = markdown_to_adf("Due by :date[1776211200000].").unwrap();
@@ -5670,6 +5691,51 @@ mod tests {
             content[1].attrs.as_ref().unwrap()["timestamp"],
             "1776211200000"
         );
+    }
+
+    #[test]
+    fn date_timestamp_attr_preferred_over_content() {
+        // When timestamp attr is present, it takes priority over the display date
+        let md = ":date[2023-11-14]{timestamp=1700000000000}\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let content = doc.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].attrs.as_ref().unwrap()["timestamp"],
+            "1700000000000",
+            "timestamp attr should be used directly"
+        );
+    }
+
+    #[test]
+    fn date_without_timestamp_attr_backward_compat() {
+        // Legacy JFM without timestamp attr still works via iso_date_to_epoch_ms
+        let md = ":date[2026-04-15]\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let content = doc.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].attrs.as_ref().unwrap()["timestamp"],
+            "1776211200000",
+            "Should fall back to computing timestamp from date string"
+        );
+    }
+
+    #[test]
+    fn date_with_local_id_and_timestamp() {
+        // Both localId and timestamp should round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"date","attrs":{"timestamp":"1700000000000","localId":"d-001"}}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("timestamp=1700000000000"),
+            "Should contain timestamp: {md}"
+        );
+        assert!(md.contains("localId=d-001"), "Should contain localId: {md}");
+        // Round-trip
+        let doc2 = markdown_to_adf(&md).unwrap();
+        let content = doc2.content[0].content.as_ref().unwrap();
+        let attrs = content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["timestamp"], "1700000000000");
+        assert_eq!(attrs["localId"], "d-001");
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes Issue #409 where non-midnight timestamps were silently corrupted during ADF-to-markdown-to-ADF round-trips. The root cause was that the date renderer in `src/atlassian/convert.rs` discarded the original epoch-ms `timestamp` attribute when converting to JFM (Jira Flavored Markdown), replacing it with a human-readable ISO date string. When the JFM was parsed back to ADF, `iso_date_to_epoch_ms` could only recover the midnight value of that date, losing the original sub-day precision entirely.

The fix preserves the original `timestamp` attribute value in JFM output as `timestamp=<value>` and prefers that attribute over the display date content when parsing JFM back to ADF, with a fallback to `iso_date_to_epoch_ms` for legacy JFM that predates this change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #409

## Changes Made

**Core Changes:**
- Modified `render_inline_node` in `src/atlassian/convert.rs` to always include `timestamp=<value>` in the JFM attrs block for date nodes, ensuring the original epoch-ms value is never discarded
- Simplified the conditional attrs-block emission logic — since `timestamp` is now always present, the `if attr_parts.is_empty()` branch is no longer needed and has been removed
- Modified `try_dispatch_inline_directive` in `src/atlassian/convert.rs` to prefer the `timestamp` attr from the parsed JFM directive over the display date content, falling back to `iso_date_to_epoch_ms` for legacy JFM that lacks the attr

**Testing:**
- Updated existing `adf_date_to_markdown` test to assert the new output format including the `{timestamp=...}` attrs block
- Updated existing `adf_date_to_markdown_invalid_timestamp` test to assert the new attrs block output
- Added `round_trip_date_non_midnight_timestamp` regression test covering Issue #409: verifies that a non-midnight epoch-ms timestamp (`1700000000000`) survives a full ADF → JFM → ADF round-trip
- Added `date_timestamp_attr_preferred_over_content` test verifying that when a `timestamp` attr is present in JFM, it takes priority over the display date string
- Added `date_without_timestamp_attr_backward_compat` test verifying that legacy JFM without a `timestamp` attr still correctly computes the epoch-ms value via `iso_date_to_epoch_ms`
- Added `date_with_local_id_and_timestamp` test verifying that both `localId` and `timestamp` attributes survive a combined round-trip

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (midnight timestamps, ISO date strings)
- [x] Tested error/edge cases (non-midnight timestamps, legacy JFM without timestamp attr)
- [x] Backward compatibility verified (legacy JFM without `timestamp` attr still parses correctly via fallback)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the directly relevant tests
cargo test atlassian::convert::tests::round_trip_date_non_midnight_timestamp
cargo test atlassian::convert::tests::date_timestamp_attr_preferred_over_content
cargo test atlassian::convert::tests::date_without_timestamp_attr_backward_compat
cargo test atlassian::convert::tests::date_with_local_id_and_timestamp

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — legacy JFM (without `timestamp` attr) must still parse correctly; the fallback path in `try_dispatch_inline_directive` covers this
- [x] Error handling — the `timestamp` attr lookup uses `and_then`/`map_or_else` to gracefully fall back without panicking

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The JFM output format for date nodes now always includes a `{timestamp=...}` attrs block (previously omitted when no other attrs were present), but the parser handles both old and new formats correctly. Existing stored JFM without the `timestamp` attr continues to parse correctly via the `iso_date_to_epoch_ms` fallback.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Storing the timestamp in the display content (e.g., `:date[1700000000000]`) rather than an attrs block — rejected because it changes the human-readable display value and breaks the semantic separation between display content and metadata
- Computing the epoch-ms from the ISO date on every render pass — this was the original (broken) approach; it only works for midnight-aligned timestamps