### PR TITLE
fix(atlassian): preserve literal newlines in text nodes across adf-markdown round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1632,6 +1632,18 @@ fn parse_inline(text: &str) -> Vec<AdfNode> {
                 }
                 chars.next();
             }
+            '\\' if text.as_bytes().get(i + 1) == Some(&b'n')
+                && text.as_bytes().get(i + 2) != Some(&b'\n') =>
+            {
+                // Issue #454: `\n` (backslash + letter n) encodes a literal
+                // newline inside a text node. Emit the newline as a separate
+                // text node so merge_adjacent_text can reassemble it.
+                flush_plain(text, plain_start, i, &mut nodes);
+                nodes.push(AdfNode::text("\n"));
+                chars.next(); // consume the '\'
+                chars.next(); // consume the 'n'
+                plain_start = chars.peek().map_or(text.len(), |&(idx, _)| idx);
+            }
             '\\' if i + 1 < text.len()
                 && !text[i..].starts_with("\\\n")
                 && text.as_bytes()[i + 1] != b'\\' =>
@@ -3373,7 +3385,16 @@ fn render_inline_node(node: &AdfNode, output: &mut String, opts: &RenderOptions)
         "text" => {
             let text = node.text.as_deref().unwrap_or("");
             let marks = node.marks.as_deref().unwrap_or(&[]);
-            render_marked_text(text, marks, output);
+            // Issue #454: A literal newline inside a text node is escaped
+            // as the two-character sequence `\n` so it survives round-trip
+            // as a single text node instead of splitting into paragraphs or
+            // being converted to hardBreak nodes.
+            if text.contains('\n') {
+                let escaped = text.replace('\n', "\\n");
+                render_marked_text(&escaped, marks, output);
+            } else {
+                render_marked_text(text, marks, output);
+            }
         }
         "hardBreak" => {
             output.push_str("\\\n");
@@ -12511,5 +12532,169 @@ C
         assert_eq!(text, "some text");
         assert_eq!(lid.as_deref(), Some("abc-123"));
         assert!(plid.is_none());
+    }
+
+    // --- Issue #454: literal newline in text node inside listItem paragraph ---
+
+    #[test]
+    fn newline_in_text_node_roundtrips_in_bullet_list() {
+        // A text node containing a literal \n inside a bullet list item
+        // must round-trip as a single text node with the embedded newline
+        // preserved, not split into multiple paragraphs or hardBreak nodes.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Run these commands:"},{"type":"hardBreak"},{"type":"text","text":"first command\nsecond command"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        // Should still be a single bulletList with one listItem
+        assert_eq!(rt.content.len(), 1);
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "bulletList");
+        let items = list.content.as_ref().unwrap();
+        assert_eq!(items.len(), 1);
+
+        // The listItem should have exactly one paragraph child
+        let item_content = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            item_content.len(),
+            1,
+            "listItem should have exactly one paragraph"
+        );
+        assert_eq!(item_content[0].node_type, "paragraph");
+
+        // The embedded newline must survive as a single text node
+        let inlines = item_content[0].content.as_ref().unwrap();
+        let types: Vec<&str> = inlines.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["text", "hardBreak", "text"],
+            "embedded newline should stay in a single text node, not produce extra hardBreaks"
+        );
+        assert_eq!(
+            inlines[2].text.as_deref(),
+            Some("first command\nsecond command")
+        );
+    }
+
+    #[test]
+    fn newline_in_text_node_roundtrips_in_ordered_list() {
+        // Same as above but in an ordered list.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","attrs":{"order":1},"content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first\nsecond"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "orderedList");
+        let items = list.content.as_ref().unwrap();
+        assert_eq!(items.len(), 1);
+
+        let item_content = items[0].content.as_ref().unwrap();
+        assert_eq!(item_content.len(), 1);
+        assert_eq!(item_content[0].node_type, "paragraph");
+
+        let inlines = item_content[0].content.as_ref().unwrap();
+        assert_eq!(inlines.len(), 1);
+        assert_eq!(inlines[0].node_type, "text");
+        assert_eq!(inlines[0].text.as_deref(), Some("first\nsecond"));
+    }
+
+    #[test]
+    fn newline_in_text_node_roundtrips_in_paragraph() {
+        // A text node with \n in a top-level paragraph should render as
+        // escaped \n and round-trip back to a single text node.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hello\nworld"}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("hello\\nworld"),
+            "newline in text node should render as escaped \\n: {md:?}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let inlines = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(inlines.len(), 1);
+        assert_eq!(inlines[0].text.as_deref(), Some("hello\nworld"));
+    }
+
+    #[test]
+    fn multiple_newlines_in_text_node_roundtrip() {
+        // Multiple \n characters should each round-trip within the same text node.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"a\nb\nc"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item_content = rt.content[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        assert_eq!(item_content.len(), 1);
+
+        let inlines = item_content[0].content.as_ref().unwrap();
+        assert_eq!(inlines.len(), 1);
+        assert_eq!(inlines[0].text.as_deref(), Some("a\nb\nc"));
+    }
+
+    #[test]
+    fn newline_in_marked_text_node_roundtrips() {
+        // A bold text node with \n should round-trip preserving both
+        // the marks and the embedded newline.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"bold\ntext","marks":[{"type":"strong"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("**bold\\ntext**"),
+            "bold text with embedded newline should stay in one marked run: {md:?}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let inlines = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(inlines.len(), 1);
+        assert_eq!(inlines[0].text.as_deref(), Some("bold\ntext"));
+        assert!(inlines[0]
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|m| m.mark_type == "strong"));
+    }
+
+    #[test]
+    fn trailing_newline_in_text_node_roundtrips() {
+        // A text node ending with \n should round-trip preserving the
+        // trailing newline.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"trailing\n"}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("trailing\\n"),
+            "trailing newline should be escaped: {md:?}"
+        );
+
+        let rt = markdown_to_adf(&md).unwrap();
+        let inlines = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(inlines.len(), 1);
+        assert_eq!(inlines[0].text.as_deref(), Some("trailing\n"));
+    }
+
+    #[test]
+    fn hardbreak_and_embedded_newline_are_distinct() {
+        // A hardBreak node and an embedded \n in a text node must not be
+        // conflated — each must round-trip to its original form.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"before"},{"type":"hardBreak"},{"type":"text","text":"mid\ndle"},{"type":"hardBreak"},{"type":"text","text":"after"}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let inlines = rt.content[0].content.as_ref().unwrap();
+        let types: Vec<&str> = inlines.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(
+            types,
+            vec!["text", "hardBreak", "text", "hardBreak", "text"]
+        );
+        assert_eq!(inlines[0].text.as_deref(), Some("before"));
+        assert_eq!(inlines[2].text.as_deref(), Some("mid\ndle"));
+        assert_eq!(inlines[4].text.as_deref(), Some("after"));
     }
 }


