### PR TITLE
feat(atlassian): add confluence page comment commands

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -104,6 +104,55 @@ pub struct ChildPage {
     pub title: String,
 }
 
+// ── Comment types ─────────────────────────────────────────────────
+
+/// A comment on a Confluence page.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceComment {
+    /// Comment ID.
+    pub id: String,
+    /// Author display name.
+    pub author: String,
+    /// Comment body as raw ADF JSON.
+    pub body_adf: Option<serde_json::Value>,
+    /// ISO 8601 creation timestamp.
+    pub created: String,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceCommentsResponse {
+    results: Vec<ConfluenceCommentEntry>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceCommentEntry {
+    id: String,
+    #[serde(default)]
+    version: Option<ConfluenceCommentVersion>,
+    #[serde(default)]
+    body: Option<ConfluenceCommentBody>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceCommentVersion {
+    #[serde(rename = "authorId", default)]
+    author_id: Option<String>,
+    #[serde(rename = "createdAt", default)]
+    created_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceCommentBody {
+    atlas_doc_format: Option<ConfluenceAtlasDoc>,
+}
+
+#[derive(Serialize)]
+struct ConfluenceAddCommentRequest {
+    #[serde(rename = "pageId")]
+    page_id: String,
+    body: ConfluenceUpdateBody,
+}
+
 // ── Create request ─────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -444,6 +493,85 @@ impl ConfluenceApi {
         }
 
         Ok(all_children)
+    }
+
+    /// Lists footer comments on a Confluence page.
+    pub async fn get_page_comments(&self, page_id: &str) -> Result<Vec<ConfluenceComment>> {
+        let url = format!(
+            "{}/wiki/api/v2/pages/{}/footer-comments?body-format=atlas_doc_format",
+            self.client.instance_url(),
+            page_id
+        );
+
+        let response = self
+            .client
+            .get_json(&url)
+            .await
+            .context("Failed to fetch Confluence page comments")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: ConfluenceCommentsResponse = response
+            .json()
+            .await
+            .context("Failed to parse Confluence comments response")?;
+
+        Ok(resp
+            .results
+            .into_iter()
+            .map(|c| {
+                let body_adf = c.body.and_then(|b| {
+                    b.atlas_doc_format
+                        .and_then(|a| serde_json::from_str(&a.value).ok())
+                });
+                let author = c
+                    .version
+                    .as_ref()
+                    .and_then(|v| v.author_id.clone())
+                    .unwrap_or_default();
+                let created = c.version.and_then(|v| v.created_at).unwrap_or_default();
+                ConfluenceComment {
+                    id: c.id,
+                    author,
+                    body_adf,
+                    created,
+                }
+            })
+            .collect())
+    }
+
+    /// Adds a footer comment to a Confluence page.
+    pub async fn add_page_comment(&self, page_id: &str, body_adf: &AdfDocument) -> Result<()> {
+        let adf_json =
+            serde_json::to_string(body_adf).context("Failed to serialize ADF document")?;
+
+        let request = ConfluenceAddCommentRequest {
+            page_id: page_id.to_string(),
+            body: ConfluenceUpdateBody {
+                representation: "atlas_doc_format".to_string(),
+                value: adf_json,
+            },
+        };
+
+        let url = format!("{}/wiki/api/v2/footer-comments", self.client.instance_url());
+
+        let response = self
+            .client
+            .post_json(&url, &request)
+            .await
+            .context("Failed to add Confluence page comment")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
     }
 
     /// Resolves a space ID to a space key via the Confluence API.
@@ -1062,5 +1190,209 @@ mod tests {
         let key = api.resolve_space_key("unknown").await.unwrap();
         // Falls back to the space ID when lookup fails
         assert_eq!(key, "unknown");
+    }
+
+    // ── get_page_comments ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_page_comments_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {
+                            "id": "100",
+                            "version": {
+                                "authorId": "user-abc",
+                                "createdAt": "2026-04-01T10:00:00.000Z"
+                            },
+                            "body": {
+                                "atlas_doc_format": {
+                                    "value": "{\"version\":1,\"type\":\"doc\",\"content\":[]}"
+                                }
+                            }
+                        },
+                        {
+                            "id": "101",
+                            "version": {
+                                "authorId": "user-def",
+                                "createdAt": "2026-04-02T14:00:00.000Z"
+                            }
+                        }
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].id, "100");
+        assert_eq!(comments[0].author, "user-abc");
+        assert!(comments[0].body_adf.is_some());
+        assert_eq!(comments[1].id, "101");
+        assert!(comments[1].body_adf.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_malformed_adf_body() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {
+                            "id": "100",
+                            "version": {
+                                "authorId": "user-abc",
+                                "createdAt": "2026-04-01T10:00:00.000Z"
+                            },
+                            "body": {
+                                "atlas_doc_format": {
+                                    "value": "{ invalid json }"
+                                }
+                            }
+                        }
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].id, "100");
+        // Malformed ADF silently becomes None
+        assert!(comments[0].body_adf.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_missing_version() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {
+                            "id": "100"
+                        }
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].author, "");
+        assert_eq!(comments[0].created, "");
+        assert!(comments[0].body_adf.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"results": []})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+        assert!(comments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/99999/footer-comments",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.get_page_comments("99999").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── add_page_comment ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_page_comment_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/wiki/api/v2/footer-comments"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id": "200"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let adf = AdfDocument::new();
+        let result = api.add_page_comment("12345", &adf).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_page_comment_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/wiki/api/v2/footer-comments"))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let adf = AdfDocument::new();
+        let err = api.add_page_comment("12345", &adf).await.unwrap_err();
+        assert!(err.to_string().contains("403"));
     }
 }

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -1,0 +1,381 @@
+//! CLI commands for Confluence page comments.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::adf::AdfDocument;
+use crate::atlassian::confluence_api::{ConfluenceApi, ConfluenceComment};
+use crate::atlassian::convert::{adf_to_markdown, markdown_to_adf};
+use crate::atlassian::document::JfmDocument;
+use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
+use crate::cli::atlassian::helpers::{create_client, read_input};
+
+/// Manages comments on a Confluence page.
+#[derive(Parser)]
+pub struct CommentCommand {
+    /// The comment subcommand to execute.
+    #[command(subcommand)]
+    pub command: CommentSubcommands,
+}
+
+/// Comment subcommands.
+#[derive(Subcommand)]
+pub enum CommentSubcommands {
+    /// Lists comments on a Confluence page.
+    List(ListCommand),
+    /// Adds a comment to a Confluence page.
+    Add(AddCommand),
+}
+
+impl CommentCommand {
+    /// Executes the comment command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            CommentSubcommands::List(cmd) => cmd.execute().await,
+            CommentSubcommands::Add(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists comments on a Confluence page.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Confluence page ID.
+    pub id: String,
+
+    /// Maximum number of comments to display.
+    #[arg(long, default_value_t = 25)]
+    pub limit: usize,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Fetches and displays comments.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        let mut comments = api.get_page_comments(&self.id).await?;
+        comments.truncate(self.limit);
+        if output_as(&comments, &self.output)? {
+            return Ok(());
+        }
+        print_comments(&comments);
+        Ok(())
+    }
+}
+
+/// Adds a comment to a Confluence page.
+#[derive(Parser)]
+pub struct AddCommand {
+    /// Confluence page ID.
+    pub id: String,
+
+    /// Input file (reads from stdin if omitted or "-").
+    pub file: Option<String>,
+
+    /// Input format.
+    #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
+    pub format: ContentFormat,
+}
+
+impl AddCommand {
+    /// Reads input, converts to ADF, and posts the comment.
+    pub async fn execute(self) -> Result<()> {
+        let adf = self.parse_input()?;
+
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        api.add_page_comment(&self.id, &adf).await?;
+
+        println!("Comment added to page {}.", self.id);
+        Ok(())
+    }
+
+    /// Parses the input file into an ADF document.
+    fn parse_input(&self) -> Result<AdfDocument> {
+        let input = read_input(self.file.as_deref())?;
+
+        match self.format {
+            ContentFormat::Jfm => {
+                // Try parsing as JFM document (with frontmatter) first,
+                // fall back to raw markdown
+                if input.starts_with("---\n") {
+                    let doc = JfmDocument::parse(&input)?;
+                    markdown_to_adf(&doc.body)
+                } else {
+                    markdown_to_adf(&input)
+                }
+            }
+            ContentFormat::Adf => {
+                serde_json::from_str(&input).context("Failed to parse ADF JSON input")
+            }
+        }
+    }
+}
+
+/// Prints comments in a readable format.
+fn print_comments(comments: &[ConfluenceComment]) {
+    if comments.is_empty() {
+        println!("No comments.");
+        return;
+    }
+
+    for (i, comment) in comments.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+
+        let timestamp = format_timestamp(&comment.created);
+        println!("--- {} | {} ---", comment.author, timestamp);
+        println!("{}", format_comment_body(&comment.body_adf));
+    }
+}
+
+/// Formats a comment body for display.
+fn format_comment_body(body_adf: &Option<serde_json::Value>) -> String {
+    let Some(adf_value) = body_adf else {
+        return "[empty]".to_string();
+    };
+
+    let Ok(adf) = serde_json::from_value::<AdfDocument>(adf_value.clone()) else {
+        return "[ADF content]".to_string();
+    };
+
+    let Ok(md) = adf_to_markdown(&adf) else {
+        return "[ADF content]".to_string();
+    };
+
+    let trimmed = md.trim();
+    if trimmed.is_empty() {
+        "[empty]".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Formats an ISO 8601 timestamp to a shorter display format.
+fn format_timestamp(ts: &str) -> &str {
+    // Return just the date+time portion (before the timezone offset or milliseconds)
+    // e.g., "2026-04-01T10:00:00.000Z" -> "2026-04-01T10:00:00"
+    ts.split('.').next().unwrap_or(ts)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn sample_comment(
+        id: &str,
+        author: &str,
+        body_adf: Option<serde_json::Value>,
+    ) -> ConfluenceComment {
+        ConfluenceComment {
+            id: id.to_string(),
+            author: author.to_string(),
+            body_adf,
+            created: "2026-04-01T10:30:00.000Z".to_string(),
+        }
+    }
+
+    // ── print_comments ─────────────────────────────────────────────
+
+    #[test]
+    fn print_comments_empty() {
+        print_comments(&[]);
+    }
+
+    #[test]
+    fn print_comments_with_adf_body() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hello world"}]}]
+        });
+        let comments = vec![sample_comment("1", "Alice", Some(adf))];
+        print_comments(&comments);
+    }
+
+    #[test]
+    fn print_comments_with_null_body() {
+        let comments = vec![sample_comment("1", "Bob", None)];
+        print_comments(&comments);
+    }
+
+    #[test]
+    fn print_comments_with_invalid_adf() {
+        let invalid = serde_json::json!({"not": "adf"});
+        let comments = vec![sample_comment("1", "Carol", Some(invalid))];
+        print_comments(&comments);
+    }
+
+    #[test]
+    fn print_comments_multiple() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "First"}]}]
+        });
+        let comments = vec![
+            sample_comment("1", "Alice", Some(adf)),
+            sample_comment("2", "Bob", None),
+        ];
+        print_comments(&comments);
+    }
+
+    // ── format_comment_body ─────────────────────────────────────────
+
+    #[test]
+    fn format_body_none() {
+        assert_eq!(format_comment_body(&None), "[empty]");
+    }
+
+    #[test]
+    fn format_body_valid_adf_with_text() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hello"}]}]
+        });
+        let result = format_comment_body(&Some(adf));
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn format_body_valid_adf_empty_content() {
+        let adf = serde_json::json!({
+            "version": 1,
+            "type": "doc",
+            "content": []
+        });
+        let result = format_comment_body(&Some(adf));
+        assert_eq!(result, "[empty]");
+    }
+
+    #[test]
+    fn format_body_invalid_adf() {
+        let invalid = serde_json::json!({"not": "adf"});
+        assert_eq!(format_comment_body(&Some(invalid)), "[ADF content]");
+    }
+
+    // ── format_timestamp ───────────────────────────────────────────
+
+    #[test]
+    fn format_timestamp_with_millis() {
+        assert_eq!(
+            format_timestamp("2026-04-01T10:30:00.000Z"),
+            "2026-04-01T10:30:00"
+        );
+    }
+
+    #[test]
+    fn format_timestamp_without_millis() {
+        assert_eq!(
+            format_timestamp("2026-04-01T10:30:00"),
+            "2026-04-01T10:30:00"
+        );
+    }
+
+    #[test]
+    fn format_timestamp_empty() {
+        assert_eq!(format_timestamp(""), "");
+    }
+
+    // ── AddCommand::parse_input ────────────────────────────────────
+
+    #[test]
+    fn parse_input_raw_markdown() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("comment.md");
+        fs::write(&file_path, "Hello **world**\n").unwrap();
+
+        let cmd = AddCommand {
+            id: "12345".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+        };
+
+        let adf = cmd.parse_input().unwrap();
+        assert!(!adf.content.is_empty());
+    }
+
+    #[test]
+    fn parse_input_jfm_with_frontmatter() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("comment.md");
+        let content =
+            "---\ntype: confluence\ninstance: https://org.atlassian.net\nid: \"12345\"\ntitle: Test\nspace_key: ENG\n---\n\nComment body\n";
+        fs::write(&file_path, content).unwrap();
+
+        let cmd = AddCommand {
+            id: "12345".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+        };
+
+        let adf = cmd.parse_input().unwrap();
+        assert!(!adf.content.is_empty());
+    }
+
+    #[test]
+    fn parse_input_adf_format() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("comment.json");
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello"}]}]}"#;
+        fs::write(&file_path, adf_json).unwrap();
+
+        let cmd = AddCommand {
+            id: "12345".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Adf,
+        };
+
+        let adf = cmd.parse_input().unwrap();
+        assert_eq!(adf.content.len(), 1);
+    }
+
+    #[test]
+    fn parse_input_invalid_adf() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("bad.json");
+        fs::write(&file_path, "not json").unwrap();
+
+        let cmd = AddCommand {
+            id: "12345".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Adf,
+        };
+
+        assert!(cmd.parse_input().is_err());
+    }
+
+    // ── CommentCommand dispatch ────────────────────────────────────
+
+    #[test]
+    fn comment_command_list_variant() {
+        let cmd = CommentCommand {
+            command: CommentSubcommands::List(ListCommand {
+                id: "12345".to_string(),
+                limit: 25,
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, CommentSubcommands::List(_)));
+    }
+
+    #[test]
+    fn comment_command_add_variant() {
+        let cmd = CommentCommand {
+            command: CommentSubcommands::Add(AddCommand {
+                id: "12345".to_string(),
+                file: None,
+                format: ContentFormat::Jfm,
+            }),
+        };
+        assert!(matches!(cmd.command, CommentSubcommands::Add(_)));
+    }
+}

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -1,5 +1,6 @@
 //! Confluence CLI subcommands.
 
