### PR TITLE
feat(atlassian): add confluence label management commands

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -153,6 +153,44 @@ struct ConfluenceAddCommentRequest {
     body: ConfluenceUpdateBody,
 }
 
+// ── Labels ─────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ConfluenceLabelsResponse {
+    results: Vec<ConfluenceLabelEntry>,
+    #[serde(rename = "_links", default)]
+    links: Option<ConfluenceLabelsLinks>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceLabelEntry {
+    id: String,
+    name: String,
+    prefix: String,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceLabelsLinks {
+    next: Option<String>,
+}
+
+/// A label on a Confluence page.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceLabel {
+    /// Label ID.
+    pub id: String,
+    /// Label name.
+    pub name: String,
+    /// Label prefix (e.g. "global").
+    pub prefix: String,
+}
+
+#[derive(Serialize)]
+struct ConfluenceAddLabelEntry {
+    prefix: String,
+    name: String,
+}
+
 // ── Create request ─────────────────────────────────────────────────
 
 #[derive(Serialize)]
@@ -599,6 +637,104 @@ impl ConfluenceApi {
             .context("Failed to parse Confluence space response")?;
 
         Ok(space.key)
+    }
+
+    /// Fetches all labels on a Confluence page, handling pagination.
+    pub async fn get_labels(&self, page_id: &str) -> Result<Vec<ConfluenceLabel>> {
+        let mut all_labels = Vec::new();
+        let mut url = format!(
+            "{}/wiki/api/v2/pages/{}/labels",
+            self.client.instance_url(),
+            page_id
+        );
+
+        loop {
+            let response = self
+                .client
+                .get_json(&url)
+                .await
+                .context("Failed to fetch page labels")?;
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let body = response.text().await.unwrap_or_default();
+                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+            }
+
+            let resp: ConfluenceLabelsResponse = response
+                .json()
+                .await
+                .context("Failed to parse labels response")?;
+
+            let page_count = resp.results.len();
+            for entry in resp.results {
+                all_labels.push(ConfluenceLabel {
+                    id: entry.id,
+                    name: entry.name,
+                    prefix: entry.prefix,
+                });
+            }
+
+            match resp.links.and_then(|l| l.next) {
+                Some(next_path) if page_count > 0 => {
+                    url = format!("{}{}", self.client.instance_url(), next_path);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(all_labels)
+    }
+
+    /// Adds one or more labels to a Confluence page.
+    pub async fn add_labels(&self, page_id: &str, labels: &[String]) -> Result<()> {
+        let url = format!(
+            "{}/wiki/rest/api/content/{}/label",
+            self.client.instance_url(),
+            page_id
+        );
+
+        let body: Vec<ConfluenceAddLabelEntry> = labels
+            .iter()
+            .map(|name| ConfluenceAddLabelEntry {
+                prefix: "global".to_string(),
+                name: name.clone(),
+            })
+            .collect();
+
+        let response = self
+            .client
+            .post_json(&url, &body)
+            .await
+            .context("Failed to add labels")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Removes a label from a Confluence page.
+    pub async fn remove_label(&self, page_id: &str, label_name: &str) -> Result<()> {
+        let url = format!(
+            "{}/wiki/rest/api/content/{}/label/{}",
+            self.client.instance_url(),
+            page_id,
+            label_name
+        );
+
+        let response = self.client.delete(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
     }
 }
 
@@ -1394,5 +1530,232 @@ mod tests {
         let adf = AdfDocument::new();
         let err = api.add_page_comment("12345", &adf).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── get_labels ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_labels_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "1", "name": "architecture", "prefix": "global"},
+                        {"id": "2", "name": "draft", "prefix": "global"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let labels = api.get_labels("12345").await.unwrap();
+
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].name, "architecture");
+        assert_eq!(labels[0].prefix, "global");
+        assert_eq!(labels[1].name, "draft");
+    }
+
+    #[tokio::test]
+    async fn get_labels_with_pagination() {
+        let server = wiremock::MockServer::start().await;
+
+        // First page returns one label with a next link.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .and(wiremock::matchers::query_param_is_missing("cursor"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "1", "name": "architecture", "prefix": "global"}
+                    ],
+                    "_links": {
+                        "next": "/wiki/api/v2/pages/12345/labels?cursor=page2"
+                    }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Second page returns another label with no next link.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .and(wiremock::matchers::query_param("cursor", "page2"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "2", "name": "draft", "prefix": "global"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let labels = api.get_labels("12345").await.unwrap();
+
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].name, "architecture");
+        assert_eq!(labels[1].name, "draft");
+    }
+
+    #[tokio::test]
+    async fn get_labels_empty() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"results": []})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let labels = api.get_labels("12345").await.unwrap();
+        assert!(labels.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_labels_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/99999/labels"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.get_labels("99999").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── add_labels ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_labels_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/label",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"prefix": "global", "name": "architecture", "id": "1"},
+                        {"prefix": "global", "name": "draft", "id": "2"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = api
+            .add_labels("12345", &["architecture".to_string(), "draft".to_string()])
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_labels_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/99999/label",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .add_labels("99999", &["test".to_string()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── remove_label ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn remove_label_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/label/architecture",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = api.remove_label("12345", "architecture").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn remove_label_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/99999/label/missing",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.remove_label("99999", "missing").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── label struct serialization ────────────────────────────────
+
+    #[test]
+    fn confluence_label_entry_deserialization() {
+        let json = r#"{"id": "1", "name": "architecture", "prefix": "global"}"#;
+        let entry: ConfluenceLabelEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.id, "1");
+        assert_eq!(entry.name, "architecture");
+        assert_eq!(entry.prefix, "global");
+    }
+
+    #[test]
+    fn confluence_add_label_entry_serialization() {
+        let entry = ConfluenceAddLabelEntry {
+            prefix: "global".to_string(),
+            name: "test".to_string(),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["prefix"], "global");
+        assert_eq!(json["name"], "test");
     }
 }

