### PR TITLE
fix(atlassian): prevent url link text from becoming inlineCard (issue #523)

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1681,9 +1681,11 @@ fn parse_inline(text: &str) -> Vec<AdfNode> {
             '[' => {
                 if let Some((end, link_text, href)) = try_parse_link(text, i) {
                     flush_plain(text, plain_start, i, &mut nodes);
-                    if link_text == href {
-                        // Bare URL link [url](url): emit as text with link mark,
+                    if link_text.starts_with("http://") || link_text.starts_with("https://") {
+                        // URL-as-link-text: emit as text with link mark,
                         // not via parse_inline which would produce an inlineCard.
+                        // Covers both exact matches and trailing-slash mismatches
+                        // (issue #523).
                         nodes.push(AdfNode::text_with_marks(
                             link_text,
                             vec![AdfMark::link(href)],
@@ -7140,6 +7142,23 @@ mod tests {
     }
 
     #[test]
+    fn url_link_text_with_trailing_slash_mismatch_becomes_link_mark() {
+        // Issue #523: [url](url/) where text and href differ only by trailing
+        // slash should produce a text node with link mark, not an inlineCard.
+        let doc =
+            markdown_to_adf("[https://octopz.example.com](https://octopz.example.com/)").unwrap();
+        let node = &doc.content[0].content.as_ref().unwrap()[0];
+        assert_eq!(node.node_type, "text");
+        assert_eq!(node.text.as_deref(), Some("https://octopz.example.com"));
+        let mark = &node.marks.as_ref().unwrap()[0];
+        assert_eq!(mark.mark_type, "link");
+        assert_eq!(
+            mark.attrs.as_ref().unwrap()["href"],
+            "https://octopz.example.com/"
+        );
+    }
+
+    #[test]
     fn named_link_does_not_become_inline_card() {
         // [#4668](url) — text differs from url, stays as a link mark
         let doc = markdown_to_adf("[#4668](https://github.com/org/repo/pull/4668)").unwrap();
@@ -7773,6 +7792,67 @@ mod tests {
             content[0].text.as_deref(),
             Some("https://example.com/some/path/to/resource")
         );
+    }
+
+    #[test]
+    fn url_text_with_link_mark_round_trips_as_text_node() {
+        // Issue #523: A text node whose content is a URL with a link mark
+        // (href differs by trailing slash) must round-trip as text+link,
+        // not become an inlineCard.
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [{
+                    "type": "text",
+                    "text": "https://octopz.example.com",
+                    "marks": [{"type": "link", "attrs": {"href": "https://octopz.example.com/"}}]
+                }]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should be a single node");
+        assert_eq!(content[0].node_type, "text", "must be text, not inlineCard");
+        assert_eq!(
+            content[0].text.as_deref(),
+            Some("https://octopz.example.com")
+        );
+        let mark = &content[0].marks.as_ref().unwrap()[0];
+        assert_eq!(mark.mark_type, "link");
+        assert_eq!(
+            mark.attrs.as_ref().unwrap()["href"],
+            "https://octopz.example.com/"
+        );
+    }
+
+    #[test]
+    fn url_text_with_exact_link_mark_round_trips() {
+        // Variant: text and href are identical (no trailing slash difference).
+        let adf_json = r#"{
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [{
+                    "type": "text",
+                    "text": "https://example.com/path",
+                    "marks": [{"type": "link", "attrs": {"href": "https://example.com/path"}}]
+                }]
+            }]
+        }"#;
+        let adf: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let jfm = adf_to_markdown(&adf).unwrap();
+        let roundtripped = markdown_to_adf(&jfm).unwrap();
+        let content = roundtripped.content[0].content.as_ref().unwrap();
+        assert_eq!(content.len(), 1, "should be a single node");
+        assert_eq!(content[0].node_type, "text");
+        assert_eq!(content[0].text.as_deref(), Some("https://example.com/path"));
+        let mark = &content[0].marks.as_ref().unwrap()[0];
+        assert_eq!(mark.mark_type, "link");
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #523 where Markdown links with a URL as the link text were incorrectly converted to `inlineCard` ADF nodes instead of `text` nodes with a `link` mark.

The root cause was in `parse_inline` in `src/atlassian/convert.rs`: the condition to emit a text-with-link-mark node (rather than delegating to `parse_inline` which produces an `inlineCard`) required `link_text == href` exactly. This failed for cases like `[https://example.com](https://example.com/)` where the text and href differ only by a trailing slash — the link was incorrectly emitted as an `inlineCard` rather than a plain text node with a link mark.

The fix broadens the bypass condition from exact text/href equality to a URL-prefix check on the link text: any link whose text starts with `http://` or `https://` is now emitted as a text node with a link mark, regardless of whether the text and href match exactly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #523

## Changes Made

**Core Changes:**
- Modified `parse_inline` in `src/atlassian/convert.rs` to replace the exact `link_text == href` equality check with a URL-prefix check (`link_text.starts_with("http://") || link_text.starts_with("https://")`), ensuring all links whose display text is a URL are emitted as text nodes with link marks rather than `inlineCard` nodes.
- Updated inline comments to document the broadened condition and reference issue #523.

**Testing:**
- Added `url_link_text_with_trailing_slash_mismatch_becomes_link_mark`: verifies that `[https://octopz.example.com](https://octopz.example.com/)` (trailing slash mismatch) produces a `text` node with a `link` mark, not an `inlineCard`.
- Added `url_text_with_link_mark_round_trips_as_text_node`: verifies full ADF→Markdown→ADF round-trip for a text node with URL content and a link mark where text and href differ by a trailing slash.
- Added `url_text_with_exact_link_mark_round_trips`: verifies the same round-trip for the case where text and href are identical (no trailing slash difference), ensuring the original fix is preserved.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (3 new regression/round-trip tests)

**Manual Testing:**
- [x] Tested error/edge cases (trailing slash mismatch, exact match, URL-as-link-text)
- [x] Backward compatibility verified (existing `named_link_does_not_become_inline_card` test still passes)

### Test Commands
```bash
# Core test suite
cargo test

# Run only Atlassian conversion tests
cargo test --lib atlassian::convert

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the broadened condition must not affect named links (e.g. `[#4668](url)`) which should still produce `text` nodes with link marks via the existing code path.
- [x] Error handling — the condition change is purely additive; it only affects link parsing when the display text is itself a URL.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a bug fix with no breaking changes. The broadened condition is strictly a superset of the previous behavior and does not affect named links or non-URL link texts.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the exact equality check (`link_text == href`) and normalizing trailing slashes before comparison. Rejected because URL normalization is complex (query params, fragments, encoding differences) and a URL-prefix check on the link text is both simpler and semantically correct: if the user wrote a URL as the link text, it should never become an `inlineCard`.