### PR TITLE
fix(atlassian): prevent bare URLs from becoming inlineCard nodes on round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1208,6 +1208,25 @@ fn escape_backticks(text: &str) -> String {
     out
 }
 
+/// Escapes bare URLs (`http://` and `https://`) in plain text so they are not
+/// parsed as `inlineCard` nodes during round-trip.  The leading `h` is
+/// backslash-escaped, which is enough to prevent the auto-link detector from
+/// matching the URL while the existing backslash-escape handler restores it on
+/// re-parse.
+fn escape_bare_urls(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    for (i, ch) in text.char_indices() {
+        if ch == 'h' {
+            let rest = &text[i..];
+            if rest.starts_with("http://") || rest.starts_with("https://") {
+                result.push('\\');
+            }
+        }
+        result.push(ch);
+    }
+    result
+}
+
 /// Escapes emoji shortcode patterns (`:name:`) in plain text so they are not
 /// parsed as emoji nodes during round-trip.  Only the leading colon is
 /// backslash-escaped, which is enough to prevent the parser from matching the
@@ -3650,6 +3669,11 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
     let escaped = escape_emphasis_markers(text);
     let escaped = escape_emoji_shortcodes(&escaped);
     let escaped = escape_backticks(&escaped);
+    let escaped = if has_link.is_none() {
+        escape_bare_urls(&escaped)
+    } else {
+        escaped
+    };
     inner.push_str(&escaped);
     if inner_em {
         inner.push('*');
@@ -4871,6 +4895,27 @@ mod tests {
     }
 
     #[test]
+    fn escape_bare_urls_unit() {
+        assert_eq!(escape_bare_urls("hello"), "hello");
+        assert_eq!(escape_bare_urls(""), "");
+        assert_eq!(
+            escape_bare_urls("https://example.com"),
+            r"\https://example.com"
+        );
+        assert_eq!(
+            escape_bare_urls("http://example.com"),
+            r"\http://example.com"
+        );
+        assert_eq!(
+            escape_bare_urls("see https://a.com and https://b.com"),
+            r"see \https://a.com and \https://b.com"
+        );
+        // "http" without "://" is not a URL scheme — leave untouched
+        assert_eq!(escape_bare_urls("http header"), "http header");
+        assert_eq!(escape_bare_urls("https is secure"), "https is secure");
+    }
+
+    #[test]
     fn heading_not_valid_without_space() {
         // "#Title" without space should be a paragraph, not heading
         let doc = markdown_to_adf("#Title").unwrap();
@@ -5958,6 +6003,163 @@ mod tests {
         let doc = markdown_to_adf("Visit https://example.com/path today").unwrap();
         let md = adf_to_markdown(&doc).unwrap();
         assert!(md.contains(":card[https://example.com/path]"));
+    }
+
+    // ── Issue #475: plain-text URL must not become inlineCard ─────────
+
+    #[test]
+    fn plain_text_url_round_trips_as_text() {
+        // A text node whose content is a bare URL (no link mark) must
+        // survive ADF→JFM→ADF as a text node, not an inlineCard.
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "https://example.com/some/path/to/resource"}
+                ]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should be a single node");
+        assert_eq!(content[0].node_type, "text");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("https://example.com/some/path/to/resource")
+        );
+    }
+
+    #[test]
+    fn plain_text_url_amid_text_round_trips() {
+        // URL embedded in surrounding text, without link mark.
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "see https://example.com for info"}
+                ]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0].node_type, "text");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("see https://example.com for info")
+        );
+    }
+
+    #[test]
+    fn plain_text_multiple_urls_round_trips() {
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "http://a.com and https://b.com"}
+                ]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0].node_type, "text");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("http://a.com and https://b.com")
+        );
+    }
+
+    #[test]
+    fn plain_text_http_prefix_no_url_unchanged() {
+        // "http" without "://" should not be escaped or altered.
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "the http header is important"}
+                ]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("the http header is important")
+        );
+    }
+
+    #[test]
+    fn linked_url_text_not_double_escaped() {
+        // A text node with a link mark should render as [text](url),
+        // not escape the URL in the link text.
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [{
+                    "type": "text",
+                    "text": "https://example.com",
+                    "marks": [{"type": "link", "attrs": {"href": "https://example.com"}}]
+                }]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        // Should render as a self-link, not as escaped text
+        assert!(!jfm.contains(r"\https"));
+        // Round-trip should preserve the link mark
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        let has_link = content.iter().any(|n| {
+            n.marks
+                .as_ref()
+                .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "link"))
+        });
+        assert!(has_link, "link mark should be preserved");
+    }
+
+    #[test]
+    fn inline_card_still_round_trips() {
+        // An actual inlineCard node should still round-trip correctly
+        // (it uses :card[url] syntax, not bare URL).
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [
+                    {"type": "inlineCard", "attrs": {"url": "https://example.com/page"}}
+                ]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        assert!(jfm.contains(":card[https://example.com/page]"));
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content[0].node_type, "inlineCard");
+        assert_eq!(
+            content[0].attrs.as_ref().unwrap()["url"],
+            "https://example.com/page"
+        );
     }
 
     // ── Block-level attribute marks (Tier 5/6) ───────────────────────


