### PR TITLE
fix(atlassian): support mediaSingle nodes as direct children of list items

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -280,7 +280,6 @@ impl<'a> MarkdownParser<'a> {
                 let mut full_text = first_line.to_string();
                 self.collect_hardbreak_continuations(&mut full_text);
                 let (item_text, local_id, para_local_id) = extract_trailing_local_id(&full_text);
-                let inline_nodes = parse_inline(item_text);
                 // Collect indented sub-content lines (2-space prefix).
                 // This captures both nested lists and continuation
                 // paragraphs that belong to the same list item.
@@ -294,16 +293,23 @@ impl<'a> MarkdownParser<'a> {
                     }
                     break;
                 }
+                // If the first line is a block-level image, parse as mediaSingle
+                // instead of wrapping in a paragraph (issue #430).
+                let first_node = if let Some(media) = try_parse_media_single_from_line(item_text) {
+                    media
+                } else {
+                    AdfNode::paragraph(parse_inline(item_text))
+                };
                 if sub_lines.is_empty() {
                     items.push(list_item_with_local_id(
-                        vec![AdfNode::paragraph(inline_nodes)],
+                        vec![first_node],
                         local_id,
                         para_local_id,
                     ));
                 } else {
                     let sub_text = sub_lines.join("\n");
                     let mut nested = MarkdownParser::new(&sub_text).parse_blocks()?;
-                    let mut item_content = vec![AdfNode::paragraph(inline_nodes)];
+                    let mut item_content = vec![first_node];
                     item_content.append(&mut nested);
                     items.push(list_item_with_local_id(
                         item_content,
@@ -336,7 +342,6 @@ impl<'a> MarkdownParser<'a> {
                 let mut full_text = first_line.to_string();
                 self.collect_hardbreak_continuations(&mut full_text);
                 let (item_text, local_id, para_local_id) = extract_trailing_local_id(&full_text);
-                let inline_nodes = parse_inline(item_text);
                 // Collect indented sub-content lines (2-space prefix).
                 let mut sub_lines: Vec<String> = Vec::new();
                 while !self.at_end() {
@@ -348,16 +353,23 @@ impl<'a> MarkdownParser<'a> {
                     }
                     break;
                 }
+                // If the first line is a block-level image, parse as mediaSingle
+                // instead of wrapping in a paragraph (issue #430).
+                let first_node = if let Some(media) = try_parse_media_single_from_line(item_text) {
+                    media
+                } else {
+                    AdfNode::paragraph(parse_inline(item_text))
+                };
                 if sub_lines.is_empty() {
                     items.push(list_item_with_local_id(
-                        vec![AdfNode::paragraph(inline_nodes)],
+                        vec![first_node],
                         local_id,
                         para_local_id,
                     ));
                 } else {
                     let sub_text = sub_lines.join("\n");
                     let mut nested = MarkdownParser::new(&sub_text).parse_blocks()?;
-                    let mut item_content = vec![AdfNode::paragraph(inline_nodes)];
+                    let mut item_content = vec![first_node];
                     item_content.append(&mut nested);
                     items.push(list_item_with_local_id(
                         item_content,
@@ -826,113 +838,9 @@ impl<'a> MarkdownParser<'a> {
 
     fn try_image(&mut self) -> Option<AdfNode> {
         let line = self.current_line().trim();
-        if !line.starts_with("![") {
-            return None;
-        }
-
-        if let Some((alt, url)) = parse_image_syntax(line) {
-            self.advance();
-            let alt_opt = if alt.is_empty() { None } else { Some(alt) };
-
-            // Check for trailing {attrs} after the image syntax
-            let img_end = line.find(')').unwrap_or(line.len()) + 1;
-            let after_img = line[img_end..].trim_start();
-
-            if after_img.starts_with('{') {
-                if let Some((_, attrs)) = parse_attrs(after_img, 0) {
-                    // Confluence file attachment — reconstruct type:file media node
-                    if attrs.get("type") == Some("file") || attrs.get("id").is_some() {
-                        let mut media_attrs = serde_json::json!({"type": "file"});
-                        if let Some(id) = attrs.get("id") {
-                            media_attrs["id"] = serde_json::Value::String(id.to_string());
-                        }
-                        if let Some(collection) = attrs.get("collection") {
-                            media_attrs["collection"] =
-                                serde_json::Value::String(collection.to_string());
-                        }
-                        if let Some(height) = attrs.get("height") {
-                            if let Ok(h) = height.parse::<u64>() {
-                                media_attrs["height"] = serde_json::json!(h);
-                            }
-                        }
-                        if let Some(width) = attrs.get("width") {
-                            if let Ok(w) = width.parse::<u64>() {
-                                media_attrs["width"] = serde_json::json!(w);
-                            }
-                        }
-                        if let Some(alt_text) = alt_opt {
-                            media_attrs["alt"] = serde_json::Value::String(alt_text.to_string());
-                        }
-                        if let Some(local_id) = attrs.get("localId") {
-                            media_attrs["localId"] =
-                                serde_json::Value::String(local_id.to_string());
-                        }
-                        let mut ms_attrs = serde_json::json!({"layout": "center"});
-                        if let Some(layout) = attrs.get("layout") {
-                            ms_attrs["layout"] = serde_json::Value::String(layout.to_string());
-                        }
-                        if let Some(ms_width) = attrs.get("mediaWidth") {
-                            if let Ok(w) = ms_width.parse::<u64>() {
-                                ms_attrs["width"] = serde_json::json!(w);
-                            }
-                        }
-                        if let Some(wt) = attrs.get("widthType") {
-                            ms_attrs["widthType"] = serde_json::Value::String(wt.to_string());
-                        }
-                        if let Some(mode) = attrs.get("mode") {
-                            ms_attrs["mode"] = serde_json::Value::String(mode.to_string());
-                        }
-                        return Some(AdfNode {
-                            node_type: "mediaSingle".to_string(),
-                            attrs: Some(ms_attrs),
-                            content: Some(vec![AdfNode {
-                                node_type: "media".to_string(),
-                                attrs: Some(media_attrs),
-                                content: None,
-                                text: None,
-                                marks: None,
-                            }]),
-                            text: None,
-                            marks: None,
-                        });
-                    }
-
-                    // External image — apply layout/width/widthType to mediaSingle attrs
-                    let mut node = AdfNode::media_single(url, alt_opt);
-                    if let Some(ref mut node_attrs) = node.attrs {
-                        if let Some(layout) = attrs.get("layout") {
-                            node_attrs["layout"] = serde_json::Value::String(layout.to_string());
-                        }
-                        if let Some(width) = attrs.get("width") {
-                            if let Ok(w) = width.parse::<u64>() {
-                                node_attrs["width"] = serde_json::json!(w);
-                            }
-                        }
-                        if let Some(wt) = attrs.get("widthType") {
-                            node_attrs["widthType"] = serde_json::Value::String(wt.to_string());
-                        }
-                        if let Some(mode) = attrs.get("mode") {
-                            node_attrs["mode"] = serde_json::Value::String(mode.to_string());
-                        }
-                    }
-                    if let Some(local_id) = attrs.get("localId") {
-                        if let Some(ref mut content) = node.content {
-                            if let Some(media) = content.first_mut() {
-                                if let Some(ref mut media_attrs) = media.attrs {
-                                    media_attrs["localId"] =
-                                        serde_json::Value::String(local_id.to_string());
-                                }
-                            }
-                        }
-                    }
-                    return Some(node);
-                }
-            }
-
-            Some(AdfNode::media_single(url, alt_opt))
-        } else {
-            None
-        }
+        let node = try_parse_media_single_from_line(line)?;
+        self.advance();
+        Some(node)
     }
 
     fn try_table(&mut self) -> Result<Option<AdfNode>> {
@@ -1330,6 +1238,112 @@ fn extract_cell_attrs(cell_text: &str) -> (String, Option<serde_json::Value>) {
     } else {
         (cell_text.to_string(), None)
     }
+}
+
+/// Tries to parse a line as a block-level image and return a mediaSingle ADF node.
+/// Used by both `try_image` (top-level blocks) and list item parsing.
+fn try_parse_media_single_from_line(line: &str) -> Option<AdfNode> {
+    let line = line.trim();
+    if !line.starts_with("![") {
+        return None;
+    }
+
+    let (alt, url) = parse_image_syntax(line)?;
+    let alt_opt = if alt.is_empty() { None } else { Some(alt) };
+
+    let img_end = line.find(')').unwrap_or(line.len()) + 1;
+    let after_img = line[img_end..].trim_start();
+
+    if after_img.starts_with('{') {
+        if let Some((_, attrs)) = parse_attrs(after_img, 0) {
+            // Confluence file attachment — reconstruct type:file media node
+            if attrs.get("type") == Some("file") || attrs.get("id").is_some() {
+                let mut media_attrs = serde_json::json!({"type": "file"});
+                if let Some(id) = attrs.get("id") {
+                    media_attrs["id"] = serde_json::Value::String(id.to_string());
+                }
+                if let Some(collection) = attrs.get("collection") {
+                    media_attrs["collection"] = serde_json::Value::String(collection.to_string());
+                }
+                if let Some(height) = attrs.get("height") {
+                    if let Ok(h) = height.parse::<u64>() {
+                        media_attrs["height"] = serde_json::json!(h);
+                    }
+                }
+                if let Some(width) = attrs.get("width") {
+                    if let Ok(w) = width.parse::<u64>() {
+                        media_attrs["width"] = serde_json::json!(w);
+                    }
+                }
+                if let Some(alt_text) = alt_opt {
+                    media_attrs["alt"] = serde_json::Value::String(alt_text.to_string());
+                }
+                if let Some(local_id) = attrs.get("localId") {
+                    media_attrs["localId"] = serde_json::Value::String(local_id.to_string());
+                }
+                let mut ms_attrs = serde_json::json!({"layout": "center"});
+                if let Some(layout) = attrs.get("layout") {
+                    ms_attrs["layout"] = serde_json::Value::String(layout.to_string());
+                }
+                if let Some(ms_width) = attrs.get("mediaWidth") {
+                    if let Ok(w) = ms_width.parse::<u64>() {
+                        ms_attrs["width"] = serde_json::json!(w);
+                    }
+                }
+                if let Some(wt) = attrs.get("widthType") {
+                    ms_attrs["widthType"] = serde_json::Value::String(wt.to_string());
+                }
+                if let Some(mode) = attrs.get("mode") {
+                    ms_attrs["mode"] = serde_json::Value::String(mode.to_string());
+                }
+                return Some(AdfNode {
+                    node_type: "mediaSingle".to_string(),
+                    attrs: Some(ms_attrs),
+                    content: Some(vec![AdfNode {
+                        node_type: "media".to_string(),
+                        attrs: Some(media_attrs),
+                        content: None,
+                        text: None,
+                        marks: None,
+                    }]),
+                    text: None,
+                    marks: None,
+                });
+            }
+
+            // External image — apply layout/width/widthType to mediaSingle attrs
+            let mut node = AdfNode::media_single(url, alt_opt);
+            if let Some(ref mut node_attrs) = node.attrs {
+                if let Some(layout) = attrs.get("layout") {
+                    node_attrs["layout"] = serde_json::Value::String(layout.to_string());
+                }
+                if let Some(width) = attrs.get("width") {
+                    if let Ok(w) = width.parse::<u64>() {
+                        node_attrs["width"] = serde_json::json!(w);
+                    }
+                }
+                if let Some(wt) = attrs.get("widthType") {
+                    node_attrs["widthType"] = serde_json::Value::String(wt.to_string());
+                }
+                if let Some(mode) = attrs.get("mode") {
+                    node_attrs["mode"] = serde_json::Value::String(mode.to_string());
+                }
+            }
+            if let Some(local_id) = attrs.get("localId") {
+                if let Some(ref mut content) = node.content {
+                    if let Some(media) = content.first_mut() {
+                        if let Some(ref mut media_attrs) = media.attrs {
+                            media_attrs["localId"] =
+                                serde_json::Value::String(local_id.to_string());
+                        }
+                    }
+                }
+            }
+            return Some(node);
+        }
+    }
+
+    Some(AdfNode::media_single(url, alt_opt))
 }
 
 /// Parses `![alt](url)` image syntax.
@@ -10276,5 +10290,268 @@ C
                 .unwrap(),
             "+ plus"
         );
+    }
+
+    // ---- Issue #430 tests: mediaSingle inside listItem ----
+
+    #[test]
+    fn issue_430_file_media_in_bullet_list_roundtrip() {
+        // Issue #430: mediaSingle (type:file) as direct child of listItem
+        // in a bulletList must survive round-trip.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","content":[{
+            "type":"mediaSingle",
+            "attrs":{"layout":"center","width":1009,"widthType":"pixel"},
+            "content":[{
+              "type":"media",
+              "attrs":{"collection":"contentId-123","height":576,"id":"00066e8e-554e-4d7e-af59-a0ef2888bdb6","type":"file","width":1009}
+            }]
+          }]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "bulletList");
+        let item = &list.content.as_ref().unwrap()[0];
+        assert_eq!(item.node_type, "listItem");
+        let ms = &item.content.as_ref().unwrap()[0];
+        assert_eq!(ms.node_type, "mediaSingle");
+        let ms_attrs = ms.attrs.as_ref().unwrap();
+        assert_eq!(ms_attrs["layout"], "center");
+        assert_eq!(ms_attrs["width"], 1009);
+        assert_eq!(ms_attrs["widthType"], "pixel");
+        let media = &ms.content.as_ref().unwrap()[0];
+        assert_eq!(media.node_type, "media");
+        let m_attrs = media.attrs.as_ref().unwrap();
+        assert_eq!(m_attrs["type"], "file");
+        assert_eq!(m_attrs["id"], "00066e8e-554e-4d7e-af59-a0ef2888bdb6");
+        assert_eq!(m_attrs["collection"], "contentId-123");
+        assert_eq!(m_attrs["height"], 576);
+        assert_eq!(m_attrs["width"], 1009);
+    }
+
+    #[test]
+    fn issue_430_file_media_in_ordered_list_roundtrip() {
+        // Same as above but inside an orderedList.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","attrs":{"order":1},"content":[
+          {"type":"listItem","content":[{
+            "type":"mediaSingle",
+            "attrs":{"layout":"center"},
+            "content":[{
+              "type":"media",
+              "attrs":{"type":"file","id":"abc-123","collection":"contentId-456","height":100,"width":200}
+            }]
+          }]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "orderedList");
+        let item = &list.content.as_ref().unwrap()[0];
+        assert_eq!(item.node_type, "listItem");
+        let ms = &item.content.as_ref().unwrap()[0];
+        assert_eq!(ms.node_type, "mediaSingle");
+        let media = &ms.content.as_ref().unwrap()[0];
+        assert_eq!(media.node_type, "media");
+        let m_attrs = media.attrs.as_ref().unwrap();
+        assert_eq!(m_attrs["type"], "file");
+        assert_eq!(m_attrs["id"], "abc-123");
+        assert_eq!(m_attrs["collection"], "contentId-456");
+    }
+
+    #[test]
+    fn issue_430_external_media_in_bullet_list_roundtrip() {
+        // External image (type:external) inside a bullet list item.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","content":[{
+            "type":"mediaSingle",
+            "attrs":{"layout":"center"},
+            "content":[{
+              "type":"media",
+              "attrs":{"type":"external","url":"https://example.com/img.png","alt":"Photo"}
+            }]
+          }]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "bulletList");
+        let item = &list.content.as_ref().unwrap()[0];
+        let ms = &item.content.as_ref().unwrap()[0];
+        assert_eq!(ms.node_type, "mediaSingle");
+        let media = &ms.content.as_ref().unwrap()[0];
+        assert_eq!(media.node_type, "media");
+        let m_attrs = media.attrs.as_ref().unwrap();
+        assert_eq!(m_attrs["type"], "external");
+        assert_eq!(m_attrs["url"], "https://example.com/img.png");
+    }
+
+    #[test]
+    fn issue_430_media_with_paragraph_siblings_in_list_item() {
+        // listItem containing a paragraph followed by a mediaSingle.
+        // Both children must survive round-trip.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","content":[
+            {"type":"paragraph","content":[{"type":"text","text":"Caption:"}]},
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"img-001","collection":"col-1","height":50,"width":100}}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let children = item.content.as_ref().unwrap();
+        assert_eq!(children.len(), 2, "expected 2 children in listItem");
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "mediaSingle");
+        let media = &children[1].content.as_ref().unwrap()[0];
+        assert_eq!(media.attrs.as_ref().unwrap()["id"], "img-001");
+    }
+
+    #[test]
+    fn issue_430_multiple_media_in_list_items() {
+        // Multiple list items each containing mediaSingle.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","content":[{
+            "type":"mediaSingle","attrs":{"layout":"center"},
+            "content":[{"type":"media","attrs":{"type":"file","id":"img-a","collection":"c1","height":10,"width":20}}]
+          }]},
+          {"type":"listItem","content":[{
+            "type":"mediaSingle","attrs":{"layout":"center"},
+            "content":[{"type":"media","attrs":{"type":"file","id":"img-b","collection":"c2","height":30,"width":40}}]
+          }]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+        for (i, expected_id) in [("img-a", "c1"), ("img-b", "c2")].iter().enumerate() {
+            let ms = &items[i].content.as_ref().unwrap()[0];
+            assert_eq!(ms.node_type, "mediaSingle");
+            let m_attrs = ms.content.as_ref().unwrap()[0].attrs.as_ref().unwrap();
+            assert_eq!(m_attrs["id"], expected_id.0);
+            assert_eq!(m_attrs["collection"], expected_id.1);
+        }
+    }
+
+    #[test]
+    fn issue_430_jfm_to_adf_media_in_bullet_item() {
+        // Parse JFM directly: image syntax on the first line of a bullet item
+        // must produce mediaSingle, not a paragraph with corrupted text.
+        let md = "- ![](){type=file id=test-id collection=col-1 height=100 width=200}\n";
+        let doc = markdown_to_adf(md).unwrap();
+
+        let list = &doc.content[0];
+        assert_eq!(list.node_type, "bulletList");
+        let item = &list.content.as_ref().unwrap()[0];
+        let ms = &item.content.as_ref().unwrap()[0];
+        assert_eq!(
+            ms.node_type, "mediaSingle",
+            "expected mediaSingle, got {}",
+            ms.node_type
+        );
+        let media = &ms.content.as_ref().unwrap()[0];
+        assert_eq!(media.node_type, "media");
+        let m_attrs = media.attrs.as_ref().unwrap();
+        assert_eq!(m_attrs["type"], "file");
+        assert_eq!(m_attrs["id"], "test-id");
+    }
+
+    #[test]
+    fn issue_430_jfm_to_adf_media_in_ordered_item() {
+        // Parse JFM directly: image syntax on the first line of an ordered list item.
+        let md = "1. ![alt text](https://example.com/photo.jpg)\n";
+        let doc = markdown_to_adf(md).unwrap();
+
+        let list = &doc.content[0];
+        assert_eq!(list.node_type, "orderedList");
+        let item = &list.content.as_ref().unwrap()[0];
+        let ms = &item.content.as_ref().unwrap()[0];
+        assert_eq!(
+            ms.node_type, "mediaSingle",
+            "expected mediaSingle, got {}",
+            ms.node_type
+        );
+    }
+
+    #[test]
+    fn issue_430_media_then_paragraph_in_bullet_list_roundtrip() {
+        // listItem with mediaSingle as first child followed by a paragraph.
+        // Exercises the sub_lines non-empty path when first_node is mediaSingle.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","content":[
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"img-first","collection":"col-1","height":50,"width":100}}]},
+            {"type":"paragraph","content":[{"type":"text","text":"Caption below"}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let children = item.content.as_ref().unwrap();
+        assert_eq!(children.len(), 2, "expected 2 children in listItem");
+        assert_eq!(children[0].node_type, "mediaSingle");
+        let media = &children[0].content.as_ref().unwrap()[0];
+        assert_eq!(media.attrs.as_ref().unwrap()["id"], "img-first");
+        assert_eq!(children[1].node_type, "paragraph");
+    }
+
+    #[test]
+    fn issue_430_media_then_paragraph_in_ordered_list_roundtrip() {
+        // Same as above but for ordered lists.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","attrs":{"order":1},"content":[
+          {"type":"listItem","content":[
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"img-ord","collection":"col-2","height":60,"width":120}}]},
+            {"type":"paragraph","content":[{"type":"text","text":"Description"}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let children = item.content.as_ref().unwrap();
+        assert_eq!(children.len(), 2, "expected 2 children in listItem");
+        assert_eq!(children[0].node_type, "mediaSingle");
+        assert_eq!(children[1].node_type, "paragraph");
+    }
+
+    #[test]
+    fn issue_430_external_media_with_width_type_roundtrip() {
+        // External image with widthType attr must survive round-trip.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{
+          "type":"mediaSingle",
+          "attrs":{"layout":"wide","width":800,"widthType":"pixel"},
+          "content":[{
+            "type":"media",
+            "attrs":{"type":"external","url":"https://example.com/photo.png","alt":"wide photo"}
+          }]
+        }]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("widthType=pixel"),
+            "expected widthType=pixel in markdown, got: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let ms = &rt.content[0];
+        assert_eq!(ms.node_type, "mediaSingle");
+        let ms_attrs = ms.attrs.as_ref().unwrap();
+        assert_eq!(ms_attrs["widthType"], "pixel");
+        assert_eq!(ms_attrs["width"], 800);
+        assert_eq!(ms_attrs["layout"], "wide");
     }
 }


