### PR TITLE
fix(atlassian): preserve empty language attrs in codeBlock round-trip conversion

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -170,7 +170,10 @@ impl<'a> MarkdownParser<'a> {
         }
 
         let language = line[3..].trim();
-        let language = if language.is_empty() {
+        let language = if language == "\"\"" {
+            // Explicit empty language attr encoded as ```""
+            Some(String::new())
+        } else if language.is_empty() {
             None
         } else {
             Some(language.to_string())
@@ -2657,14 +2660,18 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
             output.push('\n');
         }
         "codeBlock" => {
-            let language = node
-                .attrs
-                .as_ref()
-                .and_then(|a| a.get("language"))
+            let language_value = node.attrs.as_ref().and_then(|a| a.get("language"));
+            let language = language_value
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("");
             output.push_str("```");
-            output.push_str(language);
+            if language.is_empty() && language_value.is_some() {
+                // Explicit empty language attr: encode as ```"" to distinguish
+                // from a codeBlock with no attrs at all (plain ```).
+                output.push_str("\"\"");
+            } else {
+                output.push_str(language);
+            }
             output.push('\n');
             if let Some(ref content) = node.content {
                 for child in content {
@@ -4286,6 +4293,15 @@ mod tests {
     }
 
     #[test]
+    fn code_block_empty_language() {
+        let md = "```\"\"\nsome code\n```";
+        let doc = markdown_to_adf(md).unwrap();
+        assert_eq!(doc.content[0].node_type, "codeBlock");
+        let attrs = doc.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["language"], "");
+    }
+
+    #[test]
     fn horizontal_rule() {
         let doc = markdown_to_adf("---").unwrap();
         assert_eq!(doc.content[0].node_type, "rule");
@@ -5086,6 +5102,44 @@ mod tests {
 
         assert!(restored.contains("```python"));
         assert!(restored.contains("print('hello')"));
+    }
+
+    #[test]
+    fn round_trip_code_block_no_attrs() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+            {"type":"codeBlock","content":[{"type":"text","text":"plain code"}]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        assert!(doc.content[0].attrs.is_none());
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        assert!(round_tripped.content[0].attrs.is_none());
+    }
+
+    #[test]
+    fn round_trip_code_block_empty_language() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+            {"type":"codeBlock","attrs":{"language":""},"content":[{"type":"text","text":"simple code block no backtick"}]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let attrs = doc.content[0].attrs.as_ref().unwrap();
+        assert_eq!(attrs["language"], "");
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let rt_attrs = round_tripped.content[0].attrs.as_ref().unwrap();
+        assert_eq!(rt_attrs["language"], "");
+    }
+
+    #[test]
+    fn round_trip_code_block_with_language() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[
+            {"type":"codeBlock","attrs":{"language":"python"},"content":[{"type":"text","text":"print('hi')"}]}
+        ]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let round_tripped = markdown_to_adf(&md).unwrap();
+        let rt_attrs = round_tripped.content[0].attrs.as_ref().unwrap();
+        assert_eq!(rt_attrs["language"], "python");
     }
 
     #[test]
@@ -6521,6 +6575,18 @@ mod tests {
         };
         let md = adf_to_markdown(&doc).unwrap();
         assert!(md.contains("```\n"));
+        assert!(md.contains("plain code"));
+    }
+
+    #[test]
+    fn adf_code_block_empty_language_to_markdown() {
+        let doc = AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode::code_block(Some(""), "plain code")],
+        };
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(md.contains("```\"\"\n"));
         assert!(md.contains("plain code"));
     }
 


### PR DESCRIPTION
## Description

Fixes a bug (Issue #512) where ADF `codeBlock` nodes with an explicit empty language attribute (`{"language":""}`) were indistinguishable from `codeBlock` nodes with no `attrs` at all after a round-trip through markdown conversion.

**Root Cause:** When rendering a `codeBlock` to markdown, both "no attrs" and `{"language":""}` produced a plain ` ``` ` fence. When parsing markdown back to ADF, ` ``` ` always resulted in `attrs: None`, permanently losing the `language: ""` attribute.

**Solution:** Encode explicit empty language as ` ```"" ` in markdown output so it can be distinguished from a plain ` ``` ` (no attrs). On the parse side, ` ```"" ` is recognized and decoded back to an ADF `codeBlock` with `language: ""`.

This ensures a lossless round-trip for all three `codeBlock` variants: no attrs, empty language, and named language.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #512

## Changes Made

**Core Changes:**
- Modified `render_block_node()` in `src/atlassian/convert.rs` to detect when a `codeBlock` has an explicit empty `language` attribute and encode it as ` ```"" ` instead of plain ` ``` `
- Modified `MarkdownParser` in `src/atlassian/convert.rs` to recognize ` ```"" ` as an explicit empty language and parse it to `Some(String::new())` rather than `None`

**Testing:**
- Added `code_block_empty_language` unit test: verifies ` ```"" ` markdown parses to an ADF `codeBlock` with `language: ""`
- Added `round_trip_code_block_no_attrs` test: verifies attrs-less blocks remain attrs-less after round-trip
- Added `round_trip_code_block_empty_language` test: verifies `language: ""` survives a full ADF → markdown → ADF round-trip
- Added `round_trip_code_block_with_language` test: verifies named language (e.g. `"python"`) is unaffected by the change
- Added `adf_code_block_empty_language_to_markdown` test: verifies ADF-to-markdown encoding produces ` ```""\n `

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (named language round-trip unaffected)
- [x] Tested error/edge cases (no attrs, empty language, named language)
- [x] Backward compatibility verified (plain ` ``` ` still maps to attrs-less node)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new and related tests
cargo test code_block
cargo test round_trip_code_block

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — plain ` ``` ` fences must still parse to `attrs: None`, not `language: ""`
- [x] Error handling — the `language_value.is_some()` guard ensures we only emit `""` when attrs actually exist with a language key

The key logic is in `src/atlassian/convert.rs` at two locations:

1. **Parsing** (~line 170): The new branch `if language == "\"\""` is inserted *before* the existing `if language.is_empty()` check so that the empty-string sentinel takes priority.
2. **Rendering** (~line 2625): `language_value` now captures whether the `language` key was present at all, and the push is guarded by `language.is_empty() && language_value.is_some()`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. The ` ```"" ` encoding is a new, previously unused markdown representation. Existing markdown documents with plain ` ``` ` fences continue to parse as attrs-less `codeBlock` nodes.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Storing a sentinel value (e.g. a special JSON null vs. empty string distinction at the ADF level) — rejected as it would require more invasive model changes
- Treating empty language and no-attrs identically — rejected because Atlassian ADF treats these as distinct states and round-trip fidelity requires preserving the distinction