### PR TITLE
fix(atlassian): prevent consecutive paragraphs in listItem from merging

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -3213,7 +3213,23 @@ fn render_list_item_content(item: &AdfNode, output: &mut String, opts: &RenderOp
         }
         rest_start = 1;
     }
-    for child in &content[rest_start..] {
+    let rest = &content[rest_start..];
+    for (i, child) in rest.iter().enumerate() {
+        // Separate consecutive paragraph siblings with a blank indented
+        // line so they re-parse as distinct paragraphs rather than being
+        // merged into one (issue #522).
+        if child.node_type == "paragraph" {
+            let prev_is_para = if i == 0 {
+                // First rest child — check whether the first-line node
+                // (rendered above) was a paragraph.
+                first.node_type == "paragraph"
+            } else {
+                rest[i - 1].node_type == "paragraph"
+            };
+            if prev_is_para {
+                output.push_str("  \n");
+            }
+        }
         let mut nested = String::new();
         render_block_node(child, &mut nested, opts);
         for line in nested.lines() {
@@ -17068,5 +17084,167 @@ C
             Some("  "),
             "space-only text node should survive round-trip"
         );
+    }
+
+    // ── Issue #522: listItem multi-paragraph merge ──────────────────────
+
+    #[test]
+    fn issue_522_listitem_hardbreak_then_two_paragraphs_roundtrips() {
+        // The exact reproducer from issue #522: first paragraph has
+        // hardBreak nodes, followed by two sibling paragraphs.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"preamble"},{"type":"hardBreak"},{"type":"text","text":"\u00a0"},{"type":"hardBreak"},{"type":"text","text":"line with "},{"marks":[{"type":"code"}],"text":"code","type":"text"},{"type":"text","text":". "}]},{"type":"paragraph","content":[{"type":"text","text":"second paragraph"}]},{"type":"paragraph","content":[{"type":"text","text":"third paragraph"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 1);
+        let children = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "Expected 3 paragraphs in listItem, got {}",
+            children.len()
+        );
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "paragraph");
+        assert_eq!(children[2].node_type, "paragraph");
+
+        // Verify the text content of each paragraph
+        let text1 = children[1].content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap();
+        assert_eq!(text1, "second paragraph");
+        let text2 = children[2].content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap();
+        assert_eq!(text2, "third paragraph");
+    }
+
+    #[test]
+    fn issue_522_ordered_list_hardbreak_then_paragraphs_roundtrips() {
+        // Same scenario in an ordered list.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first"},{"type":"hardBreak"},{"type":"text","text":"continued"}]},{"type":"paragraph","content":[{"type":"text","text":"second para"}]},{"type":"paragraph","content":[{"type":"text","text":"third para"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        let children = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "Expected 3 paragraphs in ordered listItem, got {}",
+            children.len()
+        );
+        assert_eq!(children[1].node_type, "paragraph");
+        assert_eq!(children[2].node_type, "paragraph");
+        assert_eq!(
+            children[1].content.as_ref().unwrap()[0]
+                .text
+                .as_deref()
+                .unwrap(),
+            "second para"
+        );
+        assert_eq!(
+            children[2].content.as_ref().unwrap()[0]
+                .text
+                .as_deref()
+                .unwrap(),
+            "third para"
+        );
+    }
+
+    #[test]
+    fn issue_522_two_paragraphs_without_hardbreak_roundtrips() {
+        // Two paragraphs without hardBreak — should also remain separate.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first paragraph"}]},{"type":"paragraph","content":[{"type":"text","text":"second paragraph"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        let children = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            2,
+            "Expected 2 paragraphs in listItem, got {}",
+            children.len()
+        );
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "paragraph");
+    }
+
+    #[test]
+    fn issue_522_paragraph_then_nested_list_no_spurious_blank() {
+        // A paragraph followed by a nested list should NOT get a blank
+        // separator (only paragraph-paragraph transitions need one).
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"parent"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"child"}]}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        // Should not contain a blank indented line between parent text and sub-list
+        assert!(
+            !md.contains("  \n  -"),
+            "No blank separator between paragraph and nested list"
+        );
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        let children = items[0].content.as_ref().unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "bulletList");
+    }
+
+    #[test]
+    fn issue_522_three_paragraphs_no_hardbreak_roundtrips() {
+        // Three plain paragraphs (no hardBreak) inside a single listItem.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"alpha"}]},{"type":"paragraph","content":[{"type":"text","text":"bravo"}]},{"type":"paragraph","content":[{"type":"text","text":"charlie"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        let children = items[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "Expected 3 paragraphs, got {}",
+            children.len()
+        );
+        for (i, child) in children.iter().enumerate() {
+            assert_eq!(
+                child.node_type, "paragraph",
+                "Child {} should be a paragraph",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn issue_522_multiple_list_items_each_with_paragraphs() {
+        // Multiple list items, each with multiple paragraphs.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item1 p1"}]},{"type":"paragraph","content":[{"type":"text","text":"item1 p2"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item2 p1"},{"type":"hardBreak"},{"type":"text","text":"item2 cont"}]},{"type":"paragraph","content":[{"type":"text","text":"item2 p2"}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let items = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(items.len(), 2, "Expected 2 list items");
+
+        let item1 = items[0].content.as_ref().unwrap();
+        assert_eq!(item1.len(), 2, "Item 1 should have 2 paragraphs");
+
+        let item2 = items[1].content.as_ref().unwrap();
+        assert_eq!(item2.len(), 2, "Item 2 should have 2 paragraphs");
+        // Verify hardBreak is preserved in item2's first paragraph
+        let item2_p1_inlines = item2[0].content.as_ref().unwrap();
+        let types: Vec<&str> = item2_p1_inlines
+            .iter()
+            .map(|n| n.node_type.as_str())
+            .collect();
+        assert_eq!(types, vec!["text", "hardBreak", "text"]);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes issue #522 where multiple sibling paragraph nodes inside an ADF `listItem` were incorrectly merged into a single paragraph during ADF-to-markdown conversion. The bug occurred because consecutive paragraph nodes were rendered without a blank separator line, causing the markdown parser to re-join them into one paragraph on round-trip conversion.

The fix inserts a blank indented line (`  \n`) between consecutive paragraph siblings in `render_list_item_content`, preserving paragraph boundaries through the ADF → Markdown → ADF round-trip. Paragraph-to-nested-list transitions are intentionally unaffected.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #522

## Changes Made

**Core Changes:**
- Modified `render_list_item_content` in `src/atlassian/convert.rs` to detect consecutive paragraph siblings
- Insert a blank indented line (`  \n`) between a paragraph and a following paragraph to prevent them from merging during markdown re-parse
- Only inserts the separator for paragraph-to-paragraph transitions; paragraph-to-nested-list transitions are left unchanged

**Testing:**
- Added six regression tests in `src/atlassian/convert.rs` covering the full range of issue #522 scenarios:
  - `issue_522_listitem_hardbreak_then_two_paragraphs_roundtrips` — exact reproducer from the bug report (first paragraph with `hardBreak` nodes, followed by two sibling paragraphs)
  - `issue_522_ordered_list_hardbreak_then_paragraphs_roundtrips` — same scenario in an ordered list
  - `issue_522_two_paragraphs_without_hardbreak_roundtrips` — two plain paragraphs without `hardBreak`
  - `issue_522_paragraph_then_nested_list_no_spurious_blank` — verifies no spurious blank separator is inserted between a paragraph and a nested list
  - `issue_522_three_paragraphs_no_hardbreak_roundtrips` — three consecutive plain paragraphs
  - `issue_522_multiple_list_items_each_with_paragraphs` — multiple list items, each containing multiple paragraphs

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 regression tests)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (multi-paragraph list items round-trip correctly)
- [x] Tested edge cases (paragraph followed by nested list, three paragraphs, multiple list items)
- [x] Backward compatibility verified (single-paragraph list items and nested lists unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the issue #522 regression tests
cargo test issue_522

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the separator is only added for paragraph-to-paragraph transitions, not paragraph-to-list transitions
- [x] Error handling — logic correctly handles the edge case where the first rendered child is a paragraph and the first element of `rest` is also a paragraph

The key logic change in `render_list_item_content` (`src/atlassian/convert.rs` around line 3097):
- Previously iterated over `content[rest_start..]` with a simple `for child in` loop
- Now uses `enumerate()` to track position, checks whether the current child is a `paragraph` and whether its preceding sibling was also a `paragraph`, and inserts `  \n` if so

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using a double newline (`\n\n`) as separator instead of `  \n` — rejected because the indented blank line is more consistent with how other block separators are rendered within list items in this codebase
- Modifying the markdown parser to be more permissive about merging — rejected as it would affect more than just the list item context and could have unintended side effects