### PR TITLE
fix(atlassian): preserve listItem localId when first child is mediaSingle

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -3210,15 +3210,19 @@ fn render_list_item_content(item: &AdfNode, output: &mut String, opts: &RenderOp
         }
         return;
     } else {
-        // The first child is a block-level node (e.g. codeBlock).
-        // Render to a buffer and indent continuation lines so the
-        // entire block sits inside the list item (issue #511).
+        // Block-level first child (e.g. codeBlock, mediaSingle).
+        // Render to a buffer so we can:
+        //  1. Append listItem localId attrs to the first line (issue #525)
+        //  2. Indent continuation lines so multi-line blocks stay inside
+        //     the list item (issue #511)
         let mut buf = String::new();
         render_block_node(first, &mut buf, opts);
+        let bare = AdfNode::text("");
         let mut is_first = true;
         for line in buf.lines() {
             if is_first {
                 output.push_str(line);
+                emit_list_item_local_ids(item, &bare, output, opts);
                 output.push('\n');
                 is_first = false;
             } else {
@@ -16287,6 +16291,148 @@ C
         assert_eq!(children[1].node_type, "mediaSingle");
         let media = &children[1].content.as_ref().unwrap()[0];
         assert_eq!(media.attrs.as_ref().unwrap()["id"], "multi-hb");
+    }
+
+    // ── Issue #525: listItem localId dropped when content includes mediaSingle ──
+
+    #[test]
+    fn issue_525_listitem_localid_with_mediasingle_roundtrip() {
+        // Exact reproducer from issue #525: listItem with UUID localId whose
+        // content includes mediaSingle + paragraph + nested bulletList.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","attrs":{"localId":"aabbccdd-1234-5678-abcd-000000000001"},"content":[{"type":"mediaSingle","attrs":{"layout":"center","width":100,"widthType":"pixel"},"content":[{"type":"media","attrs":{"id":"aabbccdd-1234-5678-abcd-000000000002","type":"file","collection":"test-collection","height":100,"width":100}}]},{"type":"paragraph","content":[{"type":"text","text":"some text"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"nested item"}]}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let list = &rt.content[0];
+        assert_eq!(list.node_type, "bulletList");
+        let item = &list.content.as_ref().unwrap()[0];
+        // The localId must be preserved on the listItem.
+        let item_attrs = item.attrs.as_ref().expect("listItem attrs must be present");
+        assert_eq!(
+            item_attrs["localId"], "aabbccdd-1234-5678-abcd-000000000001",
+            "listItem localId must survive round-trip"
+        );
+        let children = item.content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "expected mediaSingle + paragraph + bulletList"
+        );
+        assert_eq!(children[0].node_type, "mediaSingle");
+        assert_eq!(children[1].node_type, "paragraph");
+        assert_eq!(children[2].node_type, "bulletList");
+    }
+
+    #[test]
+    fn issue_525_listitem_localid_with_mediasingle_only() {
+        // Minimal case: listItem with localId whose sole child is mediaSingle.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","attrs":{"localId":"li-media-only"},"content":[
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"m-001","collection":"c1","height":50,"width":100}}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let item_attrs = item.attrs.as_ref().expect("listItem attrs must be present");
+        assert_eq!(
+            item_attrs["localId"], "li-media-only",
+            "listItem localId must survive when sole child is mediaSingle"
+        );
+        assert_eq!(item.content.as_ref().unwrap()[0].node_type, "mediaSingle");
+    }
+
+    #[test]
+    fn issue_525_listitem_localid_with_external_media() {
+        // External image (URL-based) as first child with listItem localId.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","attrs":{"localId":"li-ext-media"},"content":[
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"external","url":"https://example.com/img.png","alt":"photo"}}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let item_attrs = item.attrs.as_ref().expect("listItem attrs must be present");
+        assert_eq!(
+            item_attrs["localId"], "li-ext-media",
+            "listItem localId must survive with external mediaSingle"
+        );
+    }
+
+    #[test]
+    fn issue_525_listitem_localid_with_mediasingle_in_ordered_list() {
+        // Same bug in an ordered list.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"orderedList","attrs":{"order":1},"content":[
+          {"type":"listItem","attrs":{"localId":"li-ord-media"},"content":[
+            {"type":"mediaSingle","attrs":{"layout":"center","width":200,"widthType":"pixel"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"ord-m-001","collection":"col-ord","height":80,"width":160}}]},
+            {"type":"paragraph","content":[{"type":"text","text":"ordered item text"}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let item = &rt.content[0].content.as_ref().unwrap()[0];
+        let item_attrs = item.attrs.as_ref().expect("listItem attrs must be present");
+        assert_eq!(
+            item_attrs["localId"], "li-ord-media",
+            "listItem localId must survive in ordered list with mediaSingle"
+        );
+        let children = item.content.as_ref().unwrap();
+        assert_eq!(children[0].node_type, "mediaSingle");
+        assert_eq!(children[1].node_type, "paragraph");
+    }
+
+    #[test]
+    fn issue_525_jfm_localid_on_mediasingle_line_parses_correctly() {
+        // Verify JFM→ADF: trailing {localId=...} on a mediaSingle line
+        // is assigned to the listItem, not the media node.
+        let md = "- ![](){type=file id=test-525 collection=col height=100 width=200 mediaWidth=100 widthType=pixel} {localId=li-jfm-525}\n";
+        let doc = markdown_to_adf(md).unwrap();
+
+        let item = &doc.content[0].content.as_ref().unwrap()[0];
+        let item_attrs = item
+            .attrs
+            .as_ref()
+            .expect("listItem attrs must be present from JFM");
+        assert_eq!(item_attrs["localId"], "li-jfm-525");
+        assert_eq!(item.content.as_ref().unwrap()[0].node_type, "mediaSingle");
+    }
+
+    #[test]
+    fn issue_525_encoding_emits_localid_on_mediasingle_line() {
+        // Verify the ADF→JFM encoding: localId appears on the same line
+        // as the mediaSingle image syntax.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"bulletList","content":[
+          {"type":"listItem","attrs":{"localId":"li-emit-check"},"content":[
+            {"type":"mediaSingle","attrs":{"layout":"center"},
+             "content":[{"type":"media","attrs":{"type":"file","id":"m-emit","collection":"c-emit","height":10,"width":20}}]}
+          ]}
+        ]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("{localId=li-emit-check}"),
+            "expected localId in JFM output, got: {md}"
+        );
+        // The localId must be on the same line as the image
+        for line in md.lines() {
+            if line.contains("![") {
+                assert!(
+                    line.contains("localId=li-emit-check"),
+                    "localId must be on the same line as the image: {line}"
+                );
+            }
+        }
     }
 
     // ── Placeholder node tests ────────────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes issue #525 where the `localId` attribute on a `listItem` node was silently dropped during ADF→JFM→ADF round-trip conversion when the first child of the `listItem` was a block-level node such as `mediaSingle`.

