### PR TITLE
fix(atlassian): indent hardBreak continuation lines in taskItem list items

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -3136,8 +3136,25 @@ fn render_list_item_content(item: &AdfNode, output: &mut String, opts: &RenderOp
             .iter()
             .position(|c| !is_inline_node_type(&c.node_type))
             .unwrap_or(content.len());
+        let mut buf = String::new();
         for child in &content[..rest_start] {
-            render_inline_node(child, output, opts);
+            render_inline_node(child, &mut buf, opts);
+        }
+        // Indent continuation lines produced by hardBreaks so they stay
+        // within the list item when re-parsed (issue #521).
+        let buf = buf.trim_end_matches('\n');
+        let mut is_first_line = true;
+        for line in buf.split('\n') {
+            if is_first_line {
+                output.push_str(line);
+                is_first_line = false;
+            } else {
+                output.push('\n');
+                if !line.is_empty() {
+                    output.push_str("  ");
+                }
+                output.push_str(line);
+            }
         }
         // No paragraph wrapper — pass a bare node so paraLocalId is omitted.
         let bare = AdfNode::text("");
@@ -10087,6 +10104,89 @@ mod tests {
             let inlines = para.content.as_ref().unwrap();
             assert_eq!(inlines[1].node_type, "hardBreak");
         }
+    }
+
+    /// Issue #521: sibling taskItems with numeric localIds and hardBreak —
+    /// unwrapped inline content.  The hardBreak continuation line must be
+    /// indented so it stays within the list item, and both localIds must
+    /// survive the round-trip.
+    #[test]
+    fn task_item_sibling_localid_hardbreak_unwrapped_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":""},"content":[{"type":"taskItem","attrs":{"localId":"42","state":"DONE"},"content":[{"type":"text","text":"link text","marks":[{"type":"link","attrs":{"href":"https://example.com/page"}}]},{"type":"hardBreak"},{"type":"text","text":"(parenthetical note after hard break)"}]},{"type":"taskItem","attrs":{"localId":"69","state":"DONE"},"content":[{"type":"text","text":"second task item"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        // Continuation line must be indented
+        assert!(
+            md.contains("  (parenthetical"),
+            "continuation line should be 2-space indented: {md}"
+        );
+        assert!(md.contains("localId=42"), "localId=42 missing: {md}");
+        assert!(md.contains("localId=69"), "localId=69 missing: {md}");
+        let rt = markdown_to_adf(&md).unwrap();
+        // Must remain a single taskList with 2 items
+        assert_eq!(
+            rt.content.len(),
+            1,
+            "should be one taskList: {:#?}",
+            rt.content
+        );
+        assert_eq!(rt.content[0].node_type, "taskList");
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2, "should have 2 taskItems");
+        assert_eq!(items[0].attrs.as_ref().unwrap()["localId"], "42");
+        assert_eq!(items[1].attrs.as_ref().unwrap()["localId"], "69");
+        // Verify first item has hardBreak
+        let first_content = items[0].content.as_ref().unwrap();
+        assert!(
+            first_content.iter().any(|n| n.node_type == "hardBreak"),
+            "first item should contain hardBreak"
+        );
+        // Verify second item content
+        let second_content = items[1].content.as_ref().unwrap();
+        assert_eq!(second_content[0].node_type, "text");
+        assert_eq!(
+            second_content[0].text.as_deref().unwrap(),
+            "second task item"
+        );
+    }
+
+    /// Issue #521: sibling taskItems with paragraph-wrapped content and
+    /// hardBreak — localIds must not be swapped or lost.
+    #[test]
+    fn task_item_sibling_localid_hardbreak_paragraph_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":""},"content":[{"type":"taskItem","attrs":{"localId":"42","state":"DONE"},"content":[{"type":"paragraph","content":[{"type":"text","text":"link text","marks":[{"type":"link","attrs":{"href":"https://example.com/page"}}]},{"type":"hardBreak"},{"type":"text","text":"(parenthetical note after hard break)"}]}]},{"type":"taskItem","attrs":{"localId":"69","state":"DONE"},"content":[{"type":"paragraph","content":[{"type":"text","text":"second task item"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        assert_eq!(
+            rt.content.len(),
+            1,
+            "should be one taskList: {:#?}",
+            rt.content
+        );
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].attrs.as_ref().unwrap()["localId"], "42");
+        assert_eq!(items[1].attrs.as_ref().unwrap()["localId"], "69");
+    }
+
+    /// Issue #521: three sibling taskItems — the middle one has a hardBreak.
+    /// Ensures localIds don't leak between adjacent items.
+    #[test]
+    fn task_item_three_siblings_middle_hardbreak_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"taskList","attrs":{"localId":""},"content":[{"type":"taskItem","attrs":{"localId":"10","state":"TODO"},"content":[{"type":"text","text":"first"}]},{"type":"taskItem","attrs":{"localId":"20","state":"DONE"},"content":[{"type":"text","text":"alpha"},{"type":"hardBreak"},{"type":"text","text":"beta"}]},{"type":"taskItem","attrs":{"localId":"30","state":"TODO"},"content":[{"type":"text","text":"third"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+        assert_eq!(rt.content.len(), 1);
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].attrs.as_ref().unwrap()["localId"], "10");
+        assert_eq!(items[1].attrs.as_ref().unwrap()["localId"], "20");
+        assert_eq!(items[2].attrs.as_ref().unwrap()["localId"], "30");
+        // Middle item should have hardBreak
+        let mid_content = items[1].content.as_ref().unwrap();
+        assert!(mid_content.iter().any(|n| n.node_type == "hardBreak"));
     }
 
     /// Issue #447: regression — taskList with empty localId must not inject


### PR DESCRIPTION
## Description

This PR fixes issue #521 where sibling `taskItem` nodes containing `hardBreak` nodes would lose their `localId` attributes or have continuation lines misinterpreted as new list items during the ADF-to-markdown round-trip.

The root cause was that `hardBreak`-produced newlines within a list item's inline content were rendered without indentation. When the markdown was subsequently re-parsed, the continuation line was treated as a sibling list item rather than part of the same task item. This caused `localId` values to shift between items or be dropped entirely.

The fix buffers inline content before writing to output, strips trailing newlines, then re-emits each line — indenting every continuation line (after the first) with two spaces to keep it within the list item boundary during re-parsing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #521

## Changes Made

**Core Changes:**
- In `render_list_item_content` (`src/atlassian/convert.rs`): buffer inline content into a temporary `String` rather than writing directly to `output`
- Strip trailing newlines from the buffered content using `trim_end_matches('\n')`
- Split the buffer on `'\n'` and re-emit each line, prefixing every continuation line (non-first) with two spaces to keep it inside the list item during markdown re-parsing

**Testing:**
- Added `task_item_sibling_localid_hardbreak_unwrapped_roundtrip`: verifies unwrapped inline content with a `hardBreak` is correctly indented and both `localId=42` and `localId=69` survive the round-trip
- Added `task_item_sibling_localid_hardbreak_paragraph_roundtrip`: verifies paragraph-wrapped taskItem content with a `hardBreak` preserves `localId` values on both sibling items
- Added `task_item_three_siblings_middle_hardbreak_roundtrip`: verifies that when the middle of three sibling taskItems contains a `hardBreak`, all three `localId` values (`10`, `20`, `30`) are preserved without leaking between items

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (3 regression tests)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (round-trip of ADF containing hardBreak taskItems)
- [x] Tested error/edge cases (three siblings, paragraph-wrapped content)
- [x] Backward compatibility verified (no change to items without hardBreaks)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests
cargo test task_item_sibling_localid_hardbreak
cargo test task_item_three_siblings_middle_hardbreak

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the indentation logic only affects lines after the first, so single-line task items are unaffected
- [x] Error handling — `trim_end_matches` and `split` are safe on empty strings; no edge-case panics introduced
- [x] The three regression tests covering unwrapped, paragraph-wrapped, and three-sibling scenarios

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (inline comment references issue #521)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact — the buffering of inline content is a trivially small allocation relative to the document processing already performed

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a pure bug fix. The indentation added to continuation lines is interpreted transparently by the markdown parser, and task items without `hardBreak` nodes are completely unaffected.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Root Cause Summary:**
- `render_inline_node` was writing directly to `output`, so a `hardBreak` node emitted a bare `\n` with no leading whitespace
- The markdown parser subsequently saw `\n<text>` at the start of a line and interpreted it as a new list item, consuming the next available `localId` for that phantom item and shifting all subsequent `localId` assignments

**Alternatives Considered:**
- Escaping the newline character differently (e.g., `<br>`) — rejected because it would require corresponding changes in the markdown-to-ADF parser and could affect other node types
- Post-processing the full output string — rejected as more fragile and harder to scope precisely to list item content