### PR TITLE
fix(atlassian): preserve parameters block in bodiedExtension round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -545,6 +545,13 @@ impl<'a> MarkdownParser<'a> {
                     if let Some(local_id) = dir_attrs.get("localId") {
                         node_attrs["localId"] = serde_json::Value::String(local_id.to_string());
                     }
+                    if let Some(params_str) = dir_attrs.get("params") {
+                        if let Ok(params_val) =
+                            serde_json::from_str::<serde_json::Value>(params_str)
+                        {
+                            node_attrs["parameters"] = params_val;
+                        }
+                    }
                 }
                 node
             }
@@ -2792,6 +2799,11 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
                 let mut attr_parts = vec![format!("type={ext_type}"), format!("key={ext_key}")];
                 if let Some(layout) = attrs.get("layout").and_then(serde_json::Value::as_str) {
                     attr_parts.push(format!("layout={layout}"));
+                }
+                if let Some(params) = attrs.get("parameters") {
+                    if let Ok(json_str) = serde_json::to_string(params) {
+                        attr_parts.push(format!("params='{json_str}'"));
+                    }
                 }
                 maybe_push_local_id(attrs, &mut attr_parts, opts);
                 output.push_str(&format!(":::extension{{{}}}\n", attr_parts.join(" ")));
@@ -9099,6 +9111,41 @@ mod tests {
         let round_tripped = markdown_to_adf(&md).unwrap();
         let attrs = round_tripped.content[0].attrs.as_ref().unwrap();
         assert_eq!(attrs["layout"], "wide", "layout should be preserved");
+    }
+
+    #[test]
+    fn bodied_extension_parameters_preserved_in_roundtrip() {
+        // Issue #473: parameters block inside bodiedExtension.attrs was dropped
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+          {"type":"bodiedExtension","attrs":{"extensionType":"com.atlassian.confluence.macro.core","extensionKey":"details","layout":"default","localId":"aabbccdd-1234","parameters":{"macroMetadata":{"macroId":{"value":"bbccddee-2345"},"schemaVersion":{"value":"1"},"title":"Page Properties"},"macroParams":{}}},
+           "content":[{"type":"paragraph","content":[{"type":"text","text":"Content inside bodied extension"}]}]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("params="),
+            "JFM should contain params attribute, got: {md}"
+        );
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let attrs = round_tripped.content[0].attrs.as_ref().unwrap();
+        assert_eq!(
+            attrs["parameters"]["macroMetadata"]["title"], "Page Properties",
+            "parameters should be preserved in round-trip"
+        );
+        assert_eq!(attrs["extensionKey"], "details");
+        assert_eq!(attrs["layout"], "default");
+        assert_eq!(attrs["localId"], "aabbccdd-1234");
+    }
+
+    #[test]
+    fn bodied_extension_malformed_params_ignored() {
+        // Malformed params JSON should be silently ignored, not crash
+        let md = ":::extension{type=com.atlassian.macro key=details params='not-valid-json'}\nContent\n:::\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let attrs = doc.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["extensionKey"], "details");
+        // parameters should be absent since the JSON was invalid
+        assert!(attrs.get("parameters").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #473 where the `parameters` attribute inside `bodiedExtension` nodes was silently dropped during ADF-to-markdown-to-ADF round-trips. When a `bodiedExtension` node with a `parameters` block (e.g., macro metadata for Confluence macros like "Page Properties") was converted to markdown and back to ADF, the `parameters` attribute was lost entirely.

The fix serializes `parameters` as a JSON string into a `params='...'` attribute in the fenced extension directive during ADF-to-markdown rendering, and deserializes it back into a structured JSON value during markdown-to-ADF parsing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #473

## Changes Made

**Core Changes:**
- In `render_block_node()` (`src/atlassian/convert.rs`): serialize `parameters` from `bodiedExtension` attrs as a JSON string and emit it as a `params='...'` attribute in the fenced extension directive during ADF-to-markdown rendering
- In `MarkdownParser` (`src/atlassian/convert.rs`): deserialize the `params` attribute back into a structured `serde_json::Value` and restore it as `parameters` in the node attrs during markdown-to-ADF parsing

**Testing:**
- Added regression test `bodied_extension_parameters_preserved_in_roundtrip` that verifies the full ADF→markdown→ADF round-trip preserves nested parameter values including `macroMetadata.title`, `extensionKey`, `layout`, and `localId`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

**Test Coverage:**
- New regression test covers the full round-trip for `bodiedExtension` nodes with `parameters`, verifying nested JSON structure is preserved end-to-end

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test bodied_extension_parameters_preserved_in_roundtrip

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `params` deserialization is silently skipped if the JSON string is malformed, which is intentional to avoid crashing on unexpected input
- [x] Backward compatibility — existing markdown documents without `params=` are unaffected; the parser only populates `parameters` when the attribute is present

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix: ADF documents that previously had `parameters` silently dropped will now correctly round-trip. Existing markdown documents without `params=` are parsed identically to before.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Encoding `parameters` as a separate YAML/TOML block inside the fenced directive was considered but rejected in favour of inline JSON string to keep the attribute format consistent with other `bodiedExtension` attributes and minimize parser complexity.