### PR TITLE
fix(atlassian): preserve integer vs float type for table width in ADF roundtrip

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1145,17 +1145,6 @@ impl<'a> MarkdownParser<'a> {
     }
 }
 
-/// Parses a numeric JFM attribute string, preserving integer-vs-float type.
-/// Strings without a decimal point are emitted as JSON integers; strings with a
-/// decimal point are emitted as JSON floats.
-fn parse_numeric_attr(s: &str) -> Option<serde_json::Value> {
-    if s.contains('.') {
-        s.parse::<f64>().ok().map(|n| serde_json::json!(n))
-    } else {
-        s.parse::<u64>().ok().map(|n| serde_json::json!(n))
-    }
-}
-
 /// Builds ADF cell attributes from JFM directive attrs.
 /// Maps: `bg` → `background`, `colspan` → number, `rowspan` → number, `colwidth` → array.
 fn build_cell_attrs(attrs: &crate::atlassian::attrs::Attrs) -> serde_json::Value {
@@ -3997,24 +3986,8 @@ fn render_table_level_attrs(node: &AdfNode, output: &mut String, opts: &RenderOp
                 parts.push("numbered=false".to_string());
             }
         }
-        if let Some(tw_val) = attrs.get("width") {
-            let tw_str = if tw_val.is_f64() {
-                tw_val.as_f64().map(|f| {
-                    if f.fract() == 0.0 && f.is_finite() {
-                        format!("{f:.1}")
-                    } else {
-                        f.to_string()
-                    }
-                })
-            } else {
-                tw_val
-                    .as_u64()
-                    .map(|n| n.to_string())
-                    .or_else(|| tw_val.as_i64().map(|n| n.to_string()))
-            };
-            if let Some(tw_str) = tw_str {
-                parts.push(format!("width={tw_str}"));
-            }
+        if let Some(tw_str) = attrs.get("width").and_then(fmt_numeric_attr) {
+            parts.push(format!("width={tw_str}"));
         }
         maybe_push_local_id(attrs, &mut parts, opts);
         if !parts.is_empty() {
@@ -15809,33 +15782,6 @@ mod tests {
         let table_attrs = doc2.content[0].attrs.as_ref().unwrap();
         assert_eq!(table_attrs["width"], 760.5);
         assert!(table_attrs["width"].is_f64());
-    }
-
-    #[test]
-    fn parse_numeric_attr_integer() {
-        let v = parse_numeric_attr("1420").unwrap();
-        assert!(v.is_u64(), "expected integer, got: {v:?}");
-        assert_eq!(v, serde_json::json!(1420u64));
-    }
-
-    #[test]
-    fn parse_numeric_attr_float_with_decimal() {
-        let v = parse_numeric_attr("1420.0").unwrap();
-        assert!(v.is_f64(), "expected float, got: {v:?}");
-        assert_eq!(v, serde_json::json!(1420.0));
-    }
-
-    #[test]
-    fn parse_numeric_attr_fractional() {
-        let v = parse_numeric_attr("760.5").unwrap();
-        assert!(v.is_f64());
-        assert_eq!(v, serde_json::json!(760.5));
-    }
-
-    #[test]
-    fn parse_numeric_attr_invalid() {
-        assert!(parse_numeric_attr("not-a-number").is_none());
-        assert!(parse_numeric_attr("").is_none());
     }
 
     #[test]

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -586,8 +586,8 @@ impl<'a> MarkdownParser<'a> {
                         table_attrs["isNumberColumnEnabled"] = serde_json::json!(false);
                     }
                     if let Some(tw) = attrs.get("width") {
-                        if let Ok(w) = tw.parse::<f64>() {
-                            table_attrs["width"] = serde_json::json!(w);
+                        if let Some(w) = parse_numeric_attr(tw) {
+                            table_attrs["width"] = w;
                         }
                     }
                     if let Some(local_id) = attrs.get("localId") {
@@ -1074,8 +1074,8 @@ impl<'a> MarkdownParser<'a> {
                         table_attrs["isNumberColumnEnabled"] = serde_json::json!(false);
                     }
                     if let Some(tw) = attrs.get("width") {
-                        if let Ok(w) = tw.parse::<f64>() {
-                            table_attrs["width"] = serde_json::json!(w);
+                        if let Some(w) = parse_numeric_attr(tw) {
+                            table_attrs["width"] = w;
                         }
                     }
                     if let Some(local_id) = attrs.get("localId") {
@@ -1145,6 +1145,17 @@ impl<'a> MarkdownParser<'a> {
     }
 }
 
+/// Parses a numeric JFM attribute string, preserving integer-vs-float type.
+/// Strings without a decimal point are emitted as JSON integers; strings with a
+/// decimal point are emitted as JSON floats.
+fn parse_numeric_attr(s: &str) -> Option<serde_json::Value> {
+    if s.contains('.') {
+        s.parse::<f64>().ok().map(|n| serde_json::json!(n))
+    } else {
+        s.parse::<u64>().ok().map(|n| serde_json::json!(n))
+    }
+}
+
 /// Builds ADF cell attributes from JFM directive attrs.
 /// Maps: `bg` → `background`, `colspan` → number, `rowspan` → number, `colwidth` → array.
 fn build_cell_attrs(attrs: &crate::atlassian::attrs::Attrs) -> serde_json::Value {
@@ -1165,16 +1176,7 @@ fn build_cell_attrs(attrs: &crate::atlassian::attrs::Attrs) -> serde_json::Value
     if let Some(colwidth) = attrs.get("colwidth") {
         let widths: Vec<serde_json::Value> = colwidth
             .split(',')
-            .filter_map(|s| {
-                let s = s.trim();
-                // Preserve the original number type: values without a decimal point
-                // are emitted as integers, values with a decimal point as floats.
-                if s.contains('.') {
-                    s.parse::<f64>().ok().map(|n| serde_json::json!(n))
-                } else {
-                    s.parse::<u64>().ok().map(|n| serde_json::json!(n))
-                }
-            })
+            .filter_map(|s| parse_numeric_attr(s.trim()))
             .collect();
         if !widths.is_empty() {
             adf["colwidth"] = serde_json::Value::Array(widths);
@@ -3995,13 +3997,24 @@ fn render_table_level_attrs(node: &AdfNode, output: &mut String, opts: &RenderOp
                 parts.push("numbered=false".to_string());
             }
         }
-        if let Some(tw) = attrs.get("width").and_then(serde_json::Value::as_f64) {
-            let tw_str = if tw.fract() == 0.0 {
-                (tw as u64).to_string()
+        if let Some(tw_val) = attrs.get("width") {
+            let tw_str = if tw_val.is_f64() {
+                tw_val.as_f64().map(|f| {
+                    if f.fract() == 0.0 && f.is_finite() {
+                        format!("{f:.1}")
+                    } else {
+                        f.to_string()
+                    }
+                })
             } else {
-                tw.to_string()
+                tw_val
+                    .as_u64()
+                    .map(|n| n.to_string())
+                    .or_else(|| tw_val.as_i64().map(|n| n.to_string()))
             };
-            parts.push(format!("width={tw_str}"));
+            if let Some(tw_str) = tw_str {
+                parts.push(format!("width={tw_str}"));
+            }
         }
         maybe_push_local_id(attrs, &mut parts, opts);
         if !parts.is_empty() {
@@ -15690,8 +15703,8 @@ mod tests {
         let doc: crate::atlassian::adf::AdfDocument = serde_json::from_value(adf_doc).unwrap();
         let md = adf_to_markdown(&doc).unwrap();
         assert!(
-            md.contains("width=760"),
-            "expected width=760 in markdown, got: {md}"
+            md.contains("width=760.0"),
+            "expected width=760.0 in markdown (float preserved), got: {md}"
         );
         // Round-trip back to ADF
         let doc2 = markdown_to_adf(&md).unwrap();
@@ -15699,6 +15712,146 @@ mod tests {
         assert_eq!(table.node_type, "table");
         let table_attrs = table.attrs.as_ref().unwrap();
         assert_eq!(table_attrs["width"], 760.0);
+        assert!(
+            table_attrs["width"].is_f64(),
+            "expected float width to be preserved as f64, got: {:?}",
+            table_attrs["width"]
+        );
+    }
+
+    #[test]
+    fn table_integer_width_roundtrip_preserves_integer() {
+        // Issue #577: Integer width in ADF must survive roundtrip without being
+        // coerced to a float.
+        let adf_doc = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{
+                "type": "table",
+                "attrs": {
+                    "isNumberColumnEnabled": false,
+                    "layout": "center",
+                    "localId": "abc-123",
+                    "width": 1420
+                },
+                "content": [{
+                    "type": "tableRow",
+                    "content": [{
+                        "type": "tableCell",
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Cell"}]}]
+                    }]
+                }]
+            }]
+        });
+        let doc: crate::atlassian::adf::AdfDocument =
+            serde_json::from_value(adf_doc.clone()).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("width=1420"),
+            "expected width=1420 in markdown, got: {md}"
+        );
+        assert!(
+            !md.contains("width=1420.0"),
+            "integer width should not be rendered with decimal: {md}"
+        );
+
+        let doc2 = markdown_to_adf(&md).unwrap();
+        let table = &doc2.content[0];
+        assert_eq!(table.node_type, "table");
+        let table_attrs = table.attrs.as_ref().unwrap();
+        assert_eq!(table_attrs["width"], 1420);
+        assert!(
+            table_attrs["width"].is_u64() || table_attrs["width"].is_i64(),
+            "width should remain an integer, got: {:?}",
+            table_attrs["width"]
+        );
+        assert!(
+            !table_attrs["width"].is_f64(),
+            "width should not be a float, got: {:?}",
+            table_attrs["width"]
+        );
+
+        // Full byte-fidelity: re-serialized ADF should match original JSON.
+        let roundtripped = serde_json::to_value(&doc2).unwrap();
+        let orig_width = &adf_doc["content"][0]["attrs"]["width"];
+        let rt_width = &roundtripped["content"][0]["attrs"]["width"];
+        assert_eq!(
+            orig_width, rt_width,
+            "width value must roundtrip byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn table_fractional_width_roundtrip() {
+        // Fractional float widths should also roundtrip faithfully.
+        let adf_doc = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{
+                "type": "table",
+                "attrs": {"layout": "default", "width": 760.5},
+                "content": [{
+                    "type": "tableRow",
+                    "content": [{
+                        "type": "tableHeader",
+                        "content": [{"type": "paragraph", "content": [{"type": "text", "text": "H"}]}]
+                    }]
+                }]
+            }]
+        });
+        let doc: crate::atlassian::adf::AdfDocument = serde_json::from_value(adf_doc).unwrap();
+        let md = adf_to_markdown(&doc).unwrap();
+        assert!(
+            md.contains("width=760.5"),
+            "expected width=760.5 in markdown, got: {md}"
+        );
+        let doc2 = markdown_to_adf(&md).unwrap();
+        let table_attrs = doc2.content[0].attrs.as_ref().unwrap();
+        assert_eq!(table_attrs["width"], 760.5);
+        assert!(table_attrs["width"].is_f64());
+    }
+
+    #[test]
+    fn parse_numeric_attr_integer() {
+        let v = parse_numeric_attr("1420").unwrap();
+        assert!(v.is_u64(), "expected integer, got: {v:?}");
+        assert_eq!(v, serde_json::json!(1420u64));
+    }
+
+    #[test]
+    fn parse_numeric_attr_float_with_decimal() {
+        let v = parse_numeric_attr("1420.0").unwrap();
+        assert!(v.is_f64(), "expected float, got: {v:?}");
+        assert_eq!(v, serde_json::json!(1420.0));
+    }
+
+    #[test]
+    fn parse_numeric_attr_fractional() {
+        let v = parse_numeric_attr("760.5").unwrap();
+        assert!(v.is_f64());
+        assert_eq!(v, serde_json::json!(760.5));
+    }
+
+    #[test]
+    fn parse_numeric_attr_invalid() {
+        assert!(parse_numeric_attr("not-a-number").is_none());
+        assert!(parse_numeric_attr("").is_none());
+    }
+
+    #[test]
+    fn pipe_table_integer_width_roundtrip() {
+        // Exercises the try_table() attrs-on-next-line parsing path.
+        let md = "| A | B |\n|---|---|\n| 1 | 2 |\n{layout=default width=1420}\n";
+        let doc = markdown_to_adf(md).unwrap();
+        let table = &doc.content[0];
+        assert_eq!(table.node_type, "table");
+        let attrs = table.attrs.as_ref().unwrap();
+        assert_eq!(attrs["width"], 1420);
+        assert!(
+            attrs["width"].is_u64() || attrs["width"].is_i64(),
+            "pipe-table width must stay integer, got: {:?}",
+            attrs["width"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #577 where integer table width values were being coerced to floats during ADF-to-markdown-to-ADF roundtrip conversion. When an ADF table node had an integer `width` attribute (e.g., `1420`), after converting to markdown and back, the attribute became `1420.0` (a float), causing byte-level JSON inequalities that could break downstream consumers comparing JSON values.

The root cause was that the markdown renderer used `as_f64()` to extract the width value unconditionally, discarding the original numeric type. On the round-trip back, all widths parsed from markdown were stored as `f64`, even when the original was an integer. This fix introduces a `parse_numeric_attr` helper that preserves the integer-vs-float distinction based on whether the source string contains a decimal point.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Refactoring (no functional changes)

## Related Issue

Fixes #577

## Changes Made

**Core Changes:**
- Added `parse_numeric_attr(s: &str) -> Option<serde_json::Value>` helper in `src/atlassian/convert.rs` that parses numeric attribute strings while preserving the original JSON type: strings without a decimal point become `u64` integers; strings with a decimal point become `f64` floats
- Replaced the two inline `tw.parse::<f64>()` calls in table width parsing (pipe-table and standard table paths) with `parse_numeric_attr`, so integer widths are stored as JSON integers in the parsed ADF
- Refactored `build_cell_attrs` colwidth parsing to use `parse_numeric_attr` instead of duplicating the integer/float branching logic inline
- Fixed `render_table_level_attrs` to emit `width=N.M` (with `.1` format specifier for whole-number floats like `760.0`) for float values and `width=N` for integer values, correctly distinguishing the two numeric types

**Testing:**
- Updated existing float-width roundtrip test to assert `width=760.0` format and verify the `f64` type is preserved through the roundtrip
- Added `table_integer_width_roundtrip_preserves_integer` test covering full byte-fidelity roundtrip for an integer width (`1420`), including a JSON value equality assertion between original and re-serialized ADF
- Added `table_fractional_width_roundtrip` test for fractional float widths (`760.5`)
- Added unit tests for `parse_numeric_attr`: `parse_numeric_attr_integer`, `parse_numeric_attr_float_with_decimal`, `parse_numeric_attr_fractional`, and `parse_numeric_attr_invalid`
- Added `pipe_table_integer_width_roundtrip` test exercising the attrs-on-next-line parsing path (`{layout=default width=1420}`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (integer width, float width, fractional float width)
- [x] Tested error/edge cases (invalid input to `parse_numeric_attr`)
- [x] Backward compatibility verified (existing float-width behavior preserved)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the affected module's tests
cargo test atlassian::convert::tests

# Run the specific new/updated tests
cargo test table_integer_width_roundtrip_preserves_integer
cargo test table_fractional_width_roundtrip
cargo test pipe_table_integer_width_roundtrip
cargo test parse_numeric_attr

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `parse_numeric_attr` returns `None` for unparseable input, which is silently skipped; confirm this matches existing behavior
- [x] Backward compatibility — the rendering change means float widths that were previously emitted as `width=760` are now emitted as `width=760.0`; this is intentional and tested, but reviewers should confirm no external consumers depend on the old format
- [x] Architecture changes — the new `parse_numeric_attr` helper consolidates previously duplicated logic; confirm the colwidth refactor in `build_cell_attrs` is semantically equivalent

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

The markdown rendering of whole-number float table widths changes from `width=760` to `width=760.0`. This is intentional: it preserves the float type through the roundtrip. Any external tooling that parses the JFM markdown directive and specifically expects `width=760` for a float-typed ADF attribute will need to be updated to handle the `.0` suffix. Integer-typed ADF widths are unaffected and continue to render without a decimal point.

**Backward Compatibility:**
- Integer widths: no change in rendered markdown format (`width=1420` before and after)
- Float whole-number widths: rendered format changes from `width=760` to `width=760.0`
- Float fractional widths: no change in rendered markdown format (`width=760.5`)

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Always coerce widths to `f64` during parsing and add a special-case rule to emit integers without a decimal: rejected because it loses type fidelity and makes the roundtrip non-deterministic with respect to the original JSON representation.
- Only fix the rendering side (emit `width=N` always): rejected because it would cause float-typed ADF attributes to be stored as integers after roundtrip, which is the reverse of the original bug.