### PR TITLE
fix(atlassian): preserve localId on caption nodes during ADF/JFM round-trip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -705,6 +705,7 @@ impl<'a> MarkdownParser<'a> {
                     continue;
                 }
                 if d.name == "caption" {
+                    let dir_attrs = d.attrs.clone();
                     i += 1;
                     let mut caption_lines = Vec::new();
                     while i < lines.len() {
@@ -717,7 +718,9 @@ impl<'a> MarkdownParser<'a> {
                     }
                     let caption_text = caption_lines.join("\n");
                     let inline_nodes = parse_inline(&caption_text);
-                    rows.push(AdfNode::caption(inline_nodes));
+                    let mut caption = AdfNode::caption(inline_nodes);
+                    pass_through_local_id(&dir_attrs, &mut caption);
+                    rows.push(caption);
                     continue;
                 }
             }
@@ -913,6 +916,7 @@ impl<'a> MarkdownParser<'a> {
         if !self.at_end() {
             if let Some((d, _)) = try_parse_container_open(self.current_line()) {
                 if d.name == "caption" {
+                    let dir_attrs = d.attrs;
                     self.advance(); // past :::caption
                     let mut caption_lines = Vec::new();
                     while !self.at_end() {
@@ -925,8 +929,10 @@ impl<'a> MarkdownParser<'a> {
                     }
                     let caption_text = caption_lines.join("\n");
                     let inline_nodes = parse_inline(&caption_text);
+                    let mut caption = AdfNode::caption(inline_nodes);
+                    pass_through_local_id(&dir_attrs, &mut caption);
                     if let Some(ref mut content) = node.content {
-                        content.push(AdfNode::caption(inline_nodes));
+                        content.push(caption);
                     }
                 }
             }
@@ -2794,7 +2800,15 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
                 }
                 for child in content {
                     if child.node_type == "caption" {
-                        output.push_str(":::caption\n");
+                        let mut cap_parts = Vec::new();
+                        if let Some(ref attrs) = child.attrs {
+                            maybe_push_local_id(attrs, &mut cap_parts, opts);
+                        }
+                        if cap_parts.is_empty() {
+                            output.push_str(":::caption\n");
+                        } else {
+                            output.push_str(&format!(":::caption{{{}}}\n", cap_parts.join(" ")));
+                        }
                         if let Some(ref caption_content) = child.content {
                             for inline in caption_content {
                                 render_inline_node(inline, output, opts);
@@ -3449,7 +3463,15 @@ fn render_directive_table(
 
     for row in rows {
         if row.node_type == "caption" {
-            output.push_str(":::caption\n");
+            let mut cap_parts = Vec::new();
+            if let Some(ref attrs) = row.attrs {
+                maybe_push_local_id(attrs, &mut cap_parts, opts);
+            }
+            if cap_parts.is_empty() {
+                output.push_str(":::caption\n");
+            } else {
+                output.push_str(&format!(":::caption{{{}}}\n", cap_parts.join(" ")));
+            }
             if let Some(ref content) = row.content {
                 for child in content {
                     render_inline_node(child, output, opts);
@@ -12694,6 +12716,57 @@ mod tests {
         assert_eq!(caption_text[0].text.as_deref(), Some("Image description"));
     }
 
+    // ── mediaSingle caption localId tests (issue #524) ─────────────────
+
+    #[test]
+    fn media_single_caption_localid_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"mediaSingle","attrs":{"layout":"center"},"content":[{"type":"media","attrs":{"id":"aabbccdd-1234-5678-abcd-000000000001","type":"file","collection":"test-collection"}},{"type":"caption","attrs":{"localId":"9da8c2104471"},"content":[{"type":"text","text":"a caption with hex localId"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("localId=9da8c2104471"),
+            "caption localId should appear in markdown: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let content = rt.content[0].content.as_ref().unwrap();
+        let caption = &content[1];
+        assert_eq!(caption.node_type, "caption");
+        assert_eq!(
+            caption.attrs.as_ref().unwrap()["localId"],
+            "9da8c2104471",
+            "caption localId should round-trip"
+        );
+    }
+
+    #[test]
+    fn media_single_caption_without_localid() {
+        let md = "![Screenshot](){type=file id=abc-123 collection=contentId-456 height=600 width=800}\n:::caption\nPlain caption\n:::\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let caption = &doc.content[0].content.as_ref().unwrap()[1];
+        assert_eq!(caption.node_type, "caption");
+        assert!(
+            caption.attrs.is_none(),
+            "caption without localId should not gain attrs"
+        );
+        let md2 = adf_to_markdown(&doc).unwrap();
+        assert!(
+            !md2.contains("localId"),
+            "no localId should appear in output: {md2}"
+        );
+    }
+
+    #[test]
+    fn media_single_caption_localid_stripped_when_option_set() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"mediaSingle","attrs":{"layout":"center"},"content":[{"type":"media","attrs":{"id":"aabbccdd-1234-5678-abcd-000000000001","type":"file","collection":"test-collection"}},{"type":"caption","attrs":{"localId":"9da8c2104471"},"content":[{"type":"text","text":"stripped caption"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let opts = RenderOptions {
+            strip_local_ids: true,
+            ..Default::default()
+        };
+        let md = adf_to_markdown_with_options(&doc, &opts).unwrap();
+        assert!(!md.contains("localId"), "localId should be stripped: {md}");
+    }
+
     #[test]
     fn table_width_roundtrip() {
         // ADF table with width attribute
@@ -14438,6 +14511,72 @@ C
                 .is_some_and(|m| m.iter().any(|mk| mk.mark_type == "strong"))
         });
         assert!(bold_node.is_some(), "bold mark lost in caption round-trip");
+    }
+
+    // ── table caption localId tests (issue #524) ──────────────────────
+
+    #[test]
+    fn table_caption_localid_roundtrip() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[
+          {"type":"tableRow","content":[{"type":"tableCell","attrs":{},"content":[{"type":"paragraph","content":[{"type":"text","text":"cell"}]}]}]},
+          {"type":"caption","attrs":{"localId":"abcdef123456"},"content":[{"type":"text","text":"Table with localId"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("localId=abcdef123456"),
+            "table caption localId should appear in markdown: {md}"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+        let caption = rt.content[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|n| n.node_type == "caption")
+            .expect("caption should survive round-trip");
+        assert_eq!(
+            caption.attrs.as_ref().unwrap()["localId"],
+            "abcdef123456",
+            "table caption localId should round-trip"
+        );
+    }
+
+    #[test]
+    fn table_caption_without_localid_unchanged() {
+        let md = "::::table\n:::tr\n:::td\ncell\n:::\n:::\n:::caption\nPlain caption\n:::\n::::\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let caption = doc.content[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|n| n.node_type == "caption")
+            .unwrap();
+        assert!(
+            caption.attrs.is_none(),
+            "table caption without localId should not gain attrs"
+        );
+        let md2 = adf_to_markdown(&doc).unwrap();
+        assert!(!md2.contains("localId"), "no localId should appear: {md2}");
+    }
+
+    #[test]
+    fn table_caption_localid_stripped_when_option_set() {
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"table","attrs":{"isNumberColumnEnabled":false,"layout":"default"},"content":[
+          {"type":"tableRow","content":[{"type":"tableCell","attrs":{},"content":[{"type":"paragraph","content":[{"type":"text","text":"cell"}]}]}]},
+          {"type":"caption","attrs":{"localId":"abcdef123456"},"content":[{"type":"text","text":"Stripped"}]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let opts = RenderOptions {
+            strip_local_ids: true,
+            ..Default::default()
+        };
+        let md = adf_to_markdown_with_options(&doc, &opts).unwrap();
+        assert!(
+            !md.contains("localId"),
+            "table caption localId should be stripped: {md}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #524 where the `localId` attribute on ADF `caption` nodes was silently dropped during both ADF-to-JFM and JFM-to-ADF conversion. This caused data loss on round-trips through the Atlassian convert pipeline for both `mediaSingle` and `table` caption nodes.

The root cause was twofold: the JFM parser was not capturing directive attributes before advancing past `:::caption` directives, and the renderer was not emitting `localId` back into the `:::caption{...}` directive syntax. As a result, any `localId` present on a caption in ADF was permanently discarded after conversion.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #524

## Changes Made

**Core Changes:**
- In the table caption parsing path (`src/atlassian/convert.rs` ~line 705): capture `d.attrs.clone()` before advancing past the `:::caption` directive, then call `pass_through_local_id(&dir_attrs, &mut caption)` on the constructed `AdfNode::caption` to copy the `localId` attribute from directive attrs into the ADF node
- In the `mediaSingle` caption parsing path (~line 916): similarly capture `d.attrs` before calling `self.advance()`, and apply `pass_through_local_id` to the newly constructed caption node
- In `render_block_node` (~line 2798): emit `:::caption{localId=<value>}\n` when a `localId` is present in the caption's attrs, falling back to plain `:::caption\n` when none exists; respects the existing `strip_local_ids` render option
- In `render_directive_table` (~line 3428): same `localId`-aware caption rendering logic as `render_block_node`, using `maybe_push_local_id` to conditionally include the attribute

**Testing:**
- Added `media_single_caption_localid_roundtrip`: verifies that a `mediaSingle` caption with `localId` survives a full ADF → JFM → ADF round-trip
- Added `media_single_caption_without_localid`: verifies that captions with no `localId` do not spuriously gain attrs after conversion
- Added `media_single_caption_localid_stripped_when_option_set`: verifies that `strip_local_ids: true` suppresses `localId` output for `mediaSingle` captions
- Added `table_caption_localid_roundtrip`: same round-trip preservation test for table captions
- Added `table_caption_without_localid_unchanged`: verifies table captions without `localId` remain clean
- Added `table_caption_localid_stripped_when_option_set`: verifies `strip_local_ids: true` suppresses `localId` for table captions

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 regression tests covering both node types)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (round-trip with localId present)
- [x] Tested error/edge cases (no localId present, strip_local_ids option)
- [x] Backward compatibility verified (captions without localId are unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests for issue #524
cargo test media_single_caption_localid
cargo test table_caption_localid
cargo test media_single_caption_without_localid
cargo test table_caption_without_localid

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — captions without `localId` must not gain spurious attrs
- [x] Error handling — `strip_local_ids` render option must continue to suppress all localIds including those on captions

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix. ADF documents that previously had `localId` on captions will now correctly preserve that value through conversion. Documents without `localId` on captions are unaffected.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- An alternative approach would have been to modify `AdfNode::caption` to accept an optional attrs map directly, but capturing directive attrs before advancing and using the existing `pass_through_local_id` helper is consistent with how other node types in this file handle attribute propagation and minimises the diff surface.