### PR TITLE
feat(atlassian): add jira watcher commands for listing, adding, and removing watchers

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -64,7 +64,7 @@ pub struct JiraIssue {
 }
 
 /// Response from the JIRA `/myself` endpoint.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JiraUser {
     /// User display name.
     #[serde(rename = "displayName")]
@@ -77,6 +77,16 @@ pub struct JiraUser {
     /// Account ID.
     #[serde(rename = "accountId")]
     pub account_id: String,
+}
+
+/// Result from listing watchers on a JIRA issue.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraWatcherList {
+    /// Watchers on the issue.
+    pub watchers: Vec<JiraUser>,
+
+    /// Total number of watchers.
+    pub watch_count: u32,
 }
 
 /// Result from creating a JIRA issue via the REST API.
@@ -3261,6 +3271,172 @@ mod tests {
         assert!(err.to_string().contains("403"));
     }
 
+    // ── get_watchers ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_watchers_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "watchCount": 2,
+                    "watchers": [
+                        {
+                            "accountId": "abc123",
+                            "displayName": "Alice",
+                            "emailAddress": "alice@example.com"
+                        },
+                        {
+                            "accountId": "def456",
+                            "displayName": "Bob"
+                        }
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_watchers("PROJ-1").await.unwrap();
+
+        assert_eq!(result.watch_count, 2);
+        assert_eq!(result.watchers.len(), 2);
+        assert_eq!(result.watchers[0].display_name, "Alice");
+        assert_eq!(result.watchers[0].account_id, "abc123");
+        assert_eq!(
+            result.watchers[0].email_address.as_deref(),
+            Some("alice@example.com")
+        );
+        assert_eq!(result.watchers[1].display_name, "Bob");
+        assert!(result.watchers[1].email_address.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_watchers_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "watchCount": 0,
+                    "watchers": []
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.get_watchers("PROJ-1").await.unwrap();
+
+        assert_eq!(result.watch_count, 0);
+        assert!(result.watchers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_watchers_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/NOPE-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_watchers("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── add_watcher ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_watcher_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .and(wiremock::matchers::body_json(serde_json::json!("abc123")))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.add_watcher("PROJ-1", "abc123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_watcher_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.add_watcher("PROJ-1", "abc123").await.unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    // ── remove_watcher ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn remove_watcher_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .and(wiremock::matchers::query_param("accountId", "abc123"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client.remove_watcher("PROJ-1", "abc123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn remove_watcher_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.remove_watcher("PROJ-1", "abc123").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
     #[tokio::test]
     async fn get_myself_success() {
         let server = wiremock::MockServer::start().await;
@@ -5674,6 +5850,75 @@ impl AtlassianClient {
     /// Deletes a JIRA issue.
     pub async fn delete_issue(&self, key: &str) -> Result<()> {
         let url = format!("{}/rest/api/3/issue/{}", self.instance_url, key);
+
+        let response = self.delete(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Lists watchers on a JIRA issue.
+    pub async fn get_watchers(&self, key: &str) -> Result<JiraWatcherList> {
+        let url = format!("{}/rest/api/3/issue/{}/watchers", self.instance_url, key);
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse watchers response")?;
+
+        let watch_count = json["watchCount"].as_u64().unwrap_or(0) as u32;
+
+        let watchers = json["watchers"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| serde_json::from_value::<JiraUser>(v.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(JiraWatcherList {
+            watchers,
+            watch_count,
+        })
+    }
+
+    /// Adds a user as a watcher on a JIRA issue.
+    pub async fn add_watcher(&self, key: &str, account_id: &str) -> Result<()> {
+        let url = format!("{}/rest/api/3/issue/{}/watchers", self.instance_url, key);
+
+        let body = serde_json::json!(account_id);
+
+        let response = self.post_json(&url, &body).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Removes a user from watchers on a JIRA issue.
+    pub async fn remove_watcher(&self, key: &str, account_id: &str) -> Result<()> {
+        let url = format!(
+            "{}/rest/api/3/issue/{}/watchers?accountId={}",
+            self.instance_url, key, account_id
+        );
 
         let response = self.delete(&url).await?;
 

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod sprint;
 pub(crate) mod transition;
+pub(crate) mod watcher;
 pub(crate) mod worklog;
 pub(crate) mod write;
 
@@ -64,6 +65,8 @@ pub enum JiraSubcommands {
     Changelog(changelog::ChangelogCommand),
     /// Downloads JIRA issue attachments.
     Attachment(attachment::AttachmentCommand),
+    /// Manages watchers on a JIRA issue.
+    Watcher(watcher::WatcherCommand),
     /// Manages worklogs (time tracking) on a JIRA issue.
     Worklog(worklog::WorklogCommand),
 }
@@ -88,6 +91,7 @@ impl JiraCommand {
             JiraSubcommands::Link(cmd) => cmd.execute().await,
             JiraSubcommands::Changelog(cmd) => cmd.execute().await,
             JiraSubcommands::Attachment(cmd) => cmd.execute().await,
+            JiraSubcommands::Watcher(cmd) => cmd.execute().await,
             JiraSubcommands::Worklog(cmd) => cmd.execute().await,
         }
     }
@@ -307,6 +311,19 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Attachment(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_watcher_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Watcher(watcher::WatcherCommand {
+                command: watcher::WatcherSubcommands::List(watcher::ListCommand {
+                    key: "PROJ-1".to_string(),
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Watcher(_)));
     }
 
     #[test]

--- a/src/cli/atlassian/jira/watcher.rs
+++ b/src/cli/atlassian/jira/watcher.rs
@@ -1,0 +1,386 @@
+//! CLI commands for JIRA issue watchers.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::client::{AtlassianClient, JiraWatcherList};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages watchers on a JIRA issue.
+#[derive(Parser)]
+pub struct WatcherCommand {
+    /// The watcher subcommand to execute.
+    #[command(subcommand)]
+    pub command: WatcherSubcommands,
+}
+
+/// Watcher subcommands.
+#[derive(Subcommand)]
+pub enum WatcherSubcommands {
+    /// Lists current watchers on an issue.
+    List(ListCommand),
+    /// Adds a user as a watcher on an issue.
+    Add(AddCommand),
+    /// Removes a user from watchers on an issue.
+    Remove(RemoveCommand),
+}
+
+impl WatcherCommand {
+    /// Executes the watcher command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            WatcherSubcommands::List(cmd) => cmd.execute().await,
+            WatcherSubcommands::Add(cmd) => cmd.execute().await,
+            WatcherSubcommands::Remove(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists current watchers on an issue.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Issue key (e.g., "PROJ-123").
+    pub key: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Fetches and displays watchers.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_list(&client, &self.key, &self.output).await
+    }
+}
+
+/// Fetches and displays watchers using the given client.
+async fn run_list(client: &AtlassianClient, key: &str, output: &OutputFormat) -> Result<()> {
+    let result = client.get_watchers(key).await?;
+    if output_as(&result, output)? {
+        return Ok(());
+    }
+    print_watchers(&result);
+    Ok(())
+}
+
+/// Adds a user as a watcher on an issue.
+#[derive(Parser)]
+pub struct AddCommand {
+    /// Issue key (e.g., "PROJ-123").
+    pub key: String,
+
+    /// Account ID of the user to add.
+    #[arg(long)]
+    pub user: String,
+}
+
+impl AddCommand {
+    /// Adds the user as a watcher.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_add(&client, &self.key, &self.user).await
+    }
+}
+
+/// Adds a watcher using the given client.
+async fn run_add(client: &AtlassianClient, key: &str, user: &str) -> Result<()> {
+    client.add_watcher(key, user).await?;
+    println!("Added watcher {user} to {key}.");
+    Ok(())
+}
+
+/// Removes a user from watchers on an issue.
+#[derive(Parser)]
+pub struct RemoveCommand {
+    /// Issue key (e.g., "PROJ-123").
+    pub key: String,
+
+    /// Account ID of the user to remove.
+    #[arg(long)]
+    pub user: String,
+}
+
+impl RemoveCommand {
+    /// Removes the user from watchers.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_remove(&client, &self.key, &self.user).await
+    }
+}
+
+/// Removes a watcher using the given client.
+async fn run_remove(client: &AtlassianClient, key: &str, user: &str) -> Result<()> {
+    client.remove_watcher(key, user).await?;
+    println!("Removed watcher {user} from {key}.");
+    Ok(())
+}
+
+/// Prints watchers as a formatted table.
+fn print_watchers(result: &JiraWatcherList) {
+    if result.watchers.is_empty() {
+        println!("No watchers found.");
+        return;
+    }
+
+    let name_width = result
+        .watchers
+        .iter()
+        .map(|w| w.display_name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let id_width = result
+        .watchers
+        .iter()
+        .map(|w| w.account_id.len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+
+    println!("{:<name_width$}  {:<id_width$}", "NAME", "ACCOUNT ID");
+    println!(
+        "{:<name_width$}  {:<id_width$}",
+        "-".repeat(name_width),
+        "-".repeat(id_width),
+    );
+
+    for watcher in &result.watchers {
+        println!(
+            "{:<name_width$}  {:<id_width$}",
+            watcher.display_name, watcher.account_id
+        );
+    }
+
+    println!("\n{} watcher(s) total.", result.watch_count);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::JiraUser;
+
+    fn sample_user(name: &str, account_id: &str) -> JiraUser {
+        JiraUser {
+            display_name: name.to_string(),
+            email_address: None,
+            account_id: account_id.to_string(),
+        }
+    }
+
+    fn mock_client(base_url: &str) -> AtlassianClient {
+        AtlassianClient::new(base_url, "user@test.com", "token").unwrap()
+    }
+
+    // -- print_watchers ------------------------------------------------
+
+    #[test]
+    fn print_watchers_empty() {
+        let result = JiraWatcherList {
+            watchers: vec![],
+            watch_count: 0,
+        };
+        print_watchers(&result);
+    }
+
+    #[test]
+    fn print_watchers_with_data() {
+        let result = JiraWatcherList {
+            watchers: vec![sample_user("Alice", "abc123"), sample_user("Bob", "def456")],
+            watch_count: 2,
+        };
+        print_watchers(&result);
+    }
+
+    #[test]
+    fn print_watchers_count_exceeds_list() {
+        let result = JiraWatcherList {
+            watchers: vec![sample_user("Alice", "abc123")],
+            watch_count: 5,
+        };
+        print_watchers(&result);
+    }
+
+    // -- run_list -------------------------------------------------------
+
+    #[tokio::test]
+    async fn run_list_table_output() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "watchCount": 1,
+                    "watchers": [{"accountId": "abc123", "displayName": "Alice"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let result = run_list(&client, "PROJ-1", &OutputFormat::Table).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_list_json_output() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "watchCount": 0,
+                    "watchers": []
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let result = run_list(&client, "PROJ-1", &OutputFormat::Json).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_list_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/NOPE-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_list(&client, "NOPE-1", &OutputFormat::Table)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // -- run_add --------------------------------------------------------
+
+    #[tokio::test]
+    async fn run_add_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let result = run_add(&client, "PROJ-1", "abc123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_add_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_add(&client, "PROJ-1", "abc123").await.unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    // -- run_remove -----------------------------------------------------
+
+    #[tokio::test]
+    async fn run_remove_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .and(wiremock::matchers::query_param("accountId", "abc123"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let result = run_remove(&client, "PROJ-1", "abc123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_remove_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/watchers",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_remove(&client, "PROJ-1", "abc123").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // -- dispatch -------------------------------------------------------
+
+    #[test]
+    fn watcher_command_list_variant() {
+        let cmd = WatcherCommand {
+            command: WatcherSubcommands::List(ListCommand {
+                key: "PROJ-1".to_string(),
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, WatcherSubcommands::List(_)));
+    }
+
+    #[test]
+    fn watcher_command_add_variant() {
+        let cmd = WatcherCommand {
+            command: WatcherSubcommands::Add(AddCommand {
+                key: "PROJ-1".to_string(),
+                user: "abc123".to_string(),
+            }),
+        };
+        assert!(matches!(cmd.command, WatcherSubcommands::Add(_)));
+    }
+
+    #[test]
+    fn watcher_command_remove_variant() {
+        let cmd = WatcherCommand {
+            command: WatcherSubcommands::Remove(RemoveCommand {
+                key: "PROJ-1".to_string(),
+                user: "abc123".to_string(),
+            }),
+        };
+        assert!(matches!(cmd.command, WatcherSubcommands::Remove(_)));
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -394,6 +394,7 @@ Commands:
   link        Manages JIRA issue links
   changelog   Shows change history for JIRA issues
   attachment  Downloads JIRA issue attachments
+  watcher     Manages watchers on a JIRA issue
   worklog     Manages worklogs (time tracking) on a JIRA issue
   help        Print this message or the help of the given subcommand(s)
 
@@ -956,6 +957,72 @@ Options:
       --list             Lists available transitions (same as omitting the transition argument)
   -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira watcher - Manages watchers on a JIRA issue
+
+Manages watchers on a JIRA issue
+
+Usage: watcher <COMMAND>
+
+Commands:
+  list    Lists current watchers on an issue
+  add     Adds a user as a watcher on an issue
+  remove  Removes a user from watchers on an issue
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira watcher add - Adds a user as a watcher on an issue
+
+Adds a user as a watcher on an issue
+
+Usage: add --user <USER> <KEY>
+
+Arguments:
+  <KEY>  Issue key (e.g., "PROJ-123")
+
+Options:
+      --user <USER>  Account ID of the user to add
+  -h, --help         Print help
+
+
+================================================================================
+
+omni-dev atlassian jira watcher list - Lists current watchers on an issue
+
+Lists current watchers on an issue
+
+Usage: list [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>  Issue key (e.g., "PROJ-123")
+
+Options:
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira watcher remove - Removes a user from watchers on an issue
+
+Removes a user from watchers on an issue
+
+Usage: remove --user <USER> <KEY>
+
+Arguments:
+  <KEY>  Issue key (e.g., "PROJ-123")
+
+Options:
+      --user <USER>  Account ID of the user to remove
+  -h, --help         Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements the `omni-dev atlassian jira watcher` subcommand with full CRUD support for managing watchers on JIRA issues via the REST API. Users can now list all watchers on an issue, add a user as a watcher by account ID, and remove a watcher — all from the CLI.

This addresses issue #353, providing first-class watcher management alongside existing JIRA issue commands.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #353

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `Clone` and `Serialize` derives to the existing `JiraUser` struct to support serialization in watcher responses
- Added `JiraWatcherList` struct holding a `Vec<JiraUser>` and `watch_count: u32`
- Implemented `get_watchers(&self, key: &str) -> Result<JiraWatcherList>` calling `GET /rest/api/3/issue/{key}/watchers`
- Implemented `add_watcher(&self, key: &str, account_id: &str) -> Result<()>` calling `POST /rest/api/3/issue/{key}/watchers`
- Implemented `remove_watcher(&self, key: &str, account_id: &str) -> Result<()>` calling `DELETE /rest/api/3/issue/{key}/watchers?accountId={account_id}`
- All three methods include proper HTTP error handling returning `AtlassianError::ApiRequestFailed` on non-2xx responses

**CLI Module (`src/cli/atlassian/jira/mod.rs`):**
- Registered new `pub(crate) mod watcher` module
- Added `Watcher(watcher::WatcherCommand)` variant to `JiraSubcommands` enum
- Wired dispatch for `JiraSubcommands::Watcher(cmd) => cmd.execute().await`
- Added unit test `jira_subcommands_watcher_variant` verifying the new enum variant

**New CLI Module (`src/cli/atlassian/jira/watcher.rs`):**
- Created `WatcherCommand` with `WatcherSubcommands` enum (`List`, `Add`, `Remove`)
- `ListCommand`: accepts issue `key` and `--output` flag (table/json/yaml, default: table); calls `get_watchers` and delegates to `output_as` or `print_watchers`
- `AddCommand`: accepts issue `key` and `--user <ACCOUNT_ID>`; calls `add_watcher` and prints confirmation
- `RemoveCommand`: accepts issue `key` and `--user <ACCOUNT_ID>`; calls `remove_watcher` and prints confirmation
- `print_watchers`: renders a dynamically-sized table with NAME and ACCOUNT ID columns plus total watcher count footer

**Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include `watcher` in the `jira` subcommand list
- Added full help output sections for `watcher`, `watcher list`, `watcher add`, and `watcher remove`

**Testing:**
- Unit tests for `print_watchers` covering empty list, populated list, and mismatched `watch_count` vs list length
- Unit tests for all three `WatcherSubcommands` variants (`List`, `Add`, `Remove`)
- Unit test for `JiraSubcommands::Watcher` dispatch variant in `mod.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (help snapshot updated)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (empty watcher list, API error responses)
- [x] Backward compatibility verified (additive changes only, no existing commands modified)

### Test Commands
```bash
# Core test suite
cargo test

# Run watcher-specific tests
cargo test watcher

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manual CLI verification
omni-dev atlassian jira watcher list PROJ-123
omni-dev atlassian jira watcher add PROJ-123 --user <account-id>
omni-dev atlassian jira watcher remove PROJ-123 --user <account-id>
omni-dev atlassian jira watcher list PROJ-123 --output json
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — HTTP error propagation in `get_watchers`, `add_watcher`, and `remove_watcher`
- [x] Architecture changes — `JiraUser` now derives `Clone` and `Serialize`; ensure this doesn't cause unintended serialization side effects elsewhere
- [x] User experience — table formatting in `print_watchers` with dynamic column widths

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

The watcher API calls use the same authenticated `AtlassianClient` as all other JIRA commands. Account IDs are passed directly to the JIRA REST API without additional processing — no credentials or sensitive data are logged.

## Breaking Changes

None. This is a purely additive feature. The `JiraUser` struct gains `Clone` and `Serialize` derives, which is backward-compatible. No existing commands or data structures have functional changes.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Support `--output json/yaml` on `add` and `remove` commands for scripting use cases
- Add `watcher self` shorthand command that uses the authenticated user's account ID

**Known Limitations:**
- The `list` command displays watchers visible to the authenticated user; private watchers may not appear depending on JIRA instance permissions

**Alternatives Considered:**
- Embedding watcher display directly in the `read` command output was considered but rejected in favour of a dedicated subcommand for discoverability and composability