+pub(crate) mod comment;
 pub(crate) mod create;
 pub(crate) mod delete;
 pub(crate) mod download;
@@ -22,6 +23,8 @@ pub struct ConfluenceCommand {
 /// Confluence subcommands.
 #[derive(Subcommand)]
 pub enum ConfluenceSubcommands {
+    /// Manages comments on a Confluence page.
+    Comment(comment::CommentCommand),
     /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON.
     Read(read::ReadCommand),
     /// Pushes content to a Confluence page.
@@ -42,6 +45,7 @@ impl ConfluenceCommand {
     /// Executes the Confluence command.
     pub async fn execute(self) -> Result<()> {
         match self.command {
+            ConfluenceSubcommands::Comment(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Read(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Write(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Edit(cmd) => cmd.execute().await,
@@ -57,6 +61,20 @@ impl ConfluenceCommand {
 mod tests {
     use super::*;
     use crate::cli::atlassian::format::{ContentFormat, OutputFormat};
+
+    #[test]
+    fn confluence_subcommands_comment_variant() {
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Comment(comment::CommentCommand {
+                command: comment::CommentSubcommands::List(comment::ListCommand {
+                    id: "12345".to_string(),
+                    limit: 25,
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, ConfluenceSubcommands::Comment(_)));
+    }
 
     #[test]
     fn confluence_subcommands_read_variant() {

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -181,6 +181,7 @@ Confluence page management, search, and more
 Usage: confluence <COMMAND>
 
 Commands:
+  comment   Manages comments on a Confluence page
   read      Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
   write     Pushes content to a Confluence page
   edit      Interactive fetch-edit-push cycle for a Confluence page
@@ -192,6 +193,57 @@ Commands:
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence comment - Manages comments on a Confluence page
+
+Manages comments on a Confluence page
+
+Usage: comment <COMMAND>
+
+Commands:
+  list  Lists comments on a Confluence page
+  add   Adds a comment to a Confluence page
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence comment add - Adds a comment to a Confluence page
+
+Adds a comment to a Confluence page
+
+Usage: add [OPTIONS] <ID> [FILE]
+
+Arguments:
+  <ID>    Confluence page ID
+  [FILE]  Input file (reads from stdin if omitted or "-")
+
+Options:
+      --format <FORMAT>  Input format [default: jfm] [possible values: jfm, adf]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian confluence comment list - Lists comments on a Confluence page
+
+Lists comments on a Confluence page
+
+Usage: list [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Confluence page ID
+
+Options:
+      --limit <LIMIT>    Maximum number of comments to display [default: 25]
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements `list` and `add` subcommands for Confluence page footer comments, exposed under the `omni-dev atlassian confluence comment` command group. Users can now list existing footer comments on a Confluence page and add new comments in JFM markdown or ADF JSON format, backed by new Confluence API v2 methods.

This resolves issue #354 and extends the existing Confluence CLI surface with comment management capabilities that were previously unavailable.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #354

## Changes Made

**Core API (`src/atlassian/confluence_api.rs`):**
- Added `ConfluenceComment` struct (public, `Serialize`) with `id`, `author`, `body_adf`, and `created` fields
- Added internal deserialization types: `ConfluenceCommentsResponse`, `ConfluenceCommentEntry`, `ConfluenceCommentVersion`, `ConfluenceCommentBody`, and `ConfluenceAddCommentRequest`
- Implemented `get_page_comments(&str) -> Result<Vec<ConfluenceComment>>` fetching footer comments in ADF format via `GET /wiki/api/v2/pages/{id}/footer-comments?body-format=atlas_doc_format`
- Implemented `add_page_comment(&str, &AdfDocument) -> Result<()>` posting to `POST /wiki/api/v2/footer-comments`

**CLI (`src/cli/atlassian/confluence/comment.rs` — new file):**
- Added `CommentCommand` with `List` and `Add` subcommands dispatched via `CommentCommand::execute`
- `ListCommand`: accepts page `<ID>`, `--limit` (default 25), and `-o/--output` (table/json/yaml)
- `AddCommand`: accepts page `<ID>`, optional `[FILE]` (stdin if omitted), and `--format` (jfm or adf); parses JFM with frontmatter or raw markdown via `parse_input`
- `print_comments`: human-readable table-style comment output with author, timestamp header, and ADF-to-markdown body rendering
- `format_comment_body`: converts ADF to markdown, falls back to `[ADF content]` or `[empty]`
- `format_timestamp`: trims milliseconds from ISO 8601 timestamps for display

**Wiring (`src/cli/atlassian/confluence/mod.rs`):**
- Added `pub(crate) mod comment` declaration
- Added `Comment(comment::CommentCommand)` variant to `ConfluenceSubcommands`
- Dispatched `ConfluenceSubcommands::Comment` in `ConfluenceCommand::execute`

**Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include `comment`, `comment list`, and `comment add` help sections

**Testing:**
- Unit tests for `get_page_comments` (success, empty, API error) and `add_page_comment` (success, API error) using `wiremock` in `confluence_api.rs`
- Unit tests for `format_comment_body` (none, valid ADF with text, empty content, invalid ADF), `format_timestamp` (with/without millis, empty), `AddCommand::parse_input` (raw markdown, JFM with frontmatter, ADF format, invalid ADF), `print_comments` (empty, with ADF body, null body, invalid ADF, multiple), and `CommentCommand` dispatch variants in `comment.rs`
- Integration test for `ConfluenceSubcommands::Comment` variant in `mod.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only comment-related tests
cargo test comment
cargo test get_page_comments
cargo test add_page_comment

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Example CLI usage
omni-dev atlassian confluence comment list <PAGE_ID>
omni-dev atlassian confluence comment list <PAGE_ID> --limit 10 --output json
omni-dev atlassian confluence comment add <PAGE_ID> comment.md
omni-dev atlassian confluence comment add <PAGE_ID> --format adf comment.json
echo "Hello **world**" | omni-dev atlassian confluence comment add <PAGE_ID>
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — API errors (4xx/5xx) are propagated as `AtlassianError::ApiRequestFailed`
- [x] Architecture changes — new `comment` module follows the existing `read`/`write`/`edit` pattern
- [x] User experience — `ListCommand` truncates to `--limit` client-side after fetching; pagination is not yet implemented

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications — uses the same `AtlassianClient` credential handling as all other Confluence commands

## Breaking Changes

None. This is a purely additive feature. No existing commands, API surfaces, or data structures were modified in a breaking way.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Server-side pagination support for `list` (the Confluence v2 API supports cursor-based pagination on footer-comments)
- Support for inline comments in addition to footer comments
- `--output` format support for `add` to return the created comment ID

**Known Limitations:**
- Comment author is currently displayed as the Atlassian user ID (`authorId`) rather than the display name; a follow-up could resolve the ID to a human-readable name via the Atlassian user API