### PR TITLE
fix(atlassian): preserve border mark on tableCell/tableHeader round-trip

### DIFF
--- a/src/atlassian/adf.rs
+++ b/src/atlassian/adf.rs
@@ -333,6 +333,42 @@ impl AdfNode {
         }
     }
 
+    /// Creates a table header cell node with attributes and marks.
+    #[must_use]
+    pub fn table_header_with_attrs_and_marks(
+        content: Vec<Self>,
+        attrs: Option<serde_json::Value>,
+        marks: Vec<AdfMark>,
+    ) -> Self {
+        Self {
+            node_type: "tableHeader".to_string(),
+            attrs,
+            content: Some(content),
+            text: None,
+            marks: if marks.is_empty() { None } else { Some(marks) },
+            local_id: None,
+            parameters: None,
+        }
+    }
+
+    /// Creates a table cell node with attributes and marks.
+    #[must_use]
+    pub fn table_cell_with_attrs_and_marks(
+        content: Vec<Self>,
+        attrs: Option<serde_json::Value>,
+        marks: Vec<AdfMark>,
+    ) -> Self {
+        Self {
+            node_type: "tableCell".to_string(),
+            attrs,
+            content: Some(content),
+            text: None,
+            marks: if marks.is_empty() { None } else { Some(marks) },
+            local_id: None,
+            parameters: None,
+        }
+    }
+
     /// Creates a caption node (used inside tables).
     #[must_use]
     pub fn caption(content: Vec<Self>) -> Self {
@@ -868,6 +904,15 @@ impl AdfMark {
             attrs: Some(attrs),
         }
     }
