### PR TITLE
fix(atlassian): escape literal backslashes in ADF-to-markdown rendering

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1715,14 +1715,11 @@ fn parse_inline(text: &str) -> Vec<AdfNode> {
                 chars.next(); // consume the 'n'
                 plain_start = chars.peek().map_or(text.len(), |&(idx, _)| idx);
             }
-            '\\' if i + 1 < text.len()
-                && !text[i..].starts_with("\\\n")
-                && text.as_bytes()[i + 1] != b'\\' =>
-            {
+            '\\' if i + 1 < text.len() && !text[i..].starts_with("\\\n") => {
                 // Backslash escape: skip the backslash and treat the next
-                // character as literal text (e.g. `2\. text` → `2. text`,
-                // `\*word\*` → `*word*` without emphasis,
-                // `\:fire:` → `:fire:` without emoji parsing).
+                // character as literal text (e.g. `\\` → `\`,
+                // `2\. text` → `2. text`, `\*word\*` → `*word*` without
+                // emphasis, `\:fire:` → `:fire:` without emoji parsing).
                 flush_plain(text, plain_start, i, &mut nodes);
                 chars.next(); // consume the backslash
                               // Set plain_start to the escaped character so it is included
@@ -3521,6 +3518,18 @@ fn render_inline_node(node: &AdfNode, output: &mut String, opts: &RenderOptions)
         "text" => {
             let text = node.text.as_deref().unwrap_or("");
             let marks = node.marks.as_deref().unwrap_or(&[]);
+            let has_code = marks.iter().any(|m| m.mark_type == "code");
+            // Issue #477: Escape literal backslashes before the newline
+            // encoding below so they are not consumed as JFM escape
+            // sequences on round-trip.  Code marks emit content verbatim,
+            // so backslash escaping is skipped for them.
+            let owned;
+            let text = if !has_code {
+                owned = text.replace('\\', "\\\\");
+                owned.as_str()
+            } else {
+                text
+            };
             // Issue #454: A literal newline inside a text node is escaped
             // as the two-character sequence `\n` so it survives round-trip
             // as a single text node instead of splitting into paragraphs or
@@ -5033,6 +5042,137 @@ mod tests {
         assert_eq!(escape_backticks("a ` b"), r"a \` b");
         assert_eq!(escape_backticks(""), "");
         assert_eq!(escape_backticks("`a` and `b`"), r"\`a\` and \`b\`");
+    }
+
+    // ── Issue #477: backslash escaping ──────────────────────────────
+
+    #[test]
+    fn backslash_in_text_roundtrip() {
+        // The original reproducer from issue #477
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"The path is C:\\Users\\admin\\file.txt"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should round-trip as a single text node");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some(r"The path is C:\Users\admin\file.txt")
+        );
+    }
+
+    #[test]
+    fn backslash_emitted_as_double_backslash() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a\\b"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        assert!(
+            jfm.contains(r"a\\b"),
+            "JFM should contain escaped backslash: {jfm}"
+        );
+    }
+
+    #[test]
+    fn consecutive_backslashes_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a\\\\b"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some(r"a\\b"),
+            "consecutive backslashes should survive round-trip"
+        );
+    }
+
+    #[test]
+    fn backslash_with_strong_mark_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"C:\\Users","marks":[{"type":"strong"}]}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        let strong_node = content.iter().find(|n| {
+            n.marks
+                .as_ref()
+                .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "strong"))
+        });
+        assert!(strong_node.is_some(), "should have a strong-marked node");
+        assert_eq!(strong_node.unwrap().text.as_deref(), Some(r"C:\Users"));
+    }
+
+    #[test]
+    fn backslash_with_code_mark_not_escaped() {
+        // Code marks emit content verbatim — backslashes should NOT be escaped
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"C:\\Users","marks":[{"type":"code"}]}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        assert_eq!(jfm.trim(), r"`C:\Users`");
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        let code_node = content.iter().find(|n| {
+            n.marks
+                .as_ref()
+                .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "code"))
+        });
+        assert!(code_node.is_some(), "should have a code-marked node");
+        assert_eq!(code_node.unwrap().text.as_deref(), Some(r"C:\Users"));
+    }
+
+    #[test]
+    fn backslash_before_special_chars_roundtrip() {
+        // Backslash before characters that are themselves escaped (* ` :)
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"\\*not bold\\*"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some(r"\*not bold\*"),
+            "backslash before special char should survive round-trip"
+        );
+    }
+
+    #[test]
+    fn backslash_and_newline_in_text_roundtrip() {
+        // Text with both backslashes and embedded newlines
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"C:\\path\nline2"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("C:\\path\nline2"),
+            "backslash and newline should both survive round-trip"
+        );
+    }
+
+    #[test]
+    fn lone_backslash_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a \\ b"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content[0].text.as_deref(), Some(r"a \ b"));
+    }
+
+    #[test]
+    fn trailing_backslash_in_text_roundtrip() {
+        // A trailing backslash in text content (not a hardBreak) should round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"end\\"}]}]}"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some(r"end\"),
+            "trailing backslash should survive round-trip"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #477 where backslashes in ADF (Atlassian Document Format) text nodes were silently dropped during round-trip conversion through JFM (Jira Flavoured Markdown). The root cause was a two-part bug: during rendering, backslashes were emitted as-is into JFM output, but during parsing, a guard condition prevented `\\` from being treated as an escaped backslash. Together, these meant a single `\` in ADF text became nothing after a round-trip.

A practical example: a Windows path like `C:\Users\admin\file.txt` stored in ADF would be silently corrupted to `C:Usersadminfile.txt` after any edit-and-save cycle through a Jira editor.

The fix escapes `\` as `\\` during ADF-to-JFM rendering (skipping code-marked nodes which emit content verbatim inside backtick spans), and removes the `text.as_bytes()[i + 1] != b'\\'` guard from the JFM parser so that `\\` is correctly decoded back to a single `\`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #477

## Changes Made

**Core Changes:**
- In `render_inline_node` (`src/atlassian/convert.rs`): escape `\` as `\\` for plain text nodes before emitting JFM, so backslashes survive the ADF → JFM direction of the round-trip
- Skip backslash escaping for nodes with a `code` mark, since code spans emit content verbatim inside backticks and double-escaping would corrupt them
- In `parse_inline` (`src/atlassian/convert.rs`): remove the `text.as_bytes()[i + 1] != b'\\'` guard so that `\\` in JFM is correctly decoded as a single literal `\` (restoring the JFM → ADF direction)

**Testing:**
- Added 9 regression tests in `src/atlassian/convert.rs` covering all identified edge cases for issue #477

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios (Windows-style paths with multiple backslashes)
- [x] Tested error/edge cases (lone backslash, trailing backslash, consecutive backslashes)
- [x] Backward compatibility verified (code marks, strong marks, special characters, embedded newlines all continue to work)

**New regression tests added:**
- `backslash_in_text_roundtrip` — Windows path `C:\Users\admin\file.txt` survives ADF → JFM → ADF round-trip
- `backslash_emitted_as_double_backslash` — verifies JFM output contains `\\` for a single backslash in ADF
- `consecutive_backslashes_roundtrip` — `a\\b` (two backslashes) round-trips correctly
- `backslash_with_strong_mark_roundtrip` — backslash inside bold text survives round-trip
- `backslash_with_code_mark_not_escaped` — code-marked text with backslash is emitted as `` `C:\Users` `` without double-escaping
- `backslash_before_special_chars_roundtrip` — `\*not bold\*` round-trips with backslashes intact
- `backslash_and_newline_in_text_roundtrip` — text containing both `\` and embedded newline survives round-trip
- `lone_backslash_roundtrip` — `a \ b` round-trips correctly
- `trailing_backslash_in_text_roundtrip` — trailing backslash at end of text node survives round-trip

### Test Commands
```bash
# Core test suite
cargo test

# Run only the issue #477 regression tests
cargo test backslash

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the parser change (removing the `!= b'\\'` guard) affects how `\\` sequences are parsed; this is intentional and all existing tests pass
- [x] Error handling — the code mark exemption logic ensures code spans are not double-escaped

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The fix restores correct round-trip behaviour that was previously broken. Any content that relied on the broken behaviour (i.e., deliberately relying on backslashes being stripped) would be affected, but this was never a documented or intended behaviour.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Escaping only specific backslash sequences (e.g., only before characters with special meaning in JFM) was considered but rejected in favour of the simpler and more correct approach of escaping all backslashes uniformly, since JFM backslash escaping applies to any character.