### PR TITLE
fix(atlassian): preserve multiple annotation marks on same text node

### DIFF
--- a/src/atlassian/attrs.rs
+++ b/src/atlassian/attrs.rs
@@ -12,17 +12,35 @@ pub struct Attrs {
     pub map: BTreeMap<String, String>,
     /// Boolean flags without values (e.g., `underline`, `numbered`).
     pub flags: Vec<String>,
+    /// Keys that appear more than once (e.g., multiple `annotation-id` values).
+    pub(crate) multi: BTreeMap<String, Vec<String>>,
 }
 
 impl Attrs {
     /// Returns true if there are no attributes or flags.
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty() && self.flags.is_empty()
+        self.map.is_empty() && self.multi.is_empty() && self.flags.is_empty()
     }
 
-    /// Gets a value by key.
+    /// Gets a single value by key (first occurrence for multi-valued keys).
     pub fn get(&self, key: &str) -> Option<&str> {
-        self.map.get(key).map(String::as_str)
+        self.map.get(key).map(String::as_str).or_else(|| {
+            self.multi
+                .get(key)
+                .and_then(|v| v.first())
+                .map(String::as_str)
+        })
+    }
+
+    /// Returns all values for a key that may appear more than once.
+    pub fn get_all(&self, key: &str) -> Vec<&str> {
+        if let Some(values) = self.multi.get(key) {
+            values.iter().map(String::as_str).collect()
+        } else if let Some(value) = self.map.get(key) {
+            vec![value.as_str()]
+        } else {
+            vec![]
+        }
     }
 
     /// Returns true if the given flag is present.