The root cause was in `render_list_item_content` in `src/atlassian/convert.rs`: the block-level first-child code path rendered content into a buffer and emitted it line-by-line, but never called `emit_list_item_local_ids`. As a result, the `{localId=...}` attribute was never written into the JFM output, and the `localId` was lost on re-parse. The inline-first-child code path already handled this correctly; this fix brings the block-level path into parity.

The fix appends the `localId` attrs to the first line of the buffered block output, using a bare `AdfNode::text("")` as the inline-node argument (since the actual first child is block-level, not inline). Six regression tests have been added to prevent recurrence.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #525

## Changes Made

**Core Changes:**
- In `render_list_item_content` (`src/atlassian/convert.rs`): call `emit_list_item_local_ids` after emitting the first line of buffered block output, so the `{localId=...}` attribute is included in the JFM output when the first child is a block-level node (e.g. `mediaSingle`, `codeBlock`).
- Introduce a bare `AdfNode::text("")` as the inline-node argument passed to `emit_list_item_local_ids` in this code path, consistent with how the existing inline-first-child path works.
- Updated the comment above the block-level branch to document both fixes it now handles (issue #511 indentation and issue #525 localId).

**Testing:**
- `issue_525_listitem_localid_with_mediasingle_roundtrip`: Full round-trip test with `mediaSingle` + `paragraph` + nested `bulletList` and a UUID `localId`.
- `issue_525_listitem_localid_with_mediasingle_only`: Minimal case where the sole child of the `listItem` is a `mediaSingle`.
- `issue_525_listitem_localid_with_external_media`: External URL-based image as first child with `listItem` `localId`.
- `issue_525_listitem_localid_with_mediasingle_in_ordered_list`: Same bug reproduced in an `orderedList`.
- `issue_525_jfm_localid_on_mediasingle_line_parses_correctly`: Verifies JFM→ADF: trailing `{localId=...}` on a `mediaSingle` line is assigned to the `listItem`, not the media node.
- `issue_525_encoding_emits_localid_on_mediasingle_line`: Verifies ADF→JFM encoding: `localId` appears on the same line as the `mediaSingle` image syntax.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 regression tests)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (full round-trip with mixed content)
- [x] Tested edge cases (mediaSingle-only, external media, ordered list)
- [x] Backward compatibility verified (block-level indentation from issue #511 still works)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the issue-525 regression tests
cargo test issue_525

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `emit_list_item_local_ids` call is inserted only in the first-line branch; continuation lines are unaffected, preserving the issue #511 indentation fix.
- [x] Error handling — `AdfNode::text("")` is used as a neutral stand-in; reviewers should confirm this does not cause unexpected side-effects in `emit_list_item_local_ids`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- An alternative was to detect block-level first children earlier and route them through the same code path as inline children. This was rejected because the buffered rendering approach for block nodes (needed for proper indentation) is fundamentally different from inline rendering; the targeted `emit_list_item_local_ids` call is the minimal, least-invasive fix.