### PR TITLE
fix(atlassian): resolve em mark dropped when combined with strong in markdown

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1579,10 +1579,32 @@ fn prepend_mark(node: &mut AdfNode, mark: AdfMark) {
     }
 }
 
-/// Tries to parse **bold** or *italic* or __bold__ or _italic_ starting at position `i`.
+/// Tries to parse ***bold+italic***, **bold**, *italic* (or underscore variants) starting at position `i`.
 /// Returns (end_position, inner_content, is_bold).
+///
+/// The triple-delimiter case (`***` / `___`) is checked first so that `***text***` is parsed as
+/// bold wrapping italic content, rather than having the `**` branch consume the wrong closing
+/// delimiter and leave stray `*` characters in the text (see issue #401).
 fn try_parse_emphasis(text: &str, i: usize) -> Option<(usize, &str, bool)> {
     let rest = &text[i..];
+
+    // Bold+italic: *** or ___
+    // Parse as bold wrapping italic: the inner content will be recursively parsed and pick up
+    // the inner * / _ as an em mark.
+    if rest.starts_with("***") || rest.starts_with("___") {
+        let triple = &rest[..3];
+        let after = &rest[3..];
+        if let Some(close) = after.find(triple) {
+            if close > 0 {
+                // Return a slice that includes the inner italic delimiters from the
+                // original text: for `***text***`, return `*text*`.  The recursive
+                // parse_inline call will then pick up the inner `*…*` as an em mark.
+                let content = &rest[2..=3 + close];
+                let end = i + 3 + close + 3;
+                return Some((end, content, true));
+            }
+        }
+    }
 
     // Bold: ** or __
     if rest.starts_with("**") || rest.starts_with("__") {
@@ -5464,6 +5486,104 @@ mod tests {
             vec!["link", "underline"],
             "mark order should be preserved, got: {mark_types:?}"
         );
+    }
+
+    #[test]
+    fn em_strong_round_trip() {
+        // Issue #401: em mark dropped when combined with strong
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"bold and italic","marks":[{"type":"strong"},{"type":"em"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert_eq!(md.trim(), "***bold and italic***");
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(node.text.as_deref(), Some("bold and italic"));
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["strong", "em"],
+            "both strong and em marks should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn em_strong_round_trip_em_first() {
+        // Issue #401: em+strong with em listed first
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"italic and bold","marks":[{"type":"em"},{"type":"strong"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(node.text.as_deref(), Some("italic and bold"));
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert!(
+            mark_types.contains(&"strong") && mark_types.contains(&"em"),
+            "both strong and em marks should be present, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn triple_asterisk_parse_to_adf() {
+        // Issue #401: ***text*** should parse as text with strong+em marks
+        let md = "***bold and italic***\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let node = &doc.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(node.text.as_deref(), Some("bold and italic"));
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert!(
+            mark_types.contains(&"strong") && mark_types.contains(&"em"),
+            "***text*** should produce both strong and em marks, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn triple_asterisk_with_surrounding_text() {
+        // Issue #401: surrounding text should not be affected
+        let md = "before ***bold italic*** after\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let nodes = doc.content[0].content.as_ref().unwrap();
+        // Should have: "before " (plain), "bold italic" (strong+em), " after" (plain)
+        assert!(
+            nodes.len() >= 3,
+            "expected at least 3 nodes, got {}",
+            nodes.len()
+        );
+        assert_eq!(nodes[0].text.as_deref(), Some("before "));
+        assert_eq!(nodes[1].text.as_deref(), Some("bold italic"));
+        let mark_types: Vec<&str> = nodes[1]
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert!(
+            mark_types.contains(&"strong") && mark_types.contains(&"em"),
+            "middle node should have strong+em, got: {mark_types:?}"
+        );
+        assert_eq!(nodes[2].text.as_deref(), Some(" after"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes issue #401 where text with both bold and italic marks (strong+em) would lose the `em` mark during a markdown round-trip. When converting ADF to markdown, text with both `strong` and `em` marks is correctly rendered as `***text***`, but when parsing that markdown back to ADF, the `try_parse_emphasis` function would match the `**` prefix of `***text***` and then fail to find a proper closing `**` delimiter, leaving stray `*` characters and dropping the `em` mark entirely.

The fix adds triple-delimiter (`***` / `___`) handling in `try_parse_emphasis`, checked before the double-delimiter branch so it takes priority. The inner content is returned with single delimiters (e.g. `*text*`) so the recursive `parse_inline` call correctly applies the `em` mark, resulting in both `strong` and `em` marks being preserved through the round-trip.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #401

## Changes Made

**Core Changes:**
- Added triple-delimiter (`***` / `___`) handling in `try_parse_emphasis` in `src/atlassian/convert.rs`, checked before the double-delimiter branch to ensure it takes priority
- The triple-delimiter branch returns inner content with single delimiters (e.g. for `***text***`, returns `*text*`) so the recursive `parse_inline` call picks up the inner `*…*` as an `em` mark
- Added doc comment to `try_parse_emphasis` explaining the priority ordering and referencing issue #401

**Testing:**
- Added `em_strong_round_trip` test: ADF `strong+em` → markdown → ADF preserves both marks
- Added `em_strong_round_trip_em_first` test: ADF `em+strong` (em listed first) also round-trips correctly
- Added `triple_asterisk_parse_to_adf` test: `***text***` parses to an ADF node with both `strong` and `em` marks
- Added `triple_asterisk_with_surrounding_text` test: surrounding plain text nodes are unaffected by the fix

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (ADF → markdown → ADF round-trip with strong+em)
- [x] Tested edge cases (em listed first, surrounding plain text, triple-underscore variant)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified (existing `**bold**` and `*italic*` parsing is unaffected)

### Test Commands

```bash
# Core test suite
cargo test

# Run only the new regression tests for this fix
cargo test em_strong_round_trip
cargo test triple_asterisk

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the existing `**bold**` and `*italic*` parsing paths are unchanged; only the `***` / `___` prefix is handled by the new branch
- [x] The slice indexing in the triple-delimiter branch (`&rest[2..=3 + close]`) to ensure the correct inner content (with one leading delimiter) is returned for recursive parsing
- [x] Error handling — the branch correctly guards against `close > 0` to avoid matching empty content

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix. The `**bold**` and `*italic*` parsing paths are unchanged. The triple-delimiter branch takes priority only when the input starts with `***` or `___`, which previously produced incorrect output (stray `*` characters and a dropped `em` mark).

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- An alternative approach would have been to post-process the parsed ADF nodes to detect stray `*` characters and re-parse them. The chosen approach is simpler and more correct: fix the root cause in `try_parse_emphasis` before any stray characters can be introduced.

**Known Limitations:**
- The fix handles `***` and `___` triple-delimiter variants only. Mixed delimiters (e.g. `**_text_**`) are not addressed by this PR but were not addressed by the previous implementation either.