### PR TITLE
feat(claude): add skills sync and clean subcommands for worktree-aware skill distribution

### DIFF
--- a/src/cli/ai/claude/mod.rs
+++ b/src/cli/ai/claude/mod.rs
@@ -1,6 +1,7 @@
 //! Claude Code diagnostics and inspection commands.
 
 mod cli;
+mod skills;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -18,6 +19,8 @@ pub struct ClaudeCommand {
 pub enum ClaudeSubcommands {
     /// Claude Code CLI inspection.
     Cli(cli::CliCommand),
+    /// Manages Claude Code skills across repositories and worktrees.
+    Skills(skills::SkillsCommand),
 }
 
 impl ClaudeCommand {
@@ -25,6 +28,56 @@ impl ClaudeCommand {
     pub fn execute(self) -> Result<()> {
         match self.command {
             ClaudeSubcommands::Cli(cmd) => cmd.execute(),
+            ClaudeSubcommands::Skills(cmd) => cmd.execute(),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command as ProcessCommand;
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        let status = ProcessCommand::new("git")
+            .arg("init")
+            .arg(dir)
+            .output()
+            .unwrap();
+        assert!(status.status.success());
+    }
+
+    #[test]
+    fn dispatches_skills_subcommand_via_clap() {
+        let src = tempdir();
+        init_repo(src.path());
+        let cmd = ClaudeCommand::try_parse_from([
+            "claude",
+            "skills",
+            "sync",
+            "--source",
+            src.path().to_str().unwrap(),
+            "--target",
+            src.path().to_str().unwrap(),
+        ])
+        .unwrap();
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn dispatches_cli_subcommand_via_clap() {
+        let cmd = ClaudeCommand::try_parse_from(["claude", "cli", "model", "resolve"]).unwrap();
+        cmd.execute().unwrap();
     }
 }

--- a/src/cli/ai/claude/skills/clean.rs
+++ b/src/cli/ai/claude/skills/clean.rs
@@ -1,0 +1,538 @@
+//! Clean command — removes symlinks previously created by `skills sync`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use super::common::{
+    exclude_entry_for, exclude_file_for, list_worktrees, remove_exclude_entries, resolve_toplevel,
+    SKILLS_SUBPATH,
+};
+
+/// Removes skill symlinks and associated exclude entries from one or more targets.
+#[derive(Parser)]
+pub struct CleanCommand {
+    /// Target repository or worktree to clean. Defaults to the current working directory.
+    #[arg(long, value_name = "PATH")]
+    pub target: Option<PathBuf>,
+
+    /// Also clean every worktree belonging to the target repository.
+    #[arg(long)]
+    pub worktrees: bool,
+
+    /// Preview the changes without deleting symlinks or modifying the exclude file.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl CleanCommand {
+    /// Executes the clean command.
+    pub fn execute(self) -> Result<()> {
+        let cwd = std::env::current_dir().context("Failed to determine current directory")?;
+        let target_seed = self.target.clone().unwrap_or(cwd);
+        let target_root = resolve_toplevel(&target_seed)?;
+
+        let mut targets = vec![target_root.clone()];
+        if self.worktrees {
+            for wt in list_worktrees(&target_root)? {
+                if !targets.iter().any(|t| t == &wt) {
+                    targets.push(wt);
+                }
+            }
+        }
+
+        let report = run_clean(&targets, self.dry_run)?;
+        print_report(&report, self.dry_run);
+        Ok(())
+    }
+}
+
+/// Outcome of a clean run.
+#[derive(Debug, Default)]
+pub(super) struct CleanReport {
+    pub actions: Vec<CleanAction>,
+}
+
+/// Individual action produced by the clean operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CleanAction {
+    Unlinked {
+        link: PathBuf,
+    },
+    Preserved {
+        path: PathBuf,
+        reason: String,
+    },
+    ExcludeRemoved {
+        exclude_file: PathBuf,
+        entry: String,
+    },
+    DirectoryRemoved {
+        path: PathBuf,
+    },
+}
+
+/// Cleans every supplied target, collecting actions into a single report.
+pub(super) fn run_clean(targets: &[PathBuf], dry_run: bool) -> Result<CleanReport> {
+    let mut report = CleanReport::default();
+    for target_root in targets {
+        clean_target(target_root, dry_run, &mut report)?;
+    }
+    Ok(report)
+}
+
+fn clean_target(target_root: &Path, dry_run: bool, report: &mut CleanReport) -> Result<()> {
+    let skills_dir = target_root.join(SKILLS_SUBPATH);
+    if !skills_dir.exists() {
+        return Ok(());
+    }
+
+    let mut removed_names = Vec::new();
+    let entries = fs::read_dir(&skills_dir)
+        .with_context(|| format!("Failed to read {}", skills_dir.display()))?;
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry in {}", skills_dir.display()))?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let name = name.to_string();
+        let meta = fs::symlink_metadata(&path)
+            .with_context(|| format!("Failed to inspect {}", path.display()))?;
+        if meta.file_type().is_symlink() {
+            if !dry_run {
+                fs::remove_file(&path)
+                    .with_context(|| format!("Failed to remove symlink {}", path.display()))?;
+            }
+            report.actions.push(CleanAction::Unlinked { link: path });
+            removed_names.push(name);
+        } else {
+            let reason = if meta.is_dir() {
+                "real directory".to_string()
+            } else {
+                "real file".to_string()
+            };
+            report.actions.push(CleanAction::Preserved { path, reason });
+        }
+    }
+
+    if !removed_names.is_empty() {
+        let exclude_file = exclude_file_for(target_root)?;
+        let entries_to_remove: Vec<String> =
+            removed_names.iter().map(|n| exclude_entry_for(n)).collect();
+        let removed = remove_exclude_entries(&exclude_file, &entries_to_remove, dry_run)?;
+        for entry in removed {
+            report.actions.push(CleanAction::ExcludeRemoved {
+                exclude_file: exclude_file.clone(),
+                entry,
+            });
+        }
+    }
+
+    if !dry_run && is_empty_dir(&skills_dir)? {
+        fs::remove_dir(&skills_dir)
+            .with_context(|| format!("Failed to remove empty {}", skills_dir.display()))?;
+        report
+            .actions
+            .push(CleanAction::DirectoryRemoved { path: skills_dir });
+    }
+
+    Ok(())
+}
+
+fn is_empty_dir(dir: &Path) -> Result<bool> {
+    let mut iter =
+        fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?;
+    Ok(iter.next().is_none())
+}
+
+fn print_report(report: &CleanReport, dry_run: bool) {
+    let prefix = if dry_run { "[dry-run] " } else { "" };
+    for action in &report.actions {
+        match action {
+            CleanAction::Unlinked { link } => {
+                println!("{prefix}unlinked {}", link.display());
+            }
+            CleanAction::Preserved { path, reason } => {
+                println!("{prefix}preserved {} ({reason})", path.display());
+            }
+            CleanAction::ExcludeRemoved {
+                exclude_file,
+                entry,
+            } => {
+                println!(
+                    "{prefix}removed exclude entry {} from {}",
+                    entry,
+                    exclude_file.display()
+                );
+            }
+            CleanAction::DirectoryRemoved { path } => {
+                println!("{prefix}removed empty {}", path.display());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        std::fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(dir)
+            .output()
+            .expect("git init failed to spawn");
+        assert!(status.status.success(), "git init failed: {status:?}");
+    }
+
+    #[cfg(unix)]
+    fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
+    fn make_source_skills(root: &Path, names: &[&str]) {
+        let skills = root.join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills).unwrap();
+        for name in names {
+            let skill_dir = skills.join(name);
+            fs::create_dir_all(&skill_dir).unwrap();
+            fs::write(skill_dir.join("SKILL.md"), format!("# {name}")).unwrap();
+        }
+    }
+
+    #[test]
+    fn run_clean_removes_symlinks_and_exclude_entries() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+        let exclude_path = tgt_tmp.path().join(".git/info/exclude");
+        fs::write(&exclude_path, "# comment\n.claude/skills/alpha/\n").unwrap();
+
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
+        let unlinks = report
+            .actions
+            .iter()
+            .filter(|a| matches!(a, CleanAction::Unlinked { .. }))
+            .count();
+        assert_eq!(unlinks, 1);
+        let removed_entries = report
+            .actions
+            .iter()
+            .filter(|a| matches!(a, CleanAction::ExcludeRemoved { .. }))
+            .count();
+        assert_eq!(removed_entries, 1);
+        assert!(!target_skills_dir.join("alpha").exists());
+        let content = fs::read_to_string(&exclude_path).unwrap();
+        assert!(content.contains("# comment"));
+        assert!(!content.contains(".claude/skills/alpha/"));
+        // Directory should be removed since it was left empty.
+        assert!(report
+            .actions
+            .iter()
+            .any(|a| matches!(a, CleanAction::DirectoryRemoved { .. })));
+        assert!(!target_skills_dir.exists());
+    }
+
+    #[test]
+    fn run_clean_preserves_real_files_and_directories() {
+        let tgt_tmp = tempdir();
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(target_skills_dir.join("keepme")).unwrap();
+        fs::write(target_skills_dir.join("keepme").join("SKILL.md"), "# keep").unwrap();
+
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
+        assert!(report
+            .actions
+            .iter()
+            .any(|a| matches!(a, CleanAction::Preserved { .. })));
+        assert!(target_skills_dir.join("keepme").join("SKILL.md").exists());
+        // Directory should NOT be removed because it still holds a real dir.
+        assert!(target_skills_dir.exists());
+    }
+
+    #[test]
+    fn run_clean_dry_run_does_not_modify_filesystem() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+        let exclude_path = tgt_tmp.path().join(".git/info/exclude");
+        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], true).unwrap();
+        assert!(!report.actions.is_empty());
+        assert!(target_skills_dir.join("alpha").exists());
+        let content = fs::read_to_string(&exclude_path).unwrap();
+        assert!(content.contains(".claude/skills/alpha/"));
+    }
+
+    #[test]
+    fn run_clean_missing_skills_dir_is_noop() {
+        let tgt_tmp = tempdir();
+        init_repo(tgt_tmp.path());
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
+        assert!(report.actions.is_empty());
+    }
+
+    #[test]
+    fn run_clean_preserves_real_file_reports_file_reason() {
+        // Exercises the `real file` branch of the preserved reason.
+        let tgt_tmp = tempdir();
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        fs::write(target_skills_dir.join("README.md"), "hello").unwrap();
+
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
+        let preserved = report
+            .actions
+            .iter()
+            .find_map(|a| match a {
+                CleanAction::Preserved { reason, .. } => Some(reason.clone()),
+                _ => None,
+            })
+            .expect("expected Preserved action");
+        assert_eq!(preserved, "real file");
+    }
+
+    #[test]
+    fn execute_cleans_explicit_target() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+        let exclude_path = tgt_tmp.path().join(".git/info/exclude");
+        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+
+        let cmd = CleanCommand {
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+
+        assert!(!target_skills_dir.join("alpha").exists());
+        let content = fs::read_to_string(&exclude_path).unwrap();
+        assert!(!content.contains(".claude/skills/alpha/"));
+    }
+
+    #[test]
+    fn execute_dry_run_covers_all_action_branches() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        // One symlink + one real file so both Unlinked and Preserved actions print.
+        symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+        fs::write(target_skills_dir.join("keep.txt"), "keep").unwrap();
+        let exclude_path = tgt_tmp.path().join(".git/info/exclude");
+        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+
+        let cmd = CleanCommand {
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: true,
+        };
+        cmd.execute().unwrap();
+        // Dry-run: nothing changed.
+        assert!(target_skills_dir.join("alpha").exists());
+        assert!(target_skills_dir.join("keep.txt").exists());
+    }
+
+    #[test]
+    fn execute_directory_removed_branch() {
+        // After removing the only symlink, DirectoryRemoved should print.
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        init_repo(tgt_tmp.path());
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+
+        let cmd = CleanCommand {
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+        assert!(!target_skills_dir.exists());
+    }
+
+    fn init_repo_with_commit(dir: &Path) {
+        init_repo(dir);
+        fs::write(dir.join("README.md"), "readme").unwrap();
+        let add = std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=x@x",
+                "-c",
+                "user.name=x",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(commit.status.success());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_clean_propagates_remove_file_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = tempdir();
+        let tgt = tempdir();
+        make_source_skills(src.path(), &["alpha"]);
+        init_repo(tgt.path());
+        let target_skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&target_skills_dir).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&target_skills_dir, perms).unwrap();
+
+        let result = run_clean(&[tgt.path().to_path_buf()], false);
+
+        // Restore writable perms so TempDir cleanup succeeds.
+        let mut perms = fs::metadata(&target_skills_dir).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&target_skills_dir, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to remove symlink"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // APFS rejects non-UTF-8 filenames, so this test is Linux-only. CI's
+    // tarpaulin job runs on Linux and exercises the to_str()-returns-None branch.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_clean_skips_directory_with_non_utf8_name() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let target_skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        let bad = OsStr::from_bytes(b"bad\xffname");
+        fs::create_dir_all(target_skills_dir.join(bad)).unwrap();
+
+        // Should not error and should not record an action for the bad entry.
+        let report = run_clean(&[tgt.path().to_path_buf()], false).unwrap();
+        assert!(
+            report
+                .actions
+                .iter()
+                .all(|a| !matches!(a, CleanAction::Unlinked { .. })),
+            "expected no Unlinked actions, got {:?}",
+            report.actions
+        );
+    }
+
+    #[test]
+    fn execute_with_worktrees_cleans_every_worktree() {
+        let src = tempdir();
+        let tgt_main = tempdir();
+        let wt_parent = tempdir();
+        let linked = wt_parent.path().join("linked");
+
+        make_source_skills(src.path(), &["alpha"]);
+        init_repo_with_commit(tgt_main.path());
+
+        let add_wt = std::process::Command::new("git")
+            .args(["worktree", "add", "-q"])
+            .arg(&linked)
+            .current_dir(tgt_main.path())
+            .output()
+            .unwrap();
+        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+
+        // Pre-install symlinks in both worktrees by hand.
+        for root in [tgt_main.path(), linked.as_path()] {
+            let skills_dir = root.join(SKILLS_SUBPATH);
+            fs::create_dir_all(&skills_dir).unwrap();
+            symlink(
+                &src.path().join(SKILLS_SUBPATH).join("alpha"),
+                &skills_dir.join("alpha"),
+            )
+            .unwrap();
+        }
+
+        let cmd = CleanCommand {
+            target: Some(tgt_main.path().to_path_buf()),
+            worktrees: true,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+
+        assert!(!tgt_main.path().join(SKILLS_SUBPATH).exists());
+        assert!(!linked.join(SKILLS_SUBPATH).exists());
+    }
+}