### PR DESCRIPTION
## Description

This PR fixes a bug (#475) where plain-text nodes containing bare `http://` or `https://` URLs were incorrectly converted to `inlineCard` nodes during ADF→JFM→ADF round-trip conversion. When Atlassian Document Format (ADF) content containing a plain text URL (without a link mark) was converted to Jira-Flavored Markdown and then back to ADF, the auto-link detector would transform the URL into an `inlineCard` node rather than preserving it as a plain text node.

The fix introduces an `escape_bare_urls` function that backslash-escapes the leading `h` of `http://` and `https://` URLs in plain text nodes. This prevents the auto-link detector from treating them as links during re-parsing, while the existing backslash-escape handler correctly restores the original text on re-parse. The escape is only applied when the text node has no link mark, ensuring that proper `[text](url)` Markdown links continue to render correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #475

## Changes Made

**Core Changes:**
- Added `escape_bare_urls` helper function in `src/atlassian/convert.rs` that backslash-escapes the leading `h` of any `http://` or `https://` URL sequences in plain text
- Applied `escape_bare_urls` in `render_marked_text` conditional on the absence of a link mark (`has_link.is_none()`), so only unlinked plain text is escaped and proper Markdown links are unaffected
- The escape is correctly positioned after the existing `escape_backticks` step in the escaping pipeline

**Testing:**
- Added `escape_bare_urls_unit` unit test covering: plain text without URLs, empty string, standalone `https://` URL, standalone `http://` URL, multiple embedded URLs, and `http`/`https` prefixes without `://` (which must not be escaped)
- Added `plain_text_url_round_trips_as_text` integration test verifying a bare URL text node survives ADF→JFM→ADF as a `text` node
- Added `plain_text_url_amid_text_round_trips` integration test verifying a URL embedded in surrounding text survives round-trip
- Added `plain_text_multiple_urls_round_trips` integration test verifying multiple bare URLs in one text node all survive round-trip
- Added `plain_text_http_prefix_no_url_unchanged` integration test verifying that `http` without `://` is not altered during round-trip
- Added `linked_url_text_not_double_escaped` integration test verifying that a text node with a link mark is not escaped and its link mark is preserved after round-trip
- Added `inline_card_still_round_trips` integration test verifying that actual `inlineCard` ADF nodes continue to round-trip correctly via `:card[url]` syntax

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (bare URL in plain text node round-trips correctly)
- [x] Tested error/edge cases (non-URL `http` prefix, multiple URLs, URL with link mark)
- [x] Backward compatibility verified (inlineCard nodes still work correctly)

### Test Commands
```bash
# Core test suite
cargo test

# Run specific tests for this fix
cargo test atlassian::convert::tests::escape_bare_urls_unit
cargo test atlassian::convert::tests::plain_text_url_round_trips_as_text
cargo test atlassian::convert::tests::plain_text_url_amid_text_round_trips
cargo test atlassian::convert::tests::plain_text_multiple_urls_round_trips
cargo test atlassian::convert::tests::plain_text_http_prefix_no_url_unchanged
cargo test atlassian::convert::tests::linked_url_text_not_double_escaped
cargo test atlassian::convert::tests::inline_card_still_round_trips

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `inlineCard` nodes must continue to round-trip via `:card[url]` syntax; the fix only affects unlinked plain text nodes
- [x] The condition `has_link.is_none()` in `render_marked_text` — this ensures we do not escape URLs that are the display text of an actual Markdown link

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a non-breaking bug fix. The escaping is transparent to consumers of the API — the round-tripped ADF output preserves the original plain text content, which is the correct and expected behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Implementation Details:**
- The `escape_bare_urls` function iterates character-by-character and inserts a backslash before `h` only when followed by `ttp://` or `ttps://`, which avoids false positives on words like `http header`
- The escape mechanism leverages the existing backslash-escape handler that already runs during JFM re-parsing, so no new parsing logic was required

**Alternatives Considered:**
- Escaping only the `://` portion — rejected because the auto-link detector matches from the `h` character
- Using a regex-based replacement — not used in favour of a simple linear scan consistent with the existing escaping helpers in the file