### PR TITLE
fix(atlassian): preserve trailing spaces in heading text during markdown parse

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -134,7 +134,7 @@ impl<'a> MarkdownParser<'a> {
             return None;
         }
 
-        let text = trimmed[level + 1..].trim();
+        let text = trimmed[level + 1..].trim_start();
         let inline_nodes = parse_inline(text);
 
         self.advance();
@@ -7282,6 +7282,59 @@ mod tests {
             last.text.as_deref(),
             Some(" "),
             "trailing space should be preserved in ordered list item"
+        );
+    }
+
+    #[test]
+    fn trailing_space_in_heading_text_preserved() {
+        // Issue #400: trailing space in heading text node trimmed on round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"heading","attrs":{"level":1},"content":[
+          {"type":"text","text":"Firefighting Engineers "}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("Firefighting Engineers "),
+            "trailing space in heading should be preserved"
+        );
+    }
+
+    #[test]
+    fn trailing_space_in_heading_before_bold_preserved() {
+        // Issue #400: trailing space before bold sibling in heading
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"heading","attrs":{"level":2},"content":[
+          {"type":"text","text":"Classic "},
+          {"type":"text","text":"bold","marks":[{"type":"strong"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("Classic "),
+            "trailing space in heading text before bold should be preserved"
+        );
+    }
+
+    #[test]
+    fn trailing_space_in_paragraph_text_preserved() {
+        // Issue #400: trailing space in paragraph text node preserved on round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"word followed by space "},
+          {"type":"text","text":"next node","marks":[{"type":"strong"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("word followed by space "),
+            "trailing space in paragraph text should be preserved"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes issue #400 where trailing spaces in ADF (Atlassian Document Format) heading text nodes were incorrectly trimmed during markdown round-trip conversion. The root cause was use of `.trim()` on heading text during parsing, which strips both leading and trailing whitespace. Changing to `.trim_start()` preserves intentional trailing spaces that are significant in inline content sequences — for example, a space before a bold sibling node in a heading.

This is a one-character fix with meaningful impact: without it, heading nodes like `"Classic "` followed by `**bold**` would lose the separating space on round-trip, causing words to merge incorrectly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #400

## Changes Made

**Core Changes:**
- Changed `.trim()` to `.trim_start()` in `src/atlassian/convert.rs` heading text extraction (line 117) to preserve intentional trailing spaces in ADF heading text nodes

**Testing:**
- Added test `trailing_space_in_heading_text_preserved`: verifies a heading text node with a trailing space (`"Firefighting Engineers "`) survives ADF → markdown → ADF round-trip
- Added test `trailing_space_in_heading_before_bold_preserved`: verifies that a trailing space in a heading text node preceding a bold sibling (`"Classic "` + `**bold**`) is preserved on round-trip
- Added test `trailing_space_in_paragraph_text_preserved`: verifies trailing space in a paragraph text node before a bold sibling is preserved on round-trip (confirms the paragraph path is not affected by the same bug)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (standard headings without trailing spaces unaffected)
- [x] Tested error/edge cases (trailing space before bold inline node)
- [x] Backward compatibility verified (`.trim_start()` is strictly less aggressive than `.trim()`)

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific new regression tests
cargo test trailing_space_in_heading_text_preserved
cargo test trailing_space_in_heading_before_bold_preserved
cargo test trailing_space_in_paragraph_text_preserved

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `.trim_start()` preserves the same leading-whitespace stripping behaviour while no longer stripping trailing spaces; this is safe for all existing heading parsing
- [x] Error handling — no error handling changes; this is a pure text-processing correction

The single-line change in `MarkdownParser` at line 117 of `src/atlassian/convert.rs` is the critical fix. The three new tests are the verification.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using `.trim_end()` on the other side (during output) — rejected because the fix should be at the parse boundary where the trimming incorrectly occurs, not at output time
- Stripping only specific characters — unnecessary given `.trim_start()` solves the problem with minimal risk