### PR TITLE
fix(claude): improve CI scope guidance and update rustls-webpki for RUSTSEC-2026-0098

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,9 +1809,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -67,7 +67,7 @@ TYPE SELECTION RULES (must match the commit checker's expectations):
 2. File-type constraints:
    - If only source code files (.rs, .py, .js, etc.) changed, NEVER use `docs`
    - If only test files changed, prefer `test`
-   - If only CI files (.github/, etc.) changed, prefer `ci`
+   - If only CI/CD files changed, prefer `ci` — but use the detected_scope for more specific matches
    - Changing doc comments or help text in source code is `refactor` or `fix`, not `docs`
 3. Before finalizing, verify: would the commit checker accept this type given the files that changed?
 


### PR DESCRIPTION
## Description

This PR bundles two focused fixes discovered during development:

1. **Prompt quality improvement**: Refines the AI commit-type selection rules in `src/claude/prompts.rs` to give clearer guidance when classifying CI/CD-related commits. The previous rule only mentioned `.github/` as an example of CI files, which was too narrow and caused the AI to miss commits touching other CI/CD-related files (e.g., `Makefile`, `scripts/`, `.circleci/`). The updated rule generalises to "CI/CD files" and adds guidance to consult `detected_scope` for more specific scope matching.

2. **Security dependency update**: Bumps `rustls-webpki` from `0.103.10` to `0.103.12` in `Cargo.lock` to address security advisory RUSTSEC-2026-0098.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update

## Related Issue

No linked issue. The prompt fix is an internal quality improvement; the dependency update addresses RUSTSEC-2026-0098.

## Changes Made

**Core Changes:**
- Updated commit type selection rule in `src/claude/prompts.rs`: replaced `"If only CI files (.github/, etc.) changed, prefer \`ci\`"` with `"If only CI/CD files changed, prefer \`ci\` — but use the detected_scope for more specific matches"` to broaden CI file recognition and leverage `detected_scope` signal
- Bumped `rustls-webpki` from `0.103.10` to `0.103.12` in `Cargo.lock` (checksum updated accordingly) to remediate RUSTSEC-2026-0098

**Documentation:**
- No external documentation changes required; the prompt change is internal to AI instruction text

**Testing:**
- No new automated tests required; the prompt change is a string literal and the dependency update is a lockfile-only change

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (not applicable — prompt text and lockfile changes only)

**Manual Testing:**
- [x] Tested happy path scenarios (verified updated prompt wording is clearer and unambiguous for the AI)
- [x] Backward compatibility verified (prompt changes are additive guidance; no CLI or API behaviour affected)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — confirm the updated prompt wording (`detected_scope` guidance) gives clearer, unambiguous direction to the AI without introducing new confusion
- [x] Security implications — verify the `rustls-webpki` bump to `0.103.12` fully resolves RUSTSEC-2026-0098 with no other dependency conflicts

The two changed files are:
- `src/claude/prompts.rs` line ~70 (TYPE SELECTION RULES section, file-type constraints block)
- `Cargo.lock` (`rustls-webpki` version and checksum entries)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement — `rustls-webpki` updated from `0.103.10` to `0.103.12` to address RUSTSEC-2026-0098, which affects TLS certificate validation

## Breaking Changes

None. Both changes are non-breaking: the prompt text change affects only internal AI guidance, and the `rustls-webpki` bump is a patch-level security fix with no API changes.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the `.github/` path example alongside the broader "CI/CD files" description — rejected because the specific example risks misleading the AI into classifying only `.github/` changes as `ci`, missing other CI/CD file locations such as `Makefile`, `scripts/`, `.circleci/`, `.travis.yml`, etc.