### PR TITLE
fix(atlassian): preserve leading spaces in heading text during ADF/JFM round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -139,7 +139,7 @@ impl<'a> MarkdownParser<'a> {
             return None;
         }
 
-        let mut full_text = trimmed[level + 1..].trim_start().to_string();
+        let mut full_text = trimmed[level + 1..].to_string();
         self.advance();
         // Collect indented continuation lines produced by hardBreaks (issue #433).
         self.collect_hardbreak_continuations(&mut full_text);
@@ -10313,6 +10313,54 @@ mod tests {
             inlines[0].text.as_deref(),
             Some("Classic "),
             "trailing space in heading text before bold should be preserved"
+        );
+    }
+
+    #[test]
+    fn leading_space_in_heading_text_preserved() {
+        // Issue #492: leading spaces in heading text node stripped on round-trip
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"heading","attrs":{"level":3},"content":[
+          {"type":"text","text":"  #general-channel"}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("  #general-channel"),
+            "leading spaces in heading text should be preserved"
+        );
+    }
+
+    #[test]
+    fn leading_space_in_heading_before_bold_preserved() {
+        // Issue #492: leading space before bold sibling in heading
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"heading","attrs":{"level":2},"content":[
+          {"type":"text","text":"   indented"},
+          {"type":"text","text":" bold","marks":[{"type":"strong"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let inlines = round_tripped.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("   indented"),
+            "leading spaces in heading text before bold should be preserved"
+        );
+    }
+
+    #[test]
+    fn heading_multiple_leading_spaces_markdown_parse() {
+        // Issue #492: verify JFM parsing preserves leading spaces
+        let md = "### \t  #general-channel";
+        let doc = markdown_to_adf(md).unwrap();
+        let inlines = doc.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            inlines[0].text.as_deref(),
+            Some("\t  #general-channel"),
+            "leading whitespace in heading text should be preserved during JFM parsing"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where leading whitespace in heading text nodes was incorrectly stripped during ADF-to-Markdown and Markdown-to-ADF round-trips. The root cause was a spurious `trim_start()` call in the `try_heading()` function in `src/atlassian/convert.rs` that removed leading spaces from heading text content following the mandatory single-space separator after `#` markers.

For example, a heading containing `"  #general-channel"` (with two leading spaces) would lose those spaces after a round-trip, producing `"#general-channel"` instead. This is incorrect behaviour — the single space after the `#` markers is a mandatory separator consumed by the parser, but any additional leading whitespace in the text node should be preserved.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #492

## Changes Made

**Core Changes:**
- Removed spurious `.trim_start()` call on the heading text slice in `try_heading()` in `src/atlassian/convert.rs` (line 137). The parser already advances past the mandatory single space after the `#` markers using index arithmetic (`trimmed[level + 1..]`), so `trim_start()` was incorrectly stripping additional intentional leading whitespace from the heading text content.

**Testing:**
- Added `leading_space_in_heading_text_preserved` test: round-trips a heading whose first text node starts with two leading spaces (`"  #general-channel"`) and asserts the spaces are preserved.
- Added `leading_space_in_heading_before_bold_preserved` test: verifies leading spaces in a heading text node that is followed by a bold sibling are also preserved through the round-trip.
- Added `heading_multiple_leading_spaces_markdown_parse` test: verifies that JFM parsing (`markdown_to_adf`) preserves leading whitespace (including tabs) directly from a raw Markdown heading string.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (3 regression tests for issue #492)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (headings with leading spaces round-trip correctly)
- [x] Tested edge cases (tabs + spaces, spaces before bold inline nodes)
- [x] Backward compatibility verified (normal headings without extra leading spaces unaffected)

### Test Commands

```bash
# Core test suite
cargo test

# Run the specific regression tests for this fix
cargo test leading_space_in_heading
cargo test heading_multiple_leading_spaces

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — ensure normal headings (no extra leading spaces) still parse correctly
- [x] Error handling — the one-character index advance `trimmed[level + 1..]` must remain correct for all valid heading levels (1–6)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a non-breaking bug fix. Previously, leading whitespace in heading text nodes was silently dropped; now it is correctly preserved. Any content that relied on the (incorrect) stripped behaviour would need to be re-evaluated, but correct round-trip fidelity is the expected contract.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Root Cause Detail:**
The `try_heading()` function parses a Markdown heading line by identifying the `#` prefix (length = `level`) and then slicing the remainder starting one character after (to skip the mandatory space separator): `trimmed[level + 1..]`. The subsequent `.trim_start()` was added at some point but is incorrect — it removes intentional leading whitespace that is part of the text node content. Removing it restores correct behaviour while keeping the mandatory separator logic intact.

**Related Prior Fix:**
Issue #400 addressed a similar trailing-space preservation problem in paragraph text nodes. This fix mirrors that approach for heading text nodes.