### PR DESCRIPTION
## Description

Fixes issue #430 where block-level images inside list items (both bullet and ordered) were being incorrectly wrapped in a `paragraph` node instead of being emitted as `mediaSingle` ADF nodes. When a list item's first line contained image syntax (Confluence file attachment or external image), the parser would produce an invalid `paragraph` wrapping a corrupted image reference rather than a proper `mediaSingle` → `media` node hierarchy.

The fix introduces a shared helper function `try_parse_media_single_from_line` that encapsulates the image-to-mediaSingle parsing logic, and applies it consistently across top-level block parsing (`try_image`) and both bullet and ordered list item parsing paths.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue

Fixes #430

## Changes Made

**Core Changes:**
- Extracted image-to-mediaSingle parsing logic from `try_image` into a new standalone helper function `try_parse_media_single_from_line` in `src/atlassian/convert.rs`
- Refactored `try_image` to delegate entirely to `try_parse_media_single_from_line`, removing ~90 lines of duplicated parsing code
- Applied `try_parse_media_single_from_line` in the bullet list item parsing path: when the first line of a bullet list item is an image, produce a `mediaSingle` node instead of `AdfNode::paragraph(parse_inline(...))`
- Applied the same fix in the ordered list item parsing path with identical logic
- Both simple (no sub-content) and complex (with nested sub-content) list item cases are handled correctly

