### PR TITLE
fix(atlassian): preserve localId on layout columns during ADF/markdown roundtrip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -565,6 +565,7 @@ impl<'a> MarkdownParser<'a> {
         let mut columns = Vec::new();
         let mut current_column_lines: Vec<String> = Vec::new();
         let mut current_width: f64 = 50.0;
+        let mut current_dir_attrs: Option<crate::atlassian::attrs::Attrs> = None;
         let mut in_column = false;
         let mut depth: usize = 0;
 
@@ -579,7 +580,9 @@ impl<'a> MarkdownParser<'a> {
                     if in_column && !current_column_lines.is_empty() {
                         let col_text = current_column_lines.join("\n");
                         let blocks = MarkdownParser::new(&col_text).parse_blocks()?;
-                        columns.push(AdfNode::layout_column(current_width, blocks));
+                        let mut col = AdfNode::layout_column(current_width, blocks);
+                        pass_through_local_id(&current_dir_attrs, &mut col);
+                        columns.push(col);
                         current_column_lines.clear();
                     }
                     current_width = col_d
@@ -588,6 +591,7 @@ impl<'a> MarkdownParser<'a> {
                         .and_then(|a| a.get("width"))
                         .and_then(|w| w.parse::<f64>().ok())
                         .unwrap_or(50.0);
+                    current_dir_attrs = col_d.attrs;
                     in_column = true;
                     i += 1;
                     continue;
@@ -606,8 +610,11 @@ impl<'a> MarkdownParser<'a> {
                 // End of column
                 let col_text = current_column_lines.join("\n");
                 let blocks = MarkdownParser::new(&col_text).parse_blocks()?;
-                columns.push(AdfNode::layout_column(current_width, blocks));
+                let mut col = AdfNode::layout_column(current_width, blocks);
+                pass_through_local_id(&current_dir_attrs, &mut col);
+                columns.push(col);
                 current_column_lines.clear();
+                current_dir_attrs = None;
                 in_column = false;
                 i += 1;
                 continue;
@@ -622,7 +629,9 @@ impl<'a> MarkdownParser<'a> {
         if in_column && !current_column_lines.is_empty() {
             let col_text = current_column_lines.join("\n");
             let blocks = MarkdownParser::new(&col_text).parse_blocks()?;
-            columns.push(AdfNode::layout_column(current_width, blocks));
+            let mut col = AdfNode::layout_column(current_width, blocks);
+            pass_through_local_id(&current_dir_attrs, &mut col);
+            columns.push(col);
         }
 
         Ok(columns)
@@ -2766,7 +2775,11 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
                             .and_then(|a| a.get("width"))
                             .and_then(serde_json::Value::as_f64)
                             .unwrap_or(50.0);
-                        output.push_str(&format!(":::column{{width={width}}}\n"));
+                        let mut parts = vec![format!("width={width}")];
+                        if let Some(ref attrs) = child.attrs {
+                            maybe_push_local_id(attrs, &mut parts, opts);
+                        }
+                        output.push_str(&format!(":::column{{{}}}\n", parts.join(" ")));
                         if let Some(ref col_content) = child.content {
                             render_block_children(col_content, output, opts);
                         }
@@ -5978,6 +5991,122 @@ mod tests {
         assert!(md.contains(":::column{width=50}"));
         assert!(md.contains("Left."));
         assert!(md.contains("Right."));
+    }
+
+    #[test]
+    fn layout_column_localid_roundtrip() {
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "layoutSection",
+                "content": [
+                    {
+                        "type": "layoutColumn",
+                        "attrs": {"width": 50.0, "localId": "aabb112233cc"},
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Left"}]}]
+                    },
+                    {
+                        "type": "layoutColumn",
+                        "attrs": {"width": 50.0, "localId": "ddeeff445566"},
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Right"}]}]
+                    }
+                ]
+            }]
+        }"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("localId=aabb112233cc"),
+            "first column localId should appear in markdown: {md}"
+        );
+        assert!(
+            md.contains("localId=ddeeff445566"),
+            "second column localId should appear in markdown: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let cols = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            cols[0].attrs.as_ref().unwrap()["localId"],
+            "aabb112233cc",
+            "first column localId should round-trip"
+        );
+        assert_eq!(
+            cols[1].attrs.as_ref().unwrap()["localId"],
+            "ddeeff445566",
+            "second column localId should round-trip"
+        );
+    }
+
+    #[test]
+    fn layout_column_without_localid() {
+        let md =
+            "::::layout\n:::column{width=50}\nLeft.\n:::\n:::column{width=50}\nRight.\n:::\n::::";
+        let doc = markdown_to_adf(md).unwrap();
+        let cols = doc.content[0].content.as_ref().unwrap();
+        assert!(
+            cols[0].attrs.as_ref().unwrap().get("localId").is_none(),
+            "column without localId should not gain one"
+        );
+        let md2 = adf_to_markdown(&doc).unwrap();
+        assert!(
+            !md2.contains("localId"),
+            "no localId should appear in output: {md2}"
+        );
+    }
+
+    #[test]
+    fn layout_column_localid_stripped_when_option_set() {
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "layoutSection",
+                "content": [{
+                    "type": "layoutColumn",
+                    "attrs": {"width": 50.0, "localId": "aabb112233cc"},
+                    "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Col"}]}]
+                }]
+            }]
+        }"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let opts = RenderOptions {
+            strip_local_ids: true,
+            ..Default::default()
+        };
+        let md = adf_to_markdown_with_options(&doc, &opts).unwrap();
+        assert!(!md.contains("localId"), "localId should be stripped: {md}");
+    }
+
+    #[test]
+    fn layout_column_localid_flush_previous() {
+        // Columns open without explicit `:::` close → flush-previous path
+        let md = "::::layout\n:::column{width=50 localId=aabb112233cc}\nLeft.\n:::column{width=50 localId=ddeeff445566}\nRight.\n:::\n::::";
+        let doc = markdown_to_adf(md).unwrap();
+        let cols = doc.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            cols[0].attrs.as_ref().unwrap()["localId"],
+            "aabb112233cc",
+            "flush-previous column should preserve localId"
+        );
+        assert_eq!(
+            cols[1].attrs.as_ref().unwrap()["localId"],
+            "ddeeff445566",
+            "second column localId should be preserved"
+        );
+    }
+
+    #[test]
+    fn layout_column_localid_flush_last() {
+        // Layout with no closing fence → column never explicitly closed → flush-last path
+        let md = "::::layout\n:::column{width=50 localId=aabb112233cc}\nOnly column.";
+        let doc = markdown_to_adf(md).unwrap();
+        let cols = doc.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            cols[0].attrs.as_ref().unwrap()["localId"],
+            "aabb112233cc",
+            "flush-last column should preserve localId"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a bug (Issue #474) where `localId` attributes on `layoutColumn` nodes were silently dropped during ADF-to-markdown and markdown-to-ADF conversion. Any Confluence page layout that relied on stable column identifiers (e.g. for cross-referencing or automation) would have those IDs destroyed on a roundtrip, causing data loss.

The root cause was two-fold:
1. The ADF-to-markdown renderer did not emit `localId` as part of the `:::column{...}` directive attribute string.
2. The markdown-to-ADF parser did not thread the parsed directive attributes through to the resulting `AdfNode`, so even if a `localId` was present in the directive it was discarded when constructing the column node.

Both paths are now fixed, and the existing `strip_local_ids` render option correctly suppresses `localId` emission in the markdown output.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #474

## Changes Made

**Core Changes:**
- Added `current_dir_attrs: Option<Attrs>` tracking variable to the layout section parser in `MarkdownParser` so directive attributes survive into column node construction
- In both "new column starts" and "column closes" branches, call `pass_through_local_id(&current_dir_attrs, &mut col)` before pushing the column node, copying any `localId` from the directive onto the `AdfNode`
- Reset `current_dir_attrs` to `None` after each column is closed to prevent stale attribute leakage into subsequent columns
- Extended the ADF-to-markdown renderer (`render_block_node`) to build a `parts` vector for `:::column{...}` attributes and call `maybe_push_local_id` so `localId` is included in the directive string when present and `strip_local_ids` is not set

**Testing:**
- Added `layout_column_localid_roundtrip` test: verifies that two columns each carrying distinct `localId` values survive a full ADF → markdown → ADF roundtrip with the IDs intact
- Added `layout_column_without_localid` test: verifies that columns which originally have no `localId` do not gain a spurious one after conversion in either direction
- Added `layout_column_localid_stripped_when_option_set` test: verifies that `localId` is absent from rendered markdown when `RenderOptions { strip_local_ids: true }` is used

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (columns with localId roundtrip correctly)
- [x] Tested edge cases (columns without localId, strip_local_ids option)
- [x] Backward compatibility verified (no changes to columns that never had localId)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new layout column tests
cargo test layout_column_localid
cargo test layout_column_without_localid

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the three column-close paths (new column starts, explicit `:::` close, and end-of-input fallthrough) all need to apply `pass_through_local_id` consistently; verify all three are covered
- [x] Backward compatibility — columns without a `localId` must remain unaffected in both directions

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a pure bug fix — previously lost `localId` values are now preserved. Consumers that were already working around the data loss may see IDs reappear, but this is the correct and expected behaviour.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Storing only the raw `localId` string rather than the full `Attrs` map — rejected in favour of threading the full `Attrs` through `pass_through_local_id` (the existing helper) to stay consistent with how other node types handle this and to make future attribute additions trivial.