### PR TITLE
chore(release, cargo): prepare release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-04-17
+
+### Added
+- **Confluence Label Commands**: Label management commands for adding, removing, and listing page labels
+- **Confluence User Search**: Search for Confluence users by query
+- **Confluence Page Comments**: List and add comments on Confluence pages
+- **JIRA Watcher Commands**: List, add, and remove watchers on JIRA issues
+- **JIRA Worklog Commands**: Time tracking with worklog list and add commands
+- **JIRA Sprint Management**: Create and update sprint commands
+- **JIRA Dev Status**: Dev status command for viewing development information on issues
+- **PR Auto-Push**: `--no-push` flag to skip branch push on PR creation
+- **ADF Node Support**: Added `mediaInline`, `placeholder`, `table caption`, `mediaSingle caption`, and `expand localId/parameters` node support
+- **ADF Annotation Marks**: Full annotation mark support for ADF/markdown conversion
+- **ADF localId Round-Trip**: Comprehensive `localId` round-trip support with `--strip-local-ids` option
+- **ADF Border Mark**: Border mark support for media and table cell/header nodes
+- **ADF Breakout Width**: Optional width parameter for breakout marks
+
+### Fixed
+- **ADF Round-Trip Fidelity** (50+ fixes): Extensive improvements to ADF/markdown round-trip conversion:
+  - Preserve mark ordering (link, annotation, strong/em/strike, code) across conversions
+  - Prevent consecutive paragraphs from merging in blockquotes, list items, and task items
+  - Preserve `localId` on caption, listItem/mediaSingle, layout columns, media, table, and paragraph nodes
+  - Handle nested taskList, taskItem, and ordered list nodes correctly
+  - Preserve hardBreak nodes in paragraphs, headings, list items, and table cells
+  - Preserve trailing/leading whitespace in headings, list items, table cells, and text nodes
+  - Escape backticks, backslashes, asterisks, and underscores in plain text to prevent misinterpretation
+  - Preserve NBSP content in list item paragraphs and NBSP-only paragraphs
+  - Preserve empty language attrs in codeBlock, empty attrs on tableCell, and integer colwidth values
+  - Handle parentheses in link/image URLs and bracket-link ambiguity
+  - Prevent bare URLs and URL link text from becoming inlineCard nodes
+  - Preserve emoji shortName with/without colons, date timestamps, and mention localId attribution
+  - Preserve parameters block in bodiedExtension and extension layout/localId attrs
+  - Preserve multiple annotation marks, table cell attrs, embedCard attrs, and mediaSingle mode
+  - Preserve content after directive table blocks and whitespace-only text after hardBreak
+  - Reject pipe syntax for tableCell-only first rows and intraword underscores as emphasis
+  - Escape trailing double-spaces to prevent hardBreak misinterpretation
+  - Ensure blank lines between consecutive block nodes in table cells
+- **Deterministic AI Scopes**: Make AI-generated commit scopes deterministic by post-processing with file-pattern logic
+- **CI Scope Guidance**: Improve CI scope guidance in type selection rules
+
+### Changed
+- **Function Naming**: Rename `execute_*` helper functions to `run_*` across Atlassian CLI commands
+- **Function Extraction**: Extract `run_download`, `run_images`, `run_transition` into standalone functions
+
+### Documentation
+- **ADR-0020**: Add ADR for JFM markdown dialect for ADF interchange
+- **JFM Spec**: Expand JFM spec with table, media, localId, escaping, and annotation mark sections
+- **Style Guide**: Update style guide to clarify `run_*` function extraction rules and add testing style rules
+
+### CI/CD
+- Bump `EmbarkStudios/cargo-deny-action` to 2.0.17
+- Bump `codecov/codecov-action` from 5 to 6
+- Bump `cachix/cachix-action` from 16 to 17
+- Bump Rust minor patch dependencies
+
+### Security
+- Update `rustls-webpki` to 0.103.12 for RUSTSEC-2026-0098
+
 ## [0.20.0] - 2026-04-12
 
 ### Added
@@ -716,7 +774,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation and community files (README, CONTRIBUTING, CODE_OF_CONDUCT)
 - BSD 3-Clause license
 
-[Unreleased]: https://github.com/rust-works/omni-dev/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/rust-works/omni-dev/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/rust-works/omni-dev/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/rust-works/omni-dev/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/rust-works/omni-dev/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/rust-works/omni-dev/compare/v0.17.0...v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "omni-dev"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-dev"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 authors = ["John Ky <newhoggy@gmail.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Description

This PR prepares the v0.21.0 release of omni-dev by bumping the version from 0.20.0 to 0.21.0 in `Cargo.toml` and `Cargo.lock`, and adding the v0.21.0 changelog entry documenting all changes accumulated since v0.20.0.

This is a release preparation commit — no functional code changes are included. The changelog comprehensively documents the substantial feature additions, bug fixes, refactoring, documentation improvements, CI/CD updates, and security patches that were delivered in this release cycle as part of addressing Atlassian functionality gaps (Issue #283) and related improvements.

## Type of Change

- [x] Documentation update
- [x] Dependency update

## Related Issue

Relates to #283

## Changes Made

**Release Preparation:**
- Bumped version from `0.20.0` to `0.21.0` in `Cargo.toml`
- Updated `Cargo.lock` to reflect new version
- Added `[0.21.0] - 2026-04-17` changelog entry to `CHANGELOG.md`
- Updated `[Unreleased]` diff link to point from `v0.21.0...HEAD`
- Added `[0.21.0]` comparison link between `v0.20.0...v0.21.0`

**Changelog Entry Covers:**
- Confluence label, user search, and page comment commands
- JIRA watcher, worklog, sprint management, and dev status commands
- PR auto-push `--no-push` flag
- 50+ ADF round-trip fidelity fixes (mark ordering, whitespace, escaping, nested nodes, hardBreak, NBSP, URL handling)
- ADF node support: `mediaInline`, `placeholder`, table caption, `mediaSingle` caption, `expand` localId/parameters
- ADF annotation marks, `localId` round-trip with `--strip-local-ids`, border mark, and breakout width support
- Deterministic AI-generated commit scopes via file-pattern post-processing
- CI scope guidance improvements
- Rename `execute_*` helper functions to `run_*` across Atlassian CLI commands
- Extract `run_download`, `run_images`, `run_transition` into standalone functions
- ADR-0020 for JFM markdown dialect
- Expanded JFM spec with table, media, localId, escaping, and annotation mark sections
- Updated style guide for `run_*` extraction rules and testing style
- CI/CD dependency bumps (cargo-deny-action 2.0.17, codecov-action v6, cachix-action v17)
- Security: `rustls-webpki` updated to 0.103.12 for RUSTSEC-2026-0098

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable — release prep only)

**Manual Testing:**
- [x] Version bump verified in `Cargo.toml` and `Cargo.lock`
- [x] Changelog entry is complete and accurate

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — version bump is minor, no breaking changes introduced
- [ ] Security implications — `rustls-webpki` security update is documented in changelog

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement — `rustls-webpki` updated to 0.103.12 to address RUSTSEC-2026-0098 (documented in changelog)

## Breaking Changes

No breaking changes in this release. All new functionality is additive.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Release Summary:**
v0.21.0 is a significant feature release focused on closing Atlassian functionality gaps (Issue #283), with extensive ADF round-trip fidelity improvements, new Confluence and JIRA commands, and a security patch for `rustls-webpki`.