--- a/src/cli/ai/claude/skills/common.rs
+++ b/src/cli/ai/claude/skills/common.rs
@@ -18,12 +18,7 @@ pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(path)
         .output()
-        .with_context(|| {
-            format!(
-                "Failed to run git rev-parse --show-toplevel in {}",
-                path.display()
-            )
-        })?;
+        .with_context(|| ctx_spawn_failure("git rev-parse --show-toplevel", path))?;
     if !output.status.success() {
         let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
         anyhow::bail!(
@@ -33,11 +28,7 @@ pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
     }
     let stdout = String::from_utf8(output.stdout)
         .context("git rev-parse --show-toplevel output was not UTF-8")?;
-    let trimmed = stdout.trim();
-    if trimmed.is_empty() {
-        anyhow::bail!("git rev-parse --show-toplevel returned empty path");
-    }
-    Ok(PathBuf::from(trimmed))
+    Ok(PathBuf::from(stdout.trim()))
 }
 
 /// Runs `git rev-parse --git-common-dir` from `path` and returns an absolute path.
@@ -49,12 +40,7 @@ pub(super) fn resolve_git_common_dir(path: &Path) -> Result<PathBuf> {
         .args(["rev-parse", "--git-common-dir"])
         .current_dir(path)
         .output()
-        .with_context(|| {
-            format!(
-                "Failed to run git rev-parse --git-common-dir in {}",
-                path.display()
-            )
-        })?;
+        .with_context(|| ctx_spawn_failure("git rev-parse --git-common-dir", path))?;
     if !output.status.success() {
         let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
         anyhow::bail!(
@@ -107,13 +93,10 @@ pub(super) fn enumerate_skills(source_skills_dir: &Path) -> Result<Vec<(String, 
     }
     let entries = fs::read_dir(source_skills_dir)
         .with_context(|| format!("Failed to read {}", source_skills_dir.display()))?;
+    let dir_label = source_skills_dir.display();
     for entry in entries {
-        let entry = entry.with_context(|| {
-            format!(
-                "Failed to read directory entry in {}",
-                source_skills_dir.display()
-            )
-        })?;
+        let entry =
+            entry.with_context(|| format!("Failed to read directory entry in {dir_label}"))?;
         let path = entry.path();
         if !path.is_dir() {
             continue;
@@ -213,6 +196,10 @@ pub(super) fn remove_exclude_entries(
     fs::write(exclude_file, new_content)
         .with_context(|| format!("Failed to write {}", exclude_file.display()))?;
     Ok(removed)
+}
+
+fn ctx_spawn_failure(command: &str, path: &Path) -> String {
+    format!("Failed to run {command} in {}", path.display())
 }
 
 fn read_exclude_lines(exclude_file: &Path) -> Result<Vec<String>> {

--- a/src/cli/ai/claude/skills/common.rs
+++ b/src/cli/ai/claude/skills/common.rs
@@ -1,0 +1,668 @@
+//! Shared helpers for skills sync and clean commands.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+/// Skills directory name relative to a repository or worktree root.
+pub(super) const SKILLS_SUBPATH: &str = ".claude/skills";
+
+/// Prefix used for entries written to `.git/info/exclude`.
+pub(super) const EXCLUDE_PREFIX: &str = ".claude/skills/";
+
+/// Runs `git rev-parse --show-toplevel` from `path` and returns the absolute root.
+pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(path)
+        .output()
+        .with_context(|| {
+            format!(
+                "Failed to run git rev-parse --show-toplevel in {}",
+                path.display()
+            )
+        })?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(
+            "git rev-parse --show-toplevel failed in {}: {err}",
+            path.display()
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .context("git rev-parse --show-toplevel output was not UTF-8")?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("git rev-parse --show-toplevel returned empty path");
+    }
+    Ok(PathBuf::from(trimmed))
+}
+
+/// Runs `git rev-parse --git-common-dir` from `path` and returns an absolute path.
+///
+/// The command may return a relative path (e.g. `.git`) when executed inside the
+/// main worktree; this helper resolves any such relative path against `path`.
+pub(super) fn resolve_git_common_dir(path: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(path)
+        .output()
+        .with_context(|| {
+            format!(
+                "Failed to run git rev-parse --git-common-dir in {}",
+                path.display()
+            )
+        })?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(
+            "git rev-parse --git-common-dir failed in {}: {err}",
+            path.display()
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .context("git rev-parse --git-common-dir output was not UTF-8")?;
+    let raw = PathBuf::from(stdout.trim());
+    if raw.is_absolute() {
+        Ok(raw)
+    } else {
+        Ok(path.join(raw))
+    }
+}
+
+/// Lists all worktree root paths for the repository containing `path`.
+pub(super) fn list_worktrees(path: &Path) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("Failed to run git worktree list in {}", path.display()))?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("git worktree list failed in {}: {err}", path.display());
+    }
+    let stdout =
+        String::from_utf8(output.stdout).context("git worktree list output was not UTF-8")?;
+    Ok(parse_worktree_list(&stdout))
+}
+
+/// Parses porcelain output from `git worktree list --porcelain` into root paths.
+pub(super) fn parse_worktree_list(output: &str) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            roots.push(PathBuf::from(rest));
+        }
+    }
+    roots
+}
+
+/// Lists skill directories in `source_skills_dir`, sorted by name.
+pub(super) fn enumerate_skills(source_skills_dir: &Path) -> Result<Vec<(String, PathBuf)>> {
+    let mut skills = Vec::new();
+    if !source_skills_dir.exists() {
+        return Ok(skills);
+    }
+    let entries = fs::read_dir(source_skills_dir)
+        .with_context(|| format!("Failed to read {}", source_skills_dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| {
+            format!(
+                "Failed to read directory entry in {}",
+                source_skills_dir.display()
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        skills.push((name.to_string(), path));
+    }
+    skills.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(skills)
+}
+
+/// Returns the `.git/info/exclude` path for a target directory, using the common git dir.
+pub(super) fn exclude_file_for(target_root: &Path) -> Result<PathBuf> {
+    let common = resolve_git_common_dir(target_root)?;
+    Ok(common.join("info").join("exclude"))
+}
+
+/// Returns the exclude-file entry for a given skill name.
+pub(super) fn exclude_entry_for(skill_name: &str) -> String {
+    format!("{EXCLUDE_PREFIX}{skill_name}/")
+}
+
+/// Appends missing entries to `exclude_file`, returning the list of added entries.
+///
+/// If `dry_run` is true the file is not modified but the would-be additions are
+/// still reported.
+pub(super) fn add_exclude_entries(
+    exclude_file: &Path,
+    entries: &[String],
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let existing = read_exclude_lines(exclude_file)?;
+    let mut additions = Vec::new();
+    for entry in entries {
+        if !existing.iter().any(|line| line == entry) {
+            additions.push(entry.clone());
+        }
+    }
+    if additions.is_empty() || dry_run {
+        return Ok(additions);
+    }
+    if let Some(parent) = exclude_file.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let mut content = if exclude_file.exists() {
+        fs::read_to_string(exclude_file)
+            .with_context(|| format!("Failed to read {}", exclude_file.display()))?
+    } else {
+        String::new()
+    };
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    for entry in &additions {
+        content.push_str(entry);
+        content.push('\n');
+    }
+    fs::write(exclude_file, content)
+        .with_context(|| format!("Failed to write {}", exclude_file.display()))?;
+    Ok(additions)
+}
+
+/// Removes matching entries from `exclude_file`, returning the list removed.
+///
+/// Entries are matched by exact line content. If `dry_run` is true the file is
+/// not modified.
+pub(super) fn remove_exclude_entries(
+    exclude_file: &Path,
+    entries: &[String],
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    if !exclude_file.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(exclude_file)
+        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
+    let trailing_newline = content.ends_with('\n');
+    let mut removed = Vec::new();
+    let mut kept = Vec::new();
+    for line in content.lines() {
+        if entries.iter().any(|e| e == line) {
+            removed.push(line.to_string());
+        } else {
+            kept.push(line.to_string());
+        }
+    }
+    if removed.is_empty() || dry_run {
+        return Ok(removed);
+    }
+    let mut new_content = kept.join("\n");
+    if trailing_newline && !new_content.is_empty() {
+        new_content.push('\n');
+    }
+    fs::write(exclude_file, new_content)
+        .with_context(|| format!("Failed to write {}", exclude_file.display()))?;
+    Ok(removed)
+}
+
+fn read_exclude_lines(exclude_file: &Path) -> Result<Vec<String>> {
+    if !exclude_file.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(exclude_file)
+        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
+    Ok(content.lines().map(ToString::to_string).collect())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        std::fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        let status = Command::new("git")
+            .arg("init")
+            .arg(dir)
+            .output()
+            .expect("git init failed to spawn");
+        assert!(status.status.success(), "git init failed: {status:?}");
+    }
+
+    fn init_repo_with_commit(dir: &Path) {
+        init_repo(dir);
+        fs::write(dir.join("README.md"), "readme").unwrap();
+        for (k, v) in [
+            ("add", vec!["add", "README.md"]),
+            (
+                "commit",
+                vec![
+                    "-c",
+                    "user.email=x@x",
+                    "-c",
+                    "user.name=x",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "init",
+                ],
+            ),
+        ] {
+            let status = Command::new("git")
+                .args(&v)
+                .current_dir(dir)
+                .output()
+                .unwrap_or_else(|_| panic!("git {k} failed to spawn"));
+            assert!(status.status.success(), "git {k} failed: {status:?}");
+        }
+    }
+
+    #[test]
+    fn resolve_toplevel_returns_repo_root() {
+        let dir = tempdir();
+        init_repo(dir.path());
+        // Canonicalize because macOS /var -> /private/var, while `git init` returns
+        // the canonical form.
+        let expected = fs::canonicalize(dir.path()).unwrap();
+        let result = resolve_toplevel(dir.path()).unwrap();
+        assert_eq!(fs::canonicalize(result).unwrap(), expected);
+    }
+
+    #[test]
+    fn resolve_toplevel_from_subdir_returns_repo_root() {
+        let dir = tempdir();
+        init_repo(dir.path());
+        let sub = dir.path().join("sub/dir");
+        fs::create_dir_all(&sub).unwrap();
+        let expected = fs::canonicalize(dir.path()).unwrap();
+        let result = resolve_toplevel(&sub).unwrap();
+        assert_eq!(fs::canonicalize(result).unwrap(), expected);
+    }
+
+    #[test]
+    fn resolve_toplevel_outside_repo_fails() {
+        // Use the system temp dir (not the in-repo `tmp/`) so git cannot find a
+        // parent repository from this path.
+        let dir = TempDir::new().unwrap();
+        let err = resolve_toplevel(dir.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("git rev-parse --show-toplevel failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_git_common_dir_in_main_worktree() {
+        let dir = tempdir();
+        init_repo(dir.path());
+        let common = resolve_git_common_dir(dir.path()).unwrap();
+        // Path should end in `.git` and point into the repo.
+        assert!(common.ends_with(".git"), "got {}", common.display());
+        assert!(common.join("info").exists() || !common.join("info").exists());
+    }
+
+    #[test]
+    fn resolve_git_common_dir_from_linked_worktree_points_at_main() {
+        let main = tempdir();
+        init_repo_with_commit(main.path());
+        let wt = tempdir();
+        let linked = wt.path().join("linked");
+        let status = Command::new("git")
+            .args(["worktree", "add", "-q"])
+            .arg(&linked)
+            .current_dir(main.path())
+            .output()
+            .expect("git worktree add failed");
+        assert!(status.status.success(), "git worktree add: {status:?}");
+
+        let common = resolve_git_common_dir(&linked).unwrap();
+        // The common dir of the linked worktree should be the main repo's `.git`.
+        let main_git = fs::canonicalize(main.path().join(".git")).unwrap();
+        assert_eq!(fs::canonicalize(&common).unwrap(), main_git);
+    }
+
+    #[test]
+    fn resolve_git_common_dir_outside_repo_fails() {
+        let dir = TempDir::new().unwrap();
+        let err = resolve_git_common_dir(dir.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("git rev-parse --git-common-dir failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn list_worktrees_returns_single_for_plain_repo() {
+        let dir = tempdir();
+        init_repo(dir.path());
+        let trees = list_worktrees(dir.path()).unwrap();
+        assert_eq!(trees.len(), 1);
+        assert_eq!(
+            fs::canonicalize(&trees[0]).unwrap(),
+            fs::canonicalize(dir.path()).unwrap()
+        );
+    }
+
+    #[test]
+    fn list_worktrees_returns_multiple_with_linked_worktree() {
+        let main = tempdir();
+        init_repo_with_commit(main.path());
+        let wt = tempdir();
+        let linked = wt.path().join("linked");
+        let status = Command::new("git")
+            .args(["worktree", "add", "-q"])
+            .arg(&linked)
+            .current_dir(main.path())
+            .output()
+            .expect("git worktree add failed");
+        assert!(status.status.success());
+
+        let trees = list_worktrees(main.path()).unwrap();
+        assert_eq!(trees.len(), 2);
+    }
+
+    #[test]
+    fn list_worktrees_outside_repo_fails() {
+        let dir = TempDir::new().unwrap();
+        let err = list_worktrees(dir.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("git worktree list failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // APFS rejects non-UTF-8 filenames, so this test is Linux-only. CI's
+    // tarpaulin job runs on Linux and exercises the to_str()-returns-None branch.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn enumerate_skills_skips_directory_with_non_utf8_name() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempdir();
+        let skills = dir.path().join("skills");
+        fs::create_dir_all(&skills).unwrap();
+        // Valid UTF-8 entry that should be returned.
+        fs::create_dir_all(skills.join("alpha")).unwrap();
+        // Invalid UTF-8 byte sequence — exercises the `to_str()` None branch.
+        let bad = OsStr::from_bytes(b"bad\xffname");
+        fs::create_dir_all(skills.join(bad)).unwrap();
+
+        let result = enumerate_skills(&skills).unwrap();
+        let names: Vec<_> = result.iter().map(|(n, _)| n.clone()).collect();
+        assert_eq!(names, vec!["alpha"]);
+    }
+
+    #[test]
+    fn exclude_file_for_points_to_info_exclude_under_common_dir() {
+        let dir = tempdir();
+        init_repo(dir.path());
+        let path = exclude_file_for(dir.path()).unwrap();
+        assert!(
+            path.ends_with(".git/info/exclude"),
+            "got {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn parse_worktree_list_single() {
+        let out = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n";
+        let roots = parse_worktree_list(out);
+        assert_eq!(roots, vec![PathBuf::from("/path/to/repo")]);
+    }
+
+    #[test]
+    fn parse_worktree_list_multiple() {
+        let out = "worktree /a/main\nHEAD abc\nbranch refs/heads/main\n\nworktree /a/feature\nHEAD def\nbranch refs/heads/feature\n";
+        let roots = parse_worktree_list(out);
+        assert_eq!(
+            roots,
+            vec![PathBuf::from("/a/main"), PathBuf::from("/a/feature")]
+        );
+    }
+
+    #[test]
+    fn parse_worktree_list_empty() {
+        assert!(parse_worktree_list("").is_empty());
+    }
+
+    #[test]
+    fn exclude_entry_format() {
+        assert_eq!(exclude_entry_for("review"), ".claude/skills/review/");
+    }
+
+    #[test]
+    fn enumerate_skills_missing_dir_returns_empty() {
+        let dir = tempdir();
+        let result = enumerate_skills(&dir.path().join("missing")).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn enumerate_skills_lists_sorted_directories() {
+        let dir = tempdir();
+        let skills_dir = dir.path().join("skills");
+        fs::create_dir_all(skills_dir.join("charlie")).unwrap();
+        fs::create_dir_all(skills_dir.join("alpha")).unwrap();
+        fs::create_dir_all(skills_dir.join("bravo")).unwrap();
+        // A stray file should be ignored.
+        fs::write(skills_dir.join("README.md"), "hi").unwrap();
+        let result = enumerate_skills(&skills_dir).unwrap();
+        let names: Vec<_> = result.iter().map(|(n, _)| n.clone()).collect();
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn add_exclude_entries_creates_file_and_appends() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let added = add_exclude_entries(
+            &exclude,
+            &[exclude_entry_for("review"), exclude_entry_for("init")],
+            false,
+        )
+        .unwrap();
+        assert_eq!(added.len(), 2);
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.contains(".claude/skills/review/"));
+        assert!(content.contains(".claude/skills/init/"));
+    }
+
+    #[test]
+    fn add_exclude_entries_does_not_duplicate() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let first = add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        assert_eq!(first, vec![".claude/skills/review/".to_string()]);
+        let second = add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        assert!(second.is_empty());
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(content.matches(".claude/skills/review/").count(), 1);
+    }
+
+    #[test]
+    fn add_exclude_entries_dry_run_does_not_write() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let added = add_exclude_entries(&exclude, &[exclude_entry_for("review")], true).unwrap();
+        assert_eq!(added.len(), 1);
+        assert!(!exclude.exists());
+    }
+
+    #[test]
+    fn add_exclude_entries_preserves_existing_content() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, "# comments\n*.tmp\n").unwrap();
+        add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.contains("# comments"));
+        assert!(content.contains("*.tmp"));
+        assert!(content.contains(".claude/skills/review/"));
+    }
+
+    #[test]
+    fn resolve_toplevel_propagates_spawn_failure() {
+        // current_dir() pointing at a non-existent path causes Command::spawn
+        // itself to fail (chdir-before-exec), exercising the with_context arm.
+        let err = resolve_toplevel(Path::new("/this/path/should/not/exist/skills_test_spawn"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Failed to run git rev-parse --show-toplevel"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_git_common_dir_propagates_spawn_failure() {
+        let err =
+            resolve_git_common_dir(Path::new("/this/path/should/not/exist/skills_test_spawn"))
+                .unwrap_err()
+                .to_string();
+        assert!(
+            err.contains("Failed to run git rev-parse --git-common-dir"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn add_exclude_entries_propagates_create_dir_all_failure() {
+        // Place a regular file where the exclude file's parent should be — so
+        // create_dir_all on the parent path fails.
+        let dir = tempdir();
+        let parent_path = dir.path().join("info");
+        fs::write(&parent_path, "block").unwrap();
+        let exclude = parent_path.join("exclude");
+
+        let err = add_exclude_entries(&exclude, &[exclude_entry_for("a")], false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Failed to create"), "unexpected error: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn add_exclude_entries_propagates_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir();
+        let info = dir.path().join("info");
+        fs::create_dir_all(&info).unwrap();
+        let exclude = info.join("exclude");
+        // Read-only parent — fs::write fails with EACCES.
+        let mut perms = fs::metadata(&info).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&info, perms).unwrap();
+
+        let result = add_exclude_entries(&exclude, &[exclude_entry_for("a")], false);
+
+        let mut perms = fs::metadata(&info).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&info, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to write"), "unexpected error: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_exclude_entries_propagates_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir();
+        let info = dir.path().join("info");
+        fs::create_dir_all(&info).unwrap();
+        let exclude = info.join("exclude");
+        fs::write(&exclude, ".claude/skills/a/\n").unwrap();
+        // Make the file itself read-only so fs::write to overwrite it fails.
+        let mut perms = fs::metadata(&exclude).unwrap().permissions();
+        perms.set_mode(0o400);
+        fs::set_permissions(&exclude, perms).unwrap();
+
+        let result = remove_exclude_entries(&exclude, &[exclude_entry_for("a")], false);
+
+        let mut perms = fs::metadata(&exclude).unwrap().permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(&exclude, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to write"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn add_exclude_entries_appends_newline_when_existing_lacks_one() {
+        // Existing content has no trailing newline — exercises the
+        // `content.push('\n')` branch.
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, "*.log").unwrap();
+        add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(content, "*.log\n.claude/skills/review/\n");
+    }
+
+    #[test]
+    fn remove_exclude_entries_removes_matching_lines() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(
+            &exclude,
+            "# comments\n*.tmp\n.claude/skills/review/\n.claude/skills/init/\n",
+        )
+        .unwrap();
+        let removed = remove_exclude_entries(
+            &exclude,
+            &[exclude_entry_for("review"), exclude_entry_for("init")],
+            false,
+        )
+        .unwrap();
+        assert_eq!(removed.len(), 2);
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.contains("# comments"));
+        assert!(content.contains("*.tmp"));
+        assert!(!content.contains(".claude/skills/"));
+    }
+
+    #[test]
+    fn remove_exclude_entries_missing_file_is_noop() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let removed =
+            remove_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn remove_exclude_entries_dry_run_does_not_modify() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, ".claude/skills/review/\n").unwrap();
+        let removed =
+            remove_exclude_entries(&exclude, &[exclude_entry_for("review")], true).unwrap();
+        assert_eq!(removed.len(), 1);
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.contains(".claude/skills/review/"));
+    }
+}

--- a/src/cli/ai/claude/skills/mod.rs
+++ b/src/cli/ai/claude/skills/mod.rs
@@ -1,0 +1,94 @@
+//! Claude Code skills management commands.
+
+mod clean;
+mod common;
+mod sync;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Worktree-aware distribution of Claude Code skills.
+#[derive(Parser)]
+pub struct SkillsCommand {
+    /// Skills subcommand to execute.
+    #[command(subcommand)]
+    pub command: SkillsSubcommands,
+}
+
+/// Skills subcommands.
+#[derive(Subcommand)]
+pub enum SkillsSubcommands {
+    /// Syncs skills from a source repository into one or more targets.
+    Sync(sync::SyncCommand),
+    /// Removes skill symlinks previously created by `sync`.
+    Clean(clean::CleanCommand),
+}
+
+impl SkillsCommand {
+    /// Executes the skills command.
+    pub fn execute(self) -> Result<()> {
+        match self.command {
+            SkillsSubcommands::Sync(cmd) => cmd.execute(),
+            SkillsSubcommands::Clean(cmd) => cmd.execute(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        let status = Command::new("git").arg("init").arg(dir).output().unwrap();
+        assert!(status.status.success());
+    }
+
+    #[test]
+    fn dispatch_sync() {
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        let skills_dir = src.path().join(".claude/skills/alpha");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(skills_dir.join("SKILL.md"), "# alpha").unwrap();
+
+        let cmd = SkillsCommand {
+            command: SkillsSubcommands::Sync(sync::SyncCommand {
+                source: Some(src.path().to_path_buf()),
+                target: Some(tgt.path().to_path_buf()),
+                worktrees: false,
+                dry_run: false,
+            }),
+        };
+        cmd.execute().unwrap();
+        assert!(tgt.path().join(".claude/skills/alpha").exists());
+    }
+
+    #[test]
+    fn dispatch_clean() {
+        let tgt = tempdir();
+        init_repo(tgt.path());
+
+        let cmd = SkillsCommand {
+            command: SkillsSubcommands::Clean(clean::CleanCommand {
+                target: Some(tgt.path().to_path_buf()),
+                worktrees: false,
+                dry_run: false,
+            }),
+        };
+        cmd.execute().unwrap();
+    }
+}

--- a/src/cli/ai/claude/skills/sync.rs
+++ b/src/cli/ai/claude/skills/sync.rs
@@ -187,44 +187,42 @@ enum LinkOutcome {
 }
 
 fn link_skill(link_path: &Path, source_skill: &Path, dry_run: bool) -> Result<LinkOutcome> {
-    match fs::symlink_metadata(link_path) {
-        Ok(meta) => {
-            if meta.file_type().is_symlink() {
-                if !dry_run {
-                    fs::remove_file(link_path).with_context(|| {
-                        format!("Failed to remove existing symlink {}", link_path.display())
-                    })?;
-                    create_symlink(source_skill, link_path).with_context(|| {
-                        format!(
-                            "Failed to create symlink {} -> {}",
-                            link_path.display(),
-                            source_skill.display()
-                        )
-                    })?;
-                }
-                Ok(LinkOutcome::Replaced)
-            } else {
-                Ok(LinkOutcome::Blocked(format!(
-                    "real {} already exists at {}",
-                    if meta.is_dir() { "directory" } else { "file" },
-                    link_path.display()
-                )))
-            }
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+    let outcome = match fs::symlink_metadata(link_path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
             if !dry_run {
-                create_symlink(source_skill, link_path).with_context(|| {
-                    format!(
-                        "Failed to create symlink {} -> {}",
-                        link_path.display(),
-                        source_skill.display()
-                    )
-                })?;
+                fs::remove_file(link_path).with_context(|| ctx_remove_symlink(link_path))?;
             }
-            Ok(LinkOutcome::Created)
+            LinkOutcome::Replaced
         }
-        Err(err) => Err(err).with_context(|| format!("Failed to inspect {}", link_path.display())),
+        Ok(meta) => {
+            return Ok(LinkOutcome::Blocked(format!(
+                "real {} already exists at {}",
+                if meta.is_dir() { "directory" } else { "file" },
+                link_path.display()
+            )));
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => LinkOutcome::Created,
+        Err(err) => {
+            return Err(err).with_context(|| format!("Failed to inspect {}", link_path.display()));
+        }
+    };
+    if !dry_run {
+        create_symlink(source_skill, link_path)
+            .with_context(|| ctx_create_symlink(link_path, source_skill))?;
     }
+    Ok(outcome)
+}
+
+fn ctx_remove_symlink(link: &Path) -> String {
+    format!("Failed to remove existing symlink {}", link.display())
+}
+
+fn ctx_create_symlink(link: &Path, source: &Path) -> String {
+    format!(
+        "Failed to create symlink {} -> {}",
+        link.display(),
+        source.display()
+    )
 }
 
 #[cfg(unix)]

--- a/src/cli/ai/claude/skills/sync.rs
+++ b/src/cli/ai/claude/skills/sync.rs
@@ -1,0 +1,802 @@
+//! Sync command — links Claude skills from a source repository into targets.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use super::common::{
+    add_exclude_entries, enumerate_skills, exclude_entry_for, exclude_file_for, list_worktrees,
+    resolve_toplevel, SKILLS_SUBPATH,
+};
+
+/// Syncs Claude skills from a source repository into one or more target worktrees.
+#[derive(Parser)]
+pub struct SyncCommand {
+    /// Source repository or worktree containing the canonical `.claude/skills/`.
+    /// Defaults to the current working directory.
+    #[arg(long, value_name = "PATH")]
+    pub source: Option<PathBuf>,
+
+    /// Target repository or worktree to sync into. Defaults to the source repository.
+    #[arg(long, value_name = "PATH")]
+    pub target: Option<PathBuf>,
+
+    /// Also sync to every worktree belonging to the target repository.
+    #[arg(long)]
+    pub worktrees: bool,
+
+    /// Preview the changes without creating symlinks or modifying the exclude file.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl SyncCommand {
+    /// Executes the sync command.
+    pub fn execute(self) -> Result<()> {
+        let cwd = std::env::current_dir().context("Failed to determine current directory")?;
+        let source_seed = self.source.clone().unwrap_or_else(|| cwd.clone());
+        let source_root = resolve_toplevel(&source_seed)?;
+
+        let target_seed = self.target.clone().unwrap_or_else(|| source_root.clone());
+        let target_root = resolve_toplevel(&target_seed)?;
+
+        let mut targets = vec![target_root.clone()];
+        if self.worktrees {
+            for wt in list_worktrees(&target_root)? {
+                if !targets.iter().any(|t| t == &wt) {
+                    targets.push(wt);
+                }
+            }
+        }
+
+        let report = run_sync(&source_root, &targets, self.dry_run)?;
+        print_report(&report, self.dry_run);
+
+        if !report.errors.is_empty() {
+            anyhow::bail!(
+                "{} skill(s) blocked by existing files; see errors above",
+                report.errors.len()
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Outcome of running a sync operation.
+#[derive(Debug, Default)]
+pub(super) struct SyncReport {
+    pub actions: Vec<SyncAction>,
+    pub errors: Vec<SyncError>,
+}
+
+/// Individual action produced by the sync operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SyncAction {
+    Linked {
+        link: PathBuf,
+        points_to: PathBuf,
+    },
+    Relinked {
+        link: PathBuf,
+        points_to: PathBuf,
+    },
+    Excluded {
+        exclude_file: PathBuf,
+        entry: String,
+    },
+    SkippedSameTarget {
+        target: PathBuf,
+    },
+}
+
+/// Error describing a skill that could not be synced because a real file or directory
+/// already exists at the target path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SyncError {
+    pub target: PathBuf,
+    pub reason: String,
+}
+
+/// Performs the sync operation for the given source and targets.
+pub(super) fn run_sync(
+    source_root: &Path,
+    targets: &[PathBuf],
+    dry_run: bool,
+) -> Result<SyncReport> {
+    let source_skills_dir = source_root.join(SKILLS_SUBPATH);
+    let skills = enumerate_skills(&source_skills_dir)?;
+    let mut report = SyncReport::default();
+
+    if skills.is_empty() {
+        return Ok(report);
+    }
+
+    for target_root in targets {
+        if paths_equal(target_root, source_root) {
+            report.actions.push(SyncAction::SkippedSameTarget {
+                target: target_root.clone(),
+            });
+            continue;
+        }
+        sync_to_target(target_root, &skills, dry_run, &mut report)?;
+    }
+
+    Ok(report)
+}
+
+fn sync_to_target(
+    target_root: &Path,
+    skills: &[(String, PathBuf)],
+    dry_run: bool,
+    report: &mut SyncReport,
+) -> Result<()> {
+    let target_skills_dir = target_root.join(SKILLS_SUBPATH);
+    if !dry_run {
+        fs::create_dir_all(&target_skills_dir)
+            .with_context(|| format!("Failed to create {}", target_skills_dir.display()))?;
+    }
+
+    let mut exclude_entries = Vec::new();
+    for (name, source_skill) in skills {
+        let link_path = target_skills_dir.join(name);
+        match link_skill(&link_path, source_skill, dry_run)? {
+            LinkOutcome::Created => {
+                report.actions.push(SyncAction::Linked {
+                    link: link_path.clone(),
+                    points_to: source_skill.clone(),
+                });
+                exclude_entries.push(exclude_entry_for(name));
+            }
+            LinkOutcome::Replaced => {
+                report.actions.push(SyncAction::Relinked {
+                    link: link_path.clone(),
+                    points_to: source_skill.clone(),
+                });
+                exclude_entries.push(exclude_entry_for(name));
+            }
+            LinkOutcome::Blocked(reason) => {
+                report.errors.push(SyncError {
+                    target: link_path,
+                    reason,
+                });
+            }
+        }
+    }
+
+    if !exclude_entries.is_empty() {
+        let exclude_file = exclude_file_for(target_root)?;
+        let added = add_exclude_entries(&exclude_file, &exclude_entries, dry_run)?;
+        for entry in added {
+            report.actions.push(SyncAction::Excluded {
+                exclude_file: exclude_file.clone(),
+                entry,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum LinkOutcome {
+    Created,
+    Replaced,
+    Blocked(String),
+}
+
+fn link_skill(link_path: &Path, source_skill: &Path, dry_run: bool) -> Result<LinkOutcome> {
+    match fs::symlink_metadata(link_path) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                if !dry_run {
+                    fs::remove_file(link_path).with_context(|| {
+                        format!("Failed to remove existing symlink {}", link_path.display())
+                    })?;
+                    create_symlink(source_skill, link_path).with_context(|| {
+                        format!(
+                            "Failed to create symlink {} -> {}",
+                            link_path.display(),
+                            source_skill.display()
+                        )
+                    })?;
+                }
+                Ok(LinkOutcome::Replaced)
+            } else {
+                Ok(LinkOutcome::Blocked(format!(
+                    "real {} already exists at {}",
+                    if meta.is_dir() { "directory" } else { "file" },
+                    link_path.display()
+                )))
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            if !dry_run {
+                create_symlink(source_skill, link_path).with_context(|| {
+                    format!(
+                        "Failed to create symlink {} -> {}",
+                        link_path.display(),
+                        source_skill.display()
+                    )
+                })?;
+            }
+            Ok(LinkOutcome::Created)
+        }
+        Err(err) => Err(err).with_context(|| format!("Failed to inspect {}", link_path.display())),
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    fs::canonicalize(a)
+        .ok()
+        .zip(fs::canonicalize(b).ok())
+        .map_or_else(|| a == b, |(a, b)| a == b)
+}
+
+fn print_report(report: &SyncReport, dry_run: bool) {
+    let prefix = if dry_run { "[dry-run] " } else { "" };
+    for action in &report.actions {
+        match action {
+            SyncAction::Linked { link, points_to } => {
+                println!(
+                    "{prefix}linked {} -> {}",
+                    link.display(),
+                    points_to.display()
+                );
+            }
+            SyncAction::Relinked { link, points_to } => {
+                println!(
+                    "{prefix}relinked {} -> {}",
+                    link.display(),
+                    points_to.display()
+                );
+            }
+            SyncAction::Excluded {
+                exclude_file,
+                entry,
+            } => {
+                println!("{prefix}excluded {} in {}", entry, exclude_file.display());
+            }
+            SyncAction::SkippedSameTarget { target } => {
+                println!(
+                    "{prefix}skipped {} (target equals source)",
+                    target.display()
+                );
+            }
+        }
+    }
+    for err in &report.errors {
+        eprintln!("error: {} -- {}", err.target.display(), err.reason);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        std::fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn make_source_skills(root: &Path, names: &[&str]) {
+        let skills = root.join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills).unwrap();
+        for name in names {
+            let skill_dir = skills.join(name);
+            fs::create_dir_all(&skill_dir).unwrap();
+            fs::write(skill_dir.join("SKILL.md"), format!("# {name}")).unwrap();
+        }
+    }
+
+    /// Initialises a real git repository at `dir` so commands like
+    /// `git rev-parse --git-common-dir` work as expected.
+    fn init_repo(dir: &Path) {
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(dir)
+            .output()
+            .expect("git init failed to spawn");
+        assert!(status.status.success(), "git init failed: {status:?}");
+    }
+
+    fn make_fake_repo(dir: &Path) {
+        init_repo(dir);
+    }
+
+    #[test]
+    fn run_sync_creates_symlinks_and_exclude_entries() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
+        make_fake_repo(tgt_tmp.path());
+
+        let targets = vec![tgt_tmp.path().to_path_buf()];
+        let report = run_sync(src_tmp.path(), &targets, false).unwrap();
+        assert!(report.errors.is_empty());
+
+        for name in ["alpha", "bravo"] {
+            let link = tgt_tmp.path().join(SKILLS_SUBPATH).join(name);
+            let meta = fs::symlink_metadata(&link).unwrap();
+            assert!(meta.file_type().is_symlink(), "{name} should be a symlink");
+            let points_to = fs::read_link(&link).unwrap();
+            assert_eq!(points_to, src_tmp.path().join(SKILLS_SUBPATH).join(name));
+        }
+
+        let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
+        assert!(exclude.contains(".claude/skills/alpha/"));
+        assert!(exclude.contains(".claude/skills/bravo/"));
+    }
+
+    #[test]
+    fn run_sync_replaces_existing_symlink() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        let other_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        make_source_skills(other_tmp.path(), &["alpha"]);
+        make_fake_repo(tgt_tmp.path());
+
+        // Pre-create a symlink pointing to the "other" source.
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        create_symlink(
+            &other_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+
+        let report = run_sync(src_tmp.path(), &[tgt_tmp.path().to_path_buf()], false).unwrap();
+        assert!(report.errors.is_empty());
+        let relinked = report
+            .actions
+            .iter()
+            .any(|a| matches!(a, SyncAction::Relinked { .. }));
+        assert!(relinked, "expected a Relinked action");
+
+        let link = target_skills_dir.join("alpha");
+        let points_to = fs::read_link(&link).unwrap();
+        assert_eq!(points_to, src_tmp.path().join(SKILLS_SUBPATH).join("alpha"));
+    }
+
+    #[test]
+    fn run_sync_skips_real_file_and_reports_error() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
+        make_fake_repo(tgt_tmp.path());
+
+        // Place a real directory at the target of "alpha".
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(target_skills_dir.join("alpha")).unwrap();
+        fs::write(target_skills_dir.join("alpha").join("keep.txt"), "keep").unwrap();
+
+        let report = run_sync(src_tmp.path(), &[tgt_tmp.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].target.ends_with(".claude/skills/alpha"));
+        // bravo should still have been linked
+        assert!(fs::symlink_metadata(target_skills_dir.join("bravo"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        // alpha's real file should still exist
+        assert!(target_skills_dir.join("alpha").join("keep.txt").exists());
+    }
+
+    #[test]
+    fn run_sync_dry_run_reports_but_does_not_modify() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        make_fake_repo(tgt_tmp.path());
+
+        let report = run_sync(src_tmp.path(), &[tgt_tmp.path().to_path_buf()], true).unwrap();
+        assert!(report.errors.is_empty());
+        assert!(!report.actions.is_empty());
+
+        let link = tgt_tmp.path().join(SKILLS_SUBPATH).join("alpha");
+        assert!(!link.exists());
+        let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
+        assert!(!exclude.contains(".claude/skills/alpha/"));
+    }
+
+    #[test]
+    fn run_sync_does_not_duplicate_exclude_entries() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        make_fake_repo(tgt_tmp.path());
+
+        let targets = vec![tgt_tmp.path().to_path_buf()];
+        run_sync(src_tmp.path(), &targets, false).unwrap();
+        run_sync(src_tmp.path(), &targets, false).unwrap();
+
+        let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(exclude.matches(".claude/skills/alpha/").count(), 1);
+    }
+
+    #[test]
+    fn run_sync_skips_target_equal_to_source() {
+        let src_tmp = tempdir();
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        make_fake_repo(src_tmp.path());
+
+        let targets = vec![src_tmp.path().to_path_buf()];
+        let report = run_sync(src_tmp.path(), &targets, false).unwrap();
+        assert!(report.errors.is_empty());
+        assert!(report
+            .actions
+            .iter()
+            .any(|a| matches!(a, SyncAction::SkippedSameTarget { .. })));
+
+        // Original skill directory must not have been touched or replaced.
+        let skill = src_tmp.path().join(SKILLS_SUBPATH).join("alpha");
+        let meta = fs::symlink_metadata(&skill).unwrap();
+        assert!(meta.is_dir() && !meta.file_type().is_symlink());
+    }
+
+    #[test]
+    fn run_sync_with_no_source_skills_is_noop() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        make_fake_repo(tgt_tmp.path());
+
+        let targets = vec![tgt_tmp.path().to_path_buf()];
+        let report = run_sync(src_tmp.path(), &targets, false).unwrap();
+        assert!(report.actions.is_empty());
+        assert!(report.errors.is_empty());
+        let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
+        assert!(!exclude.contains(".claude/skills/"));
+    }
+
+    #[test]
+    fn paths_equal_returns_true_for_same_canonical_path() {
+        let dir = tempdir();
+        let a = dir.path().to_path_buf();
+        let b = dir.path().to_path_buf();
+        assert!(paths_equal(&a, &b));
+    }
+
+    #[test]
+    fn paths_equal_returns_false_for_different_dirs() {
+        let a = tempdir();
+        let b = tempdir();
+        assert!(!paths_equal(a.path(), b.path()));
+    }
+
+    #[test]
+    fn paths_equal_falls_back_to_literal_comparison_when_canonicalize_fails() {
+        // Neither path exists so canonicalize returns Err — exercises the
+        // fallback `|| a == b` branch.
+        assert!(paths_equal(
+            Path::new("/nonexistent/skills/a"),
+            Path::new("/nonexistent/skills/a")
+        ));
+        assert!(!paths_equal(
+            Path::new("/nonexistent/skills/a"),
+            Path::new("/nonexistent/skills/b")
+        ));
+    }
+
+    #[test]
+    fn execute_syncs_to_explicit_target() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        init_repo(src_tmp.path());
+        init_repo(tgt_tmp.path());
+        make_source_skills(src_tmp.path(), &["alpha"]);
+
+        let cmd = SyncCommand {
+            source: Some(src_tmp.path().to_path_buf()),
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+
+        let link = tgt_tmp.path().join(SKILLS_SUBPATH).join("alpha");
+        assert!(fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    fn execute_dry_run_covers_all_action_branches() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        init_repo(src_tmp.path());
+        init_repo(tgt_tmp.path());
+        make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
+        // Pre-create a symlink so "alpha" is reported as Relinked.
+        let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        create_symlink(
+            &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+
+        let cmd = SyncCommand {
+            source: Some(src_tmp.path().to_path_buf()),
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: true,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn execute_returns_error_when_blocked() {
+        let src_tmp = tempdir();
+        let tgt_tmp = tempdir();
+        init_repo(src_tmp.path());
+        init_repo(tgt_tmp.path());
+        make_source_skills(src_tmp.path(), &["alpha"]);
+        // Place a real dir so the sync is blocked.
+        fs::create_dir_all(tgt_tmp.path().join(SKILLS_SUBPATH).join("alpha")).unwrap();
+
+        let cmd = SyncCommand {
+            source: Some(src_tmp.path().to_path_buf()),
+            target: Some(tgt_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+        };
+        let err = cmd.execute().unwrap_err().to_string();
+        assert!(err.contains("blocked by existing files"));
+    }
+
+    #[test]
+    fn execute_skipped_same_target_covers_print_branch() {
+        // Exercises the SkippedSameTarget print path via execute.
+        let src_tmp = tempdir();
+        init_repo(src_tmp.path());
+        make_source_skills(src_tmp.path(), &["alpha"]);
+
+        let cmd = SyncCommand {
+            source: Some(src_tmp.path().to_path_buf()),
+            target: Some(src_tmp.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+    }
+
+    /// Initialise a repo with one commit so linked worktrees can be created from it.
+    fn init_repo_with_commit(dir: &Path) {
+        init_repo(dir);
+        fs::write(dir.join("README.md"), "readme").unwrap();
+        let add = std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=x@x",
+                "-c",
+                "user.name=x",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(commit.status.success());
+    }
+
+    #[test]
+    fn execute_source_defaults_to_cwd() {
+        // Covers the `source.unwrap_or_else(|| cwd.clone())` branch. Uses
+        // dry_run so no filesystem writes occur on the inferred source repo.
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let cmd = SyncCommand {
+            source: None,
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            dry_run: true,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn execute_target_defaults_to_source() {
+        // Covers the `target.unwrap_or_else(|| source_root.clone())` branch.
+        // With target == source the run skips with SkippedSameTarget, so no
+        // filesystem writes occur even though dry_run is false.
+        let src = tempdir();
+        init_repo(src.path());
+        make_source_skills(src.path(), &["alpha"]);
+
+        let cmd = SyncCommand {
+            source: Some(src.path().to_path_buf()),
+            target: None,
+            worktrees: false,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+        // Source directory must remain a real directory.
+        let skill = src.path().join(SKILLS_SUBPATH).join("alpha");
+        let meta = fs::symlink_metadata(&skill).unwrap();
+        assert!(meta.is_dir() && !meta.file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn link_skill_propagates_lstat_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        make_source_skills(src.path(), &["alpha"]);
+
+        let target_skills = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills).unwrap();
+        // Removing search permission causes lstat on a path inside this dir to
+        // return EACCES (not NotFound), exercising the catch-all error arm.
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let result = run_sync(src.path(), &[tgt.path().to_path_buf()], false);
+
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to inspect") || err.contains("Failed to create symlink"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn link_skill_propagates_relink_failure_for_existing_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = tempdir();
+        let other = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        make_source_skills(src.path(), &["alpha"]);
+        make_source_skills(other.path(), &["alpha"]);
+
+        // Pre-create a symlink at the target then make the parent read-only so
+        // the subsequent remove_file/create_symlink fails.
+        let target_skills = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills).unwrap();
+        create_symlink(
+            &other.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills.join("alpha"),
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let result = run_sync(src.path(), &[tgt.path().to_path_buf()], false);
+
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to remove existing symlink")
+                || err.contains("Failed to create symlink"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn link_skill_propagates_create_symlink_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        make_source_skills(src.path(), &["alpha"]);
+
+        let target_skills = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills).unwrap();
+        // Make the skills directory read-only so create_symlink within it fails.
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let result = run_sync(src.path(), &[tgt.path().to_path_buf()], false);
+
+        // Restore writable perms so TempDir cleanup succeeds.
+        let mut perms = fs::metadata(&target_skills).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&target_skills, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to create symlink") || err.contains("Failed to inspect"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn run_sync_propagates_create_dir_all_failure() {
+        // Place a regular file at `<target>/.claude` so that creating
+        // `<target>/.claude/skills` fails with a context-wrapped error.
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        make_source_skills(src.path(), &["alpha"]);
+        fs::write(tgt.path().join(".claude"), "block").unwrap();
+
+        let err = run_sync(src.path(), &[tgt.path().to_path_buf()], false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Failed to create"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn execute_with_worktrees_syncs_to_all_worktrees() {
+        let src = tempdir();
+        let tgt_main = tempdir();
+        let wt_parent = tempdir();
+        let linked = wt_parent.path().join("linked");
+
+        init_repo(src.path());
+        make_source_skills(src.path(), &["alpha"]);
+        init_repo_with_commit(tgt_main.path());
+
+        let add_wt = std::process::Command::new("git")
+            .args(["worktree", "add", "-q"])
+            .arg(&linked)
+            .current_dir(tgt_main.path())
+            .output()
+            .unwrap();
+        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+
+        let cmd = SyncCommand {
+            source: Some(src.path().to_path_buf()),
+            target: Some(tgt_main.path().to_path_buf()),
+            worktrees: true,
+            dry_run: false,
+        };
+        cmd.execute().unwrap();
+
+        assert!(
+            fs::symlink_metadata(tgt_main.path().join(".claude/skills/alpha"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(fs::symlink_metadata(linked.join(".claude/skills/alpha"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -61,8 +61,9 @@ Claude Code diagnostics and inspection
 Usage: claude <COMMAND>
 
 Commands:
-  cli   Claude Code CLI inspection
-  help  Print this message or the help of the given subcommand(s)
+  cli     Claude Code CLI inspection
+  skills  Manages Claude Code skills across repositories and worktrees
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -110,6 +111,54 @@ Usage: resolve
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev ai claude skills - Manages Claude Code skills across repositories and worktrees
+
+Manages Claude Code skills across repositories and worktrees
+
+Usage: skills <COMMAND>
+
+Commands:
+  sync   Syncs skills from a source repository into one or more targets
+  clean  Removes skill symlinks previously created by `sync`
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev ai claude skills clean - Removes skill symlinks previously created by `sync`
+
+Removes skill symlinks previously created by `sync`
+
+Usage: clean [OPTIONS]
+
+Options:
+      --target <PATH>  Target repository or worktree to clean. Defaults to the current working directory
+      --worktrees      Also clean every worktree belonging to the target repository
+      --dry-run        Preview the changes without deleting symlinks or modifying the exclude file
+  -h, --help           Print help
+
+
+================================================================================
+
+omni-dev ai claude skills sync - Syncs skills from a source repository into one or more targets
+
+Syncs skills from a source repository into one or more targets
+
+Usage: sync [OPTIONS]
+
+Options:
+      --source <PATH>  Source repository or worktree containing the canonical `.claude/skills/`. Defaults to the current working directory
+      --target <PATH>  Target repository or worktree to sync into. Defaults to the source repository
+      --worktrees      Also sync to every worktree belonging to the target repository
+      --dry-run        Preview the changes without creating symlinks or modifying the exclude file
+  -h, --help           Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR introduces a new `skills` subcommand under the `claude` CLI command that manages Claude Code skill directories across repositories and worktrees via symlinks. Users working with multiple git worktrees can now synchronize a canonical set of `.claude/skills/` directories into each worktree without committing them, with automatic `.git/info/exclude` management to prevent accidental inclusion.

The feature solves the problem of skill duplication across worktrees by maintaining a single source of truth in one repository and distributing symlinks to all other worktrees. Each symlinked skill is registered in `.git/info/exclude` so git ignores it without modifying `.gitignore`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Relates to #558

## Changes Made

**Core Changes:**
- Added `src/cli/ai/claude/skills/mod.rs` — defines `SkillsCommand` and `SkillsSubcommands` (Sync, Clean) with clap parser wiring
- Added `src/cli/ai/claude/skills/sync.rs` — implements `skills sync` command that creates symlinks from a source repository's `.claude/skills/` into one or more target worktrees; supports `--source`, `--target`, `--worktrees`, and `--dry-run` flags; blocks on real files/directories and reports errors
- Added `src/cli/ai/claude/skills/clean.rs` — implements `skills clean` command that removes symlinks previously created by sync, strips corresponding `.git/info/exclude` entries, and removes the skills directory when empty; supports `--target`, `--worktrees`, and `--dry-run` flags
- Added `src/cli/ai/claude/skills/common.rs` — shared helper module providing `resolve_toplevel`, `resolve_git_common_dir`, `list_worktrees`, `parse_worktree_list`, `enumerate_skills`, `add_exclude_entries`, `remove_exclude_entries`, and related constants (`SKILLS_SUBPATH`, `EXCLUDE_PREFIX`)
- Modified `src/cli/ai/claude/mod.rs` — wired `SkillsCommand` into `ClaudeSubcommands` enum and added dispatch in `execute()`

**Testing:**
- `sync.rs` unit tests: symlink creation and exclude entry registration, existing symlink replacement (relink), blocking on real files while continuing to sync others, dry-run no-op verification, duplicate exclude entry prevention, source-equals-target skip, and no-source-skills no-op
- `clean.rs` unit tests: symlink removal and exclude entry cleanup, empty directory removal after all symlinks cleaned, preservation of real files and directories, dry-run no-op verification, missing skills directory no-op
- `common.rs` unit tests: `parse_worktree_list` with single, multiple, and empty inputs; `exclude_entry_for` format; `enumerate_skills` with missing directory and sorted directories (ignoring non-directory files); `add_exclude_entries` creation, no-duplication, dry-run, and existing content preservation; `remove_exclude_entries` removal, missing file no-op, and dry-run preservation

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run skills-specific tests
cargo test skills

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
cargo build
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — new `skills` module hierarchy under `claude` with shared `common` helpers
- [x] Error handling — sync blocks on real files but continues syncing other skills; clean preserves real files/directories
- [x] Backward compatibility — purely additive; no existing commands or APIs changed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact — operations are local filesystem and git subprocess calls; only executed on demand

## Security Considerations

- [x] No security implications — symlinks are created within the local filesystem under user control; no external data or credentials involved

## Breaking Changes

None. This is a purely additive feature. No existing commands, APIs, or configuration files are modified.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Support for additional skill sources beyond the local filesystem (e.g., remote repositories)
- A `skills list` subcommand to inspect which skills are currently synced in a worktree
- Integration with `omni-dev` project configuration to define default source repositories

**Known Limitations:**
- Symlink creation on Windows uses `symlink_dir` which may require elevated privileges or Developer Mode enabled
- The `--worktrees` fan-out relies on `git worktree list --porcelain` and will not work in bare repositories without at least one linked worktree

**Alternatives Considered:**
- Copying skill directories instead of symlinking — rejected because updates to the source would not propagate automatically
- Using `.gitignore` instead of `.git/info/exclude` — rejected because `.gitignore` would be committed, potentially affecting all contributors