### PR TITLE
fix(atlassian): escape backticks in plain text to prevent code span parsing

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1157,6 +1157,22 @@ fn escape_emphasis_markers(text: &str) -> String {
     out
 }
 
+/// Escapes backtick characters in text that would otherwise be parsed as
+/// inline code spans (`` `…` ``).
+///
+/// Each backtick is prefixed with a backslash so that the JFM parser treats
+/// it as a literal character rather than an inline-code delimiter.
+fn escape_backticks(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch == '`' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
 /// Escapes a leading list-marker pattern on a line so it is not
 /// re-parsed as a new list item.  `"2. text"` → `"2\. text"`,
 /// `"- text"` → `"\- text"`.
@@ -3444,7 +3460,7 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
     if inner_em {
         inner.push('*');
     }
-    inner.push_str(&escape_emphasis_markers(text));
+    inner.push_str(&escape_backticks(&escape_emphasis_markers(text)));
     if inner_em {
         inner.push('*');
     }
@@ -4572,6 +4588,96 @@ mod tests {
         });
         assert!(strong_node.is_some(), "should have a strong-marked node");
         assert_eq!(strong_node.unwrap().text.as_deref(), Some("call **kwargs"));
+    }
+
+    #[test]
+    fn backtick_code_roundtrip() {
+        // The original reproducer from issue #453
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Set `max_retries` to 3 in the config"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should round-trip as a single text node");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("Set `max_retries` to 3 in the config")
+        );
+        assert!(content[0].marks.is_none());
+    }
+
+    #[test]
+    fn multiple_backtick_spans_roundtrip() {
+        // Multiple backtick-delimited spans in a single text node
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Use `foo` and `bar` together"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should round-trip as a single text node");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("Use `foo` and `bar` together")
+        );
+        assert!(content[0].marks.is_none());
+    }
+
+    #[test]
+    fn lone_backtick_roundtrip() {
+        // A single backtick that cannot form a code span should round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Use a ` character"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should round-trip as a single text node");
+        assert_eq!(content[0].text.as_deref(), Some("Use a ` character"));
+        assert!(content[0].marks.is_none());
+    }
+
+    #[test]
+    fn backtick_with_code_mark_roundtrip() {
+        // Text that already has a code mark should preserve both the mark and content
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"max_retries","marks":[{"type":"code"}]}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        assert_eq!(jfm.trim(), "`max_retries`");
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        let code_node = content.iter().find(|n| {
+            n.marks
+                .as_ref()
+                .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "code"))
+        });
+        assert!(code_node.is_some(), "should have a code-marked node");
+        assert_eq!(code_node.unwrap().text.as_deref(), Some("max_retries"));
+    }
+
+    #[test]
+    fn backtick_with_em_mark_roundtrip() {
+        // Backtick inside em-marked text should preserve both
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"use `cfg`","marks":[{"type":"em"}]}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        let em_node = content.iter().find(|n| {
+            n.marks
+                .as_ref()
+                .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "em"))
+        });
+        assert!(em_node.is_some(), "should have an em-marked node");
+        assert_eq!(em_node.unwrap().text.as_deref(), Some("use `cfg`"));
+    }
+
+    #[test]
+    fn escape_backticks_unit() {
+        assert_eq!(escape_backticks("hello"), "hello");
+        assert_eq!(escape_backticks("`code`"), r"\`code\`");
+        assert_eq!(escape_backticks("no ticks"), "no ticks");
+        assert_eq!(escape_backticks("a ` b"), r"a \` b");
+        assert_eq!(escape_backticks(""), "");
+        assert_eq!(escape_backticks("`a` and `b`"), r"\`a\` and \`b\`");
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a round-trip conversion failure (issue #453) where plain-text ADF nodes containing backtick-delimited substrings (e.g., `` `max_retries` ``) were incorrectly re-parsed as inline code spans when converted back through `markdown_to_adf`. The root cause was that `render_marked_text` in `src/atlassian/convert.rs` did not escape backtick characters before emitting JFM/Markdown, so the JFM parser treated them as inline-code delimiters on the return trip.

The fix adds an `escape_backticks` helper that prefixes every backtick with a backslash, and applies it inside `render_marked_text` wrapping the existing `escape_emphasis_markers` call. This ensures the JFM parser sees backticks as literal characters rather than code-span delimiters.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #453

## Changes Made

**Core Changes:**
- Added `escape_backticks(text: &str) -> String` helper function in `src/atlassian/convert.rs` that prefixes each `` ` `` character with a backslash
- Applied `escape_backticks` inside `render_marked_text`, composing it with the existing `escape_emphasis_markers` call: `escape_backticks(&escape_emphasis_markers(text))`

**Testing:**
- Added `backtick_code_roundtrip` — the original reproducer from issue #453 (plain text node `"Set \`max_retries\` to 3 in the config"`)
- Added `multiple_backtick_spans_roundtrip` — multiple backtick-delimited spans in a single text node
- Added `lone_backtick_roundtrip` — a single backtick that cannot form a code span
- Added `backtick_with_code_mark_roundtrip` — text with an explicit `code` mark should still round-trip correctly
- Added `backtick_with_em_mark_roundtrip` — backtick inside `em`-marked text should preserve both mark and content
- Added `escape_backticks_unit` — direct unit tests for the new helper function covering empty string, no-tick strings, single tick, and multiple spans

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 regression and unit tests)
- [x] Integration tests updated/added (round-trip tests via `adf_to_markdown` → `markdown_to_adf`)

**Manual Testing:**
- [x] Tested happy path scenarios (plain text with backtick-delimited words round-trips correctly)
- [x] Tested edge cases (lone backtick, multiple spans, empty string, code-marked nodes, em-marked nodes with backticks)
- [x] Backward compatibility verified (code-marked text still renders with backtick delimiters)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the atlassian convert tests
cargo test atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `escape_backticks` is composed with `escape_emphasis_markers` inside `render_marked_text`; text nodes that already carry a `code` mark use a separate rendering path and are not affected
- [x] Error handling — the fix is purely string-level; no error conditions are introduced

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The `escape_backticks` function performs a single linear scan over the text string (same complexity as the existing `escape_emphasis_markers`). No measurable performance difference is expected.

## Security Considerations
- [x] No security implications

## Breaking Changes

None. The change only affects how plain-text ADF nodes are serialized to JFM/Markdown. Existing documents and code-marked nodes are unaffected.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- This fix targets single-character backtick escaping. Multi-character backtick fences (` `` `) in plain-text nodes are not exercised by the current test suite but would also be escaped correctly by the character-level approach.

**Alternatives Considered:**
- Replacing backticks with a Unicode lookalike: rejected because it silently mutates content rather than preserving it faithfully.
- Wrapping the entire text in a code span: rejected because it would change the semantic meaning of the node for content that does not carry a `code` mark.