### PR TITLE
fix(atlassian): prevent mention localId from being misattributed to list items

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2107,8 +2107,14 @@ fn extract_trailing_local_id(text: &str) -> (&str, Option<String>, Option<String
     if !trimmed.ends_with('}') {
         return (text, None, None);
     }
-    // Find the opening brace
+    // Find the opening brace.  Only match a standalone `{…}` block that is
+    // preceded by whitespace (or is at the start of the string).  A `{` that
+    // immediately follows `]` is part of an inline directive (e.g.
+    // `:mention[text]{id=… localId=…}`) and must NOT be consumed here.
     if let Some(brace_pos) = trimmed.rfind('{') {
+        if brace_pos > 0 && !trimmed.as_bytes()[brace_pos - 1].is_ascii_whitespace() {
+            return (text, None, None);
+        }
         let attr_str = &trimmed[brace_pos..];
         if let Some((_, attrs)) = parse_attrs(attr_str, 0) {
             let local_id = attrs.get("localId").map(str::to_string);
@@ -11047,5 +11053,155 @@ C
         let md = adf_to_markdown(&doc).unwrap();
         // With no attrs, nothing is emitted for the placeholder
         assert!(!md.contains("placeholder"));
+    }
+
+    // Issue #446: mention in table+list loses id and misplaces localId
+    #[test]
+    fn mention_in_table_bullet_list_preserves_id_and_local_id() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{"colspan":1,"colwidth":[200],"rowspan":1},"content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"prefix text "},{"type":"mention","attrs":{"id":"aabbccdd11223344aabbccdd","localId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","text":"@Alice Example"}},{"type":"text","text":" "}]}]}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        // Navigate: doc → table → tableRow → tableCell → bulletList → listItem → paragraph
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let list = &cell.content.as_ref().unwrap()[0];
+        let list_item = &list.content.as_ref().unwrap()[0];
+
+        // listItem must NOT have a localId attribute
+        assert!(
+            list_item
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("localId"))
+                .is_none(),
+            "localId should stay on the mention, not the listItem"
+        );
+
+        let para = &list_item.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+
+        // Should have: text("prefix text "), mention, text(" ")
+        assert_eq!(inlines.len(), 3, "expected 3 inline nodes, got {inlines:?}");
+
+        assert_eq!(inlines[0].node_type, "text");
+        assert_eq!(inlines[0].text.as_deref(), Some("prefix text "));
+
+        assert_eq!(inlines[1].node_type, "mention");
+        let mention_attrs = inlines[1].attrs.as_ref().unwrap();
+        assert_eq!(
+            mention_attrs["id"], "aabbccdd11223344aabbccdd",
+            "mention id must be preserved"
+        );
+        assert_eq!(
+            mention_attrs["localId"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "mention localId must be preserved"
+        );
+        assert_eq!(mention_attrs["text"], "@Alice Example");
+
+        assert_eq!(inlines[2].node_type, "text");
+        assert_eq!(inlines[2].text.as_deref(), Some(" "));
+    }
+
+    #[test]
+    fn mention_in_bullet_list_preserves_id_and_local_id() {
+        // Same bug outside of a table context
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"mention","attrs":{"id":"user123","localId":"11111111-2222-3333-4444-555555555555","text":"@Bob"}},{"type":"text","text":" "}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list_item = &rt.content[0].content.as_ref().unwrap()[0];
+        assert!(
+            list_item
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("localId"))
+                .is_none(),
+            "localId should stay on the mention, not the listItem"
+        );
+
+        let para = &list_item.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+        assert_eq!(inlines[0].node_type, "mention");
+        let mention_attrs = inlines[0].attrs.as_ref().unwrap();
+        assert_eq!(mention_attrs["id"], "user123");
+        assert_eq!(
+            mention_attrs["localId"],
+            "11111111-2222-3333-4444-555555555555"
+        );
+    }
+
+    #[test]
+    fn mention_in_ordered_list_preserves_id_and_local_id() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"see "},{"type":"mention","attrs":{"id":"xyz","localId":"aaaa-bbbb","text":"@Carol"}}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list_item = &rt.content[0].content.as_ref().unwrap()[0];
+        assert!(
+            list_item
+                .attrs
+                .as_ref()
+                .and_then(|a| a.get("localId"))
+                .is_none(),
+            "localId should stay on the mention, not the listItem"
+        );
+
+        let para = &list_item.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+        assert_eq!(inlines[1].node_type, "mention");
+        let mention_attrs = inlines[1].attrs.as_ref().unwrap();
+        assert_eq!(mention_attrs["id"], "xyz");
+        assert_eq!(mention_attrs["localId"], "aaaa-bbbb");
+    }
+
+    #[test]
+    fn list_item_own_local_id_with_mention_both_preserved() {
+        // When a listItem has its own localId AND contains a mention with localId,
+        // both should be preserved independently.
+        let md = "- hello :mention[@Eve]{id=e1 localId=mention-lid} {localId=item-lid}\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let list_item = &doc.content[0].content.as_ref().unwrap()[0];
+
+        // listItem should have its own localId
+        let item_attrs = list_item.attrs.as_ref().unwrap();
+        assert_eq!(item_attrs["localId"], "item-lid");
+
+        // mention should have its own localId
+        let para = &list_item.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+        let mention = inlines.iter().find(|n| n.node_type == "mention").unwrap();
+        let mention_attrs = mention.attrs.as_ref().unwrap();
+        assert_eq!(mention_attrs["id"], "e1");
+        assert_eq!(mention_attrs["localId"], "mention-lid");
+    }
+
+    #[test]
+    fn extract_trailing_local_id_ignores_directive_attrs() {
+        // Directly test the helper: a line ending with a directive's {…}
+        // should NOT be treated as a trailing localId.
+        let line = "text :mention[@X]{id=abc localId=uuid}";
+        let (text, lid, plid) = extract_trailing_local_id(line);
+        assert_eq!(text, line, "text should be unchanged");
+        assert!(
+            lid.is_none(),
+            "should not extract localId from directive attrs"
+        );
+        assert!(plid.is_none());
+    }
+
+    #[test]
+    fn extract_trailing_local_id_matches_standalone_block() {
+        // A standalone trailing {localId=…} separated by whitespace should still work.
+        let line = "some text {localId=abc-123}";
+        let (text, lid, plid) = extract_trailing_local_id(line);
+        assert_eq!(text, "some text");
+        assert_eq!(lid.as_deref(), Some("abc-123"));
+        assert!(plid.is_none());
     }
 }


