### PR TITLE
fix(atlassian): support annotation marks on non-text inline nodes

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -3405,6 +3405,57 @@ fn render_inline_node(node: &AdfNode, output: &mut String, opts: &RenderOptions)
         "hardBreak" => {
             output.push_str("\\\n");
         }
+        other => {
+            // Issue #471: Non-text inline nodes (emoji, status, date, mention, etc.)
+            // may carry annotation marks. Render the node body first, then wrap it
+            // in bracketed-span syntax if annotation marks are present.
+            let mut body = String::new();
+            render_non_text_inline_body(other, node, &mut body, opts);
+
+            let annotations: Vec<&AdfMark> = node
+                .marks
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .filter(|m| m.mark_type == "annotation")
+                .collect();
+
+            if annotations.is_empty() {
+                output.push_str(&body);
+            } else {
+                let mut attr_parts = Vec::new();
+                for ann in &annotations {
+                    if let Some(ref attrs) = ann.attrs {
+                        if let Some(id) = attrs.get("id").and_then(serde_json::Value::as_str) {
+                            let escaped = id.replace('\\', "\\\\").replace('"', "\\\"");
+                            attr_parts.push(format!("annotation-id=\"{escaped}\""));
+                        }
+                        if let Some(at) = attrs
+                            .get("annotationType")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            attr_parts.push(format!("annotation-type={at}"));
+                        }
+                    }
+                }
+                output.push('[');
+                output.push_str(&body);
+                output.push_str("]{");
+                output.push_str(&attr_parts.join(" "));
+                output.push('}');
+            }
+        }
+    }
+}
+
+/// Renders the body of a non-text inline node (without mark wrapping).
+fn render_non_text_inline_body(
+    node_type: &str,
+    node: &AdfNode,
+    output: &mut String,
+    opts: &RenderOptions,
+) {
+    match node_type {
         "inlineCard" => {
             if let Some(ref attrs) = node.attrs {
                 if let Some(url) = attrs.get("url").and_then(serde_json::Value::as_str) {
@@ -6785,6 +6836,240 @@ mod tests {
             2,
             "should have 2 annotation marks, got: {annotations:?}"
         );
+    }
+
+    // ── Issue #471: annotation marks on non-text inline nodes ─────────
+
+    #[test]
+    fn annotation_on_emoji_round_trip() {
+        // Issue #471: annotation mark on emoji node should survive round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"emoji","attrs":{"id":"1f4dd","shortName":":memo:","text":"📝"},"marks":[
+            {"type":"annotation","attrs":{"id":"ccddee11-2233-4455-aabb-ccddee112233","annotationType":"inlineComment"}}
+          ]},
+          {"type":"text","text":" annotated text","marks":[
+            {"type":"annotation","attrs":{"id":"ccddee11-2233-4455-aabb-ccddee112233","annotationType":"inlineComment"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for emoji, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+
+        // Emoji node should retain annotation mark
+        let emoji_node = nodes.iter().find(|n| n.node_type == "emoji").unwrap();
+        let emoji_marks = emoji_node.marks.as_ref().expect("emoji should have marks");
+        assert!(
+            emoji_marks.iter().any(|m| m.mark_type == "annotation"),
+            "emoji should have annotation mark, got: {emoji_marks:?}"
+        );
+        let ann = emoji_marks
+            .iter()
+            .find(|m| m.mark_type == "annotation")
+            .unwrap();
+        assert_eq!(
+            ann.attrs.as_ref().unwrap()["id"],
+            "ccddee11-2233-4455-aabb-ccddee112233"
+        );
+
+        // Text node should also retain annotation mark
+        let text_node = nodes.iter().find(|n| n.node_type == "text").unwrap();
+        let text_marks = text_node.marks.as_ref().expect("text should have marks");
+        assert!(
+            text_marks.iter().any(|m| m.mark_type == "annotation"),
+            "text should have annotation mark"
+        );
+    }
+
+    #[test]
+    fn annotation_on_status_round_trip() {
+        let mut status = AdfNode::status("In Progress", "blue");
+        status.marks = Some(vec![AdfMark::annotation("ann-status-1", "inlineComment")]);
+
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![status])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for status, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let status_node = nodes.iter().find(|n| n.node_type == "status").unwrap();
+        let marks = status_node
+            .marks
+            .as_ref()
+            .expect("status should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "status should have annotation mark, got: {marks:?}"
+        );
+    }
+
+    #[test]
+    fn annotation_on_date_round_trip() {
+        let mut date = AdfNode::date("1704067200000");
+        date.marks = Some(vec![AdfMark::annotation("ann-date-1", "inlineComment")]);
+
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![date])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for date, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let date_node = nodes.iter().find(|n| n.node_type == "date").unwrap();
+        let marks = date_node.marks.as_ref().expect("date should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "date should have annotation mark, got: {marks:?}"
+        );
+    }
+
+    #[test]
+    fn annotation_on_mention_round_trip() {
+        let mut mention = AdfNode::mention("user-123", "@Alice");
+        mention.marks = Some(vec![AdfMark::annotation("ann-mention-1", "inlineComment")]);
+
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![mention])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for mention, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let mention_node = nodes.iter().find(|n| n.node_type == "mention").unwrap();
+        let marks = mention_node
+            .marks
+            .as_ref()
+            .expect("mention should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "mention should have annotation mark, got: {marks:?}"
+        );
+    }
+
+    #[test]
+    fn annotation_on_inline_card_round_trip() {
+        let mut card = AdfNode::inline_card("https://example.com");
+        card.marks = Some(vec![AdfMark::annotation("ann-card-1", "inlineComment")]);
+
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![card])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for inlineCard, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let card_node = nodes.iter().find(|n| n.node_type == "inlineCard").unwrap();
+        let marks = card_node
+            .marks
+            .as_ref()
+            .expect("inlineCard should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "inlineCard should have annotation mark, got: {marks:?}"
+        );
+    }
+
+    #[test]
+    fn annotation_on_placeholder_round_trip() {
+        let mut placeholder = AdfNode::placeholder("Enter text here");
+        placeholder.marks = Some(vec![AdfMark::annotation("ann-ph-1", "inlineComment")]);
+
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![placeholder])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("annotation-id="),
+            "JFM should contain annotation-id for placeholder, got: {md}"
+        );
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let ph_node = nodes.iter().find(|n| n.node_type == "placeholder").unwrap();
+        let marks = ph_node
+            .marks
+            .as_ref()
+            .expect("placeholder should have marks");
+        assert!(
+            marks.iter().any(|m| m.mark_type == "annotation"),
+            "placeholder should have annotation mark, got: {marks:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_annotations_on_emoji_round_trip() {
+        // Multiple annotation marks on a single emoji node
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"emoji","attrs":{"shortName":":fire:","text":"🔥"},"marks":[
+            {"type":"annotation","attrs":{"id":"ann-1","annotationType":"inlineComment"}},
+            {"type":"annotation","attrs":{"id":"ann-2","annotationType":"inlineComment"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let nodes = round_tripped.content[0].content.as_ref().unwrap();
+        let emoji_node = nodes.iter().find(|n| n.node_type == "emoji").unwrap();
+        let marks = emoji_node.marks.as_ref().expect("emoji should have marks");
+        let annotations: Vec<_> = marks
+            .iter()
+            .filter(|m| m.mark_type == "annotation")
+            .collect();
+        assert_eq!(
+            annotations.len(),
+            2,
+            "emoji should have 2 annotation marks, got: {annotations:?}"
+        );
+    }
+
+    #[test]
+    fn emoji_without_annotation_unchanged() {
+        // Ensure emoji nodes without annotation marks are not affected
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::paragraph(vec![AdfNode::emoji(":fire:")])],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        // Should NOT have bracketed span wrapping
+        assert!(
+            !md.contains('['),
+            "emoji without annotation should not be wrapped in brackets, got: {md}"
+        );
+        assert!(md.contains(":fire:"));
     }
 
     // ── Inline directive tests (Tier 4) ───────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes issue #471 where annotation marks on non-text inline ADF nodes (emoji, status, date, mention, inlineCard, placeholder) were silently dropped during ADF-to-markdown conversion. This breakage prevented round-trip fidelity for annotated non-text inline content.

The root cause was that the `render_inline_node` function handled text nodes with annotation marks explicitly, but the catch-all arm for other inline node types had no corresponding annotation-wrapping logic. As a result, annotation marks attached to non-text inline nodes were discarded during conversion to Jira Flavoured Markdown (JFM).

The fix introduces a new `other` match arm in `render_inline_node` that renders the node body first via a new `render_non_text_inline_body` helper, then checks for annotation marks and wraps the output in bracketed-span syntax (`[content]{annotation-id="..." annotation-type=...}`) when annotations are present. Nodes without annotation marks are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #471

## Changes Made

**Core Changes:**
- Added `other` arm to `render_inline_node` in `src/atlassian/convert.rs` that collects annotation marks from non-text inline nodes and wraps the rendered body in bracketed-span syntax when annotations are present
- Extracted `render_non_text_inline_body` helper function to render non-text inline node content separately from mark wrapping, enabling reuse of existing node handlers (inlineCard, emoji, status, date, mention, placeholder, hardBreak, etc.)
- Emits `annotation-id` and `annotation-type` attributes in the bracketed-span for each annotation mark found on the node

**Testing:**
- Added `annotation_on_emoji_round_trip` test verifying full ADF → JFM → ADF round-trip for annotated emoji nodes
- Added `annotation_on_status_round_trip` test for annotated status nodes
- Added `annotation_on_date_round_trip` test for annotated date nodes
- Added `annotation_on_mention_round_trip` test for annotated mention nodes
- Added `annotation_on_inline_card_round_trip` test for annotated inlineCard nodes
- Added `annotation_on_placeholder_round_trip` test for annotated placeholder nodes
- Added `multiple_annotations_on_emoji_round_trip` test verifying multiple annotation marks on a single emoji node are all preserved
- Added `emoji_without_annotation_unchanged` regression test confirming unannotated emoji nodes are not wrapped in brackets

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — 8 new round-trip and regression tests covering all affected node types

**Manual Testing:**
- [x] Tested happy path scenarios (single annotation on each node type)
- [x] Tested edge cases (multiple annotations on one node, unannotated nodes unchanged)
- [x] Backward compatibility verified (existing emoji/status/date/mention/inlineCard/placeholder rendering unchanged when no annotation marks present)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new annotation tests
cargo test annotation_on
cargo test emoji_without_annotation_unchanged
cargo test multiple_annotations_on_emoji

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `other` arm now handles all node types not explicitly matched; confirm that nodes previously handled in that position (inlineCard, hardBreak, etc.) are correctly delegated to `render_non_text_inline_body` and produce identical output to before
- [x] Error handling — attribute extraction uses `.and_then` chains that gracefully skip missing `id`/`annotationType` fields without panicking
- [x] Architecture changes — the extraction of `render_non_text_inline_body` separates body rendering from mark wrapping, which is the key structural change enabling this fix

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix. Nodes without annotation marks produce identical output to before. The `render_non_text_inline_body` helper is a private function extracted from existing logic.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Handling each non-text node type explicitly with duplicated annotation-wrapping logic — rejected in favour of the single `other` arm + helper to avoid code duplication and ensure any future inline node types automatically benefit from annotation support.