### PR DESCRIPTION
## Description

This PR fixes issue #454 where a literal newline character (`\n`) embedded in an ADF (Atlassian Document Format) text node was not surviving a round-trip through ADF-to-Markdown rendering and back. The bare newline was being interpreted as a paragraph break or converted to a `hardBreak` node, corrupting document structure — particularly inside list items where the list item would be incorrectly split into multiple paragraphs.

The fix implements a two-part encoding strategy:
- **Render side** (`render_inline_node`): Text nodes containing `\n` are now rendered with the two-character escape sequence `\n` (backslash + letter n), allowing the newline to survive in the Markdown representation without being interpreted as a line/paragraph break.
- **Parse side** (`parse_inline`): The escape sequence `\n` (backslash + letter n) is now decoded back to a literal newline character, distinguishing it from the `\\\n` hard-break marker used by the Markdown renderer.

This approach keeps `hardBreak` ADF nodes and embedded newlines in text nodes cleanly distinct across the full round-trip.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #454

## Changes Made

**Core Changes:**
- Modified `render_inline_node` in `src/atlassian/convert.rs`: when a `"text"` ADF node's content contains `\n`, escape each newline as the two-character sequence `\n` before passing to `render_marked_text`, preserving inline marks (bold, italic, etc.) on the escaped text
- Modified `parse_inline` in `src/atlassian/convert.rs`: added a new match arm for `\` followed by letter `n` (but not `\\\n`) that decodes the escape back to a literal newline character, emitting it as a separate text node for `merge_adjacent_text` to reassemble
- The `hardBreak` rendering path (`\\\n`) is unaffected; the new `\n` escape is distinct and cannot be confused with it

**Testing:**
- Added 7 regression tests in `src/atlassian/convert.rs` covering:
  - Literal `\n` in a bullet list item paragraph round-trips as a single text node (`newline_in_text_node_roundtrips_in_bullet_list`)
  - Literal `\n` in an ordered list item paragraph round-trips correctly (`newline_in_text_node_roundtrips_in_ordered_list`)
  - Literal `\n` in a top-level paragraph renders as `hello\nworld` in Markdown and round-trips back (`newline_in_text_node_roundtrips_in_paragraph`)
  - Multiple consecutive `\n` characters each round-trip within the same text node (`multiple_newlines_in_text_node_roundtrip`)
  - `\n` in a bold text node preserves the `strong` mark on round-trip (`newline_in_marked_text_node_roundtrips`)
  - Trailing `\n` at end of a text node round-trips correctly (`trailing_newline_in_text_node_roundtrips`)
  - `hardBreak` nodes and embedded `\n` in text nodes are kept distinct across round-trip (`hardbreak_and_embedded_newline_are_distinct`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (7 regression tests)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (round-trip of ADF with `\n` in text nodes inside bullet and ordered lists)
- [x] Tested error/edge cases (trailing newlines, multiple consecutive newlines, marked text, `hardBreak` vs embedded newline distinction)
- [x] Backward compatibility verified (documents without `\n` in text nodes follow the unchanged `else` branch; `hardBreak` node rendering is unaffected)

### Test Commands
```bash
# Run all tests
cargo test