**Testing:**
- Added seven regression tests in `src/atlassian/convert.rs` covering the full scope of issue #430:
  - `issue_430_file_media_in_bullet_list_roundtrip`: file attachment mediaSingle in a bullet list item, full ADF → markdown → ADF round-trip
  - `issue_430_file_media_in_ordered_list_roundtrip`: file attachment mediaSingle in an ordered list item, full round-trip
  - `issue_430_external_media_in_bullet_list_roundtrip`: external image mediaSingle in a bullet list item
  - `issue_430_media_with_paragraph_siblings_in_list_item`: listItem with a paragraph followed by a mediaSingle, verifying both children survive round-trip
  - `issue_430_multiple_media_in_list_items`: multiple list items each containing a mediaSingle
  - `issue_430_jfm_to_adf_media_in_bullet_item`: direct JFM → ADF parse of image syntax as first line of a bullet item
  - `issue_430_jfm_to_adf_media_in_ordered_item`: direct JFM → ADF parse of image syntax as first line of an ordered list item

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (7 regression tests for issue #430)
- [x] Integration tests updated/added (round-trip ADF → markdown → ADF tests)

**Manual Testing:**
- [x] Tested happy path scenarios (file attachments, external images in list items)
- [x] Tested edge cases (mixed paragraph/media siblings, multiple items, empty alt text)
- [x] Backward compatibility verified (existing `try_image` behavior is identical via delegation to helper)

### Test Commands
```bash
# Run full test suite
cargo test

# Run issue #430 specific regression tests
cargo test issue_430

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `try_parse_media_single_from_line` is a new free function used by both `try_image` and list item parsing; verify its placement and visibility are appropriate
- [x] Backward compatibility — `try_image` now delegates fully to the helper; confirm behavior is identical to the previous inline implementation
- [x] Error handling — both list item parsing paths now correctly fall back to `AdfNode::paragraph(parse_inline(...))` when the line is not an image

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Duplicating the fix inline in both list item parsing paths (bullet and ordered) without extracting a helper — rejected in favour of the DRY approach to prevent future drift between the two paths.

**Known Limitations:**
- The fix applies only to the *first line* of a list item being an image. A mediaSingle that appears as a non-first child (e.g., after a paragraph) is handled by the existing sub-content recursive parser and was already working correctly for text sub-content; the new tests confirm this continues to work.