### PR TITLE
fix(atlassian): add pagination support to get_page_comments

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -151,6 +151,13 @@ pub struct ConfluenceComment {
 #[derive(Deserialize)]
 struct ConfluenceCommentsResponse {
     results: Vec<ConfluenceCommentEntry>,
+    #[serde(rename = "_links", default)]
+    links: Option<ConfluenceCommentsLinks>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceCommentsLinks {
+    next: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -616,35 +623,35 @@ impl ConfluenceApi {
         Ok(all_pages)
     }
 
-    /// Lists footer comments on a Confluence page.
+    /// Lists footer comments on a Confluence page, handling pagination.
     pub async fn get_page_comments(&self, page_id: &str) -> Result<Vec<ConfluenceComment>> {
-        let url = format!(
+        let mut all_comments = Vec::new();
+        let mut url = format!(
             "{}/wiki/api/v2/pages/{}/footer-comments?body-format=atlas_doc_format",
             self.client.instance_url(),
             page_id
         );
 
-        let response = self
-            .client
-            .get_json(&url)
-            .await
-            .context("Failed to fetch Confluence page comments")?;
+        loop {
+            let response = self
+                .client
+                .get_json(&url)
+                .await
+                .context("Failed to fetch Confluence page comments")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let body = response.text().await.unwrap_or_default();
+                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+            }
 
-        let resp: ConfluenceCommentsResponse = response
-            .json()
-            .await
-            .context("Failed to parse Confluence comments response")?;
+            let resp: ConfluenceCommentsResponse = response
+                .json()
+                .await
+                .context("Failed to parse Confluence comments response")?;
 
-        Ok(resp
-            .results
-            .into_iter()
-            .map(|c| {
+            let page_count = resp.results.len();
+            for c in resp.results {
                 let body_adf = c.body.and_then(|b| {
                     b.atlas_doc_format
                         .and_then(|a| serde_json::from_str(&a.value).ok())
@@ -655,14 +662,23 @@ impl ConfluenceApi {
                     .and_then(|v| v.author_id.clone())
                     .unwrap_or_default();
                 let created = c.version.and_then(|v| v.created_at).unwrap_or_default();
-                ConfluenceComment {
+                all_comments.push(ConfluenceComment {
                     id: c.id,
                     author,
                     body_adf,
                     created,
+                });
+            }
+
+            match resp.links.and_then(|l| l.next) {
+                Some(next_path) if page_count > 0 => {
+                    url = format!("{}{}", self.client.instance_url(), next_path);
                 }
-            })
-            .collect())
+                _ => break,
+            }
+        }
+
+        Ok(all_comments)
     }
 
     /// Adds a footer comment to a Confluence page.
@@ -1719,6 +1735,104 @@ mod tests {
         let api = ConfluenceApi::new(client);
         let err = api.get_page_comments("99999").await.unwrap_err();
         assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_with_pagination() {
+        let server = wiremock::MockServer::start().await;
+
+        // First page returns one comment with a next link.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .and(wiremock::matchers::query_param_is_missing("cursor"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {
+                            "id": "100",
+                            "version": {
+                                "authorId": "user-abc",
+                                "createdAt": "2026-04-01T10:00:00.000Z"
+                            },
+                            "body": {
+                                "atlas_doc_format": {
+                                    "value": "{\"version\":1,\"type\":\"doc\",\"content\":[]}"
+                                }
+                            }
+                        }
+                    ],
+                    "_links": {
+                        "next": "/wiki/api/v2/pages/12345/footer-comments?body-format=atlas_doc_format&cursor=page2"
+                    }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Second page returns another comment with no next link.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .and(wiremock::matchers::query_param("cursor", "page2"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {
+                            "id": "101",
+                            "version": {
+                                "authorId": "user-def",
+                                "createdAt": "2026-04-02T14:00:00.000Z"
+                            }
+                        }
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].id, "100");
+        assert_eq!(comments[0].author, "user-abc");
+        assert!(comments[0].body_adf.is_some());
+        assert_eq!(comments[1].id, "101");
+        assert_eq!(comments[1].author, "user-def");
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_pagination_stops_on_empty_page() {
+        let server = wiremock::MockServer::start().await;
+
+        // Response advertises a next link but returns no results; loop must stop
+        // to avoid infinite pagination.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [],
+                    "_links": {
+                        "next": "/wiki/api/v2/pages/12345/footer-comments?cursor=loop"
+                    }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let comments = api.get_page_comments("12345").await.unwrap();
+        assert!(comments.is_empty());
     }
 
     // ── add_page_comment ──────────────────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes `get_page_comments` in the Confluence API client to retrieve all footer comments rather than just the first page. Previously, the function made a single HTTP request and returned only the first batch of results. For pages with many comments, this silently truncated the result set.

The fix refactors `get_page_comments` into a pagination loop that follows `_links.next` cursor URLs until there are no more results, matching the behavior of other paginated endpoints in the client.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #544

## Changes Made

**Core Changes:**
- Added `ConfluenceCommentsLinks` struct to deserialise the `_links.next` field from Confluence footer-comments API responses
- Added `links` field (optional, `#[serde(default)]`) to `ConfluenceCommentsResponse` to carry pagination metadata
- Refactored `get_page_comments` from a single-request fetch into a `loop` that collects results across pages and follows `_links.next` URLs until exhausted
- Added an empty-results guard (`page_count > 0`) to break the loop when a page returns no results even if a `next` link is present, preventing infinite loops

**Testing:**
- Added `get_page_comments_with_pagination` test: verifies two-page fetch using `wiremock`, asserting both comments are returned with correct IDs and authors
- Added `get_page_comments_pagination_stops_on_empty_page` test: verifies the empty-results guard prevents infinite pagination when a next link exists but results are empty

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (multi-page comment retrieval)
- [x] Tested error/edge cases (empty-results guard, HTTP error propagation)
- [x] Backward compatibility verified (function signature unchanged, return type unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run only Confluence API tests
cargo test --test '*' atlassian::confluence_api

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — HTTP errors are now checked inside the loop; confirm they still propagate correctly on any page
- [x] Backward compatibility — function signature (`&self, page_id: &str`) and return type (`Result<Vec<ConfluenceComment>>`) are unchanged
- [x] Infinite-loop guard — the `page_count > 0` condition in the `match` arm is the only protection against a misbehaving server returning a next link with empty results

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Potential performance impact (describe below)

The function now issues multiple HTTP requests for pages with many comments instead of one. This is necessary for correctness; callers that previously received a truncated list will now receive a complete one, which may take longer for pages with a large number of comment pages. No caching changes are introduced.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The public interface of `get_page_comments` is unchanged. Callers will now receive more results than before (the full set instead of only the first page), which is a correctness fix.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Using a `limit` query parameter set to a very large value to fetch all comments in one request. This was rejected because the Confluence API does not guarantee honoring large limit values and the cursor-based approach is the documented pattern for full result retrieval.