# Run the new regression tests for issue #454
cargo test newline_in_text_node
cargo test multiple_newlines_in_text_node
cargo test newline_in_marked_text_node
cargo test trailing_newline_in_text_node
cargo test hardbreak_and_embedded_newline

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the render change only activates when `\n` is present in a text node; documents without embedded newlines follow the unchanged `else` branch
- [x] The parse-side match arm guard `&& text.as_bytes().get(i + 2) != Some(&b'\n')` ensures `\\\n` (hard break) is not accidentally consumed by the new escape decoder
- [x] Error handling — the `flush_plain` / `plain_start` bookkeeping correctly handles leading, trailing, and consecutive `\n` characters
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the `text.contains('\n')` check is a fast scan that short-circuits for all documents that don't contain embedded newlines in text nodes, which is the common case

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive bug fix. Documents without `\n` in text nodes are entirely unaffected. Documents that previously had `\n` in text nodes were producing incorrect round-trip output (paragraph splits, spurious `hardBreak` nodes); they now produce correct output. No API or data-format contract changes are introduced.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Pre-processing the ADF document tree to split text nodes containing `\n` into separate `text` + `hardBreak` + `text` node sequences before rendering. Rejected because it would require mutating or cloning the document tree; the inline rendering escape is simpler and more targeted.
- Emitting a `hardBreak` for embedded newlines (matching the visual rendering). Rejected because it changes the semantic ADF structure and conflates two distinct node types that must remain distinguishable on round-trip.
- Stripping `\n` characters silently. Rejected as it causes data loss.