--- a/src/cli/atlassian/confluence/label.rs
+++ b/src/cli/atlassian/confluence/label.rs
@@ -1,0 +1,446 @@
+//! CLI commands for managing Confluence page labels.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::confluence_api::{ConfluenceApi, ConfluenceLabel};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages labels on Confluence pages.
+#[derive(Parser)]
+pub struct LabelCommand {
+    /// The label subcommand to execute.
+    #[command(subcommand)]
+    pub command: LabelSubcommands,
+}
+
+/// Label subcommands.
+#[derive(Subcommand)]
+pub enum LabelSubcommands {
+    /// Lists labels on a Confluence page.
+    List(ListCommand),
+    /// Adds labels to a Confluence page.
+    Add(AddCommand),
+    /// Removes labels from a Confluence page.
+    Remove(RemoveCommand),
+}
+
+impl LabelCommand {
+    /// Executes the label command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            LabelSubcommands::List(cmd) => cmd.execute().await,
+            LabelSubcommands::Add(cmd) => cmd.execute().await,
+            LabelSubcommands::Remove(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists labels on a Confluence page.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Confluence page ID (e.g., 12345678).
+    pub id: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Executes the list labels command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        execute_list(&api, &self.id, &self.output).await
+    }
+}
+
+/// Fetches and displays labels for a page.
+async fn execute_list(api: &ConfluenceApi, id: &str, output: &OutputFormat) -> Result<()> {
+    let labels = api.get_labels(id).await?;
+    display_labels(&labels, output)
+}
+
+/// Formats and displays labels in the requested output format.
+fn display_labels(labels: &Vec<ConfluenceLabel>, output: &OutputFormat) -> Result<()> {
+    if output_as(labels, output)? {
+        return Ok(());
+    }
+    print_labels(labels);
+    Ok(())
+}
+
+/// Adds labels to a Confluence page.
+#[derive(Parser)]
+pub struct AddCommand {
+    /// Confluence page ID (e.g., 12345678).
+    pub id: String,
+
+    /// Comma-separated list of labels to add.
+    #[arg(long, value_delimiter = ',', required = true)]
+    pub labels: Vec<String>,
+}
+
+impl AddCommand {
+    /// Executes the add labels command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        execute_add(&api, &self.id, &self.labels).await
+    }
+}
+
+/// Adds labels to a page and prints confirmation.
+async fn execute_add(api: &ConfluenceApi, id: &str, labels: &[String]) -> Result<()> {
+    api.add_labels(id, labels).await?;
+    print_add_confirmation(labels.len(), id);
+    Ok(())
+}
+
+/// Prints confirmation after adding labels.
+fn print_add_confirmation(count: usize, id: &str) {
+    println!("Added {count} label(s) to page {id}.");
+}
+
+/// Removes labels from a Confluence page.
+#[derive(Parser)]
+pub struct RemoveCommand {
+    /// Confluence page ID (e.g., 12345678).
+    pub id: String,
+
+    /// Comma-separated list of labels to remove.
+    #[arg(long, value_delimiter = ',', required = true)]
+    pub labels: Vec<String>,
+}
+
+impl RemoveCommand {
+    /// Executes the remove labels command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        execute_remove(&api, &self.id, &self.labels).await
+    }
+}
+
+/// Removes labels from a page and prints confirmation.
+async fn execute_remove(api: &ConfluenceApi, id: &str, labels: &[String]) -> Result<()> {
+    for label in labels {
+        api.remove_label(id, label).await?;
+    }
+    print_remove_confirmation(labels.len(), id);
+    Ok(())
+}
+
+/// Prints confirmation after removing labels.
+fn print_remove_confirmation(count: usize, id: &str) {
+    println!("Removed {count} label(s) from page {id}.");
+}
+
+/// Prints labels as a formatted table.
+fn print_labels(labels: &[crate::atlassian::confluence_api::ConfluenceLabel]) {
+    if labels.is_empty() {
+        println!("No labels found.");
+        return;
+    }
+
+    let name_width = labels
+        .iter()
+        .map(|l| l.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let prefix_width = labels
+        .iter()
+        .map(|l| l.prefix.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    println!("{:<name_width$}  {:<prefix_width$}", "NAME", "PREFIX");
+    println!(
+        "{:<name_width$}  {:<prefix_width$}",
+        "-".repeat(name_width),
+        "-".repeat(prefix_width),
+    );
+
+    for label in labels {
+        println!(
+            "{:<name_width$}  {:<prefix_width$}",
+            label.name, label.prefix
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn sample_label(id: &str, name: &str, prefix: &str) -> ConfluenceLabel {
+        ConfluenceLabel {
+            id: id.to_string(),
+            name: name.to_string(),
+            prefix: prefix.to_string(),
+        }
+    }
+
+    // ── LabelCommand struct ───────────────────────────────────────
+
+    #[test]
+    fn label_subcommands_list_variant() {
+        let cmd = LabelCommand {
+            command: LabelSubcommands::List(ListCommand {
+                id: "12345".to_string(),
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, LabelSubcommands::List(_)));
+    }
+
+    #[test]
+    fn label_subcommands_add_variant() {
+        let cmd = LabelCommand {
+            command: LabelSubcommands::Add(AddCommand {
+                id: "12345".to_string(),
+                labels: vec!["architecture".to_string(), "draft".to_string()],
+            }),
+        };
+        assert!(matches!(cmd.command, LabelSubcommands::Add(_)));
+    }
+
+    #[test]
+    fn label_subcommands_remove_variant() {
+        let cmd = LabelCommand {
+            command: LabelSubcommands::Remove(RemoveCommand {
+                id: "12345".to_string(),
+                labels: vec!["draft".to_string()],
+            }),
+        };
+        assert!(matches!(cmd.command, LabelSubcommands::Remove(_)));
+    }
+
+    // ── display_labels ────────────────────────────────────────────
+
+    #[test]
+    fn display_labels_table() {
+        let labels = vec![
+            sample_label("1", "architecture", "global"),
+            sample_label("2", "draft", "global"),
+        ];
+        assert!(display_labels(&labels, &OutputFormat::Table).is_ok());
+    }
+
+    #[test]
+    fn display_labels_json() {
+        let labels = vec![sample_label("1", "architecture", "global")];
+        assert!(display_labels(&labels, &OutputFormat::Json).is_ok());
+    }
+
+    #[test]
+    fn display_labels_yaml() {
+        let labels = vec![sample_label("1", "architecture", "global")];
+        assert!(display_labels(&labels, &OutputFormat::Yaml).is_ok());
+    }
+
+    #[test]
+    fn display_labels_empty_table() {
+        assert!(display_labels(&vec![], &OutputFormat::Table).is_ok());
+    }
+
+    // ── print_labels ──────────────────────────────────────────────
+
+    #[test]
+    fn print_labels_empty() {
+        print_labels(&[]);
+    }
+
+    #[test]
+    fn print_labels_with_entries() {
+        let labels = vec![
+            sample_label("1", "architecture", "global"),
+            sample_label("2", "draft", "global"),
+        ];
+        print_labels(&labels);
+    }
+
+    // ── print confirmations ───────────────────────────────────────
+
+    #[test]
+    fn print_add_confirmation_single() {
+        print_add_confirmation(1, "12345");
+    }
+
+    #[test]
+    fn print_add_confirmation_multiple() {
+        print_add_confirmation(3, "12345");
+    }
+
+    #[test]
+    fn print_remove_confirmation_single() {
+        print_remove_confirmation(1, "12345");
+    }
+
+    #[test]
+    fn print_remove_confirmation_multiple() {
+        print_remove_confirmation(2, "12345");
+    }
+
+    // ── execute_list (wiremock) ──────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_list_table_output() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "1", "name": "architecture", "prefix": "global"},
+                        {"id": "2", "name": "draft", "prefix": "global"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(execute_list(&api, "12345", &OutputFormat::Table)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_list_json_output() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345/labels"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "1", "name": "architecture", "prefix": "global"}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(execute_list(&api, "12345", &OutputFormat::Json)
+            .await
+            .is_ok());
+    }
+
+    // ── execute_add (wiremock) ────────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_add_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/label",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{"prefix": "global", "name": "arch", "id": "1"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(execute_add(&api, "12345", &["arch".to_string()])
+            .await
+            .is_ok());
+    }
+
+    // ── execute_remove (wiremock) ─────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_remove_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/label/draft",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(execute_remove(&api, "12345", &["draft".to_string()])
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn execute_remove_multiple() {
+        let server = wiremock::MockServer::start().await;
+
+        for label in &["draft", "old"] {
+            wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+                .and(wiremock::matchers::path(format!(
+                    "/wiki/rest/api/content/12345/label/{label}"
+                )))
+                .respond_with(wiremock::ResponseTemplate::new(204))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(
+            execute_remove(&api, "12345", &["draft".to_string(), "old".to_string()])
+                .await
+                .is_ok()
+        );
+    }
+
+    // ── AddCommand struct ─────────────────────────────────────────
+
+    #[test]
+    fn add_command_fields() {
+        let cmd = AddCommand {
+            id: "12345".to_string(),
+            labels: vec!["test".to_string()],
+        };
+        assert_eq!(cmd.id, "12345");
+        assert_eq!(cmd.labels, vec!["test"]);
+    }
+
+    // ── RemoveCommand struct ──────────────────────────────────────
+
+    #[test]
+    fn remove_command_fields() {
+        let cmd = RemoveCommand {
+            id: "12345".to_string(),
+            labels: vec!["test".to_string()],
+        };
+        assert_eq!(cmd.id, "12345");
+        assert_eq!(cmd.labels, vec!["test"]);
+    }
+}

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod create;
 pub(crate) mod delete;
 pub(crate) mod download;
 pub(crate) mod edit;
+pub(crate) mod label;
 pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod user;
@@ -38,6 +39,8 @@ pub enum ConfluenceSubcommands {
     Create(create::CreateCommand),
     /// Deletes a Confluence page.
     Delete(delete::DeleteCommand),
+    /// Manages labels on Confluence pages.
+    Label(label::LabelCommand),
     /// Recursively downloads a Confluence page tree.
     Download(download::DownloadCommand),
     /// Confluence user operations.
@@ -54,6 +57,7 @@ impl ConfluenceCommand {
             ConfluenceSubcommands::Edit(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Search(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Create(cmd) => cmd.execute().await,
+            ConfluenceSubcommands::Label(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Delete(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Download(cmd) => cmd.execute().await,
             ConfluenceSubcommands::User(cmd) => cmd.execute().await,
@@ -143,6 +147,19 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Create(_)));
+    }
+
+    #[test]
+    fn confluence_subcommands_label_variant() {
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Label(label::LabelCommand {
+                command: label::LabelSubcommands::List(label::ListCommand {
+                    id: "12345".to_string(),
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, ConfluenceSubcommands::Label(_)));
     }
 
     #[test]

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -188,6 +188,7 @@ Commands:
   search    Searches Confluence pages using CQL
   create    Creates a new Confluence page
   delete    Deletes a Confluence page
+  label     Manages labels on Confluence pages
   download  Recursively downloads a Confluence page tree
   user      Confluence user operations
   help      Print this message or the help of the given subcommand(s)
@@ -318,6 +319,72 @@ Arguments:
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence label - Manages labels on Confluence pages
+
+Manages labels on Confluence pages
+
+Usage: label <COMMAND>
+
+Commands:
+  list    Lists labels on a Confluence page
+  add     Adds labels to a Confluence page
+  remove  Removes labels from a Confluence page
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence label add - Adds labels to a Confluence page
+
+Adds labels to a Confluence page
+
+Usage: add --labels <LABELS> <ID>
+
+Arguments:
+  <ID>  Confluence page ID (e.g., 12345678)
+
+Options:
+      --labels <LABELS>  Comma-separated list of labels to add
+  -h, --help             Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence label list - Lists labels on a Confluence page
+
+Lists labels on a Confluence page
+
+Usage: list [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Confluence page ID (e.g., 12345678)
+
+Options:
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian confluence label remove - Removes labels from a Confluence page
+
+Removes labels from a Confluence page
+
+Usage: remove --labels <LABELS> <ID>
+
+Arguments:
+  <ID>  Confluence page ID (e.g., 12345678)
+
+Options:
+      --labels <LABELS>  Comma-separated list of labels to remove
+  -h, --help             Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements label management for Confluence pages, resolving issue #355. Users can now list, add, and remove labels on Confluence pages directly through the CLI. The implementation adds three new subcommands under `omni-dev atlassian confluence label` and the corresponding API methods to `ConfluenceApi`, including full pagination support for label listing.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #355

## Changes Made

**Core Changes:**
- Added `ConfluenceLabel` public struct (with `id`, `name`, `prefix` fields) and internal `ConfluenceLabelsResponse`, `ConfluenceLabelEntry`, `ConfluenceLabelsLinks`, and `ConfluenceAddLabelEntry` structs to `src/atlassian/confluence_api.rs`
- Implemented `get_labels(page_id)` on `ConfluenceApi` using the REST v2 endpoint (`/wiki/api/v2/pages/{id}/labels`) with full `_links.next` pagination support
- Implemented `add_labels(page_id, labels)` using the REST v1 content label endpoint (`/wiki/rest/api/content/{id}/label`), accepting multiple labels in a single POST
- Implemented `remove_label(page_id, label_name)` using HTTP DELETE on `/wiki/rest/api/content/{id}/label/{name}`
- Created `src/cli/atlassian/confluence/label.rs` with `LabelCommand`, `LabelSubcommands`, `ListCommand`, `AddCommand`, and `RemoveCommand`
- `ListCommand` supports `--output` flag (table/json/yaml) and falls back to a formatted table via `print_labels()`
- `AddCommand` and `RemoveCommand` accept `--labels` as a comma-separated list
- Registered `pub(crate) mod label` and `Label(label::LabelCommand)` variant in `ConfluenceSubcommands` in `src/cli/atlassian/confluence/mod.rs`
- Wired up `ConfluenceSubcommands::Label(cmd) => cmd.execute().await` in the command dispatcher

**Testing:**
- Added unit tests for `get_labels`: success (2-label response), empty result, and 404 API error cases
- Added unit tests for `add_labels`: success (multi-label POST) and 404 API error cases
- Added unit tests for `remove_label`: success (204 DELETE) and 404 API error cases
- Added serialization/deserialization tests for `ConfluenceLabelEntry` and `ConfluenceAddLabelEntry`
- Added unit tests for `LabelCommand` struct variants (List, Add, Remove)
- Added unit tests for `print_labels` helper (empty case and populated case)
- Added unit tests for `AddCommand` and `RemoveCommand` field verification
- Added `confluence_subcommands_label_variant` test in `mod.rs`
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include help text for `label`, `label list`, `label add`, and `label remove` subcommands

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (API methods and CLI command structs)
- [x] Integration tests updated/added (help snapshot updated)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (404 responses for all three API methods)
- [x] Backward compatibility verified (additive changes only)

### Test Commands
```bash
# Core test suite
cargo test

# Run label-specific tests
cargo test label
cargo test get_labels
cargo test add_labels
cargo test remove_label

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — all three API methods propagate `AtlassianError::ApiRequestFailed` on non-2xx responses
- [x] Architecture changes — `label` module follows the same pattern as existing `create`, `delete`, `edit` modules
- [x] Backward compatibility — purely additive; no existing commands or API surface changed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive feature. No existing CLI commands, API methods, or public types were modified.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Pagination could be exposed via a `--limit` or `--cursor` flag on `label list` if needed
- The `add` and `remove` subcommands could benefit from a `--dry-run` flag for safety

**Known Limitations:**
- `add_labels` always uses the `"global"` prefix; user-defined prefixes are not currently supported via the CLI

**Alternatives Considered:**
- Used the v1 REST endpoint for add/remove (consistent with the Confluence REST API capabilities) and the v2 endpoint for list (which includes pagination via `_links.next`), matching Atlassian's current API guidance