### PR TITLE
fix(atlassian): preserve mark order for underline with strong/em/strike and link

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -3828,9 +3828,9 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
     };
 
     // Partition formatting marks into outer (before link) and inner (after link / no link).
-    let outer_strike = has_strike && is_before_link("strike");
-    let outer_strong = has_strong && is_before_link("strong");
-    let outer_em = has_em && is_before_link("em");
+    let mut outer_strike = has_strike && is_before_link("strike");
+    let mut outer_strong = has_strong && is_before_link("strong");
+    let mut outer_em = has_em && is_before_link("em");
     let inner_strike = has_strike && !outer_strike;
     let inner_strong = has_strong && !outer_strong;
     let inner_em = has_em && !outer_em;
@@ -3960,8 +3960,64 @@ fn render_marked_text(text: &str, marks: &[AdfMark], output: &mut String) {
                     .is_some_and(|lp| marks[..lp].iter().any(|m| m.mark_type == "annotation"))
             {
                 // Bracketed span wraps the link: [[text](url)]{underline}
-                let link_part = format!("[{inner}]({href})");
-                core = format!("[{link_part}]{{{}}}", attr_parts.join(" "));
+                // Outer formatting marks that appear after underline in the
+                // original mark array must go inside the brackets so that
+                // round-trip parsing restores the original mark order.
+                let underline_pos = marks.iter().position(|m| m.mark_type == "underline");
+                let bracket_inner_strike = outer_strike
+                    && underline_pos.is_some_and(|up| {
+                        marks
+                            .iter()
+                            .position(|m| m.mark_type == "strike")
+                            .is_some_and(|sp| sp > up)
+                    });
+                let bracket_inner_strong = outer_strong
+                    && underline_pos.is_some_and(|up| {
+                        marks
+                            .iter()
+                            .position(|m| m.mark_type == "strong")
+                            .is_some_and(|sp| sp > up)
+                    });
+                let bracket_inner_em = outer_em
+                    && underline_pos.is_some_and(|up| {
+                        marks
+                            .iter()
+                            .position(|m| m.mark_type == "em")
+                            .is_some_and(|sp| sp > up)
+                    });
+
+                let mut bracket_content = String::new();
+                if bracket_inner_strike {
+                    bracket_content.push_str("~~");
+                }
+                if bracket_inner_strong {
+                    bracket_content.push_str("**");
+                }
+                if bracket_inner_em {
+                    bracket_content.push('*');
+                }
+                bracket_content.push_str(&format!("[{inner}]({href})"));
+                if bracket_inner_em {
+                    bracket_content.push('*');
+                }
+                if bracket_inner_strong {
+                    bracket_content.push_str("**");
+                }
+                if bracket_inner_strike {
+                    bracket_content.push_str("~~");
+                }
+
+                if bracket_inner_strike {
+                    outer_strike = false;
+                }
+                if bracket_inner_strong {
+                    outer_strong = false;
+                }
+                if bracket_inner_em {
+                    outer_em = false;
+                }
+
+                core = format!("[{bracket_content}]{{{}}}", attr_parts.join(" "));
             } else {
                 // Link wraps the bracketed span: [[text]{underline}](url)
                 core.push('[');
@@ -7238,6 +7294,147 @@ mod tests {
         assert_eq!(
             mark_types,
             vec!["link", "underline"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn mark_ordering_underline_strong_link_preserved() {
+        // Issue #491: [underline, strong, link] reordered to [strong, underline, link]
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"bold underlined link","marks":[
+            {"type":"underline"},
+            {"type":"strong"},
+            {"type":"link","attrs":{"href":"https://example.com/page"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["underline", "strong", "link"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn mark_ordering_strong_underline_link_preserved() {
+        // Issue #491: verify [strong, underline, link] is preserved
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"bold underlined link","marks":[
+            {"type":"strong"},
+            {"type":"underline"},
+            {"type":"link","attrs":{"href":"https://example.com/page"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["strong", "underline", "link"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn mark_ordering_underline_em_link_preserved() {
+        // Issue #491: verify [underline, em, link] is preserved
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"italic underlined link","marks":[
+            {"type":"underline"},
+            {"type":"em"},
+            {"type":"link","attrs":{"href":"https://example.com/page"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["underline", "em", "link"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn mark_ordering_underline_strike_link_preserved() {
+        // Issue #491: verify [underline, strike, link] is preserved
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"struck underlined link","marks":[
+            {"type":"underline"},
+            {"type":"strike"},
+            {"type":"link","attrs":{"href":"https://example.com/page"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["underline", "strike", "link"],
+            "mark order should be preserved, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn mark_ordering_underline_strong_em_link_preserved() {
+        // Issue #491: verify four-mark combo [underline, strong, em, link] is preserved
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+          {"type":"text","text":"all the marks","marks":[
+            {"type":"underline"},
+            {"type":"strong"},
+            {"type":"em"},
+            {"type":"link","attrs":{"href":"https://example.com/page"}}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let node = &round_tripped.content[0].content.as_ref().unwrap()[0];
+        let mark_types: Vec<&str> = node
+            .marks
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|m| m.mark_type.as_str())
+            .collect();
+        assert_eq!(
+            mark_types,
+            vec!["underline", "strong", "em", "link"],
             "mark order should be preserved, got: {mark_types:?}"
         );
     }


### PR DESCRIPTION
## Description

Fixes issue #491 where ADF marks combining underline, strong/em/strike, and link were not round-tripping correctly through the markdown conversion. When a bracketed span wraps a link (the underline annotation pattern `[[text](url)]{underline}`), formatting marks that appeared **after** the underline mark in the original ADF array were being placed outside the brackets. This caused the mark order to be lost on re-parse, silently reordering marks in the round-tripped document.

The fix detects when a formatting mark (strong, em, strike) appears after the underline mark in the original ADF array and must go inside the link brackets, then builds the `bracket_content` string correctly before wrapping it in the bracketed span annotation. Outer flags for moved marks are cleared to prevent double-application.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #491

## Changes Made

**Core Changes:**
- Changed `outer_strike`, `outer_strong`, and `outer_em` from immutable to `mut` bindings so they can be cleared after a mark is moved inside the brackets
- Added position-aware detection logic: for each formatting mark (strong, em, strike), checks whether its position in the original ADF `marks` array is after the underline mark's position — if so, it must be placed inside the bracketed span rather than outside
- Replaced the simple `format!("[{inner}]({href})")` link-part construction with a `bracket_content` builder that wraps the link with the correct inner marks (strike/strong/em symmetrically)
- Cleared the corresponding `outer_*` flag for any mark moved inside to prevent it from also being applied as an outer wrapper

**Testing:**
- Added five round-trip regression tests in `src/atlassian/convert.rs` covering all affected mark combinations:
  - `[underline, strong, link]` — primary reported case
  - `[strong, underline, link]` — verify pre-existing order is also preserved
  - `[underline, em, link]`
  - `[underline, strike, link]`
  - `[underline, strong, em, link]` — four-mark combo

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — five round-trip tests added directly to `src/atlassian/convert.rs`

**Manual Testing:**
- [x] Tested happy path scenarios (all five mark combinations round-trip correctly)
- [x] Tested error/edge cases (pre-existing `[strong, underline, link]` order also verified)
- [x] Backward compatibility verified — the fix is scoped to the bracketed-span-wraps-link path and does not affect other mark rendering

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression tests for issue #491
cargo test mark_ordering_underline_strong_link_preserved
cargo test mark_ordering_strong_underline_link_preserved
cargo test mark_ordering_underline_em_link_preserved
cargo test mark_ordering_underline_strike_link_preserved
cargo test mark_ordering_underline_strong_em_link_preserved

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `bracket_inner_*` detection logic only triggers in the `annotation` + `link` branch of `render_marked_text`; all other mark paths are unaffected
- [x] Error handling — `underline_pos.is_some_and(...)` safely handles the case where no underline mark is found, falling back to `false`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact — the additional position lookups are O(n) over the small `marks` array (typically ≤ 5 elements) and only execute in the bracketed-span-wraps-link code path

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely corrective change to mark serialization order within the bracketed span annotation path. Documents that previously round-tripped with incorrect mark ordering will now round-trip correctly, which is the intended behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- A general mark-reordering post-pass after rendering was considered but rejected as overly broad — the issue is specifically about where marks are serialized relative to bracket boundaries, not about global ordering.
- Sorting marks by position in the original array universally was considered but could change behavior for other rendering paths that are currently correct.