### PR TITLE
feat(atlassian): add JIRA worklog (time tracking) commands

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -12,6 +12,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::atlassian::adf::AdfDocument;
+use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::error::AtlassianError;
 
 /// HTTP request timeout for Atlassian API calls.
@@ -419,6 +420,33 @@ pub struct JiraDevStatusSummary {
     pub repository: JiraDevStatusCount,
 }
 
+/// A JIRA issue worklog entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraWorklog {
+    /// Worklog ID.
+    pub id: String,
+    /// Author display name.
+    pub author: String,
+    /// Time spent in human-readable format (e.g., "2h 30m").
+    pub time_spent: String,
+    /// Time spent in seconds.
+    pub time_spent_seconds: u64,
+    /// ISO 8601 timestamp when the work was started.
+    pub started: String,
+    /// Comment text (plain text, extracted from ADF).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Result from listing JIRA worklogs.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraWorklogList {
+    /// Worklog entries.
+    pub worklogs: Vec<JiraWorklog>,
+    /// Total number of worklogs.
+    pub total: u32,
+}
+
 // ── Internal API response structs ───────────────────────────────────
 
 #[derive(Deserialize)]
@@ -488,6 +516,26 @@ struct JiraCommentEntry {
 struct JiraCommentAuthor {
     #[serde(rename = "displayName")]
     display_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JiraWorklogResponse {
+    #[serde(default)]
+    worklogs: Vec<JiraWorklogEntry>,
+    #[serde(default)]
+    total: u32,
+}
+
+#[derive(Deserialize)]
+struct JiraWorklogEntry {
+    id: String,
+    author: Option<JiraCommentAuthor>,
+    #[serde(rename = "timeSpent")]
+    time_spent: Option<String>,
+    #[serde(rename = "timeSpentSeconds", default)]
+    time_spent_seconds: u64,
+    started: Option<String>,
+    comment: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -3742,6 +3790,279 @@ mod tests {
         assert!(public.author.is_none());
         assert!(public.timestamp.is_none());
     }
+
+    // ── extract_worklog_comment ────────────────────────────────────
+
+    #[test]
+    fn extract_worklog_comment_none() {
+        assert_eq!(AtlassianClient::extract_worklog_comment(None), None);
+    }
+
+    #[test]
+    fn extract_worklog_comment_valid_adf() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": [{
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Fixed the login bug"}]
+            }]
+        });
+        let result = AtlassianClient::extract_worklog_comment(Some(&adf));
+        assert_eq!(result.as_deref(), Some("Fixed the login bug"));
+    }
+
+    #[test]
+    fn extract_worklog_comment_empty_adf() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": []
+        });
+        let result = AtlassianClient::extract_worklog_comment(Some(&adf));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_worklog_comment_invalid_json() {
+        let invalid = serde_json::json!({"not": "adf"});
+        let result = AtlassianClient::extract_worklog_comment(Some(&invalid));
+        assert_eq!(result, None);
+    }
+
+    // ── worklog deserialization ────────────────────────────────────
+
+    #[test]
+    fn worklog_response_deserializes() {
+        let json = r#"{
+            "worklogs": [
+                {
+                    "id": "100",
+                    "author": {"displayName": "Alice"},
+                    "timeSpent": "2h",
+                    "timeSpentSeconds": 7200,
+                    "started": "2026-04-16T09:00:00.000+0000",
+                    "comment": {
+                        "version": 1,
+                        "type": "doc",
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Debugging"}]}]
+                    }
+                },
+                {
+                    "id": "101",
+                    "author": {"displayName": "Bob"},
+                    "timeSpent": "1d",
+                    "timeSpentSeconds": 28800,
+                    "started": "2026-04-15T10:00:00.000+0000"
+                }
+            ],
+            "total": 2
+        }"#;
+        let resp: JiraWorklogResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.worklogs.len(), 2);
+        assert_eq!(resp.worklogs[0].id, "100");
+        assert_eq!(resp.worklogs[0].time_spent.as_deref(), Some("2h"));
+        assert_eq!(resp.worklogs[0].time_spent_seconds, 7200);
+        assert!(resp.worklogs[0].comment.is_some());
+        assert!(resp.worklogs[1].comment.is_none());
+    }
+
+    #[test]
+    fn worklog_response_empty() {
+        let json = r#"{"worklogs": [], "total": 0}"#;
+        let resp: JiraWorklogResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.total, 0);
+        assert!(resp.worklogs.is_empty());
+    }
+
+    #[test]
+    fn worklog_response_missing_optional_fields() {
+        let json = r#"{
+            "worklogs": [{
+                "id": "200",
+                "timeSpentSeconds": 3600
+            }],
+            "total": 1
+        }"#;
+        let resp: JiraWorklogResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.worklogs[0].author.is_none());
+        assert!(resp.worklogs[0].time_spent.is_none());
+        assert!(resp.worklogs[0].started.is_none());
+    }
+
+    // ── worklog wiremock tests ────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_worklogs_success() {
+        let server = wiremock::MockServer::start().await;
+
+        let worklog_json = serde_json::json!({
+            "worklogs": [
+                {
+                    "id": "100",
+                    "author": {"displayName": "Alice"},
+                    "timeSpent": "2h",
+                    "timeSpentSeconds": 7200,
+                    "started": "2026-04-16T09:00:00.000+0000",
+                    "comment": {
+                        "version": 1,
+                        "type": "doc",
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Debugging login"}]}]
+                    }
+                },
+                {
+                    "id": "101",
+                    "author": {"displayName": "Bob"},
+                    "timeSpent": "1d",
+                    "timeSpentSeconds": 28800,
+                    "started": "2026-04-15T10:00:00.000+0000"
+                }
+            ],
+            "total": 2
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(worklog_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_worklogs("PROJ-1", 50).await.unwrap();
+
+        assert_eq!(result.total, 2);
+        assert_eq!(result.worklogs.len(), 2);
+        assert_eq!(result.worklogs[0].author, "Alice");
+        assert_eq!(result.worklogs[0].time_spent, "2h");
+        assert_eq!(result.worklogs[0].time_spent_seconds, 7200);
+        assert_eq!(
+            result.worklogs[0].comment.as_deref(),
+            Some("Debugging login")
+        );
+        assert_eq!(result.worklogs[1].author, "Bob");
+        assert_eq!(result.worklogs[1].comment, None);
+    }
+
+    #[tokio::test]
+    async fn get_worklogs_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"worklogs": [], "total": 0})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_worklogs("PROJ-1", 50).await.unwrap();
+
+        assert_eq!(result.total, 0);
+        assert!(result.worklogs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_worklogs_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_worklogs("PROJ-1", 50).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_worklog_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.add_worklog("PROJ-1", "2h", None, None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_worklog_with_all_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client
+            .add_worklog(
+                "PROJ-1",
+                "2h 30m",
+                Some("2026-04-16T09:00:00.000+0000"),
+                Some("Fixed the bug"),
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_worklog_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(400).set_body_string("Bad Request"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.add_worklog("PROJ-1", "2h", None, None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_worklogs_respects_limit() {
+        let server = wiremock::MockServer::start().await;
+
+        let worklog_json = serde_json::json!({
+            "worklogs": [
+                {"id": "1", "author": {"displayName": "A"}, "timeSpent": "1h", "timeSpentSeconds": 3600, "started": "2026-04-16T09:00:00.000+0000"},
+                {"id": "2", "author": {"displayName": "B"}, "timeSpent": "2h", "timeSpentSeconds": 7200, "started": "2026-04-16T10:00:00.000+0000"},
+                {"id": "3", "author": {"displayName": "C"}, "timeSpent": "3h", "timeSpentSeconds": 10800, "started": "2026-04-16T11:00:00.000+0000"}
+            ],
+            "total": 3
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/PROJ-1/worklog"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(worklog_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_worklogs("PROJ-1", 2).await.unwrap();
+
+        assert_eq!(result.worklogs.len(), 2);
+        assert_eq!(result.total, 3);
+    }
 }
 
 impl AtlassianClient {
@@ -4114,6 +4435,105 @@ impl AtlassianClient {
         }
 
         Ok(())
+    }
+
+    /// Lists worklogs for a JIRA issue.
+    pub async fn get_worklogs(&self, key: &str, limit: u32) -> Result<JiraWorklogList> {
+        let effective_limit = if limit == 0 { u32::MAX } else { limit };
+        let url = format!(
+            "{}/rest/api/3/issue/{}/worklog?maxResults={}",
+            self.instance_url,
+            key,
+            effective_limit.min(5000)
+        );
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: JiraWorklogResponse = response
+            .json()
+            .await
+            .context("Failed to parse worklog response")?;
+
+        let worklogs: Vec<JiraWorklog> = resp
+            .worklogs
+            .into_iter()
+            .take(effective_limit as usize)
+            .map(|w| JiraWorklog {
+                id: w.id,
+                author: w.author.and_then(|a| a.display_name).unwrap_or_default(),
+                time_spent: w.time_spent.unwrap_or_default(),
+                time_spent_seconds: w.time_spent_seconds,
+                started: w.started.unwrap_or_default(),
+                comment: Self::extract_worklog_comment(w.comment.as_ref()),
+            })
+            .collect();
+
+        Ok(JiraWorklogList {
+            total: resp.total,
+            worklogs,
+        })
+    }
+
+    /// Adds a worklog entry to a JIRA issue.
+    pub async fn add_worklog(
+        &self,
+        key: &str,
+        time_spent: &str,
+        started: Option<&str>,
+        comment: Option<&str>,
+    ) -> Result<()> {
+        let url = format!("{}/rest/api/3/issue/{}/worklog", self.instance_url, key);
+
+        let mut body = serde_json::json!({
+            "timeSpent": time_spent,
+        });
+
+        if let Some(started) = started {
+            body["started"] = serde_json::Value::String(started.to_string());
+        }
+
+        if let Some(comment_text) = comment {
+            body["comment"] = serde_json::json!({
+                "type": "doc",
+                "version": 1,
+                "content": [{
+                    "type": "paragraph",
+                    "content": [{
+                        "type": "text",
+                        "text": comment_text
+                    }]
+                }]
+            });
+        }
+
+        let response = self.post_json(&url, &body).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Extracts plain text from a worklog comment ADF value.
+    fn extract_worklog_comment(adf_value: Option<&serde_json::Value>) -> Option<String> {
+        let adf_value = adf_value?;
+        let adf: AdfDocument = serde_json::from_value(adf_value.clone()).ok()?;
+        let md = adf_to_markdown(&adf).ok()?;
+        let trimmed = md.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
     }
 
     /// Lists available transitions for a JIRA issue.

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod sprint;
 pub(crate) mod transition;
+pub(crate) mod worklog;
 pub(crate) mod write;
 
 use anyhow::Result;
@@ -63,6 +64,8 @@ pub enum JiraSubcommands {
     Changelog(changelog::ChangelogCommand),
     /// Downloads JIRA issue attachments.
     Attachment(attachment::AttachmentCommand),
+    /// Manages worklogs (time tracking) on a JIRA issue.
+    Worklog(worklog::WorklogCommand),
 }
 
 impl JiraCommand {
@@ -85,6 +88,7 @@ impl JiraCommand {
             JiraSubcommands::Link(cmd) => cmd.execute().await,
             JiraSubcommands::Changelog(cmd) => cmd.execute().await,
             JiraSubcommands::Attachment(cmd) => cmd.execute().await,
+            JiraSubcommands::Worklog(cmd) => cmd.execute().await,
         }
     }
 }
@@ -303,5 +307,19 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Attachment(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_worklog_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Worklog(worklog::WorklogCommand {
+                command: worklog::WorklogSubcommands::List(worklog::ListCommand {
+                    key: "PROJ-1".to_string(),
+                    limit: 50,
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Worklog(_)));
     }
 }

--- a/src/cli/atlassian/jira/worklog.rs
+++ b/src/cli/atlassian/jira/worklog.rs
@@ -1,0 +1,334 @@
+//! CLI commands for JIRA issue worklogs.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::client::JiraWorklogList;
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages worklogs (time tracking) on a JIRA issue.
+#[derive(Parser)]
+pub struct WorklogCommand {
+    /// The worklog subcommand to execute.
+    #[command(subcommand)]
+    pub command: WorklogSubcommands,
+}
+
+/// Worklog subcommands.
+#[derive(Subcommand)]
+pub enum WorklogSubcommands {
+    /// Lists worklogs on a JIRA issue.
+    List(ListCommand),
+    /// Adds a worklog entry to a JIRA issue.
+    Add(AddCommand),
+}
+
+impl WorklogCommand {
+    /// Executes the worklog command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            WorklogSubcommands::List(cmd) => cmd.execute().await,
+            WorklogSubcommands::Add(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists worklogs on a JIRA issue.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
+
+    /// Maximum number of results, 0 for unlimited (default: 50).
+    #[arg(long, default_value_t = 50)]
+    pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Fetches and displays worklogs.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let result = client.get_worklogs(&self.key, self.limit).await?;
+        if output_as(&result, &self.output)? {
+            return Ok(());
+        }
+        print_worklogs(&result);
+        Ok(())
+    }
+}
+
+/// Adds a worklog entry to a JIRA issue.
+#[derive(Parser)]
+pub struct AddCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
+
+    /// Time spent in JIRA duration format (e.g., "2h 30m", "1d", "45m").
+    #[arg(long)]
+    pub time_spent: String,
+
+    /// When the work was started (ISO 8601, e.g., "2026-04-16T09:00:00.000+0000").
+    #[arg(long)]
+    pub started: Option<String>,
+
+    /// Comment describing the work performed.
+    #[arg(long)]
+    pub comment: Option<String>,
+}
+
+impl AddCommand {
+    /// Posts the worklog entry.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        client
+            .add_worklog(
+                &self.key,
+                &self.time_spent,
+                self.started.as_deref(),
+                self.comment.as_deref(),
+            )
+            .await?;
+
+        println!("Worklog added to {} ({}).", self.key, self.time_spent);
+        Ok(())
+    }
+}
+
+/// Prints worklogs as a formatted table.
+fn print_worklogs(result: &JiraWorklogList) {
+    if result.worklogs.is_empty() {
+        println!("No worklogs.");
+        return;
+    }
+
+    let author_width = result
+        .worklogs
+        .iter()
+        .map(|w| w.author.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let time_width = result
+        .worklogs
+        .iter()
+        .map(|w| w.time_spent.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+
+    println!(
+        "{:<author_width$}  {:<time_width$}  STARTED     COMMENT",
+        "AUTHOR", "SPENT"
+    );
+    let comment_sep = "-".repeat(7);
+    println!(
+        "{:<author_width$}  {:<time_width$}  ----------  {comment_sep}",
+        "-".repeat(author_width),
+        "-".repeat(time_width),
+    );
+
+    for worklog in &result.worklogs {
+        let started = format_date(&worklog.started);
+        let comment = worklog.comment.as_deref().unwrap_or("-");
+        // Truncate long comments for table display.
+        let comment_display = if comment.len() > 60 {
+            format!("{}...", &comment[..57])
+        } else {
+            comment.to_string()
+        };
+        println!(
+            "{:<author_width$}  {:<time_width$}  {:<10}  {}",
+            worklog.author, worklog.time_spent, started, comment_display
+        );
+    }
+
+    if result.total > result.worklogs.len() as u32 {
+        println!(
+            "\nShowing {} of {} worklogs.",
+            result.worklogs.len(),
+            result.total
+        );
+    }
+}
+
+/// Formats an ISO date string to just the date portion.
+fn format_date(date: &str) -> &str {
+    if date.len() >= 10 {
+        &date[..10]
+    } else {
+        date
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::JiraWorklog;
+
+    fn sample_worklog(
+        id: &str,
+        author: &str,
+        time_spent: &str,
+        seconds: u64,
+        started: &str,
+        comment: Option<&str>,
+    ) -> JiraWorklog {
+        JiraWorklog {
+            id: id.to_string(),
+            author: author.to_string(),
+            time_spent: time_spent.to_string(),
+            time_spent_seconds: seconds,
+            started: started.to_string(),
+            comment: comment.map(String::from),
+        }
+    }
+
+    // ── format_date ────────────────────────────────────────────────
+
+    #[test]
+    fn format_date_full_iso() {
+        assert_eq!(format_date("2026-04-16T09:00:00.000+0000"), "2026-04-16");
+    }
+
+    #[test]
+    fn format_date_just_date() {
+        assert_eq!(format_date("2026-04-16"), "2026-04-16");
+    }
+
+    #[test]
+    fn format_date_short() {
+        assert_eq!(format_date("2026"), "2026");
+    }
+
+    #[test]
+    fn format_date_empty() {
+        assert_eq!(format_date(""), "");
+    }
+
+    // ── print_worklogs ─────────────────────────────────────────────
+
+    #[test]
+    fn print_worklogs_empty() {
+        let result = JiraWorklogList {
+            worklogs: vec![],
+            total: 0,
+        };
+        print_worklogs(&result);
+    }
+
+    #[test]
+    fn print_worklogs_with_data() {
+        let result = JiraWorklogList {
+            worklogs: vec![
+                sample_worklog(
+                    "1",
+                    "Alice",
+                    "2h",
+                    7200,
+                    "2026-04-16T09:00:00.000+0000",
+                    Some("Debugging login"),
+                ),
+                sample_worklog(
+                    "2",
+                    "Bob",
+                    "1d",
+                    28800,
+                    "2026-04-15T10:00:00.000+0000",
+                    None,
+                ),
+            ],
+            total: 2,
+        };
+        print_worklogs(&result);
+    }
+
+    #[test]
+    fn print_worklogs_with_pagination() {
+        let result = JiraWorklogList {
+            worklogs: vec![sample_worklog(
+                "1",
+                "Alice",
+                "30m",
+                1800,
+                "2026-04-16",
+                None,
+            )],
+            total: 50,
+        };
+        print_worklogs(&result);
+    }
+
+    #[test]
+    fn print_worklogs_long_comment_truncated() {
+        let long_comment = "a".repeat(100);
+        let result = JiraWorklogList {
+            worklogs: vec![sample_worklog(
+                "1",
+                "Alice",
+                "1h",
+                3600,
+                "2026-04-16",
+                Some(&long_comment),
+            )],
+            total: 1,
+        };
+        print_worklogs(&result);
+    }
+
+    // ── dispatch ───────────────────────────────────────────────────
+
+    #[test]
+    fn worklog_command_list_variant() {
+        let cmd = WorklogCommand {
+            command: WorklogSubcommands::List(ListCommand {
+                key: "PROJ-1".to_string(),
+                limit: 50,
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, WorklogSubcommands::List(_)));
+    }
+
+    #[test]
+    fn worklog_command_add_variant() {
+        let cmd = WorklogCommand {
+            command: WorklogSubcommands::Add(AddCommand {
+                key: "PROJ-1".to_string(),
+                time_spent: "2h".to_string(),
+                started: None,
+                comment: None,
+            }),
+        };
+        assert!(matches!(cmd.command, WorklogSubcommands::Add(_)));
+    }
+
+    #[test]
+    fn add_command_all_fields() {
+        let cmd = AddCommand {
+            key: "PROJ-1".to_string(),
+            time_spent: "2h 30m".to_string(),
+            started: Some("2026-04-16T09:00:00.000+0000".to_string()),
+            comment: Some("Fixed the bug".to_string()),
+        };
+        assert_eq!(cmd.key, "PROJ-1");
+        assert_eq!(cmd.time_spent, "2h 30m");
+        assert_eq!(cmd.started.as_deref(), Some("2026-04-16T09:00:00.000+0000"));
+        assert_eq!(cmd.comment.as_deref(), Some("Fixed the bug"));
+    }
+
+    #[test]
+    fn list_command_custom_limit() {
+        let cmd = ListCommand {
+            key: "PROJ-1".to_string(),
+            limit: 10,
+            output: OutputFormat::Table,
+        };
+        assert_eq!(cmd.limit, 10);
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -394,6 +394,7 @@ Commands:
   link        Manages JIRA issue links
   changelog   Shows change history for JIRA issues
   attachment  Downloads JIRA issue attachments
+  worklog     Manages worklogs (time tracking) on a JIRA issue
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -953,6 +954,58 @@ Arguments:
 
 Options:
       --list             Lists available transitions (same as omitting the transition argument)
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira worklog - Manages worklogs (time tracking) on a JIRA issue
+
+Manages worklogs (time tracking) on a JIRA issue
+
+Usage: worklog <COMMAND>
+
+Commands:
+  list  Lists worklogs on a JIRA issue
+  add   Adds a worklog entry to a JIRA issue
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira worklog add - Adds a worklog entry to a JIRA issue
+
+Adds a worklog entry to a JIRA issue
+
+Usage: add [OPTIONS] --time-spent <TIME_SPENT> <KEY>
+
+Arguments:
+  <KEY>  JIRA issue key (e.g., PROJ-123)
+
+Options:
+      --time-spent <TIME_SPENT>  Time spent in JIRA duration format (e.g., "2h 30m", "1d", "45m")
+      --started <STARTED>        When the work was started (ISO 8601, e.g., "2026-04-16T09:00:00.000+0000")
+      --comment <COMMENT>        Comment describing the work performed
+  -h, --help                     Print help
+
+
+================================================================================
+
+omni-dev atlassian jira worklog list - Lists worklogs on a JIRA issue
+
+Lists worklogs on a JIRA issue
+
+Usage: list [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>  JIRA issue key (e.g., PROJ-123)
+
+Options:
+      --limit <LIMIT>    Maximum number of results, 0 for unlimited (default: 50) [default: 50]
   -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
   -h, --help             Print help (see more with '--help')
 


### PR DESCRIPTION
## Description

This PR implements JIRA worklog (time tracking) commands as part of Issue #352. Users can now list existing worklogs on a JIRA issue and add new worklog entries directly from the CLI. This closes a gap in the JIRA CLI feature set, enabling time tracking workflows without leaving the terminal.

The implementation adds two subcommands under `omni-dev atlassian jira worklog`:
- `list` — retrieves and displays worklogs for a given issue key in table, JSON, or YAML format
- `add` — posts a new worklog entry with configurable time spent, start time, and comment

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #352

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `JiraWorklog` struct (id, author, time_spent, time_spent_seconds, started, comment) as the public data model for worklog entries
- Added `JiraWorklogList` struct wrapping a `Vec<JiraWorklog>` with a `total` count
- Added internal `JiraWorklogResponse` and `JiraWorklogEntry` deserialization structs for the JIRA REST API v3 response format
- Implemented `AtlassianClient::get_worklogs(&self, key, limit)` — calls `GET /rest/api/3/issue/{key}/worklog`, handles pagination via `maxResults`, and maps API entries to `JiraWorklog` values
- Implemented `AtlassianClient::add_worklog(&self, key, time_spent, started, comment)` — posts to `POST /rest/api/3/issue/{key}/worklog` with an ADF-formatted comment body when provided
- Added private helper `extract_worklog_comment()` to convert ADF comment values to plain-text markdown using the existing `adf_to_markdown` utility

**New CLI Module (`src/cli/atlassian/jira/worklog.rs`):**
- `WorklogCommand` / `WorklogSubcommands` — top-level clap parser routing to `list` or `add`
- `ListCommand` — accepts `<KEY>`, `--limit` (default 50, 0 = unlimited), and `-o/--output` (table/json/yaml)
- `AddCommand` — accepts `<KEY>`, `--time-spent` (required), `--started` (optional ISO 8601), `--comment` (optional)
- `print_worklogs()` — renders a dynamic-width table with AUTHOR, SPENT, STARTED, and COMMENT columns; truncates comments longer than 60 characters; shows pagination summary when `total > shown`
- `format_date()` — trims ISO 8601 timestamps to the `YYYY-MM-DD` date portion for compact table display

**CLI Registration (`src/cli/atlassian/jira/mod.rs`):**
- Declared `pub(crate) mod worklog` and added `Worklog(worklog::WorklogCommand)` variant to `JiraSubcommands`
- Wired `JiraSubcommands::Worklog(cmd) => cmd.execute().await` in the dispatch match

**Snapshot Update (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help-all snapshot to include the new `worklog` subcommand entry and full help text for `worklog`, `worklog list`, and `worklog add`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (help snapshot updated)

**New unit tests in `src/cli/atlassian/jira/worklog.rs`:**
- `format_date_full_iso` — extracts date from full ISO timestamp
- `format_date_just_date` — passthrough for already-short dates
- `format_date_short` / `format_date_empty` — edge cases for short/empty strings
- `print_worklogs_empty` — handles empty worklog list gracefully
- `print_worklogs_with_data` — renders two-entry table with and without comments
- `print_worklogs_with_pagination` — shows "Showing X of Y" footer when total exceeds result count
- `print_worklogs_long_comment_truncated` — truncates 100-char comment to 57 chars + `...`
- `worklog_command_list_variant` / `worklog_command_add_variant` — command dispatch variant matching
- `add_command_all_fields` / `list_command_custom_limit` — field value assertions

**New unit test in `src/cli/atlassian/jira/mod.rs`:**
- `jira_subcommands_worklog_variant` — verifies `JiraSubcommands::Worklog` variant is correctly constructed and matched

### Test Commands
```bash
# Core test suite
cargo test

# Run only worklog-related tests
cargo test worklog

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — API errors from `get_worklogs` and `add_worklog` propagate via `AtlassianError::ApiRequestFailed`; comment ADF parsing failures are silently treated as `None` to be non-fatal
- [x] Architecture changes — The worklog module follows the same pattern as `attachment`, `transition`, and other existing JIRA subcommand modules
- [x] Backward compatibility — purely additive; no existing commands or data structures were modified

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact — worklog API calls are on-demand and use the same HTTP client pattern as all other Atlassian API methods

## Security Considerations
- [x] No security implications — credentials are handled by the existing `create_client()` helper; no new credential handling is introduced. Worklog comment content is passed through as-is to the JIRA API.

## Breaking Changes

None. This is a purely additive feature with no changes to existing commands, structs, or behaviors.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- `worklog delete` — remove an existing worklog entry by ID
- `worklog update` — edit time spent or comment on an existing entry
- Filter worklogs by author or date range in the `list` command

**Known Limitations:**
- The JIRA REST API caps `maxResults` at a maximum enforced server-side; the client clamps the request to 5000 as a practical upper bound when `limit=0` is specified