### PR TITLE
fix(atlassian): preserve embedCard originalHeight and width attrs on round-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ perf.data*
 
 # Coverage
 tarpaulin-report.html
+tarpaulin-report.json
 cobertura.xml
 lcov.info
 

--- a/src/atlassian/adf.rs
+++ b/src/atlassian/adf.rs
@@ -440,10 +440,18 @@ impl AdfNode {
 
     /// Creates an embed card node.
     #[must_use]
-    pub fn embed_card(url: &str, layout: Option<&str>, width: Option<u32>) -> Self {
+    pub fn embed_card(
+        url: &str,
+        layout: Option<&str>,
+        original_height: Option<f64>,
+        width: Option<f64>,
+    ) -> Self {
         let mut attrs = serde_json::json!({"url": url});
         if let Some(l) = layout {
             attrs["layout"] = serde_json::Value::String(l.to_string());
+        }
+        if let Some(h) = original_height {
+            attrs["originalHeight"] = serde_json::json!(h);
         }
         if let Some(w) = width {
             attrs["width"] = serde_json::json!(w);
@@ -1059,19 +1067,26 @@ mod tests {
 
     #[test]
     fn embed_card_with_all_options() {
-        let card = AdfNode::embed_card("https://example.com", Some("wide"), Some(800));
+        let card = AdfNode::embed_card(
+            "https://example.com",
+            Some("wide"),
+            Some(732.0),
+            Some(100.0),
+        );
         let attrs = card.attrs.as_ref().unwrap();
         assert_eq!(attrs["url"], "https://example.com");
         assert_eq!(attrs["layout"], "wide");
-        assert_eq!(attrs["width"], 800);
+        assert_eq!(attrs["originalHeight"], 732.0);
+        assert_eq!(attrs["width"], 100.0);
     }
 
     #[test]
     fn embed_card_minimal() {
-        let card = AdfNode::embed_card("https://example.com", None, None);
+        let card = AdfNode::embed_card("https://example.com", None, None, None);
         let attrs = card.attrs.as_ref().unwrap();
         assert_eq!(attrs["url"], "https://example.com");
         assert!(attrs.get("layout").is_none());
+        assert!(attrs.get("originalHeight").is_none());
         assert!(attrs.get("width").is_none());
     }
 

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -758,12 +758,17 @@ impl<'a> MarkdownParser<'a> {
             "embed" => {
                 let url = d.content.as_deref().unwrap_or("");
                 let layout = d.attrs.as_ref().and_then(|a| a.get("layout"));
+                let original_height = d
+                    .attrs
+                    .as_ref()
+                    .and_then(|a| a.get("originalHeight"))
+                    .and_then(|v| v.parse::<f64>().ok());
                 let width = d
                     .attrs
                     .as_ref()
                     .and_then(|a| a.get("width"))
-                    .and_then(|w| w.parse::<u32>().ok());
-                AdfNode::embed_card(url, layout, width)
+                    .and_then(|w| w.parse::<f64>().ok());
+                AdfNode::embed_card(url, layout, original_height, width)
             }
             "extension" => {
                 let ext_type = d.attrs.as_ref().and_then(|a| a.get("type")).unwrap_or("");
@@ -1960,6 +1965,16 @@ fn render_block_children(children: &[AdfNode], output: &mut String, opts: &Rende
     }
 }
 
+/// Formats a float as an integer string when it has no fractional part,
+/// otherwise as a regular float string.
+fn fmt_f64_attr(v: f64) -> String {
+    if v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        v.to_string()
+    }
+}
+
 /// Renders a block-level ADF node to markdown.
 fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) {
     match node.node_type.as_str() {
@@ -2126,8 +2141,14 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
                 if let Some(layout) = attrs.get("layout").and_then(serde_json::Value::as_str) {
                     attr_parts.push(format!("layout={layout}"));
                 }
-                if let Some(width) = attrs.get("width").and_then(serde_json::Value::as_u64) {
-                    attr_parts.push(format!("width={width}"));
+                if let Some(h) = attrs
+                    .get("originalHeight")
+                    .and_then(serde_json::Value::as_f64)
+                {
+                    attr_parts.push(format!("originalHeight={}", fmt_f64_attr(h)));
+                }
+                if let Some(w) = attrs.get("width").and_then(serde_json::Value::as_f64) {
+                    attr_parts.push(format!("width={}", fmt_f64_attr(w)));
                 }
                 if !attr_parts.is_empty() {
                     output.push_str(&format!("{{{}}}", attr_parts.join(" ")));
@@ -4687,11 +4708,24 @@ mod tests {
         let doc =
             markdown_to_adf("::embed[https://figma.com/file/abc]{layout=wide width=80}").unwrap();
         assert_eq!(doc.content[0].node_type, "embedCard");
-        assert_eq!(
-            doc.content[0].attrs.as_ref().unwrap()["url"],
-            "https://figma.com/file/abc"
-        );
-        assert_eq!(doc.content[0].attrs.as_ref().unwrap()["layout"], "wide");
+        let attrs = doc.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["url"], "https://figma.com/file/abc");
+        assert_eq!(attrs["layout"], "wide");
+        assert_eq!(attrs["width"], 80.0);
+    }
+
+    #[test]
+    fn leaf_embed_card_with_original_height() {
+        let doc = markdown_to_adf(
+            "::embed[https://example.com]{layout=center originalHeight=732 width=100}",
+        )
+        .unwrap();
+        assert_eq!(doc.content[0].node_type, "embedCard");
+        let attrs = doc.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["url"], "https://example.com");
+        assert_eq!(attrs["layout"], "center");
+        assert_eq!(attrs["originalHeight"], 732.0);
+        assert_eq!(attrs["width"], 100.0);
     }
 
     #[test]
@@ -4702,11 +4736,113 @@ mod tests {
             content: vec![AdfNode::embed_card(
                 "https://figma.com/file/abc",
                 Some("wide"),
-                Some(80),
+                None,
+                Some(80.0),
             )],
         };
         let md = adf_to_markdown(&doc).unwrap();
         assert!(md.contains("::embed[https://figma.com/file/abc]{layout=wide width=80}"));
+    }
+
+    #[test]
+    fn adf_embed_card_original_height_to_markdown() {
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::embed_card(
+                "https://example.com",
+                Some("center"),
+                Some(732.0),
+                Some(100.0),
+            )],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("::embed[https://example.com]{layout=center originalHeight=732 width=100}"),
+            "expected originalHeight and width in md: {md}"
+        );
+    }
+
+    #[test]
+    fn embed_card_roundtrip_with_all_attrs() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{
+            "type":"embedCard",
+            "attrs":{"layout":"center","originalHeight":732.0,"url":"https://example.com","width":100.0}
+        }]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("originalHeight=732"),
+            "originalHeight missing from md: {md}"
+        );
+        assert!(md.contains("width=100"), "width missing from md: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let attrs = rt.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["originalHeight"], 732.0);
+        assert_eq!(attrs["width"], 100.0);
+        assert_eq!(attrs["layout"], "center");
+        assert_eq!(attrs["url"], "https://example.com");
+    }
+
+    #[test]
+    fn embed_card_fractional_dimensions() {
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::embed_card(
+                "https://example.com",
+                Some("center"),
+                Some(732.5),
+                Some(99.9),
+            )],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("originalHeight=732.5"),
+            "fractional originalHeight missing: {md}"
+        );
+        assert!(md.contains("width=99.9"), "fractional width missing: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let attrs = rt.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["originalHeight"], 732.5);
+        assert_eq!(attrs["width"], 99.9);
+    }
+
+    #[test]
+    fn embed_card_integer_width_in_json() {
+        // JSON integer (not float) should also be extracted via as_f64()
+        let adf_json = r#"{"version":1,"type":"doc","content":[{
+            "type":"embedCard",
+            "attrs":{"url":"https://example.com","width":100}
+        }]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("width=100"),
+            "integer width missing from md: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        assert_eq!(rt.content[0].attrs.as_ref().unwrap()["width"], 100.0);
+    }
+
+    #[test]
+    fn embed_card_only_original_height() {
+        // originalHeight without width
+        let adf_json = r#"{"version":1,"type":"doc","content":[{
+            "type":"embedCard",
+            "attrs":{"url":"https://example.com","originalHeight":500.0}
+        }]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("originalHeight=500"),
+            "originalHeight missing: {md}"
+        );
+        assert!(!md.contains("width="), "width should not appear: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let attrs = rt.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["originalHeight"], 500.0);
+        assert!(attrs.get("width").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a bug where the `originalHeight` attribute was silently dropped during ADF-to-markdown and markdown-to-ADF conversion for `embedCard` nodes. Additionally, the `width` attribute type was incorrect (`u32` instead of `f64`), causing fractional width values to be silently discarded during the round-trip.

The root cause was twofold:
1. `AdfNode::embed_card` had no parameter for `originalHeight`, so it was never serialized into the markdown directive attributes.
2. `width` was typed as `Option<u32>`, meaning any fractional value (e.g. `99.9`) would fail the `parse::<u32>()` and be silently dropped.

After this fix, both `originalHeight` and `width` survive a full ADF → markdown → ADF round-trip, with integer values rendered without a decimal point and fractional values rendered with full precision.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #404

## Changes Made

**Core Changes (`src/atlassian/adf.rs`):**
- Added `original_height: Option<f64>` parameter to `AdfNode::embed_card`
- Changed `width` parameter type from `Option<u32>` to `Option<f64>` to support fractional values
- Updated `embed_card` constructor to serialize `originalHeight` into the ADF node attrs when present
- Updated existing unit tests (`embed_card_with_all_options`, `embed_card_minimal`) to match new signature

**Core Changes (`src/atlassian/convert.rs`):**
- Updated the markdown parser (`MarkdownParser`) to parse `originalHeight` from embed directive attributes as `f64` and pass it through to `AdfNode::embed_card`
- Changed `width` parsing from `parse::<u32>()` to `parse::<f64>()` so fractional widths are preserved
- Updated the ADF renderer (`render_block_node`) to emit `originalHeight` into the markdown directive attribute string
- Changed `width` rendering from `as_u64()` to `as_f64()` to support fractional values
- Both `originalHeight` and `width` are rendered as integer strings when their fractional part is zero (e.g. `732` not `732.0`), otherwise as floating-point strings (e.g. `732.5`)

**Testing:**
- Added `leaf_embed_card_with_original_height` — parses a directive containing `originalHeight` and asserts it appears in ADF attrs
- Added `adf_embed_card_original_height_to_markdown` — renders an ADF embedCard with `originalHeight` and asserts it appears in the markdown output
- Added `embed_card_roundtrip_with_all_attrs` — full ADF JSON → markdown → ADF round-trip covering `layout`, `originalHeight`, `width`, and `url`
- Added `embed_card_fractional_dimensions` — verifies fractional values (`732.5`, `99.9`) survive the round-trip without truncation
- Updated `leaf_embed_card` test to assert `width` as `f64` (`80.0`)
- Updated `adf_embed_card_to_markdown` test to pass `None` for `original_height` and `Some(80.0)` for `width`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (integer `originalHeight` and `width`)
- [x] Tested error/edge cases (fractional dimensions, missing attrs)
- [x] Backward compatibility verified (existing callers updated to pass `None` for `original_height`)

### Test Commands

```bash
# Core test suite
cargo test

# Run only atlassian-related tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `AdfNode::embed_card` signature changed; all call sites updated in the same commit
- [x] Error handling — fractional/integer rendering logic in `render_block_node` for `originalHeight` and `width`
- [x] Architecture changes — `width` type widened from `u32` to `f64` throughout the call chain

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

The `AdfNode::embed_card` function signature changed — a new `original_height: Option<f64>` parameter was inserted before `width`, and `width` changed from `Option<u32>` to `Option<f64>`. All internal call sites have been updated in this PR. If any downstream code outside this repository calls `AdfNode::embed_card` directly, callers must be updated to pass `None` (or a value) for `original_height` and to use `f64` for `width`.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `width` as `u32` and adding a separate `width_f64` field was rejected in favour of simply widening the type to `f64`, which is a strict superset of the previous `u32` behaviour for non-fractional values.