### PR TITLE
fix(atlassian): preserve paragraph wrapper inside taskItem on ADF-markdown round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -263,9 +263,21 @@ impl<'a> MarkdownParser<'a> {
             // Detect task list items: - [ ] or - [x]
             if let Some((state, text)) = try_parse_task_marker(after_marker) {
                 is_task_list = true;
-                let (item_text, local_id, _para_local_id) = extract_trailing_local_id(text);
+                let (item_text, local_id, para_local_id) = extract_trailing_local_id(text);
                 let inline_nodes = parse_inline(item_text);
-                let mut task = AdfNode::task_item(state, inline_nodes);
+                // If a paraLocalId marker is present the original ADF had a
+                // paragraph wrapper around the inline content — restore it
+                // so the round-trip is lossless (issue #478).
+                let content = if let Some(ref plid) = para_local_id {
+                    let mut para = AdfNode::paragraph(inline_nodes);
+                    if plid != "_" {
+                        para.attrs = Some(serde_json::json!({"localId": plid}));
+                    }
+                    vec![para]
+                } else {
+                    inline_nodes
+                };
+                let mut task = AdfNode::task_item(state, content);
                 // Override the placeholder localId if one was parsed
                 if let Some(id) = local_id {
                     if let Some(ref mut attrs) = task.attrs {
@@ -3018,11 +3030,20 @@ fn emit_list_item_local_ids(
     if let Some(ref attrs) = item.attrs {
         maybe_push_local_id(attrs, &mut parts, opts);
     }
-    if let Some(ref attrs) = paragraph.attrs {
-        if let Some(local_id) = attrs.get("localId").and_then(serde_json::Value::as_str) {
-            if !local_id.is_empty() && local_id != "00000000-0000-0000-0000-000000000000" {
-                parts.push(format!("paraLocalId={local_id}"));
-            }
+    if paragraph.node_type == "paragraph" {
+        let has_real_id = paragraph
+            .attrs
+            .as_ref()
+            .and_then(|a| a.get("localId"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty() && *id != "00000000-0000-0000-0000-000000000000");
+        if let Some(local_id) = has_real_id {
+            parts.push(format!("paraLocalId={local_id}"));
+        } else if item.node_type == "taskItem" {
+            // taskItem content may or may not have a paragraph wrapper;
+            // emit a sentinel so the round-trip can distinguish the two
+            // forms and restore the wrapper (issue #478).
+            parts.push("paraLocalId=_".to_string());
         }
     }
     if !parts.is_empty() {
@@ -8219,6 +8240,150 @@ mod tests {
             rt.content[0].attrs.as_ref().unwrap()["localId"],
             "tl-xyz",
             "taskList localId should survive round-trip"
+        );
+    }
+
+    /// Issue #478: taskItem with paragraph wrapper (no localId) preserves wrapper on round-trip.
+    #[test]
+    fn task_item_paragraph_wrapper_roundtrip_no_localid() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"paragraph","content":[{"type":"text","text":"A task with paragraph wrapper"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("paraLocalId=_"),
+            "should emit paraLocalId=_ sentinel: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let content = item.content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should have one child: {content:#?}");
+        assert_eq!(
+            content[0].node_type, "paragraph",
+            "child should be a paragraph: {content:#?}"
+        );
+        let para_content = content[0].content.as_ref().unwrap();
+        assert_eq!(
+            para_content[0].text.as_deref(),
+            Some("A task with paragraph wrapper")
+        );
+        // Paragraph should have no attrs (localId was absent in the original)
+        assert!(
+            content[0].attrs.is_none(),
+            "paragraph should have no attrs: {:?}",
+            content[0].attrs
+        );
+    }
+
+    /// Issue #478: taskItem with paragraph wrapper AND paraLocalId preserves both.
+    #[test]
+    fn task_item_paragraph_wrapper_roundtrip_with_localid() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"paragraph","attrs":{"localId":"p-001"},"content":[{"type":"text","text":"task with para id"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("paraLocalId=p-001"),
+            "should emit paraLocalId=p-001: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let content = item.content.as_ref().unwrap();
+        assert_eq!(content[0].node_type, "paragraph");
+        assert_eq!(
+            content[0].attrs.as_ref().unwrap()["localId"],
+            "p-001",
+            "paragraph localId should be preserved"
+        );
+    }
+
+    /// Issue #478: taskItem WITHOUT paragraph wrapper (unwrapped inline) still round-trips correctly.
+    #[test]
+    fn task_item_unwrapped_inline_no_paragraph_on_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"text","text":"unwrapped task"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            !md.contains("paraLocalId"),
+            "should NOT emit paraLocalId for unwrapped inline: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let content = item.content.as_ref().unwrap();
+        assert_eq!(
+            content[0].node_type, "text",
+            "should remain unwrapped: {content:#?}"
+        );
+    }
+
+    /// Issue #478: DONE taskItem with paragraph wrapper round-trips.
+    #[test]
+    fn task_item_done_paragraph_wrapper_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"DONE"},"content":[{"type":"paragraph","content":[{"type":"text","text":"completed task"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("- [x]"), "should render as done: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(item.attrs.as_ref().unwrap()["state"], "DONE");
+        let content = item.content.as_ref().unwrap();
+        assert_eq!(content[0].node_type, "paragraph");
+    }
+
+    /// Issue #478: mixed taskItems — some with paragraph wrapper, some without.
+    #[test]
+    fn task_item_mixed_paragraph_and_unwrapped_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"paragraph","content":[{"type":"text","text":"wrapped"}]}]},{"type":"taskItem","attrs":{"localId":"ti-002","state":"DONE"},"content":[{"type":"text","text":"unwrapped"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+        // First item: paragraph wrapper preserved
+        let c1 = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            c1[0].node_type, "paragraph",
+            "first item should have paragraph wrapper"
+        );
+        // Second item: no paragraph wrapper
+        let c2 = items[1].content.as_ref().unwrap();
+        assert_eq!(
+            c2[0].node_type, "text",
+            "second item should remain unwrapped"
+        );
+    }
+
+    /// Issue #478: taskItem with paragraph wrapper containing marks round-trips.
+    #[test]
+    fn task_item_paragraph_wrapper_with_marks_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"paragraph","content":[{"type":"text","text":"bold "},{"type":"text","text":"text","marks":[{"type":"strong"}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let content = item.content.as_ref().unwrap();
+        assert_eq!(content[0].node_type, "paragraph");
+        let para_children = content[0].content.as_ref().unwrap();
+        assert!(
+            para_children.len() >= 2,
+            "paragraph should contain multiple inline nodes"
+        );
+    }
+
+    /// Issue #478: strip_local_ids suppresses the paraLocalId=_ sentinel too.
+    #[test]
+    fn task_item_paragraph_wrapper_stripped_with_option() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":"tl-001"},"content":[{"type":"taskItem","attrs":{"localId":"ti-001","state":"TODO"},"content":[{"type":"paragraph","content":[{"type":"text","text":"task"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let opts = RenderOptions {
+            strip_local_ids: true,
+        };
+        let md = adf_to_markdown_with_options(&doc, &opts).unwrap();
+        assert!(
+            !md.contains("paraLocalId"),
+            "paraLocalId should be stripped: {md}"
+        );
+        assert!(
+            !md.contains("localId"),
+            "all localIds should be stripped: {md}"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes issue #478 where a `taskItem` whose ADF content was wrapped in a `paragraph` node lost that wrapper after a round-trip through markdown. The `paragraph` wrapper is structurally significant in ADF and must be preserved to maintain a lossless ADF↔markdown conversion.

The root cause was that the ADF-to-markdown emitter discarded information about whether a `taskItem`'s inline content was wrapped in a `paragraph` node. On the markdown-to-ADF path, there was no signal to reconstruct that wrapper.

The fix introduces a sentinel marker `paraLocalId=_` emitted during ADF-to-markdown conversion whenever a `taskItem` contains a `paragraph` wrapper without a real `localId`. On the markdown-to-ADF path, the presence of any `paraLocalId` marker (either a real UUID or the sentinel `_`) signals that a `paragraph` node should be reconstructed around the inline content.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #478

## Changes Made

**Core Changes:**
- Modified `emit_list_item_local_ids` in `src/atlassian/convert.rs` to emit a `paraLocalId=_` sentinel when a `taskItem` contains a `paragraph` wrapper that has no meaningful `localId` (i.e., absent or the null UUID). Previously, only paragraphs with real `localId` values emitted a `paraLocalId=` marker, leaving no trace of the wrapper when no `localId` was present.
- Updated the `MarkdownParser` task item parsing path to read the `para_local_id` field (previously discarded with `_para_local_id`). When a `paraLocalId` marker is present, the inline nodes are wrapped in a reconstructed `paragraph` node. The `localId` attribute is set on the paragraph only when the value is not the sentinel `_`.

**Testing:**
- Added seven regression tests in `src/atlassian/convert.rs` covering all relevant round-trip scenarios for issue #478.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

Seven new regression tests were added:

1. `task_item_paragraph_wrapper_roundtrip_no_localid` — `taskItem` with paragraph wrapper (no `localId`) preserves wrapper on round-trip; paragraph has no attrs.
2. `task_item_paragraph_wrapper_roundtrip_with_localid` — `taskItem` with paragraph wrapper AND a real `paraLocalId` preserves both the wrapper and the `localId`.
3. `task_item_unwrapped_inline_no_paragraph_on_roundtrip` — `taskItem` with unwrapped inline content (no paragraph) does NOT emit `paraLocalId` and round-trips without a paragraph wrapper.
4. `task_item_done_paragraph_wrapper_roundtrip` — DONE-state `taskItem` with paragraph wrapper round-trips correctly.
5. `task_item_mixed_paragraph_and_unwrapped_roundtrip` — Mixed `taskList` with one wrapped and one unwrapped item both round-trip to their respective forms.
6. `task_item_paragraph_wrapper_with_marks_roundtrip` — `taskItem` paragraph wrapper containing multiple inline nodes (including marks) round-trips correctly.
7. `task_item_paragraph_wrapper_stripped_with_option` — `strip_local_ids: true` suppresses the `paraLocalId=_` sentinel as expected.

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test task_item_paragraph_wrapper
cargo test task_item_unwrapped_inline
cargo test task_item_done_paragraph
cargo test task_item_mixed_paragraph
cargo test task_item_paragraph_wrapper_stripped_with_option

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the sentinel `paraLocalId=_` is a new token in the markdown intermediate representation. Existing markdown that was produced before this fix will not contain this token, so those `taskItem`s will continue to parse as unwrapped inline content (no regression for pre-existing data).
- [x] Error handling — the sentinel value `_` is explicitly chosen to be invalid as a real UUID, making it safe to use as a signal without colliding with user data.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Storing paragraph-wrapper presence as a separate boolean marker (e.g., `hasParagraph`) was considered but `paraLocalId=_` was preferred because it unifies the two cases (with/without `localId`) into a single marker, keeping the existing parsing logic minimal.
- Storing the full paragraph node structure in a dedicated markdown comment was rejected as it would break the human-readability goal of the intermediate markdown format.