### PR TITLE
fix(atlassian): strip trailing newline from hardbreak to prevent list split

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2823,6 +2823,12 @@ fn render_list_item_content(item: &AdfNode, output: &mut String, opts: &RenderOp
     if first.node_type == "paragraph" {
         let mut buf = String::new();
         render_inline_content(first, &mut buf, opts);
+        // A trailing hardBreak produces a trailing `\\\n` in the buffer.
+        // Strip the final newline so it doesn't create a blank line after
+        // the list item marker, which would split the list on re-parse
+        // (issue #472).  The `\` is kept so round-trip preserves the
+        // hardBreak, and `output.push('\n')` below supplies the terminator.
+        let buf = buf.trim_end_matches('\n');
         // Indent continuation lines produced by hardBreaks so they stay
         // within the list item when re-parsed (issue #402).
         let mut is_first_line = true;
@@ -12696,5 +12702,281 @@ C
         assert_eq!(inlines[0].text.as_deref(), Some("before"));
         assert_eq!(inlines[2].text.as_deref(), Some("mid\ndle"));
         assert_eq!(inlines[4].text.as_deref(), Some("after"));
+    }
+
+    // ---- Issue #472 tests ----
+
+    #[test]
+    fn issue_472_bullet_list_trailing_hardbreak_roundtrips() {
+        // Issue #472: trailing hardBreak at end of listItem paragraph must
+        // not split the parent bulletList on round-trip.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"First item"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Second item"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        // Must remain a single bulletList
+        assert_eq!(
+            rt.content.len(),
+            1,
+            "Should be 1 block (bulletList), got {}",
+            rt.content.len()
+        );
+        assert_eq!(rt.content[0].node_type, "bulletList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            items.len(),
+            2,
+            "Should have 2 listItems, got {}",
+            items.len()
+        );
+
+        // First item: text + hardBreak (trailing)
+        let p1 = items[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        let types1: Vec<&str> = p1.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(types1, vec!["text", "hardBreak"]);
+        assert_eq!(p1[0].text.as_deref(), Some("First item"));
+
+        // Second item: text only
+        let p2 = items[1].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        assert_eq!(p2[0].text.as_deref(), Some("Second item"));
+    }
+
+    #[test]
+    fn issue_472_ordered_list_trailing_hardbreak_roundtrips() {
+        // Ordered list variant of issue #472.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"orderedList","attrs":{"order":1},"content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Alpha"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Beta"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        assert_eq!(rt.content.len(), 1);
+        assert_eq!(rt.content[0].node_type, "orderedList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+
+        let p1 = items[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        let types1: Vec<&str> = p1.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(types1, vec!["text", "hardBreak"]);
+        assert_eq!(p1[0].text.as_deref(), Some("Alpha"));
+    }
+
+    #[test]
+    fn issue_472_trailing_hardbreak_jfm_no_blank_line() {
+        // The rendered JFM must not contain a blank line after the
+        // trailing hardBreak — that would split the list.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Hello"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"World"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+
+        // Should produce "- Hello\\n- World\n" (no blank line between items).
+        assert_eq!(md, "- Hello\\\n- World\n");
+    }
+
+    #[test]
+    fn issue_472_multiple_trailing_hardbreaks_roundtrip() {
+        // Multiple trailing hardBreaks at the end of a listItem paragraph.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Item"},
+                {"type":"hardBreak"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Next"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        // Must remain a single bulletList
+        assert_eq!(rt.content.len(), 1);
+        assert_eq!(rt.content[0].node_type, "bulletList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+
+        // First item should preserve both hardBreaks
+        let p1 = items[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        let types1: Vec<&str> = p1.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(types1, vec!["text", "hardBreak", "hardBreak"]);
+    }
+
+    #[test]
+    fn issue_472_hardbreak_mid_and_trailing_roundtrip() {
+        // A hardBreak in the middle AND at the end of a listItem paragraph.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Line one"},
+                {"type":"hardBreak"},
+                {"type":"text","text":"Line two"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Other item"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        assert_eq!(rt.content.len(), 1);
+        assert_eq!(rt.content[0].node_type, "bulletList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+
+        let p1 = items[0].content.as_ref().unwrap()[0]
+            .content
+            .as_ref()
+            .unwrap();
+        let types1: Vec<&str> = p1.iter().map(|n| n.node_type.as_str()).collect();
+        assert_eq!(types1, vec!["text", "hardBreak", "text", "hardBreak"]);
+        assert_eq!(p1[0].text.as_deref(), Some("Line one"));
+        assert_eq!(p1[2].text.as_deref(), Some("Line two"));
+    }
+
+    #[test]
+    fn issue_472_only_hardbreak_in_listitem_paragraph() {
+        // Edge case: paragraph contains only a hardBreak, no text.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"After"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        // Must remain a single bulletList with 2 items
+        assert_eq!(rt.content.len(), 1);
+        assert_eq!(rt.content[0].node_type, "bulletList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn issue_472_three_items_middle_has_trailing_hardbreak() {
+        // Three-item list where only the middle item has a trailing hardBreak.
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"First"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Second"},
+                {"type":"hardBreak"}
+              ]}
+            ]},
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[
+                {"type":"text","text":"Third"}
+              ]}
+            ]}
+          ]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        assert_eq!(rt.content.len(), 1);
+        assert_eq!(rt.content[0].node_type, "bulletList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(
+            items[0].content.as_ref().unwrap()[0]
+                .content
+                .as_ref()
+                .unwrap()[0]
+                .text
+                .as_deref(),
+            Some("First")
+        );
+        assert_eq!(
+            items[2].content.as_ref().unwrap()[0]
+                .content
+                .as_ref()
+                .unwrap()[0]
+                .text
+                .as_deref(),
+            Some("Third")
+        );
     }
 }


### PR DESCRIPTION
## Description

Fixes issue #472 where a trailing `hardBreak` node at the end of a `listItem` paragraph caused the rendered JFM markdown to include a blank line after the list item marker. This blank line caused the parent list to be split into multiple separate lists when the markdown was re-parsed on round-trip.

The root cause was that `render_inline_content` produces a trailing `\\\n` for each `hardBreak` node. When this appeared as the last inline in a paragraph, the buffer ended with `\n`, and the subsequent `output.push('\n')` call in `render_list_item_content` produced a blank line — the list-splitting sentinel in Markdown parsers.

The fix trims the trailing `\n` from the rendered buffer using `trim_end_matches('\n')` before the continuation-line indentation logic runs. The backslash (`\`) is preserved so that round-trip parsing retains the `hardBreak` node, and the newline terminator is correctly supplied by the existing `output.push('\n')` call below.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #472

## Changes Made

**Core Changes:**
- In `render_list_item_content` (`src/atlassian/convert.rs`): added `trim_end_matches('\n')` call on the inline content buffer before indenting continuation lines, preventing the trailing newline from a `hardBreak` from producing a blank line that splits the list.

**Testing:**
- Added seven regression tests in `src/atlassian/convert.rs` covering all identified scenarios for issue #472:
  1. `issue_472_bullet_list_trailing_hardbreak_roundtrips` — bullet list with trailing `hardBreak` on first item round-trips as a single `bulletList`
  2. `issue_472_ordered_list_trailing_hardbreak_roundtrips` — ordered list variant of the same scenario
  3. `issue_472_trailing_hardbreak_jfm_no_blank_line` — verifies the rendered JFM string contains no blank line between list items (`"- Hello\\\n- World\n"`)
  4. `issue_472_multiple_trailing_hardbreaks_roundtrip` — multiple consecutive trailing `hardBreak` nodes are handled correctly
  5. `issue_472_hardbreak_mid_and_trailing_roundtrip` — mid-paragraph `hardBreak` followed by a trailing `hardBreak` both survive the round-trip
  6. `issue_472_only_hardbreak_in_listitem_paragraph` — edge case where the paragraph contains only a `hardBreak` and no text
  7. `issue_472_three_items_middle_has_trailing_hardbreak` — three-item list where only the middle item has a trailing `hardBreak` remains a single list with all three items

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (7 regression tests for issue #472)

**Manual Testing:**
- [x] Tested happy path scenarios (bullet and ordered lists with trailing `hardBreak`)
- [x] Tested error/edge cases (paragraph with only a `hardBreak`, multiple trailing `hardBreak` nodes, mixed mid + trailing)
- [x] Backward compatibility verified (the `\` continuation character is preserved, so existing round-trips for mid-paragraph `hardBreak` are unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only issue #472 regression tests
cargo test issue_472

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — specifically the interaction between `trim_end_matches('\n')` and the continuation-line indentation loop that follows, ensuring mid-paragraph `hardBreak` newlines are not accidentally stripped
- [x] Backward compatibility — the `\` backslash must be preserved after trimming so that `hardBreak` nodes survive round-trip parsing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a pure bug fix. The rendered markdown output changes only for the specific case of a trailing `hardBreak` in a list item paragraph (the spurious blank line is removed), which restores the correct and previously expected behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Filtering out trailing `hardBreak` nodes before rendering inline content was considered but rejected because it would silently discard ADF structure that the user intentionally authored. The chosen approach preserves the `\` so the node survives a round-trip, and only suppresses the extra newline character that was causing the list split.