@@ -34,17 +52,26 @@ impl Attrs {
     pub fn render(&self) -> String {
         let mut parts = Vec::new();
         for (k, v) in &self.map {
-            if v.contains(' ') || v.contains('"') {
-                let escaped = v.replace('"', "\\\"");
-                parts.push(format!("{k}=\"{escaped}\""));
-            } else {
-                parts.push(format!("{k}={v}"));
+            Self::push_kv(&mut parts, k, v);
+        }
+        for (k, values) in &self.multi {
+            for v in values {
+                Self::push_kv(&mut parts, k, v);
             }
         }
         for f in &self.flags {
             parts.push(f.clone());
         }
         format!("{{{}}}", parts.join(" "))
+    }
+
+    fn push_kv(parts: &mut Vec<String>, k: &str, v: &str) {
+        if v.contains(' ') || v.contains('"') {
+            let escaped = v.replace('"', "\\\"");
+            parts.push(format!("{k}=\"{escaped}\""));
+        } else {
+            parts.push(format!("{k}={v}"));
+        }
     }
 }
 
@@ -124,7 +151,19 @@ fn parse_inner(inner: &str) -> Option<Attrs> {
             // Key-value pair (no trim after '=' so empty values like key= are detected)
             rest = &rest[1..];
             let (value, remaining) = parse_value(rest)?;
-            attrs.map.insert(key.to_string(), value);
+            if let Some(existing) = attrs.map.remove(key) {
+                // Key already seen once — promote to multi-valued.
+                attrs
+                    .multi
+                    .entry(key.to_string())
+                    .or_default()
+                    .extend([existing, value]);
+            } else if let Some(values) = attrs.multi.get_mut(key) {
+                // Key already multi-valued — append.
+                values.push(value);
+            } else {
+                attrs.map.insert(key.to_string(), value);
+            }
             rest = remaining.trim_start();
         } else {
             // Boolean flag
@@ -303,5 +342,57 @@ mod tests {
         assert_eq!(end, 11);
         assert_eq!(attrs.get("type"), Some("info"));
         assert_eq!(&text[end..], " and more text");
+    }
+
+    #[test]
+    fn duplicate_keys_parsed_as_multi() {
+        // Issue #439: duplicate keys should all be preserved
+        let input = r#"{annotation-id="id1" annotation-type=inlineComment annotation-id="id2" annotation-type=inlineComment}"#;
+        let (_, attrs) = parse_attrs(input, 0).unwrap();
+        let ids = attrs.get_all("annotation-id");
+        assert_eq!(ids, vec!["id1", "id2"]);
+        let types = attrs.get_all("annotation-type");
+        assert_eq!(types, vec!["inlineComment", "inlineComment"]);
+    }
+
+    #[test]
+    fn duplicate_keys_get_returns_first() {
+        let input = "{k=\"first\" k=\"second\"}";
+        let (_, attrs) = parse_attrs(input, 0).unwrap();
+        assert_eq!(attrs.get("k"), Some("first"));
+        assert_eq!(attrs.get_all("k"), vec!["first", "second"]);
+    }
+
+    #[test]
+    fn three_duplicate_keys() {
+        let input = "{x=a x=b x=c}";
+        let (_, attrs) = parse_attrs(input, 0).unwrap();
+        assert_eq!(attrs.get_all("x"), vec!["a", "b", "c"]);
+        assert_eq!(attrs.get("x"), Some("a"));
+    }
+
+    #[test]
+    fn duplicate_keys_render_round_trip() {
+        let input = r#"{annotation-id="id1" annotation-type=inlineComment annotation-id="id2" annotation-type=inlineComment}"#;
+        let (_, original) = parse_attrs(input, 0).unwrap();
+        let rendered = original.render();
+        let (_, reparsed) = parse_attrs(&rendered, 0).unwrap();
+        assert_eq!(original, reparsed);
+    }
+
+    #[test]
+    fn get_all_single_value() {
+        let (_, attrs) = parse_attrs("{type=info}", 0).unwrap();
+        assert_eq!(attrs.get_all("type"), vec!["info"]);
+        assert!(attrs.get_all("missing").is_empty());
+    }
+
+    #[test]
+    fn mixed_single_and_duplicate_keys() {
+        let input = "{underline a=1 a=2 b=3}";
+        let (_, attrs) = parse_attrs(input, 0).unwrap();
+        assert!(attrs.has_flag("underline"));
+        assert_eq!(attrs.get_all("a"), vec!["1", "2"]);
+        assert_eq!(attrs.get("b"), Some("3"));
     }
 }

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1738,8 +1738,10 @@ fn try_parse_bracketed_span(text: &str, i: usize) -> Option<(usize, Vec<AdfNode>
     if attrs.has_flag("underline") {
         marks.push(AdfMark::underline());
     }
-    if let Some(ann_id) = attrs.get("annotation-id") {
-        let ann_type = attrs.get("annotation-type").unwrap_or("inlineComment");
+    let ann_ids = attrs.get_all("annotation-id");
+    let ann_types = attrs.get_all("annotation-type");
+    for (idx, ann_id) in ann_ids.iter().enumerate() {
+        let ann_type = ann_types.get(idx).copied().unwrap_or("inlineComment");
         marks.push(AdfMark::annotation(ann_id, ann_type));
     }
 
@@ -5785,6 +5787,142 @@ mod tests {
         assert!(
             marks.iter().any(|m| m.mark_type == "strong"),
             "should have strong"
+        );
+    }
+
+    #[test]
+    fn multiple_annotation_marks_round_trip() {
+        // Issue #439: multiple annotation marks on same text node — all but last dropped
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"some annotated text","marks":[
+            {"type":"annotation","attrs":{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","annotationType":"inlineComment"}},
+            {"type":"annotation","attrs":{"id":"ffffffff-1111-2222-3333-444444444444","annotationType":"inlineComment"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            "JFM should contain first annotation id, got: {md}"
+        );
+        assert!(
+            md.contains("ffffffff-1111-2222-3333-444444444444"),
+            "JFM should contain second annotation id, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(text_node.text.as_deref(), Some("some annotated text"));
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        let annotations: Vec<_> = marks
+            .iter()
+            .filter(|m| m.mark_type == "annotation")
+            .collect();
+        assert_eq!(
+            annotations.len(),
+            2,
+            "should have 2 annotation marks, got: {annotations:?}"
+        );
+        let ids: Vec<_> = annotations
+            .iter()
+            .map(|a| a.attrs.as_ref().unwrap()["id"].as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        assert!(ids.contains(&"ffffffff-1111-2222-3333-444444444444"));
+    }
+
+    #[test]
+    fn three_annotation_marks_round_trip() {
+        // Verify three overlapping annotations all survive
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![AdfNode::text_with_marks(
+                "triple annotated",
+                vec![
+                    AdfMark::annotation("id-1", "inlineComment"),
+                    AdfMark::annotation("id-2", "inlineComment"),
+                    AdfMark::annotation("id-3", "inlineComment"),
+                ],
+            )])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        let annotations: Vec<_> = marks
+            .iter()
+            .filter(|m| m.mark_type == "annotation")
+            .collect();
+        assert_eq!(
+            annotations.len(),
+            3,
+            "should have 3 annotation marks, got: {annotations:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_annotations_with_bold_round_trip() {
+        // Multiple annotations + bold should all survive
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![AdfNode::text_with_marks(
+                "bold double annotated",
+                vec![
+                    AdfMark::strong(),
+                    AdfMark::annotation("ann-a", "inlineComment"),
+                    AdfMark::annotation("ann-b", "inlineComment"),
+                ],
+            )])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "strong"),
+            "should have strong mark"
+        );
+        let annotations: Vec<_> = marks
+            .iter()
+            .filter(|m| m.mark_type == "annotation")
+            .collect();
+        assert_eq!(
+            annotations.len(),
+            2,
+            "should have 2 annotation marks, got: {annotations:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_annotations_with_link_round_trip() {
+        // Multiple annotations + link should all survive
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"linked text","marks":[
+            {"type":"annotation","attrs":{"id":"ann-x","annotationType":"inlineComment"}},
+            {"type":"annotation","attrs":{"id":"ann-y","annotationType":"inlineComment"}},
+            {"type":"link","attrs":{"href":"https://example.com"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let text_node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let marks = text_node.marks.as_ref().expect("should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "link"),
+            "should have link mark"
+        );
+        let annotations: Vec<_> = marks
+            .iter()
+            .filter(|m| m.mark_type == "annotation")
+            .collect();
+        assert_eq!(
+            annotations.len(),
+            2,
+            "should have 2 annotation marks, got: {annotations:?}"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes Issue #439 where text nodes with multiple inline comment annotations lost all but the first annotation during ADF (Atlassian Document Format) round-trip conversion.

The root cause was that the attribute parser in `src/atlassian/attrs.rs` stored key-value pairs in a flat `BTreeMap<String, String>`, so duplicate keys (e.g., multiple `annotation-id` values from a bracketed span like `{annotation-id="id1" annotation-type=inlineComment annotation-id="id2" annotation-type=inlineComment}`) silently overwrote each other. This meant that when converting ADF → Markdown → ADF, only the first annotation mark survived.

The fix introduces a `multi: BTreeMap<String, Vec<String>>` field on the `Attrs` struct to hold repeated key values, with promotion logic that moves a key from the single-value map to `multi` on first collision. The `try_parse_bracketed_span` function in `convert.rs` is then updated to iterate all annotation ids and types using `get_all()`, emitting one `AdfMark::annotation` per entry.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #439

## Changes Made

**Core Changes (`src/atlassian/attrs.rs`):**
- Added `pub(crate) multi: BTreeMap<String, Vec<String>>` field to `Attrs` struct to store repeated keys
- Updated `is_empty()` to account for the new `multi` field
- Added `get_all(key)` method returning all values for a key (covering both single and multi-valued entries)
- Updated `get(key)` to fall back to the first multi-value entry when the key is not in the primary map
- Extracted shared `push_kv()` helper to deduplicate rendering logic
- Updated `render()` to emit all repeated keys via the `push_kv` helper
- Updated `parse_inner()` to promote duplicate keys into `multi` on collision: first collision promotes the existing single value + new value into `multi`; subsequent collisions append directly

**Core Changes (`src/atlassian/convert.rs`):**
- Updated `try_parse_bracketed_span()` to call `attrs.get_all("annotation-id")` and `attrs.get_all("annotation-type")` instead of single `get()` calls
- Iterates all annotation id/type pairs, emitting one `AdfMark::annotation` per entry, preserving all annotations on a text node

**Testing (`src/atlassian/attrs.rs` tests):**
- `duplicate_keys_parsed_as_multi`: verifies duplicate keys are all preserved
- `duplicate_keys_get_returns_first`: verifies `get()` returns the first occurrence for multi-valued keys
- `three_duplicate_keys`: verifies three occurrences of the same key are all captured
- `duplicate_keys_render_round_trip`: verifies parse → render → parse produces identical `Attrs`
- `get_all_single_value`: verifies `get_all()` works correctly for single-value and missing keys
- `mixed_single_and_duplicate_keys`: verifies correct handling when mixed single and multi-valued keys coexist alongside flags

**Testing (`src/atlassian/convert.rs` tests):**
- `multiple_annotation_marks_round_trip`: full ADF → Markdown → ADF round-trip for two annotations on the same text node
- `three_annotation_marks_round_trip`: verifies three overlapping annotations all survive the round-trip
- `multiple_annotations_with_bold_round_trip`: verifies multiple annotations combined with bold mark all survive
- `multiple_annotations_with_link_round_trip`: verifies multiple annotations combined with a link mark all survive

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (10 new unit and integration tests across both files)
- [x] Integration tests updated/added (round-trip tests for 2 and 3 annotations, combined with bold and link marks)

**Manual Testing:**
- [x] Tested happy path scenarios (multiple annotations on a text node round-trip cleanly)
- [x] Tested error/edge cases (three annotations, annotations + bold, annotations + link, missing annotation-type falling back to `inlineComment`)
- [x] Backward compatibility verified (single annotation behaviour is unchanged; `get()` still returns first value)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the atlassian-related tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `get()` semantics are preserved (returns first value); `get_all()` is additive
- [x] Error handling — `ann_types.get(idx)` gracefully falls back to `"inlineComment"` when there are fewer annotation-type entries than annotation-id entries
- [x] Architecture changes — the `multi` field is `pub(crate)` to keep the internal promotion logic encapsulated while still allowing test access

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the `multi` map is only populated on key collision, so the common single-annotation case has no overhead beyond an additional `BTreeMap` field that remains empty.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix. Existing behaviour for text nodes with zero or one annotation is completely unchanged. The `get()` method continues to return the first value for any key.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Replacing `BTreeMap<String, String>` entirely with `BTreeMap<String, Vec<String>>` — rejected because it would change the public API of `Attrs` (all `get()` callers would need updating) and would regress performance for the common single-value case.
- Using `indexmap` or `multimap` crates — rejected to avoid adding a new dependency for a focused internal data structure change.