### PR TITLE
fix(atlassian): prevent consecutive blockquote paragraphs from merging

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -2720,7 +2720,16 @@ fn render_block_node(node: &AdfNode, output: &mut String, opts: &RenderOptions) 
         }
         "blockquote" => {
             if let Some(ref content) = node.content {
-                for child in content {
+                for (i, child) in content.iter().enumerate() {
+                    // Separate consecutive paragraph siblings with a blank
+                    // blockquote-prefixed line so they re-parse as distinct
+                    // paragraphs rather than being merged into one (issue #531).
+                    if i > 0
+                        && child.node_type == "paragraph"
+                        && content[i - 1].node_type == "paragraph"
+                    {
+                        output.push_str(">\n");
+                    }
                     let mut inner = String::new();
                     render_block_node(child, &mut inner, opts);
                     for line in inner.lines() {
@@ -17611,5 +17620,109 @@ C
             .map(|n| n.node_type.as_str())
             .collect();
         assert_eq!(types, vec!["text", "hardBreak", "text"]);
+    }
+
+    #[test]
+    fn issue_531_blockquote_hardbreak_then_two_paragraphs_roundtrips() {
+        // The exact reproducer from issue #531: blockquote with first
+        // paragraph containing hardBreak nodes, followed by two sibling
+        // paragraphs.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"preamble"},{"type":"hardBreak"},{"type":"text","text":"\u00a0"},{"type":"hardBreak"},{"type":"text","text":"line with "},{"marks":[{"type":"code"}],"text":"code","type":"text"},{"type":"text","text":". "}]},{"type":"paragraph","content":[{"type":"text","text":"second paragraph"}]},{"type":"paragraph","content":[{"type":"text","text":"third paragraph"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let children = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "Expected 3 paragraphs in blockquote, got {}",
+            children.len()
+        );
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "paragraph");
+        assert_eq!(children[2].node_type, "paragraph");
+
+        let text1 = children[1].content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap();
+        assert_eq!(text1, "second paragraph");
+        let text2 = children[2].content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap();
+        assert_eq!(text2, "third paragraph");
+    }
+
+    #[test]
+    fn issue_531_blockquote_two_paragraphs_without_hardbreak_roundtrips() {
+        // Two simple paragraphs inside a blockquote, no hardBreak.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"first"}]},{"type":"paragraph","content":[{"type":"text","text":"second"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let children = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            2,
+            "Expected 2 paragraphs in blockquote, got {}",
+            children.len()
+        );
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "paragraph");
+    }
+
+    #[test]
+    fn issue_531_blockquote_three_paragraphs_no_hardbreak_roundtrips() {
+        // Three paragraphs, none with hardBreak.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"alpha"}]},{"type":"paragraph","content":[{"type":"text","text":"beta"}]},{"type":"paragraph","content":[{"type":"text","text":"gamma"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let children = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(
+            children.len(),
+            3,
+            "Expected 3 paragraphs in blockquote, got {}",
+            children.len()
+        );
+        for child in children {
+            assert_eq!(child.node_type, "paragraph");
+        }
+    }
+
+    #[test]
+    fn issue_531_blockquote_paragraph_then_list_no_spurious_blank() {
+        // A paragraph followed by a nested list inside a blockquote —
+        // should NOT insert a blank separator line.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"intro"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item one"}]}]}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let children = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(children[0].node_type, "paragraph");
+        assert_eq!(children[1].node_type, "bulletList");
+    }
+
+    #[test]
+    fn issue_531_blockquote_single_paragraph_unchanged() {
+        // A single paragraph in a blockquote should remain unchanged.
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"solo"}]}]}]}"#;
+        let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        let rt = markdown_to_adf(&md).unwrap();
+
+        let children = rt.content[0].content.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].node_type, "paragraph");
+        let text = children[0].content.as_ref().unwrap()[0]
+            .text
+            .as_deref()
+            .unwrap();
+        assert_eq!(text, "solo");
     }
 }


### PR DESCRIPTION
## Description

When rendering blockquote nodes in the Atlassian Document Format (ADF) to Markdown converter, consecutive sibling `paragraph` nodes were being merged into a single paragraph on round-trip conversion. This happened because no blank line separator was emitted between adjacent paragraphs inside a blockquote, causing the Markdown parser to treat them as one paragraph when converting back to ADF.

This PR fixes the issue by inserting a blank blockquote-prefixed separator line (`>\n`) between consecutive `paragraph` siblings during blockquote rendering, ensuring each paragraph remains distinct after round-tripping through Markdown.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #531

## Changes Made

**Core Changes:**
- Modified the `"blockquote"` arm of `render_block_node` in `src/atlassian/convert.rs` to iterate with index (`enumerate`) instead of a plain `for` loop
- Added a conditional that inserts `">\n"` between consecutive `paragraph`-typed children within a blockquote, preventing paragraph merging on Markdown round-trip

**Testing:**
- Added regression test `issue_531_blockquote_hardbreak_then_two_paragraphs_roundtrips` covering the exact reproducer from issue #531 (blockquote with a `hardBreak`-containing first paragraph followed by two sibling paragraphs)
- Added test `issue_531_blockquote_two_paragraphs_without_hardbreak_roundtrips` for two simple paragraphs without `hardBreak`
- Added test `issue_531_blockquote_three_paragraphs_no_hardbreak_roundtrips` for three paragraphs without `hardBreak`
- Added test `issue_531_blockquote_paragraph_then_list_no_spurious_blank` confirming no blank separator is inserted between a paragraph and a nested `bulletList`
- Added test `issue_531_blockquote_single_paragraph_unchanged` confirming a single-paragraph blockquote is unaffected

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (multiple paragraph blockquotes round-trip correctly)
- [x] Tested error/edge cases (single paragraph, paragraph + list, paragraphs with `hardBreak`)
- [x] Backward compatibility verified (non-blockquote rendering unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new regression tests for issue #531
cargo test issue_531

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the separator is only inserted between adjacent `paragraph` nodes, not between a paragraph and any other node type (e.g., `bulletList`, `orderedList`, `heading`)
- [x] Error handling — the fix uses `content[i - 1]` which is safe because the guard `i > 0` ensures the index is valid

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Emitting a blank `>\n` line after every paragraph child unconditionally — rejected because it would add a trailing blank line at the end of a blockquote, potentially affecting downstream rendering.
- Handling this at the Markdown parser level rather than the renderer — rejected because the fix is cleaner and more targeted at the output generation stage.