+
+    /// Creates a border mark for table cells/headers.
+    #[must_use]
+    pub fn border(color: &str, size: u32) -> Self {
+        Self {
+            mark_type: "border".to_string(),
+            attrs: Some(serde_json::json!({"color": color, "size": size})),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1385,5 +1430,58 @@ mod tests {
         assert_eq!(mark.mark_type, "breakout");
         assert_eq!(mark.attrs.as_ref().unwrap()["mode"], "wide");
         assert_eq!(mark.attrs.as_ref().unwrap()["width"], 1200);
+    }
+
+    #[test]
+    fn border_mark() {
+        let mark = AdfMark::border("#ff000033", 2);
+        assert_eq!(mark.mark_type, "border");
+        let attrs = mark.attrs.as_ref().unwrap();
+        assert_eq!(attrs["color"], "#ff000033");
+        assert_eq!(attrs["size"], 2);
+    }
+
+    #[test]
+    fn table_cell_with_attrs_and_marks_builder() {
+        let cell = AdfNode::table_cell_with_attrs_and_marks(
+            vec![AdfNode::paragraph(vec![])],
+            Some(serde_json::json!({"background": "#e6fcff"})),
+            vec![AdfMark::border("#ff0000", 1)],
+        );
+        assert_eq!(cell.node_type, "tableCell");
+        assert!(cell.marks.is_some());
+        assert_eq!(cell.marks.as_ref().unwrap()[0].mark_type, "border");
+    }
+
+    #[test]
+    fn table_header_with_attrs_and_marks_builder() {
+        let cell = AdfNode::table_header_with_attrs_and_marks(
+            vec![AdfNode::paragraph(vec![])],
+            None,
+            vec![AdfMark::border("#0000ff", 3)],
+        );
+        assert_eq!(cell.node_type, "tableHeader");
+        assert!(cell.marks.is_some());
+        assert_eq!(cell.marks.as_ref().unwrap()[0].mark_type, "border");
+    }
+
+    #[test]
+    fn table_cell_with_empty_marks_has_none() {
+        let cell = AdfNode::table_cell_with_attrs_and_marks(
+            vec![AdfNode::paragraph(vec![])],
+            None,
+            vec![],
+        );
+        assert!(cell.marks.is_none(), "empty marks vec should become None");
+    }
+
+    #[test]
+    fn border_mark_serde_roundtrip() {
+        let mark = AdfMark::border("#ff000033", 2);
+        let json = serde_json::to_string(&mark).unwrap();
+        let deserialized: AdfMark = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.mark_type, "border");
+        assert_eq!(deserialized.attrs.as_ref().unwrap()["color"], "#ff000033");
+        assert_eq!(deserialized.attrs.as_ref().unwrap()["size"], 2);
     }
 }

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -748,18 +748,28 @@ impl<'a> MarkdownParser<'a> {
         let cell_text = cell_lines.join("\n");
         let blocks = MarkdownParser::new(&cell_text).parse_blocks()?;
 
-        let adf_attrs = cell_attrs.map(|a| build_cell_attrs(&a));
+        let adf_attrs = cell_attrs.as_ref().map(build_cell_attrs);
+        let cell_marks = cell_attrs
+            .as_ref()
+            .map(build_cell_marks)
+            .unwrap_or_default();
 
-        let cell = if is_header {
-            if let Some(attrs) = adf_attrs {
-                AdfNode::table_header_with_attrs(blocks, attrs)
+        let cell = if cell_marks.is_empty() {
+            if is_header {
+                if let Some(attrs) = adf_attrs {
+                    AdfNode::table_header_with_attrs(blocks, attrs)
+                } else {
+                    AdfNode::table_header(blocks)
+                }
+            } else if let Some(attrs) = adf_attrs {
+                AdfNode::table_cell_with_attrs(blocks, attrs)
             } else {
-                AdfNode::table_header(blocks)
+                AdfNode::table_cell(blocks)
             }
-        } else if let Some(attrs) = adf_attrs {
-            AdfNode::table_cell_with_attrs(blocks, attrs)
+        } else if is_header {
+            AdfNode::table_header_with_attrs_and_marks(blocks, adf_attrs, cell_marks)
         } else {
-            AdfNode::table_cell(blocks)
+            AdfNode::table_cell_with_attrs_and_marks(blocks, adf_attrs, cell_marks)
         };
 
         Ok((cell, i))
@@ -1037,6 +1047,19 @@ fn build_cell_attrs(attrs: &crate::atlassian::attrs::Attrs) -> serde_json::Value
         adf["localId"] = serde_json::Value::String(local_id.to_string());
     }
     adf
+}
+
+/// Extracts cell-level marks (e.g., border) from directive attributes.
+fn build_cell_marks(attrs: &crate::atlassian::attrs::Attrs) -> Vec<AdfMark> {
+    let mut marks = Vec::new();
+    let border_color = attrs.get("border-color");
+    let border_size = attrs.get("border-size");
+    if border_color.is_some() || border_size.is_some() {
+        let color = border_color.unwrap_or("#000000");
+        let size = border_size.and_then(|s| s.parse::<u32>().ok()).unwrap_or(1);
+        marks.push(AdfMark::border(color, size));
+    }
+    marks
 }
 
 /// Converts an ISO 8601 date string (e.g., "2026-04-15") to epoch milliseconds string.
@@ -2929,6 +2952,11 @@ fn table_qualifies_for_pipe_syntax(rows: &[AdfNode]) -> bool {
             if cell_contains_hard_break(&content[0]) {
                 return false;
             }
+            // Cell-level marks (e.g., border) cannot be represented in pipe
+            // form — fall back to directive form
+            if cell.marks.as_ref().is_some_and(|m| !m.is_empty()) {
+                return false;
+            }
             // Paragraph-level localId would be lost in pipe form (the paragraph
             // is unwrapped into the cell text) — fall back to directive form
             if content[0]
@@ -3071,7 +3099,33 @@ fn render_directive_table(
                     cell_attr_str.push_str(&lid_parts.join(" "));
                 }
             }
-            if cell_attr_str.is_empty() && cell.attrs.is_none() {
+            // Append border mark attrs if present
+            if let Some(ref marks) = cell.marks {
+                for mark in marks {
+                    if mark.mark_type == "border" {
+                        if let Some(ref attrs) = mark.attrs {
+                            if let Some(color) =
+                                attrs.get("color").and_then(serde_json::Value::as_str)
+                            {
+                                if !cell_attr_str.is_empty() {
+                                    cell_attr_str.push(' ');
+                                }
+                                cell_attr_str.push_str(&format!("border-color={color}"));
+                            }
+                            if let Some(size) =
+                                attrs.get("size").and_then(serde_json::Value::as_u64)
+                            {
+                                if !cell_attr_str.is_empty() {
+                                    cell_attr_str.push(' ');
+                                }
+                                cell_attr_str.push_str(&format!("border-size={size}"));
+                            }
+                        }
+                    }
+                }
+            }
+            let has_marks = cell.marks.as_ref().is_some_and(|m| !m.is_empty());
+            if cell_attr_str.is_empty() && cell.attrs.is_none() && !has_marks {
                 output.push_str(&format!(":::{directive_name}\n"));
             } else {
                 output.push_str(&format!(":::{directive_name}{{{cell_attr_str}}}\n"));
@@ -6964,6 +7018,118 @@ mod tests {
             "tc-001",
             "tableCell localId should round-trip"
         );
+    }
+
+    #[test]
+    fn table_cell_border_mark_roundtrip() {
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{},"marks":[{"type":"border","attrs":{"color":"#ff000033","size":2}}],"content":[{"type":"paragraph","content":[{"type":"text","text":"cell with border"}]}]}]}]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("border-color=#ff000033"),
+            "tableCell should have border-color in md: {md}"
+        );
+        assert!(
+            md.contains("border-size=2"),
+            "tableCell should have border-size in md: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let marks = cell.marks.as_ref().expect("tableCell should have marks");
+        assert_eq!(marks.len(), 1);
+        assert_eq!(marks[0].mark_type, "border");
+        let attrs = marks[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["color"], "#ff000033");
+        assert_eq!(attrs["size"], 2);
+    }
+
+    #[test]
+    fn table_header_border_mark_roundtrip() {
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableHeader","attrs":{},"marks":[{"type":"border","attrs":{"color":"#0000ff","size":3}}],"content":[{"type":"paragraph","content":[{"type":"text","text":"header"}]}]}]}]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("border-color=#0000ff"), "md: {md}");
+        assert!(md.contains("border-size=3"), "md: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(cell.node_type, "tableHeader");
+        let marks = cell.marks.as_ref().expect("tableHeader should have marks");
+        assert_eq!(marks[0].mark_type, "border");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["color"], "#0000ff");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["size"], 3);
+    }
+
+    #[test]
+    fn table_cell_border_mark_with_attrs_roundtrip() {
+        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","attrs":{"background":"#e6fcff","colspan":2},"marks":[{"type":"border","attrs":{"color":"#ff000033","size":1}}],"content":[{"type":"paragraph","content":[{"type":"text","text":"styled"}]}]}]}]}]}"##;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("bg=#e6fcff"), "md: {md}");
+        assert!(md.contains("colspan=2"), "md: {md}");
+        assert!(md.contains("border-color=#ff000033"), "md: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(cell.attrs.as_ref().unwrap()["background"], "#e6fcff");
+        assert_eq!(cell.attrs.as_ref().unwrap()["colspan"], 2);
+        let marks = cell.marks.as_ref().expect("should have marks");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["color"], "#ff000033");
+    }
+
+    #[test]
+    fn table_cell_no_border_mark_unchanged() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"plain"}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            !md.contains("border-color"),
+            "no border attrs expected: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let cell = &rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        assert!(cell.marks.is_none(), "no marks expected on plain cell");
+    }
+
+    #[test]
+    fn table_cell_border_size_only_defaults_color() {
+        // border-size without border-color should still produce a border mark
+        // with the default color
+        let md = "::::table\n:::tr\n:::td{border-size=3}\ncell\n:::\n:::\n::::\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let cell = &doc.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let marks = cell.marks.as_ref().expect("should have border mark");
+        assert_eq!(marks[0].mark_type, "border");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["color"], "#000000");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["size"], 3);
+    }
+
+    #[test]
+    fn table_cell_border_color_only_defaults_size() {
+        // border-color without border-size should default size to 1
+        let md = "::::table\n:::tr\n:::td{border-color=#ff0000}\ncell\n:::\n:::\n::::\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let cell = &doc.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap()[0];
+        let marks = cell.marks.as_ref().expect("should have border mark");
+        assert_eq!(marks[0].mark_type, "border");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["color"], "#ff0000");
+        assert_eq!(marks[0].attrs.as_ref().unwrap()["size"], 1);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a data loss bug where the `border` mark on ADF `tableCell` and `tableHeader` nodes was silently dropped during ADF-to-markdown and markdown-to-ADF round-trips. Confluence documents that define visual border styling on table cells using the `border` mark would lose that styling information after any round-trip conversion, producing incorrect output.

