### PR TITLE
fix(atlassian): preserve trailing whitespace before hex-format localId

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2203,8 +2203,9 @@ fn extract_trailing_local_id(text: &str) -> (&str, Option<String>, Option<String
             let local_id = attrs.get("localId").map(str::to_string);
             let para_local_id = attrs.get("paraLocalId").map(str::to_string);
             if local_id.is_some() || para_local_id.is_some() {
-                let before =
-                    trimmed[..brace_pos].trim_end_matches(|c: char| c.is_ascii_whitespace());
+                let before = trimmed[..brace_pos]
+                    .strip_suffix(' ')
+                    .unwrap_or(&trimmed[..brace_pos]);
                 return (before, local_id, para_local_id);
             }
         }
@@ -6870,6 +6871,56 @@ mod tests {
             "tl-xyz",
             "taskList localId should survive round-trip"
         );
+    }
+
+    #[test]
+    fn trailing_space_preserved_with_hex_localid() {
+        // Issue #449: trailing whitespace stripped from text node
+        // when listItem has a hex-format localId (no hyphens)
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","attrs":{"localId":"aabb112233cc"},"content":[{"type":"paragraph","content":[{"type":"text","text":"trailing space "}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(
+            item.attrs.as_ref().unwrap()["localId"],
+            "aabb112233cc",
+            "localId should round-trip"
+        );
+        let para = &item.content.as_ref().unwrap()[0];
+        let inlines = para.content.as_ref().unwrap();
+        let last = inlines.last().unwrap();
+        assert!(
+            last.text.as_deref().unwrap_or("").ends_with(' '),
+            "trailing space should be preserved, got nodes: {:?}",
+            inlines
+                .iter()
+                .map(|n| (&n.node_type, &n.text))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn extract_trailing_local_id_preserves_trailing_space() {
+        // Issue #449: only strip the single separator space before {localId=...}
+        let (before, lid, _) = extract_trailing_local_id("trailing space  {localId=aabb112233cc}");
+        assert_eq!(before, "trailing space ");
+        assert_eq!(lid.as_deref(), Some("aabb112233cc"));
+    }
+
+    #[test]
+    fn extract_trailing_local_id_no_trailing_space() {
+        let (before, lid, _) = extract_trailing_local_id("text {localId=abc123}");
+        assert_eq!(before, "text");
+        assert_eq!(lid.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn extract_trailing_local_id_no_attrs() {
+        let (before, lid, pid) = extract_trailing_local_id("plain text");
+        assert_eq!(before, "plain text");
+        assert!(lid.is_none());
+        assert!(pid.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes issue #449 where trailing whitespace was being stripped from text nodes when a `listItem` had a hex-format `localId` (i.e., a UUID with no hyphens, such as `aabb112233cc`).

The root cause was in `extract_trailing_local_id` in `src/atlassian/convert.rs`. The function used `trim_end_matches(|c: char| c.is_ascii_whitespace())` on the text before the `{localId=...}` marker, which unconditionally removed **all** trailing whitespace — including intentional whitespace that was part of the original text node content.

The fix replaces the `trim_end_matches` call with `strip_suffix(' ').unwrap_or(...)`, so that only the single separator space between the text content and the `{localId=...}` marker is removed. Any additional trailing whitespace that was part of the original text is now correctly preserved through the round-trip.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #449

## Changes Made

**Core Changes:**
- In `src/atlassian/convert.rs`, replaced `trimmed[..brace_pos].trim_end_matches(|c: char| c.is_ascii_whitespace())` with `trimmed[..brace_pos].strip_suffix(' ').unwrap_or(&trimmed[..brace_pos])` inside `extract_trailing_local_id` to only strip the single separator space before the `{localId=...}` marker, preserving any intentional trailing whitespace in the text node.

**Testing:**
- Added `trailing_space_preserved_with_hex_localid`: full round-trip regression test for issue #449 — converts ADF with a `bulletList` containing a `listItem` with a hex-format `localId` and a text node with a trailing space, then verifies the trailing space survives the round-trip.
- Added `extract_trailing_local_id_preserves_trailing_space`: unit test confirming that only the single separator space is stripped when additional trailing whitespace is present before the marker.
- Added `extract_trailing_local_id_no_trailing_space`: unit test confirming the normal case (single separator space stripped, no extra whitespace) continues to work correctly.
- Added `extract_trailing_local_id_no_attrs`: unit test confirming that text without a `{localId=...}` marker is returned unchanged.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (4 new unit/integration tests)
- [x] Integration tests updated/added (round-trip regression test for issue #449)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (no trailing space, no attrs, multiple trailing spaces)
- [x] Backward compatibility verified (existing `list_item_localid_stripped` test unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the atlassian convert tests
cargo test --lib atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the `unwrap_or` fallback in `strip_suffix(' ')` ensures the function degrades gracefully when there is no separator space.
- [x] Backward compatibility — only the handling of the single separator space before `{localId=...}` has changed; all other whitespace stripping behaviour is removed, which is the correct and intended behaviour.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using `trim_end_matches(' ')` was considered but rejected because it would strip *all* trailing spaces rather than just the single separator space, which would still exhibit the same bug for inputs like `"trailing space  {localId=...}"`.
- Keeping `trim_end_matches` and adjusting callers was considered but rejected as the fix is cleanly localised to `extract_trailing_local_id` with no impact on other call sites.