### PR TITLE
feat(atlassian,cli): implement jira dev-status command

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -3,6 +3,7 @@
 //! Provides HTTP access to JIRA Cloud REST API v3 for reading and
 //! writing issues. Uses Basic Auth (email + API token).
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -299,6 +300,123 @@ pub struct JiraTransition {
     pub id: String,
     /// Transition name (e.g., "In Progress", "Done").
     pub name: String,
+}
+
+/// A pull request from Jira's DevStatus API.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevPullRequest {
+    /// PR identifier (e.g., "#2174").
+    pub id: String,
+    /// PR title.
+    pub name: String,
+    /// Status (e.g., "OPEN", "MERGED", "DECLINED").
+    pub status: String,
+    /// URL to the pull request.
+    pub url: String,
+    /// Repository name (e.g., "org/repo").
+    pub repository_name: String,
+    /// Source branch name.
+    pub source_branch: String,
+    /// Destination branch name.
+    pub destination_branch: String,
+    /// PR author name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Reviewer names.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reviewers: Vec<String>,
+    /// Number of comments on the PR.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_count: Option<u32>,
+    /// Last update timestamp (ISO 8601).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_update: Option<String>,
+}
+
+/// A commit from Jira's DevStatus API.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevCommit {
+    /// Full commit SHA.
+    pub id: String,
+    /// Short commit SHA.
+    pub display_id: String,
+    /// Commit message.
+    pub message: String,
+    /// Commit author name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Author timestamp (ISO 8601).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    /// URL to the commit.
+    pub url: String,
+    /// Number of files changed.
+    pub file_count: u32,
+    /// Whether this is a merge commit.
+    pub merge: bool,
+}
+
+/// A branch from Jira's DevStatus API.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevBranch {
+    /// Branch name.
+    pub name: String,
+    /// URL to the branch.
+    pub url: String,
+    /// Repository name (e.g., "org/repo").
+    pub repository_name: String,
+    /// URL to create a pull request from this branch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_pr_url: Option<String>,
+    /// Most recent commit on this branch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_commit: Option<JiraDevCommit>,
+}
+
+/// A repository from Jira's DevStatus API.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevRepository {
+    /// Repository name (e.g., "org/repo").
+    pub name: String,
+    /// URL to the repository.
+    pub url: String,
+    /// Commits linked to this issue in the repository.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub commits: Vec<JiraDevCommit>,
+}
+
+/// Development status information for a Jira issue.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevStatus {
+    /// Linked pull requests.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pull_requests: Vec<JiraDevPullRequest>,
+    /// Linked branches.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub branches: Vec<JiraDevBranch>,
+    /// Linked repositories.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<JiraDevRepository>,
+}
+
+/// Summary counts for a category of development status.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevStatusCount {
+    /// Number of items.
+    pub count: u32,
+    /// Application type names that have data (e.g., "GitHub", "bitbucket").
+    pub providers: Vec<String>,
+}
+
+/// High-level development status summary for a Jira issue.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraDevStatusSummary {
+    /// Pull request summary.
+    pub pullrequest: JiraDevStatusCount,
+    /// Branch summary.
+    pub branch: JiraDevStatusCount,
+    /// Repository summary.
+    pub repository: JiraDevStatusCount,
 }
 
 // ── Internal API response structs ───────────────────────────────────