The fix adds full round-trip support for the `border` mark by serializing it as `border-color` and `border-size` directive attributes in markdown form, and deserializing those attributes back into `AdfMark::border` instances when converting back to ADF. Cells carrying marks are automatically routed through directive form rather than pipe-syntax to avoid data loss.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #451

## Changes Made

**Core Changes (`src/atlassian/adf.rs`):**
- Added `AdfMark::border(color, size)` constructor for creating border marks with `color` and `size` attributes
- Added `AdfNode::table_header_with_attrs_and_marks(content, attrs, marks)` builder that accepts both attrs and marks
- Added `AdfNode::table_cell_with_attrs_and_marks(content, attrs, marks)` builder that accepts both attrs and marks
- Empty marks vec is normalised to `None` in both new builders to keep ADF output clean

**Core Changes (`src/atlassian/convert.rs`):**
- Added `build_cell_marks` function that extracts `border-color` and `border-size` directive attributes into `AdfMark::border` instances, defaulting color to `#000000` and size to `1` when only one is present
- Updated `parse_table_cell` to call `build_cell_marks` and attach the resulting marks when converting markdown directives back to ADF; cells with marks use the new `_with_attrs_and_marks` builders
- Updated `render_directive_table` to serialize `border` mark attributes (`border-color`, `border-size`) into the directive attribute string
- Updated `table_qualifies_for_pipe_syntax` to return `false` when any cell carries marks, falling back to directive form to prevent data loss