### PR DESCRIPTION
## Description

Fixes a bug (#446) where the `extract_trailing_local_id` helper in `src/atlassian/convert.rs` would incorrectly consume the `{id=… localId=…}` attribute block from an inline directive (e.g. `:mention[text]{id=… localId=…}`) and attach the `localId` to the enclosing list item instead of keeping it on the mention node.

This caused ADF round-trip failures for documents containing mentions inside bullet lists, ordered lists, and table cell bullet lists — the mention would lose its `id` and `localId`, and those values would instead appear on the wrong node (the `listItem`).

The fix adds a guard in `extract_trailing_local_id` so that a `{…}` block is only treated as a standalone trailing attribute block when it is preceded by whitespace (or appears at the very start of the string). A `{` that immediately follows `]` (as in a directive's inline attribute block) is now left untouched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #446

## Changes Made

**Core Changes:**
- Added a whitespace-precedence guard in `extract_trailing_local_id` (`src/atlassian/convert.rs`) — if the `{` opening a trailing attribute block is immediately preceded by a non-whitespace character (e.g. `]`), the function now returns early without consuming the block, leaving it for the inline directive parser to handle.

**Testing:**
- Added regression test `mention_in_table_bullet_list_preserves_id_and_local_id`: verifies that a mention inside a table cell bullet list retains its `id` and `localId` after ADF → Markdown → ADF round-trip, and that the `listItem` does not acquire a spurious `localId`.
- Added regression test `mention_in_bullet_list_preserves_id_and_local_id`: same verification for a plain bullet list (outside a table).
- Added regression test `mention_in_ordered_list_preserves_id_and_local_id`: same verification for an ordered list.
- Added regression test `list_item_own_local_id_with_mention_both_preserved`: verifies that when a `listItem` has its own `localId` and also contains a mention with a `localId`, both are preserved independently without interference.
- Added unit test `extract_trailing_local_id_ignores_directive_attrs`: directly tests the helper to confirm that a line ending with a directive's `{…}` block is not mistakenly parsed as a trailing `localId` block.
- Added unit test `extract_trailing_local_id_matches_standalone_block`: confirms that a legitimate standalone trailing `{localId=…}` block separated by whitespace continues to be extracted correctly.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 regression/unit tests covering the bug and edge cases)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (ADF round-trip with mention in table+list)
- [x] Tested error/edge cases (listItem with its own localId alongside a mention with localId)
- [x] Backward compatibility verified (standalone trailing `{localId=…}` blocks still work)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the atlassian-related tests
cargo test atlassian

# Run the specific regression tests for this fix
cargo test mention_in_table_bullet_list_preserves_id_and_local_id
cargo test mention_in_bullet_list_preserves_id_and_local_id
cargo test mention_in_ordered_list_preserves_id_and_local_id
cargo test list_item_own_local_id_with_mention_both_preserved
cargo test extract_trailing_local_id_ignores_directive_attrs
cargo test extract_trailing_local_id_matches_standalone_block

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the guard in `extract_trailing_local_id` must correctly distinguish directive inline attrs from standalone trailing blocks in all edge cases
- [x] Backward compatibility — existing documents that use standalone trailing `{localId=…}` blocks on list items must continue to round-trip correctly

The key logic change is small (4 lines in `extract_trailing_local_id`) but the surrounding context is important: the function must still correctly handle the case where a list item has both a trailing standalone `{localId=…}` block AND contains an inline mention directive with its own `{…}` block.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- An alternative approach would have been to check whether the `{…}` block is preceded specifically by `]`, but checking for any non-whitespace character is more robust — it catches any inline directive syntax that might end a block with `}` directly adjacent to its preceding token, not just mention directives.