@@ -627,6 +745,155 @@ struct JiraCreateResponse {
     id: String,
     #[serde(rename = "self")]
     self_url: String,
+}
+
+// ── DevStatus API response structs ─────────────────────────────────
+
+/// Minimal response for resolving an issue key to its numeric ID.
+#[derive(Deserialize)]
+struct JiraIssueIdResponse {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct DevStatusResponse {
+    #[serde(default)]
+    detail: Vec<DevStatusDetail>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusDetail {
+    #[serde(rename = "pullRequests", default)]
+    pull_requests: Vec<DevStatusPullRequest>,
+    #[serde(default)]
+    branches: Vec<DevStatusBranch>,
+    #[serde(default)]
+    repositories: Vec<DevStatusRepositoryEntry>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusPullRequest {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "repositoryName", default)]
+    repository_name: String,
+    #[serde(default)]
+    source: Option<DevStatusBranchRef>,
+    #[serde(default)]
+    destination: Option<DevStatusBranchRef>,
+    #[serde(default)]
+    author: Option<DevStatusAuthor>,
+    #[serde(default)]
+    reviewers: Vec<DevStatusReviewer>,
+    #[serde(rename = "commentCount", default)]
+    comment_count: Option<u32>,
+    #[serde(rename = "lastUpdate", default)]
+    last_update: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusBranchRef {
+    #[serde(default)]
+    branch: String,
+}
+
+#[derive(Deserialize)]
+struct DevStatusAuthor {
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct DevStatusReviewer {
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct DevStatusCommit {
+    #[serde(default)]
+    id: String,
+    #[serde(rename = "displayId", default)]
+    display_id: String,
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    author: Option<DevStatusAuthor>,
+    #[serde(rename = "authorTimestamp", default)]
+    author_timestamp: Option<String>,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "fileCount", default)]
+    file_count: u32,
+    #[serde(default)]
+    merge: bool,
+}
+
+#[derive(Deserialize)]
+struct DevStatusBranch {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "repositoryName", default)]
+    repository_name: String,
+    #[serde(rename = "createPullRequestUrl", default)]
+    create_pr_url: Option<String>,
+    #[serde(rename = "lastCommit", default)]
+    last_commit: Option<DevStatusCommit>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusRepositoryEntry {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    commits: Vec<DevStatusCommit>,
+}
+
+// ── DevStatus summary response structs ────────────────────────────
+
+#[derive(Deserialize)]
+struct DevStatusSummaryResponse {
+    #[serde(default)]
+    summary: DevStatusSummaryData,
+}
+
+#[derive(Deserialize, Default)]
+struct DevStatusSummaryData {
+    #[serde(default)]
+    pullrequest: Option<DevStatusSummaryCategory>,
+    #[serde(default)]
+    branch: Option<DevStatusSummaryCategory>,
+    #[serde(default)]
+    repository: Option<DevStatusSummaryCategory>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusSummaryCategory {
+    overall: Option<DevStatusSummaryOverall>,
+    #[serde(rename = "byInstanceType", default)]
+    by_instance_type: HashMap<String, DevStatusSummaryInstance>,
+}
+
+#[derive(Deserialize)]
+struct DevStatusSummaryOverall {
+    #[serde(default)]
+    count: u32,
+}
+
+#[derive(Deserialize)]
+struct DevStatusSummaryInstance {
+    #[serde(default)]
+    name: String,
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -2832,6 +3099,496 @@ mod tests {
         let err = client.get_myself().await.unwrap_err();
         assert!(err.to_string().contains("401"));
     }
+
+    // ── get_issue_id ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_issue_id_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"id": "12345", "key": "PROJ-1", "fields": {}}),
+                ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let id = client.get_issue_id("PROJ-1").await.unwrap();
+        assert_eq!(id, "12345");
+    }
+
+    #[tokio::test]
+    async fn get_issue_id_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/NOPE-1"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_issue_id("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── get_dev_status_summary ────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_dev_status_summary_success() {
+        let server = wiremock::MockServer::start().await;
+
+        // Mock issue ID resolution.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"id": "10001", "key": "PROJ-1", "fields": {}}),
+                ),
+            )
+            .mount(&server)
+            .await;
+
+        // Mock summary endpoint.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/summary",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "summary": {
+                        "pullrequest": {
+                            "overall": {"count": 2},
+                            "byInstanceType": {"GitHub": {"count": 2, "name": "GitHub"}}
+                        },
+                        "branch": {
+                            "overall": {"count": 1},
+                            "byInstanceType": {"GitHub": {"count": 1, "name": "GitHub"}}
+                        },
+                        "repository": {
+                            "overall": {"count": 1},
+                            "byInstanceType": {}
+                        }
+                    }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let summary = client.get_dev_status_summary("PROJ-1").await.unwrap();
+        assert_eq!(summary.pullrequest.count, 2);
+        assert_eq!(summary.pullrequest.providers, vec!["GitHub"]);
+        assert_eq!(summary.branch.count, 1);
+        assert_eq!(summary.repository.count, 1);
+        assert!(summary.repository.providers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_summary_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"id": "10001", "key": "PROJ-1", "fields": {}}),
+                ),
+            )
+            .mount(&server)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/summary",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_dev_status_summary("PROJ-1").await.unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    // ── get_dev_status ────────────────────────────────────────────
+
+    /// Helper: mounts a mock for issue ID resolution returning id "10001".
+    async fn mount_issue_id_mock(server: &wiremock::MockServer) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"id": "10001", "key": "PROJ-1", "fields": {}}),
+                ),
+            )
+            .mount(server)
+            .await;
+    }
+
+    /// Helper: mounts a mock for the dev-status summary returning GitHub as the only provider.
+    async fn mount_summary_mock(server: &wiremock::MockServer) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/summary",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "summary": {
+                        "pullrequest": {
+                            "overall": {"count": 1},
+                            "byInstanceType": {"GitHub": {"count": 1, "name": "GitHub"}}
+                        },
+                        "branch": {
+                            "overall": {"count": 0},
+                            "byInstanceType": {}
+                        },
+                        "repository": {
+                            "overall": {"count": 0},
+                            "byInstanceType": {}
+                        }
+                    }
+                })),
+            )
+            .mount(server)
+            .await;
+    }
+
+    fn dev_status_detail_response() -> serde_json::Value {
+        serde_json::json!({
+            "detail": [{
+                "pullRequests": [{
+                    "id": "#42",
+                    "name": "Fix login bug",
+                    "status": "MERGED",
+                    "url": "https://github.com/org/repo/pull/42",
+                    "repositoryName": "org/repo",
+                    "source": {"branch": "fix-login"},
+                    "destination": {"branch": "main"},
+                    "author": {"name": "Alice"},
+                    "reviewers": [{"name": "Bob"}],
+                    "commentCount": 3,
+                    "lastUpdate": "2024-01-15T10:30:00.000+0000"
+                }],
+                "branches": [{
+                    "name": "fix-login",
+                    "url": "https://github.com/org/repo/tree/fix-login",
+                    "repositoryName": "org/repo",
+                    "createPullRequestUrl": "https://github.com/org/repo/compare/fix-login",
+                    "lastCommit": {
+                        "id": "abc123def456",
+                        "displayId": "abc123d",
+                        "message": "Fix the login",
+                        "author": {"name": "Alice"},
+                        "authorTimestamp": "2024-01-14T08:00:00.000+0000",
+                        "url": "https://github.com/org/repo/commit/abc123d",
+                        "fileCount": 2,
+                        "merge": false
+                    }
+                }],
+                "repositories": [{
+                    "name": "org/repo",
+                    "url": "https://github.com/org/repo",
+                    "commits": [{
+                        "id": "abc123def456",
+                        "displayId": "abc123d",
+                        "message": "Fix the login",
+                        "author": {"name": "Alice"},
+                        "authorTimestamp": "2024-01-14T08:00:00.000+0000",
+                        "url": "https://github.com/org/repo/commit/abc123d",
+                        "fileCount": 2,
+                        "merge": false
+                    }]
+                }],
+                "_instance": {"name": "GitHub", "type": "GitHub"}
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_pullrequest_fields() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .and(wiremock::matchers::query_param("dataType", "pullrequest"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(dev_status_detail_response()),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", Some("pullrequest"), Some("GitHub"))
+            .await
+            .unwrap();
+
+        assert_eq!(status.pull_requests.len(), 1);
+        let pr = &status.pull_requests[0];
+        assert_eq!(pr.id, "#42");
+        assert_eq!(pr.status, "MERGED");
+        assert_eq!(pr.author.as_deref(), Some("Alice"));
+        assert_eq!(pr.reviewers, vec!["Bob"]);
+        assert_eq!(pr.comment_count, Some(3));
+        assert!(pr.last_update.is_some());
+        assert_eq!(pr.source_branch, "fix-login");
+        assert_eq!(pr.destination_branch, "main");
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_branch_fields() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .and(wiremock::matchers::query_param("dataType", "branch"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(dev_status_detail_response()),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", Some("branch"), Some("GitHub"))
+            .await
+            .unwrap();
+
+        assert_eq!(status.branches.len(), 1);
+        let branch = &status.branches[0];
+        assert_eq!(branch.name, "fix-login");
+        assert!(branch.create_pr_url.is_some());
+        let commit = branch.last_commit.as_ref().unwrap();
+        assert_eq!(commit.display_id, "abc123d");
+        assert_eq!(commit.file_count, 2);
+        assert!(!commit.merge);
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_repository_with_commits() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .and(wiremock::matchers::query_param("dataType", "repository"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(dev_status_detail_response()),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", Some("repository"), Some("GitHub"))
+            .await
+            .unwrap();
+
+        assert_eq!(status.repositories.len(), 1);
+        assert_eq!(status.repositories[0].commits.len(), 1);
+        assert_eq!(status.repositories[0].commits[0].display_id, "abc123d");
+        assert_eq!(
+            status.repositories[0].commits[0].author.as_deref(),
+            Some("Alice")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_auto_discovers_providers() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+        mount_summary_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(dev_status_detail_response()),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", Some("pullrequest"), None)
+            .await
+            .unwrap();
+
+        assert_eq!(status.pull_requests.len(), 1);
+        assert_eq!(status.pull_requests[0].name, "Fix login bug");
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_empty_response() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"detail": []})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", None, Some("GitHub"))
+            .await
+            .unwrap();
+
+        assert!(status.pull_requests.is_empty());
+        assert!(status.branches.is_empty());
+        assert!(status.repositories.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_detail_api_error() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string("Server Error"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .get_dev_status("PROJ-1", Some("pullrequest"), Some("GitHub"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_with_data_type_filter() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        // Only return branch data.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/detail",
+            ))
+            .and(wiremock::matchers::query_param("dataType", "branch"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "detail": [{
+                        "pullRequests": [],
+                        "branches": [{
+                            "name": "feature-x",
+                            "url": "https://github.com/org/repo/tree/feature-x",
+                            "repositoryName": "org/repo"
+                        }],
+                        "repositories": []
+                    }]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let status = client
+            .get_dev_status("PROJ-1", Some("branch"), Some("GitHub"))
+            .await
+            .unwrap();
+
+        assert!(status.pull_requests.is_empty());
+        assert_eq!(status.branches.len(), 1);
+        assert_eq!(status.branches[0].name, "feature-x");
+        assert!(status.branches[0].last_commit.is_none());
+        assert!(status.branches[0].create_pr_url.is_none());
+        assert!(status.repositories.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_dev_status_summary_empty() {
+        let server = wiremock::MockServer::start().await;
+        mount_issue_id_mock(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/dev-status/1.0/issue/summary",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"summary": {}})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let summary = client.get_dev_status_summary("PROJ-1").await.unwrap();
+        assert_eq!(summary.pullrequest.count, 0);
+        assert_eq!(summary.branch.count, 0);
+        assert_eq!(summary.repository.count, 0);
+    }
+
+    #[tokio::test]
+    async fn convert_commit_maps_all_fields() {
+        let internal = DevStatusCommit {
+            id: "abc123".to_string(),
+            display_id: "abc".to_string(),
+            message: "Test commit".to_string(),
+            author: Some(DevStatusAuthor {
+                name: "Alice".to_string(),
+            }),
+            author_timestamp: Some("2024-01-01T00:00:00.000+0000".to_string()),
+            url: "https://example.com/commit/abc".to_string(),
+            file_count: 5,
+            merge: true,
+        };
+        let public = AtlassianClient::convert_commit(internal);
+        assert_eq!(public.id, "abc123");
+        assert_eq!(public.display_id, "abc");
+        assert_eq!(public.message, "Test commit");
+        assert_eq!(public.author.as_deref(), Some("Alice"));
+        assert!(public.timestamp.is_some());
+        assert_eq!(public.file_count, 5);
+        assert!(public.merge);
+    }
+
+    #[tokio::test]
+    async fn convert_commit_no_author() {
+        let internal = DevStatusCommit {
+            id: "def456".to_string(),
+            display_id: "def".to_string(),
+            message: "Anonymous".to_string(),
+            author: None,
+            author_timestamp: None,
+            url: "https://example.com/commit/def".to_string(),
+            file_count: 0,
+            merge: false,
+        };
+        let public = AtlassianClient::convert_commit(internal);
+        assert!(public.author.is_none());
+        assert!(public.timestamp.is_none());
+    }
 }
 
 impl AtlassianClient {
@@ -3803,6 +4560,196 @@ impl AtlassianClient {
             return Err(AtlassianError::ApiRequestFailed { status, body }.into());
         }
         Ok(())
+    }
+
+    /// Resolves a JIRA issue key to its numeric ID.
+    pub async fn get_issue_id(&self, key: &str) -> Result<String> {
+        let url = format!("{}/rest/api/3/issue/{}?fields=", self.instance_url, key);
+        let response = self.get_json(&url).await?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+        let resp: JiraIssueIdResponse = response
+            .json()
+            .await
+            .context("Failed to parse issue ID response")?;
+        Ok(resp.id)
+    }
+
+    /// Fetches a development status summary (counts per category) for a JIRA issue.
+    ///
+    /// Uses the DevStatus summary endpoint. Returns counts and provider names
+    /// for each category (pull requests, branches, repositories).
+    pub async fn get_dev_status_summary(&self, key: &str) -> Result<JiraDevStatusSummary> {
+        let issue_id = self.get_issue_id(key).await?;
+        let url = format!(
+            "{}/rest/dev-status/1.0/issue/summary?issueId={}",
+            self.instance_url, issue_id
+        );
+        let response = self.get_json(&url).await?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+        let resp: DevStatusSummaryResponse = response
+            .json()
+            .await
+            .context("Failed to parse DevStatus summary response")?;
+
+        fn extract_count(cat: Option<DevStatusSummaryCategory>) -> JiraDevStatusCount {
+            match cat {
+                Some(c) => JiraDevStatusCount {
+                    count: c.overall.map_or(0, |o| o.count),
+                    providers: c
+                        .by_instance_type
+                        .into_values()
+                        .map(|i| i.name)
+                        .filter(|n| !n.is_empty())
+                        .collect(),
+                },
+                None => JiraDevStatusCount {
+                    count: 0,
+                    providers: Vec::new(),
+                },
+            }
+        }
+
+        Ok(JiraDevStatusSummary {
+            pullrequest: extract_count(resp.summary.pullrequest),
+            branch: extract_count(resp.summary.branch),
+            repository: extract_count(resp.summary.repository),
+        })
+    }
+
+    /// Fetches development status (PRs, branches, repositories) for a JIRA issue.
+    ///
+    /// Uses the DevStatus API which requires the numeric issue ID. The key is
+    /// resolved automatically via [`get_issue_id`](Self::get_issue_id).
+    ///
+    /// If `application_type` is `None`, discovers available providers via the
+    /// summary endpoint and queries each one. If `Some`, queries only that
+    /// provider (e.g., "GitHub", "bitbucket", "stash").
+    pub async fn get_dev_status(
+        &self,
+        key: &str,
+        data_type: Option<&str>,
+        application_type: Option<&str>,
+    ) -> Result<JiraDevStatus> {
+        let issue_id = self.get_issue_id(key).await?;
+
+        let app_types: Vec<String> = if let Some(app) = application_type {
+            vec![app.to_string()]
+        } else {
+            // Discover available providers via the summary endpoint.
+            let summary = self.get_dev_status_summary(key).await?;
+            let mut providers: Vec<String> = Vec::new();
+            for p in summary
+                .pullrequest
+                .providers
+                .into_iter()
+                .chain(summary.branch.providers)
+                .chain(summary.repository.providers)
+            {
+                if !providers.contains(&p) {
+                    providers.push(p);
+                }
+            }
+            if providers.is_empty() {
+                providers.push("GitHub".to_string());
+            }
+            providers
+        };
+
+        let data_types: Vec<&str> = match data_type {
+            Some(dt) => vec![dt],
+            None => vec!["pullrequest", "branch", "repository"],
+        };
+
+        let mut status = JiraDevStatus {
+            pull_requests: Vec::new(),
+            branches: Vec::new(),
+            repositories: Vec::new(),
+        };
+
+        for app in &app_types {
+            for dt in &data_types {
+                let url = format!(
+                    "{}/rest/dev-status/1.0/issue/detail?issueId={}&applicationType={}&dataType={}",
+                    self.instance_url, issue_id, app, dt
+                );
+                let response = self.get_json(&url).await?;
+                if !response.status().is_success() {
+                    let http_status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(AtlassianError::ApiRequestFailed {
+                        status: http_status,
+                        body,
+                    }
+                    .into());
+                }
+
+                let resp: DevStatusResponse = response
+                    .json()
+                    .await
+                    .context("Failed to parse DevStatus response")?;
+
+                for detail in resp.detail {
+                    for pr in detail.pull_requests {
+                        status.pull_requests.push(JiraDevPullRequest {
+                            id: pr.id,
+                            name: pr.name,
+                            status: pr.status,
+                            url: pr.url,
+                            repository_name: pr.repository_name,
+                            source_branch: pr.source.map(|s| s.branch).unwrap_or_default(),
+                            destination_branch: pr
+                                .destination
+                                .map(|d| d.branch)
+                                .unwrap_or_default(),
+                            author: pr.author.map(|a| a.name),
+                            reviewers: pr.reviewers.into_iter().map(|r| r.name).collect(),
+                            comment_count: pr.comment_count,
+                            last_update: pr.last_update,
+                        });
+                    }
+                    for branch in detail.branches {
+                        status.branches.push(JiraDevBranch {
+                            name: branch.name,
+                            url: branch.url,
+                            repository_name: branch.repository_name,
+                            create_pr_url: branch.create_pr_url,
+                            last_commit: branch.last_commit.map(Self::convert_commit),
+                        });
+                    }
+                    for repo in detail.repositories {
+                        status.repositories.push(JiraDevRepository {
+                            name: repo.name,
+                            url: repo.url,
+                            commits: repo.commits.into_iter().map(Self::convert_commit).collect(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(status)
+    }
+
+    /// Converts an internal `DevStatusCommit` to a public `JiraDevCommit`.
+    fn convert_commit(c: DevStatusCommit) -> JiraDevCommit {
+        JiraDevCommit {
+            id: c.id,
+            display_id: c.display_id,
+            message: c.message,
+            author: c.author.map(|a| a.name),
+            timestamp: c.author_timestamp,
+            url: c.url,
+            file_count: c.file_count,
+            merge: c.merge,
+        }
     }
 
     /// Gets attachment metadata for a JIRA issue.

--- a/src/cli/atlassian/jira/dev.rs
+++ b/src/cli/atlassian/jira/dev.rs
@@ -1,0 +1,535 @@
+//! CLI command for JIRA DevStatus (linked PRs, branches, repositories).
+
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+
+use crate::atlassian::client::{
+    JiraDevBranch, JiraDevCommit, JiraDevPullRequest, JiraDevRepository, JiraDevStatus,
+    JiraDevStatusSummary,
+};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Shows development status (PRs, branches, repositories) for a JIRA issue.
+#[derive(Parser)]
+pub struct DevCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
+
+    /// Data type filter.
+    #[arg(long)]
+    pub r#type: Option<DevDataType>,
+
+    /// Application type filter (e.g., GitHub, bitbucket, stash).
+    /// If omitted, queries all available integrations.
+    #[arg(long)]
+    pub app: Option<String>,
+
+    /// Show summary counts instead of full details.
+    #[arg(long)]
+    pub summary: bool,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+/// Development data type to retrieve.
+#[derive(Clone, ValueEnum)]
+pub enum DevDataType {
+    /// Pull requests.
+    Pullrequest,
+    /// Branches.
+    Branch,
+    /// Repositories.
+    Repository,
+}
+
+impl DevDataType {
+    /// Returns the API data type string.
+    fn as_api_str(&self) -> &str {
+        match self {
+            Self::Pullrequest => "pullrequest",
+            Self::Branch => "branch",
+            Self::Repository => "repository",
+        }
+    }
+}
+
+impl DevCommand {
+    /// Executes the dev-status command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+
+        if self.summary {
+            let summary = client.get_dev_status_summary(&self.key).await?;
+            if output_as(&summary, &self.output)? {
+                return Ok(());
+            }
+            print_summary(&self.key, &summary);
+            return Ok(());
+        }
+
+        let data_type = self.r#type.as_ref().map(DevDataType::as_api_str);
+        let app_type = self.app.as_deref();
+        let status = client
+            .get_dev_status(&self.key, data_type, app_type)
+            .await?;
+
+        if output_as(&status, &self.output)? {
+            return Ok(());
+        }
+
+        print_dev_status(&self.key, &status);
+        Ok(())
+    }
+}
+
+/// Prints a development status summary as a formatted table.
+fn print_summary(key: &str, summary: &JiraDevStatusSummary) {
+    if summary.pullrequest.count == 0 && summary.branch.count == 0 && summary.repository.count == 0
+    {
+        println!("{key}: no development information.");
+        return;
+    }
+
+    println!("{key}:");
+
+    let rows = [
+        ("pullrequest", &summary.pullrequest),
+        ("branch", &summary.branch),
+        ("repository", &summary.repository),
+    ];
+
+    let type_w = rows.iter().map(|(t, _)| t.len()).max().unwrap_or(4).max(4);
+
+    println!("  {:<type_w$}  {:>5}  PROVIDERS", "TYPE", "COUNT");
+    println!(
+        "  {:<type_w$}  {:>5}  {}",
+        "-".repeat(type_w),
+        "-----",
+        "-".repeat(9),
+    );
+
+    for (name, count) in &rows {
+        let providers = if count.providers.is_empty() {
+            "-".to_string()
+        } else {
+            count.providers.join(", ")
+        };
+        println!("  {:<type_w$}  {:>5}  {}", name, count.count, providers);
+    }
+}
+
+/// Prints development status as formatted tables.
+fn print_dev_status(key: &str, status: &JiraDevStatus) {
+    if status.pull_requests.is_empty()
+        && status.branches.is_empty()
+        && status.repositories.is_empty()
+    {
+        println!("{key}: no development information.");
+        return;
+    }
+
+    if !status.pull_requests.is_empty() {
+        print_pull_requests(&status.pull_requests);
+    }
+
+    if !status.branches.is_empty() {
+        if !status.pull_requests.is_empty() {
+            println!();
+        }
+        print_branches(&status.branches);
+    }
+
+    if !status.repositories.is_empty() {
+        if !status.pull_requests.is_empty() || !status.branches.is_empty() {
+            println!();
+        }
+        print_repositories(&status.repositories);
+    }
+}
+
+/// Prints pull requests as a formatted table.
+fn print_pull_requests(prs: &[JiraDevPullRequest]) {
+    let id_w = prs.iter().map(|p| p.id.len()).max().unwrap_or(2).max(2);
+    let status_w = prs.iter().map(|p| p.status.len()).max().unwrap_or(6).max(6);
+    let author_w = prs
+        .iter()
+        .map(|p| p.author.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let repo_w = prs
+        .iter()
+        .map(|p| p.repository_name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let src_w = prs
+        .iter()
+        .map(|p| p.source_branch.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let dst_w = prs
+        .iter()
+        .map(|p| p.destination_branch.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    println!("Pull Requests:");
+    println!(
+        "  {:<id_w$}  {:<status_w$}  {:<author_w$}  {:<repo_w$}  {:<src_w$}  {:<dst_w$}  NAME",
+        "ID", "STATUS", "AUTHOR", "REPO", "SOURCE", "TARGET"
+    );
+    println!(
+        "  {:<id_w$}  {:<status_w$}  {:<author_w$}  {:<repo_w$}  {:<src_w$}  {:<dst_w$}  {}",
+        "-".repeat(id_w),
+        "-".repeat(status_w),
+        "-".repeat(author_w),
+        "-".repeat(repo_w),
+        "-".repeat(src_w),
+        "-".repeat(dst_w),
+        "-".repeat(4),
+    );
+
+    for pr in prs {
+        let author = pr.author.as_deref().unwrap_or("-");
+        println!(
+            "  {:<id_w$}  {:<status_w$}  {:<author_w$}  {:<repo_w$}  {:<src_w$}  {:<dst_w$}  {}",
+            pr.id,
+            pr.status,
+            author,
+            pr.repository_name,
+            pr.source_branch,
+            pr.destination_branch,
+            pr.name
+        );
+    }
+}
+
+/// Prints branches as a formatted table.
+fn print_branches(branches: &[JiraDevBranch]) {
+    let repo_w = branches
+        .iter()
+        .map(|b| b.repository_name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let name_w = branches
+        .iter()
+        .map(|b| b.name.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let commit_w = 7; // short SHA length
+
+    println!("Branches:");
+    println!(
+        "  {:<repo_w$}  {:<name_w$}  {:<commit_w$}  URL",
+        "REPO", "BRANCH", "COMMIT"
+    );
+    println!(
+        "  {:<repo_w$}  {:<name_w$}  {:<commit_w$}  {}",
+        "-".repeat(repo_w),
+        "-".repeat(name_w),
+        "-".repeat(commit_w),
+        "-".repeat(3),
+    );
+
+    for branch in branches {
+        let commit = branch
+            .last_commit
+            .as_ref()
+            .map_or("-", |c| c.display_id.as_str());
+        println!(
+            "  {:<repo_w$}  {:<name_w$}  {:<commit_w$}  {}",
+            branch.repository_name, branch.name, commit, branch.url
+        );
+    }
+}
+
+/// Prints repositories as a formatted table, including commits.
+fn print_repositories(repos: &[JiraDevRepository]) {
+    let name_w = repos.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4);
+
+    println!("Repositories:");
+    println!("  {:<name_w$}  URL", "NAME");
+    println!("  {:<name_w$}  {}", "-".repeat(name_w), "-".repeat(3));
+
+    for repo in repos {
+        println!("  {:<name_w$}  {}", repo.name, repo.url);
+        if !repo.commits.is_empty() {
+            print_commits(&repo.commits);
+        }
+    }
+}
+
+/// Prints commits as a sub-table indented under a repository.
+fn print_commits(commits: &[JiraDevCommit]) {
+    let sha_w = 7; // short SHA
+    let author_w = commits
+        .iter()
+        .map(|c| c.author.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    println!("    {:<sha_w$}  {:<author_w$}  MESSAGE", "SHA", "AUTHOR");
+
+    for commit in commits {
+        let author = commit.author.as_deref().unwrap_or("-");
+        // Truncate message to first line.
+        let msg = commit.message.lines().next().unwrap_or("");
+        println!(
+            "    {:<sha_w$}  {:<author_w$}  {}",
+            commit.display_id, author, msg
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::JiraDevStatusCount;
+
+    fn sample_pr() -> JiraDevPullRequest {
+        JiraDevPullRequest {
+            id: "#42".to_string(),
+            name: "Fix login bug".to_string(),
+            status: "MERGED".to_string(),
+            url: "https://github.com/org/repo/pull/42".to_string(),
+            repository_name: "org/repo".to_string(),
+            source_branch: "fix-login".to_string(),
+            destination_branch: "main".to_string(),
+            author: Some("John Doe".to_string()),
+            reviewers: vec!["Jane Smith".to_string()],
+            comment_count: Some(3),
+            last_update: Some("2024-01-15T10:30:00.000+0000".to_string()),
+        }
+    }
+
+    fn sample_commit() -> JiraDevCommit {
+        JiraDevCommit {
+            id: "abc123def456789".to_string(),
+            display_id: "abc123d".to_string(),
+            message: "Fix issue PROJ-123".to_string(),
+            author: Some("John Doe".to_string()),
+            timestamp: Some("2024-01-15T12:42:57.000+0000".to_string()),
+            url: "https://github.com/org/repo/commit/abc123d".to_string(),
+            file_count: 3,
+            merge: false,
+        }
+    }
+
+    fn sample_branch() -> JiraDevBranch {
+        JiraDevBranch {
+            name: "feature/new-ui".to_string(),
+            url: "https://github.com/org/repo/tree/feature/new-ui".to_string(),
+            repository_name: "org/repo".to_string(),
+            create_pr_url: Some("https://github.com/org/repo/compare/feature/new-ui".to_string()),
+            last_commit: Some(sample_commit()),
+        }
+    }
+
+    fn sample_repo() -> JiraDevRepository {
+        JiraDevRepository {
+            name: "org/repo".to_string(),
+            url: "https://github.com/org/repo".to_string(),
+            commits: vec![sample_commit()],
+        }
+    }
+
+    // ── DevDataType ───────────────────────────────────────────────
+
+    #[test]
+    fn dev_data_type_as_api_str() {
+        assert_eq!(DevDataType::Pullrequest.as_api_str(), "pullrequest");
+        assert_eq!(DevDataType::Branch.as_api_str(), "branch");
+        assert_eq!(DevDataType::Repository.as_api_str(), "repository");
+    }
+
+    // ── print helpers ─────────────────────────────────────────────
+
+    #[test]
+    fn print_dev_status_empty() {
+        let status = JiraDevStatus {
+            pull_requests: vec![],
+            branches: vec![],
+            repositories: vec![],
+        };
+        print_dev_status("PROJ-1", &status);
+    }
+
+    #[test]
+    fn print_dev_status_with_prs() {
+        let status = JiraDevStatus {
+            pull_requests: vec![sample_pr()],
+            branches: vec![],
+            repositories: vec![],
+        };
+        print_dev_status("PROJ-1", &status);
+    }
+
+    #[test]
+    fn print_dev_status_with_branches() {
+        let status = JiraDevStatus {
+            pull_requests: vec![],
+            branches: vec![sample_branch()],
+            repositories: vec![],
+        };
+        print_dev_status("PROJ-1", &status);
+    }
+
+    #[test]
+    fn print_dev_status_with_repositories() {
+        let status = JiraDevStatus {
+            pull_requests: vec![],
+            branches: vec![],
+            repositories: vec![sample_repo()],
+        };
+        print_dev_status("PROJ-1", &status);
+    }
+
+    #[test]
+    fn print_dev_status_all_sections() {
+        let status = JiraDevStatus {
+            pull_requests: vec![sample_pr()],
+            branches: vec![sample_branch()],
+            repositories: vec![sample_repo()],
+        };
+        print_dev_status("PROJ-1", &status);
+    }
+
+    #[test]
+    fn print_summary_empty() {
+        let summary = JiraDevStatusSummary {
+            pullrequest: JiraDevStatusCount {
+                count: 0,
+                providers: vec![],
+            },
+            branch: JiraDevStatusCount {
+                count: 0,
+                providers: vec![],
+            },
+            repository: JiraDevStatusCount {
+                count: 0,
+                providers: vec![],
+            },
+        };
+        print_summary("PROJ-1", &summary);
+    }
+
+    #[test]
+    fn print_summary_with_data() {
+        let summary = JiraDevStatusSummary {
+            pullrequest: JiraDevStatusCount {
+                count: 2,
+                providers: vec!["GitHub".to_string()],
+            },
+            branch: JiraDevStatusCount {
+                count: 1,
+                providers: vec!["GitHub".to_string()],
+            },
+            repository: JiraDevStatusCount {
+                count: 1,
+                providers: vec!["GitHub".to_string(), "bitbucket".to_string()],
+            },
+        };
+        print_summary("PROJ-1", &summary);
+    }
+
+    #[test]
+    fn print_commits_table() {
+        let commits = vec![sample_commit()];
+        print_commits(&commits);
+    }
+
+    // ── struct fields ─────────────────────────────────────────────
+
+    #[test]
+    fn dev_command_fields() {
+        let cmd = DevCommand {
+            key: "PROJ-1".to_string(),
+            r#type: None,
+            app: None,
+            summary: false,
+            output: OutputFormat::Table,
+        };
+        assert_eq!(cmd.key, "PROJ-1");
+        assert!(cmd.r#type.is_none());
+        assert!(cmd.app.is_none());
+        assert!(!cmd.summary);
+    }
+
+    #[test]
+    fn dev_command_with_type_filter() {
+        let cmd = DevCommand {
+            key: "PROJ-1".to_string(),
+            r#type: Some(DevDataType::Pullrequest),
+            app: None,
+            summary: false,
+            output: OutputFormat::Json,
+        };
+        assert_eq!(cmd.key, "PROJ-1");
+        assert!(cmd.r#type.is_some());
+    }
+
+    #[test]
+    fn dev_command_with_app_filter() {
+        let cmd = DevCommand {
+            key: "PROJ-1".to_string(),
+            r#type: None,
+            app: Some("GitHub".to_string()),
+            summary: false,
+            output: OutputFormat::Table,
+        };
+        assert_eq!(cmd.app.as_deref(), Some("GitHub"));
+    }
+
+    #[test]
+    fn dev_command_summary_mode() {
+        let cmd = DevCommand {
+            key: "PROJ-1".to_string(),
+            r#type: None,
+            app: None,
+            summary: true,
+            output: OutputFormat::Table,
+        };
+        assert!(cmd.summary);
+    }
+
+    #[test]
+    fn pr_author_and_reviewers() {
+        let pr = sample_pr();
+        assert_eq!(pr.author.as_deref(), Some("John Doe"));
+        assert_eq!(pr.reviewers, vec!["Jane Smith"]);
+        assert_eq!(pr.comment_count, Some(3));
+        assert!(pr.last_update.is_some());
+    }
+
+    #[test]
+    fn commit_fields() {
+        let commit = sample_commit();
+        assert_eq!(commit.display_id, "abc123d");
+        assert_eq!(commit.file_count, 3);
+        assert!(!commit.merge);
+    }
+
+    #[test]
+    fn branch_last_commit() {
+        let branch = sample_branch();
+        assert!(branch.last_commit.is_some());
+        assert!(branch.create_pr_url.is_some());
+    }
+
+    #[test]
+    fn repo_with_commits() {
+        let repo = sample_repo();
+        assert_eq!(repo.commits.len(), 1);
+        assert_eq!(repo.commits[0].display_id, "abc123d");
+    }
+}

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod changelog;
 pub(crate) mod comment;
 pub(crate) mod create;
 pub(crate) mod delete;
+pub(crate) mod dev;
 pub(crate) mod edit;
 pub(crate) mod field;
 pub(crate) mod link;
@@ -46,6 +47,8 @@ pub enum JiraSubcommands {
     Comment(comment::CommentCommand),
     /// Deletes a JIRA issue.
     Delete(delete::DeleteCommand),
+    /// Shows development status (linked PRs, branches, repositories) for a JIRA issue.
+    Dev(dev::DevCommand),
     /// Lists JIRA projects.
     Project(project::ProjectCommand),
     /// Manages JIRA field definitions and options.
@@ -74,6 +77,7 @@ impl JiraCommand {
             JiraSubcommands::Transition(cmd) => cmd.execute().await,
             JiraSubcommands::Comment(cmd) => cmd.execute().await,
             JiraSubcommands::Delete(cmd) => cmd.execute().await,
+            JiraSubcommands::Dev(cmd) => cmd.execute().await,
             JiraSubcommands::Project(cmd) => cmd.execute().await,
             JiraSubcommands::Field(cmd) => cmd.execute().await,
             JiraSubcommands::Board(cmd) => cmd.execute().await,
@@ -191,6 +195,20 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Delete(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_dev_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Dev(dev::DevCommand {
+                key: "PROJ-1".to_string(),
+                r#type: None,
+                app: None,
+                summary: false,
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Dev(_)));
     }
 
     #[test]

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -386,6 +386,7 @@ Commands:
   transition  Lists or executes workflow transitions on a JIRA issue
   comment     Manages comments on a JIRA issue
   delete      Deletes a JIRA issue
+  dev         Shows development status (linked PRs, branches, repositories) for a JIRA issue
   project     Lists JIRA projects
   field       Manages JIRA field definitions and options
   board       Manages JIRA agile boards
@@ -599,6 +600,25 @@ Arguments:
 Options:
       --force  Skips the confirmation prompt
   -h, --help   Print help
+
+
+================================================================================
+
+omni-dev atlassian jira dev - Shows development status (linked PRs, branches, repositories) for a JIRA issue
+
+Shows development status (linked PRs, branches, repositories) for a JIRA issue
+
+Usage: dev [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>  JIRA issue key (e.g., PROJ-123)
+
+Options:
+      --type <TYPE>      Data type filter [possible values: pullrequest, branch, repository]
+      --app <APP>        Application type filter (e.g., GitHub, bitbucket, stash). If omitted, queries all available integrations
+      --summary          Show summary counts instead of full details
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements the `omni-dev atlassian jira dev` subcommand, which queries the Jira DevStatus API to surface linked pull requests, branches, and repositories for a given issue key. This addresses Issue #480 and enables developers to quickly inspect the development activity associated with any Jira issue directly from the CLI.

The DevStatus API requires a numeric issue ID rather than the human-readable key, so issue key resolution is handled transparently. When no application type is specified, the command automatically discovers available integration providers (GitHub, Bitbucket, Stash, etc.) via the summary endpoint before querying for full details.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #480

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added public data structures: `JiraDevPullRequest`, `JiraDevCommit`, `JiraDevBranch`, `JiraDevRepository`, `JiraDevStatus`, `JiraDevStatusSummary`, and `JiraDevStatusCount`
- Added internal deserialization structs for the DevStatus API response format: `DevStatusResponse`, `DevStatusDetail`, `DevStatusPullRequest`, `DevStatusBranch`, `DevStatusCommit`, `DevStatusRepositoryEntry`, `DevStatusSummaryResponse`, `DevStatusSummaryData`, `DevStatusSummaryCategory`, `DevStatusSummaryOverall`, `DevStatusSummaryInstance`
- Implemented `get_issue_id()` to resolve a Jira issue key to its numeric ID via `GET /rest/api/3/issue/{key}?fields=`
- Implemented `get_dev_status_summary()` for high-level counts of PRs, branches, and repositories per integration provider via `GET /rest/dev-status/1.0/issue/summary`
- Implemented `get_dev_status()` with automatic provider discovery via the summary endpoint when no application type is specified; iterates over all discovered providers and requested data types to aggregate results
- Added private `convert_commit()` helper to map internal `DevStatusCommit` to the public `JiraDevCommit` type

**CLI (`src/cli/atlassian/jira/dev.rs` — new file):**
- Added `DevCommand` struct with `--type` (pullrequest/branch/repository), `--app` (application type filter), `--summary` (counts-only mode), and `--output` (table/json/yaml) flags
- Added `DevDataType` enum with `as_api_str()` method
- Implemented `print_summary()` for formatted table output of per-provider counts
- Implemented `print_dev_status()` dispatching to `print_pull_requests()`, `print_branches()`, and `print_repositories()` for detailed output
- All table formatters use dynamic column widths based on actual data

**CLI Wiring (`src/cli/atlassian/jira/mod.rs`):**
- Registered `dev` module with `pub(crate) mod dev`
- Added `Dev(dev::DevCommand)` variant to `JiraSubcommands` enum
- Added dispatch arm `JiraSubcommands::Dev(cmd) => cmd.execute().await` in `JiraCommand::execute()`

**Testing:**
- Added unit tests in `src/cli/atlassian/jira/dev.rs` covering: `DevDataType::as_api_str()`, `print_dev_status()` for all section combinations (empty, PRs only, branches only, repositories only, all sections), `print_summary()` for empty and populated data, `print_commits()`, and all `DevCommand` field/flag configurations
- Added `jira_subcommands_dev_variant` test in `src/cli/atlassian/jira/mod.rs`
- Updated help snapshot `tests/snapshots/integration_test__help_all_output.snap` to include the new `dev` subcommand entry and its full help text

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (help snapshot updated)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (empty dev status, missing optional fields)
- [x] Backward compatibility verified (purely additive; no existing commands modified)

### Test Commands
```bash
# Core test suite
cargo test

# Run dev command-specific tests
cargo test atlassian::jira::dev
cargo test jira_subcommands_dev_variant

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manual integration (requires Jira credentials configured)
omni-dev atlassian jira dev PROJ-123
omni-dev atlassian jira dev PROJ-123 --summary
omni-dev atlassian jira dev PROJ-123 --type pullrequest --app GitHub
omni-dev atlassian jira dev PROJ-123 --output json
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — API credentials are passed via the existing `create_client()` helper; no new credential handling introduced
- [x] Error handling — all HTTP responses are checked for non-2xx status codes before deserialization; errors propagate via `anyhow::Result`
- [x] Architecture changes — provider auto-discovery logic in `get_dev_status()` makes two round trips when `application_type` is `None` (summary + detail); this is intentional and consistent with the Jira DevStatus API design

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Potential performance impact — when `--app` is not specified, `get_dev_status()` first calls the summary endpoint to discover providers, then issues one request per (provider × data-type) combination. For issues with many integrations this could result in several HTTP calls. The current design prioritises correctness and completeness; caching or batching can be explored as a follow-up.

## Security Considerations
- [x] No security implications — authentication reuses the existing `AtlassianClient` Basic Auth mechanism (email + API token). No new credentials, secrets, or sensitive data paths are introduced.

## Breaking Changes

None. This is a purely additive change. No existing commands, data structures, or API surfaces have been modified.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Add pagination support for issues with large numbers of linked PRs or commits
- Cache the issue-key-to-ID resolution to avoid redundant API calls when the same key is queried multiple times
- Extend `--type` to accept a comma-separated list for querying multiple data types in a single invocation

**Known Limitations:**
- The Jira DevStatus API is an undocumented/internal API endpoint (`/rest/dev-status/1.0/`); its availability and response format may vary between Jira Cloud instances or change without notice
- When `--app` is omitted and the summary endpoint returns no providers, the implementation falls back to querying `GitHub` as a default

**Alternatives Considered:**
- Hardcoding a fixed list of known application types (GitHub, bitbucket, stash) instead of auto-discovery — rejected in favour of dynamic discovery to avoid missing integrations configured on the specific Jira instance