**Testing (`src/atlassian/adf.rs` and `src/atlassian/convert.rs`):**
- Added `border_mark` unit test for `AdfMark::border` constructor
- Added `table_cell_with_attrs_and_marks_builder` unit test
- Added `table_header_with_attrs_and_marks_builder` unit test
- Added `table_cell_with_empty_marks_has_none` unit test verifying normalisation
- Added `border_mark_serde_roundtrip` unit test verifying JSON serialisation/deserialisation
- Added `table_cell_border_mark_roundtrip` integration test (ADF → markdown → ADF)
- Added `table_header_border_mark_roundtrip` integration test
- Added `table_cell_border_mark_with_attrs_roundtrip` integration test for cells that combine `background`, `colspan`, and `border` mark together
- Added `table_cell_no_border_mark_unchanged` regression test ensuring plain cells are unaffected
- Added `table_cell_border_size_only_defaults_color` test verifying default color inference
- Added `table_cell_border_color_only_defaults_size` test verifying default size inference

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (cell with border mark only)
- [x] Tested error/edge cases (empty marks vec, cell with no marks, combined attrs + marks, partial border attrs)
- [x] Backward compatibility verified (plain cells without marks are unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only atlassian-related tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `build_cell_marks` gracefully handles missing or malformed `border-size` values by defaulting to `1`, and missing `border-color` defaults to `#000000`
- [x] Backward compatibility — cells without marks continue to use the existing `table_cell_with_attrs` / `table_header_with_attrs` paths unchanged; the new `_with_attrs_and_marks` builders are only invoked when marks are non-empty
- [x] Architecture changes — the `table_qualifies_for_pipe_syntax` guard now also checks for cell-level marks to ensure directive fallback, preventing silent data loss

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. All existing behaviour is preserved. The new builders and mark extractor are purely additive. Cells without marks continue to follow the original code paths unchanged.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Encoding the `border` mark inline in pipe-syntax tables was rejected because pipe syntax cannot represent cell-level metadata without data loss; directive form is the correct representation for any cell that carries marks.

**Known Limitations:**
- Only the `border` mark is currently extracted from directive attributes. Other potential cell-level marks (if any are introduced in future ADF versions) would need their own handling added to `build_cell_marks`.