### PR TITLE
fix(cli,git): make AI-generated scopes deterministic by post-processing with file-pattern logic

### DIFF
--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -5,6 +5,8 @@ use clap::Parser;
 use tracing::debug;
 
 use super::parse_beta_header;
+use crate::data::amendments::AmendmentFile;
+use crate::data::RepositoryView;
 
 /// Twiddle command options.
 #[derive(Parser)]
@@ -179,7 +181,7 @@ impl TwiddleCommand {
             println!("🤖 Analyzing commits with Claude AI...");
         }
 
-        let amendments = if let Some(ctx) = context {
+        let mut amendments = if let Some(ctx) = context {
             claude_client
                 .generate_contextual_amendments_with_options(&full_repo_view, &ctx, self.is_fresh())
                 .await?
@@ -188,6 +190,8 @@ impl TwiddleCommand {
                 .generate_amendments_with_options(&full_repo_view, self.is_fresh())
                 .await?
         };
+
+        refine_amendment_scopes(&mut amendments, &full_repo_view, &scope_defs);
 
         // 6. Handle different output modes
         if let Some(save_path) = self.save_only {
@@ -250,7 +254,6 @@ impl TwiddleCommand {
 
         use crate::claude::batch;
         use crate::claude::token_budget;
-        use crate::data::amendments::AmendmentFile;
 
         let concurrency = self.concurrency;
 
@@ -497,7 +500,7 @@ impl TwiddleCommand {
         // Reduce phase: optional coherence pass
         // Skip when all commits were in a single batch (AI already saw them together)
         let single_batch = batch_plan.batches.len() <= 1;
-        let all_amendments = if !self.no_coherence && !single_batch && successes.len() >= 2 {
+        let mut all_amendments = if !self.no_coherence && !single_batch && successes.len() >= 2 {
             println!("🔗 Running cross-commit coherence pass...");
             match claude_client.refine_amendments_coherence(&successes).await {
                 Ok(refined) => refined,
@@ -513,6 +516,8 @@ impl TwiddleCommand {
                 amendments: successes.into_iter().map(|(a, _)| a).collect(),
             }
         };
+
+        refine_amendment_scopes(&mut all_amendments, &full_repo_view, &scope_defs);
 
         println!(
             "✅ All commits processed! Found {} amendments.",
@@ -1058,8 +1063,6 @@ impl TwiddleCommand {
     /// If the check finds errors with suggestions, automatically applies the
     /// suggestions and re-checks, up to 3 retries.
     async fn run_post_twiddle_check(&self) -> Result<()> {
-        use crate::data::amendments::AmendmentFile;
-
         const MAX_CHECK_RETRIES: u32 = 3;
 
         // Load guidelines, scopes, and Claude client once (they don't change between retries)
@@ -1736,6 +1739,32 @@ fn format_scope_list(scopes: &[crate::data::context::ScopeDefinition]) -> String
         .map(|s| s.name.as_str())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Refine scopes in generated amendment messages using the same deterministic
+/// file-pattern logic the checker uses, so generator and checker agree.
+fn refine_amendment_scopes(
+    amendments: &mut AmendmentFile,
+    repo_view: &RepositoryView,
+    scope_defs: &[crate::data::context::ScopeDefinition],
+) {
+    for amendment in &mut amendments.amendments {
+        if let Some(commit) = repo_view
+            .commits
+            .iter()
+            .find(|c| c.hash == amendment.commit)
+        {
+            let files: Vec<&str> = commit
+                .analysis
+                .file_changes
+                .file_list
+                .iter()
+                .map(|f| f.file.as_str())
+                .collect();
+            amendment.message =
+                crate::git::refine_message_scope(&amendment.message, &files, scope_defs);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2423,5 +2452,93 @@ mod tests {
         .unwrap();
         assert!(failed.is_empty(), "retry succeeded → failed cleared");
         assert_eq!(successes.len(), 1);
+    }
+
+    #[test]
+    fn refine_amendment_scopes_replaces_scope_from_file_patterns() {
+        use crate::data::amendments::Amendment;
+        use crate::data::context::ScopeDefinition;
+        use crate::git::commit::FileChange;
+
+        // Build a commit whose files match the "cli" scope pattern.
+        let (mut commit, _tmp) = make_twiddle_commit("aaa00000");
+        commit.analysis.file_changes.file_list = vec![FileChange {
+            status: "M".to_string(),
+            file: "src/cli/git/twiddle.rs".to_string(),
+        }];
+
+        let repo_view = make_twiddle_repo_view(vec![commit]);
+
+        let scope_defs = vec![ScopeDefinition {
+            name: "cli".to_string(),
+            description: "CLI commands".to_string(),
+            examples: vec![],
+            file_patterns: vec!["src/cli/**".to_string()],
+        }];
+
+        let mut amendments = AmendmentFile {
+            amendments: vec![Amendment {
+                commit: "aaa00000".to_string(),
+                message: "fix(wrong-scope): tweak something".to_string(),
+                summary: None,
+            }],
+        };
+
+        refine_amendment_scopes(&mut amendments, &repo_view, &scope_defs);
+
+        assert_eq!(
+            amendments.amendments[0].message,
+            "fix(cli): tweak something",
+        );
+    }
+
+    #[test]
+    fn refine_amendment_scopes_no_match_leaves_message_unchanged() {
+        use crate::data::amendments::Amendment;
+
+        let (commit, _tmp) = make_twiddle_commit("bbb00000");
+        let repo_view = make_twiddle_repo_view(vec![commit]);
+
+        let mut amendments = AmendmentFile {
+            amendments: vec![Amendment {
+                commit: "bbb00000".to_string(),
+                message: "feat(stuff): add feature".to_string(),
+                summary: None,
+            }],
+        };
+
+        // No scope defs → no refinement.
+        refine_amendment_scopes(&mut amendments, &repo_view, &[]);
+
+        assert_eq!(amendments.amendments[0].message, "feat(stuff): add feature",);
+    }
+
+    #[test]
+    fn refine_amendment_scopes_skips_unknown_commits() {
+        use crate::data::amendments::Amendment;
+        use crate::data::context::ScopeDefinition;
+
+        let (commit, _tmp) = make_twiddle_commit("ccc00000");
+        let repo_view = make_twiddle_repo_view(vec![commit]);
+
+        let scope_defs = vec![ScopeDefinition {
+            name: "cli".to_string(),
+            description: "CLI".to_string(),
+            examples: vec![],
+            file_patterns: vec!["src/cli/**".to_string()],
+        }];
+
+        let mut amendments = AmendmentFile {
+            amendments: vec![Amendment {
+                commit: "unknown_hash".to_string(),
+                message: "fix(wrong): something".to_string(),
+                summary: None,
+            }],
+        };
+
+        refine_amendment_scopes(&mut amendments, &repo_view, &scope_defs);
+
+        // Message unchanged because commit wasn't found in repo_view.
+        assert_eq!(amendments.amendments[0].message, "fix(wrong): something",);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,7 +7,10 @@ pub mod remote;
 pub mod repository;
 
 pub use amendment::AmendmentHandler;
-pub use commit::{CommitAnalysis, CommitAnalysisForAI, CommitInfo, CommitInfoForAI, FileDiffRef};
+pub use commit::{
+    refine_message_scope, resolve_scope, CommitAnalysis, CommitAnalysisForAI, CommitInfo,
+    CommitInfoForAI, FileDiffRef,
+};
 pub use diff_split::{split_by_file, split_file_by_hunk, FileDiff, HunkDiff};
 pub use remote::RemoteInfo;
 pub use repository::GitRepository;

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -384,91 +384,16 @@ impl CommitAnalysis {
     /// with ", ". If no scope definitions match, the existing detected_scope
     /// is kept as a fallback.
     pub fn refine_scope(&mut self, scope_defs: &[ScopeDefinition]) {
-        if scope_defs.is_empty() {
-            return;
-        }
         let files: Vec<&str> = self
             .file_changes
             .file_list
             .iter()
             .map(|f| f.file.as_str())
             .collect();
-        if files.is_empty() {
-            return;
+
+        if let Some(resolved) = resolve_scope(&files, scope_defs) {
+            self.detected_scope = resolved;
         }
-
-        let mut matches: Vec<(&str, usize)> = Vec::new();
-        for scope_def in scope_defs {
-            if let Some(specificity) = Self::scope_matches_files(&files, &scope_def.file_patterns) {
-                matches.push((&scope_def.name, specificity));
-            }
-        }
-
-        if matches.is_empty() {
-            return;
-        }
-
-        // SAFETY: matches is non-empty (guarded by early return above)
-        #[allow(clippy::expect_used)] // Guarded by is_empty() check above
-        let max_specificity = matches.iter().map(|(_, s)| *s).max().expect("non-empty");
-        let best: Vec<&str> = matches
-            .into_iter()
-            .filter(|(_, s)| *s == max_specificity)
-            .map(|(name, _)| name)
-            .collect();
-
-        self.detected_scope = best.join(", ");
-    }
-
-    /// Checks if a scope's file_patterns match any of the given files.
-    ///
-    /// Returns `Some(max_specificity)` if at least one file matches the scope
-    /// (after applying negation patterns), or `None` if no file matches.
-    fn scope_matches_files(files: &[&str], patterns: &[String]) -> Option<usize> {
-        let mut positive = Vec::new();
-        let mut negative = Vec::new();
-        for pat in patterns {
-            if let Some(stripped) = pat.strip_prefix('!') {
-                negative.push(stripped);
-            } else {
-                positive.push(pat.as_str());
-            }
-        }
-
-        // Build negative matchers
-        let neg_matchers: Vec<_> = negative
-            .iter()
-            .filter_map(|p| Glob::new(p).ok().map(|g| g.compile_matcher()))
-            .collect();
-
-        let mut max_specificity: Option<usize> = None;
-        for pat in &positive {
-            let Ok(glob) = Glob::new(pat) else {
-                continue;
-            };
-            let matcher = glob.compile_matcher();
-            for file in files {
-                if matcher.is_match(file) && !neg_matchers.iter().any(|neg| neg.is_match(file)) {
-                    let specificity = Self::count_specificity(pat);
-                    max_specificity =
-                        Some(max_specificity.map_or(specificity, |cur| cur.max(specificity)));
-                }
-            }
-        }
-        max_specificity
-    }
-
-    /// Counts the number of literal (non-wildcard) path segments in a glob pattern.
-    ///
-    /// - `docs/adrs/**` → 2 (`docs`, `adrs`)
-    /// - `docs/**` → 1 (`docs`)
-    /// - `*.md` → 0
-    /// - `src/main/scala/**` → 3
-    fn count_specificity(pattern: &str) -> usize {
-        pattern
-            .split('/')
-            .filter(|segment| !segment.contains('*') && !segment.contains('?'))
-            .count()
     }
 
     /// Generates a proposed conventional commit message.
@@ -799,6 +724,134 @@ impl CommitInfoForAI {
     }
 }
 
+/// Resolves the best scope for a set of files using scope definition file patterns.
+///
+/// More specific patterns (more literal path components) win regardless of
+/// definition order in `scopes.yaml`. Equally specific matches are joined
+/// with ", ". Returns `None` when `scope_defs` or `files` is empty, or no
+/// scope definition matches.
+pub fn resolve_scope(files: &[&str], scope_defs: &[ScopeDefinition]) -> Option<String> {
+    if scope_defs.is_empty() || files.is_empty() {
+        return None;
+    }
+
+    let mut matches: Vec<(&str, usize)> = Vec::new();
+    for scope_def in scope_defs {
+        if let Some(specificity) = scope_matches_files(files, &scope_def.file_patterns) {
+            matches.push((&scope_def.name, specificity));
+        }
+    }
+
+    if matches.is_empty() {
+        return None;
+    }
+
+    // SAFETY: matches is non-empty (guarded by early return above)
+    #[allow(clippy::expect_used)] // Guarded by is_empty() check above
+    let max_specificity = matches.iter().map(|(_, s)| *s).max().expect("non-empty");
+    let best: Vec<&str> = matches
+        .into_iter()
+        .filter(|(_, s)| *s == max_specificity)
+        .map(|(name, _)| name)
+        .collect();
+
+    Some(best.join(", "))
+}
+
+/// Replaces the scope in a conventional commit message with the deterministically
+/// resolved scope based on the given files and scope definitions.
+///
+/// If the message does not contain a conventional commit scope, or if no scope
+/// can be resolved from the files, the message is returned unchanged.
+pub fn refine_message_scope(
+    message: &str,
+    files: &[&str],
+    scope_defs: &[ScopeDefinition],
+) -> String {
+    let Some(resolved) = resolve_scope(files, scope_defs) else {
+        return message.to_string();
+    };
+
+    // Split into first line and rest
+    let (first_line, rest) = message
+        .split_once('\n')
+        .map_or((message, ""), |(f, r)| (f, r));
+
+    let Some(caps) = SCOPE_RE.captures(first_line) else {
+        return message.to_string();
+    };
+
+    // Determine which capture group matched (group 1 = breaking, group 2 = normal)
+    let existing_scope = caps
+        .get(1)
+        .or_else(|| caps.get(2))
+        .map_or("", |m| m.as_str());
+
+    if existing_scope == resolved {
+        return message.to_string();
+    }
+
+    let new_first_line =
+        first_line.replacen(&format!("({existing_scope})"), &format!("({resolved})"), 1);
+
+    if rest.is_empty() {
+        new_first_line
+    } else {
+        format!("{new_first_line}\n{rest}")
+    }
+}
+
+/// Checks if a scope's file patterns match any of the given files.
+///
+/// Returns `Some(max_specificity)` if at least one file matches the scope
+/// (after applying negation patterns), or `None` if no file matches.
+fn scope_matches_files(files: &[&str], patterns: &[String]) -> Option<usize> {
+    let mut positive = Vec::new();
+    let mut negative = Vec::new();
+    for pat in patterns {
+        if let Some(stripped) = pat.strip_prefix('!') {
+            negative.push(stripped);
+        } else {
+            positive.push(pat.as_str());
+        }
+    }
+
+    // Build negative matchers
+    let neg_matchers: Vec<_> = negative
+        .iter()
+        .filter_map(|p| Glob::new(p).ok().map(|g| g.compile_matcher()))
+        .collect();
+
+    let mut max_specificity: Option<usize> = None;
+    for pat in &positive {
+        let Ok(glob) = Glob::new(pat) else {
+            continue;
+        };
+        let matcher = glob.compile_matcher();
+        for file in files {
+            if matcher.is_match(file) && !neg_matchers.iter().any(|neg| neg.is_match(file)) {
+                let specificity = count_specificity(pat);
+                max_specificity =
+                    Some(max_specificity.map_or(specificity, |cur| cur.max(specificity)));
+            }
+        }
+    }
+    max_specificity
+}
+
+/// Counts the number of literal (non-wildcard) path segments in a glob pattern.
+///
+/// - `docs/adrs/**` → 2 (`docs`, `adrs`)
+/// - `docs/**` → 1 (`docs`)
+/// - `*.md` → 0
+/// - `src/main/scala/**` → 3
+fn count_specificity(pattern: &str) -> usize {
+    pattern
+        .split('/')
+        .filter(|segment| !segment.contains('*') && !segment.contains('?'))
+        .count()
+}
+
 impl CommitAnalysisForAI {
     /// Converts from a basic `CommitAnalysis` by loading diff content from file.
     pub fn from_commit_analysis(analysis: CommitAnalysis) -> Result<Self> {
@@ -955,22 +1008,22 @@ mod tests {
 
     #[test]
     fn count_specificity_deep_path() {
-        assert_eq!(CommitAnalysis::count_specificity("src/main/scala/**"), 3);
+        assert_eq!(super::count_specificity("src/main/scala/**"), 3);
     }
 
     #[test]
     fn count_specificity_shallow() {
-        assert_eq!(CommitAnalysis::count_specificity("docs/**"), 1);
+        assert_eq!(super::count_specificity("docs/**"), 1);
     }
 
     #[test]
     fn count_specificity_wildcard_only() {
-        assert_eq!(CommitAnalysis::count_specificity("*.md"), 0);
+        assert_eq!(super::count_specificity("*.md"), 0);
     }
 
     #[test]
     fn count_specificity_no_wildcards() {
-        assert_eq!(CommitAnalysis::count_specificity("src/lib.rs"), 2);
+        assert_eq!(super::count_specificity("src/lib.rs"), 2);
     }
 
     // ── scope_matches_files ──────────────────────────────────────────
@@ -979,14 +1032,14 @@ mod tests {
     fn scope_matches_positive_patterns() {
         let patterns = vec!["src/cli/**".to_string()];
         let files = &["src/cli/commands.rs"];
-        assert!(CommitAnalysis::scope_matches_files(files, &patterns).is_some());
+        assert!(super::scope_matches_files(files, &patterns).is_some());
     }
 
     #[test]
     fn scope_matches_no_match() {
         let patterns = vec!["src/cli/**".to_string()];
         let files = &["src/git/remote.rs"];
-        assert!(CommitAnalysis::scope_matches_files(files, &patterns).is_none());
+        assert!(super::scope_matches_files(files, &patterns).is_none());
     }
 
     #[test]
@@ -994,11 +1047,11 @@ mod tests {
         let patterns = vec!["src/**".to_string(), "!src/test/**".to_string()];
         // File in src/ but not in src/test/ should match
         let files = &["src/lib.rs"];
-        assert!(CommitAnalysis::scope_matches_files(files, &patterns).is_some());
+        assert!(super::scope_matches_files(files, &patterns).is_some());
 
         // File in src/test/ should be excluded
         let test_files = &["src/test/helper.rs"];
-        assert!(CommitAnalysis::scope_matches_files(test_files, &patterns).is_none());
+        assert!(super::scope_matches_files(test_files, &patterns).is_none());
     }
 
     // ── refine_scope ─────────────────────────────────────────────────
@@ -1088,6 +1141,79 @@ mod tests {
             "expected joined scopes, got: {}",
             analysis.detected_scope
         );
+    }
+
+    // ── refine_message_scope ───────────────────────────────────────────
+
+    #[test]
+    fn refine_message_scope_replaces_less_specific() {
+        let scope_defs = vec![
+            make_scope_def("ci", &[".github/**"]),
+            make_scope_def("workflows", &[".github/workflows/**"]),
+        ];
+        let files = &[".github/workflows/ci.yml"];
+        let result = super::refine_message_scope(
+            "chore(ci): bump EmbarkStudios/cargo-deny-action from 2.0.15 to 2.0.17",
+            files,
+            &scope_defs,
+        );
+        assert_eq!(
+            result,
+            "chore(workflows): bump EmbarkStudios/cargo-deny-action from 2.0.15 to 2.0.17"
+        );
+    }
+
+    #[test]
+    fn refine_message_scope_keeps_already_correct() {
+        let scope_defs = vec![
+            make_scope_def("ci", &[".github/**"]),
+            make_scope_def("workflows", &[".github/workflows/**"]),
+        ];
+        let files = &[".github/workflows/ci.yml"];
+        let msg = "chore(workflows): bump something";
+        assert_eq!(super::refine_message_scope(msg, files, &scope_defs), msg);
+    }
+
+    #[test]
+    fn refine_message_scope_no_scope_in_message() {
+        let scope_defs = vec![make_scope_def("cli", &["src/cli/**"])];
+        let files = &["src/cli/commands.rs"];
+        let msg = "chore: do something";
+        assert_eq!(super::refine_message_scope(msg, files, &scope_defs), msg);
+    }
+
+    #[test]
+    fn refine_message_scope_preserves_body() {
+        let scope_defs = vec![
+            make_scope_def("ci", &[".github/**"]),
+            make_scope_def("workflows", &[".github/workflows/**"]),
+        ];
+        let files = &[".github/workflows/ci.yml"];
+        let msg = "chore(ci): bump dep\n\nSome body text\nMore details";
+        let result = super::refine_message_scope(msg, files, &scope_defs);
+        assert_eq!(
+            result,
+            "chore(workflows): bump dep\n\nSome body text\nMore details"
+        );
+    }
+
+    #[test]
+    fn refine_message_scope_breaking_change() {
+        let scope_defs = vec![
+            make_scope_def("ci", &[".github/**"]),
+            make_scope_def("workflows", &[".github/workflows/**"]),
+        ];
+        let files = &[".github/workflows/ci.yml"];
+        let result = super::refine_message_scope("feat!(ci): breaking change", files, &scope_defs);
+        assert_eq!(result, "feat!(workflows): breaking change");
+    }
+
+    #[test]
+    fn refine_message_scope_no_matching_scope_defs() {
+        let scope_defs = vec![make_scope_def("cli", &["src/cli/**"])];
+        let files = &["README.md"];
+        let msg = "docs(docs): update readme";
+        assert_eq!(super::refine_message_scope(msg, files, &scope_defs), msg);
     }
 
     // ── run_pre_validation_checks ────────────────────────────────────
@@ -1213,7 +1339,7 @@ mod tests {
             #[test]
             fn count_specificity_nonnegative(pattern in ".*") {
                 // usize is always >= 0; this test catches panics on arbitrary input
-                let _ = CommitAnalysis::count_specificity(&pattern);
+                let _ = super::count_specificity(&pattern);
             }
 
             #[test]
@@ -1221,7 +1347,7 @@ mod tests {
                 segments in proptest::collection::vec("[a-z*?]{1,10}", 1..6),
             ) {
                 let pattern = segments.join("/");
-                let result = CommitAnalysis::count_specificity(&pattern);
+                let result = super::count_specificity(&pattern);
                 prop_assert!(result <= segments.len());
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a consistency issue where the AI commit message generator (`twiddle`) and the commit checker would disagree on the correct scope for a given set of changed files. The root cause was that the AI could freely choose any scope string, while the checker applied a deterministic file-pattern matching algorithm from `scopes.yaml`. After this fix, the generator post-processes every AI-generated amendment to rewrite the scope using the same deterministic logic, ensuring generator and checker always agree.

The fix also refactors the private scope-matching helpers out of `CommitAnalysis` into public free functions (`resolve_scope`, `refine_message_scope`, `scope_matches_files`, `count_specificity`) so they can be shared between the commit analysis path and the twiddle generator path without duplication.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue

Fixes #493

## Changes Made

**Core Changes (`src/git/commit.rs`):**
- Extracted `resolve_scope` as a public free function that returns the best-matching scope string for a list of files and scope definitions, replacing the inlined logic previously embedded in `CommitAnalysis::refine_scope`
- Extracted `refine_message_scope` as a new public free function that rewrites the scope in an existing conventional commit message subject line, preserving the commit body and handling breaking-change (`!`) markers correctly
- Simplified `CommitAnalysis::refine_scope` to delegate to `resolve_scope` (removing ~60 lines of duplicated logic)
- Moved `scope_matches_files` and `count_specificity` from associated methods on `CommitAnalysis` to module-level free functions

**Generator Fix (`src/cli/git/twiddle.rs`):**
- Applied `refine_message_scope` to every generated amendment in the single-batch code path (after `generate_contextual_amendments_with_options` / `generate_amendments_with_options`)
- Applied `refine_message_scope` to every generated amendment in the multi-batch coherence-pass code path (after `refine_amendments_coherence`)
- Changed `amendments` and `all_amendments` bindings to `mut` to allow in-place scope refinement

**Public API (`src/git.rs`):**
- Re-exported `resolve_scope` and `refine_message_scope` from the `git` module so callers can use them via `crate::git::refine_message_scope`

**Testing (`src/git/commit.rs` test module):**
- Updated all existing test call sites for `count_specificity` and `scope_matches_files` from `CommitAnalysis::` associated-method calls to `super::` free-function calls
- Added 6 new unit tests for `refine_message_scope` covering: scope replacement with less-specific scope, no-op when scope is already correct, message with no scope present, body preservation across multi-line messages, breaking-change (`!`) marker handling, and no-matching-scope-definition case

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`refine_message_scope` test suite)
- [x] Existing `count_specificity` and `scope_matches_files` tests updated to match refactored call sites

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (no scope in message, no matching scope defs, breaking-change markers)
- [x] Backward compatibility verified — `CommitAnalysis::refine_scope` behavior is unchanged

### Test Commands
```bash
# Core test suite
cargo test

# Run scope-specific tests
cargo test refine_message_scope
cargo test refine_scope
cargo test scope_matches
cargo test count_specificity

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — scope helpers are now free functions shared across two code paths
- [x] Backward compatibility — `CommitAnalysis::refine_scope` public API is unchanged; only internals moved

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Passing additional context/instructions to the AI prompt to encourage it to use scope names from `scopes.yaml` — rejected because prompt-based approaches are inherently non-deterministic and the AI can still deviate from instructions.
- Validating the AI-chosen scope against `scopes.yaml` and re-prompting on mismatch — rejected as more complex and slower than a simple post-processing rewrite pass.