### PR TITLE
fix(atlassian): handle optional account_id in Confluence user search and add yamls output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Confluence Bulk Space Download**: `confluence download` now accepts `--space <KEY>` to recursively download every page in a Confluence space, plus `--title-filter` to download only pages whose title contains a substring (case-insensitive)
 - **JIRA Comment Pagination** ([#543](https://github.com/rust-works/omni-dev/issues/543)): `jira comment list` now auto-paginates the JIRA comments REST API (previously only the first page was returned) and accepts a `--limit` flag to cap the total number of comments (use `0` for unlimited)
+- **YAML Stream Output** ([#546](https://github.com/rust-works/omni-dev/issues/546)): New `-o yamls` output format emits results as `---`-separated YAML documents (YAML multi-document streams). For sequence results, each item becomes its own document; other values emit as a single `---`-prefixed document. Streams parse with standard YAML tooling (`yaml.safe_load_all()`, `yq`) and enable future per-page streaming for auto-paginated commands.
 
 ### Changed
 - **CI Coverage**: Switched coverage tooling from `cargo-tarpaulin` to `cargo-llvm-cov` to eliminate `.await?` false negatives and improve accuracy for async code, macros, and generics


### PR DESCRIPTION
## Description

This PR fixes deserialization failures in the Confluence user search API where certain user records (app users, deactivated users) lack an `accountId` field. Previously, such entries caused hard failures because `account_id` was typed as `String` rather than `Option<String>`. Additionally, this PR restructures the deserialization of `ConfluenceUserSearchEntry` to correctly match the actual Confluence Search API response shape, which nests user data under a `user` field rather than at the top level.

As a companion feature, a new `-o yamls` output format is added that emits results as `---`-separated YAML multi-document streams. This enables per-item streaming for sequence results and is compatible with standard YAML tooling (`yaml.safe_load_all()`, `yq`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue

Fixes #546

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Changed `ConfluenceUserSearchResult.account_id` from `String` to `Option<String>` and added `#[serde(skip_serializing_if = "Option::is_none")]`
- Added `#[serde(skip_serializing_if = "Option::is_none")]` to `email` field in `ConfluenceUserSearchResult`
- Restructured `ConfluenceUserSearchEntry` to nest user data under an optional `user: Option<ConfluenceSearchUser>` field, matching the actual Confluence Search API response shape
- Added new `ConfluenceSearchUser` struct with `account_id`, `display_name`, `email`, and `public_name` fields (all optional)
- Updated `search_confluence_users` implementation to skip entries where `user` is absent (non-user entity types)
- Added fallback to `publicName` when `displayName` is absent in user records

**Output Format (`src/cli/atlassian/format.rs`):**
- Added `OutputFormat::Yamls` variant for YAML multi-document stream output
- Implemented `format_yaml_stream` helper: emits each item in a sequence as its own `---`-prefixed YAML document; non-sequence values emit as a single `---`-prefixed document
- Updated `output_as` to handle the new `Yamls` variant

**Display Formatting (`src/cli/atlassian/confluence/user.rs`):**
- Updated `print_user_results` to render missing `account_id` as `-` using `.as_deref().unwrap_or("-")`
- Updated column width calculation to handle `Option<String>` account IDs
- Updated `sample_user` test helper to accept `Option<&str>` for `account_id`

**Documentation (`CHANGELOG.md`):**
- Added entry for the new `-o yamls` YAML stream output format referencing issue #546

**Testing:**
- Added regression test `search_confluence_users_missing_account_id`: verifies that entries without `accountId` deserialize correctly and don't cause failures
- Added regression test `search_confluence_users_uses_public_name_when_no_display_name`: verifies fallback to `publicName` when `displayName` is absent
- Added regression test `search_confluence_users_skips_entries_without_user`: verifies that non-user entity entries (e.g. `entityType: content`) are silently skipped
- Updated all existing Confluence user search tests to use the nested `user` object structure matching the real API
- Added comprehensive `format_yaml_stream` unit tests covering: one-doc-per-item for sequences, empty sequence, single-item sequence, non-sequence values, scalars, nested sequences, and round-trip deserialization via `serde_yaml::Deserializer`
- Added `print_results_with_missing_account_id` display test

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (user search with full user data)
- [x] Tested error/edge cases (missing `accountId`, missing `displayName`, non-user entries)
- [x] Backward compatibility verified (existing JSON/YAML output formats unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run Atlassian-specific tests
cargo test atlassian

# Run format-specific tests
cargo test format_yaml_stream

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the `skip entries without user` logic in `search_confluence_users` silently drops non-user entities; confirm this is the desired behavior
- [x] Backward compatibility — `account_id` is now `Option<String>` in `ConfluenceUserSearchResult`; any code consuming this struct directly must handle `None`
- [x] User experience — display now renders `-` for missing account IDs, consistent with how missing emails are displayed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

The `ConfluenceUserSearchResult.account_id` field type has changed from `String` to `Option<String>`. Any code that directly accesses `.account_id` without handling `Option` will fail to compile. Callers should use `.account_id.as_deref().unwrap_or("-")` or similar.

**Backward Compatibility:**
- Serialized JSON/YAML output for results with a present `accountId` is unchanged (field is emitted as before). Results without `accountId` will now omit the field from serialized output (via `skip_serializing_if`).

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `-o yamls` format enables future per-page streaming for auto-paginated commands, allowing consumers to process results as they arrive rather than waiting for full collection

**Known Limitations:**
- The `format_yaml_stream` helper serializes the full value into memory before streaming; true streaming (writing documents as they are fetched) would require a more significant refactor of the pagination layer

**Alternatives Considered:**
- Keeping `account_id` as `String` with a sentinel value (e.g. empty string) was rejected in favor of `Option<String>` for correctness and clarity