### PR TITLE
ci(workflows): switch coverage tooling from cargo-tarpaulin to cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,15 @@ jobs:
       with:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
-    - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report
-      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml --fail-under 30
+      run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json --fail-under-lines 30
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        files: codecov.json
         fail_ci_if_error: true
 
   nix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Confluence Bulk Space Download**: `confluence download` now accepts `--space <KEY>` to recursively download every page in a Confluence space, plus `--title-filter` to download only pages whose title contains a substring (case-insensitive)
 
+### Changed
+- **CI Coverage**: Switched coverage tooling from `cargo-tarpaulin` to `cargo-llvm-cov` to eliminate `.await?` false negatives and improve accuracy for async code, macros, and generics
+
 ### Fixed
 - **Empty Task Checkboxes**: Recognise `- [ ]` and `- [x]` markdown task markers
   even when the checkbox is not followed by a trailing space. Fixes ADF


### PR DESCRIPTION
## Description

This PR replaces `cargo-tarpaulin` with `cargo-llvm-cov` as the code coverage tooling in the CI pipeline. The change eliminates false negatives on `.await?` expressions that tarpaulin historically misreports, and improves overall coverage accuracy for async code, macros, and generics — all of which are prevalent in this codebase.

The switch aligns the CI coverage output with the Codecov upload format by generating a `codecov.json` file directly, replacing the previously used XML output format.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [x] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #589

## Changes Made

**CI/CD (`github/workflows/ci.yml`):**
- Replaced `cargo install cargo-tarpaulin` step with `taiki-e/install-action@cargo-llvm-cov` for faster, cached installation
- Updated coverage command from `cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml --fail-under 30` to `cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json --fail-under-lines 30`
- Added `files: codecov.json` to the `codecov/codecov-action@v6` upload step so Codecov receives the correct output file

**Documentation (`CHANGELOG.md`):**
- Added entry under `### Changed` in the Unreleased section documenting the tooling switch and the reason for it

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- This change improves the accuracy of coverage reporting rather than changing test coverage itself. The `--fail-under-lines 30` threshold is equivalent to the prior `--fail-under 30` threshold.

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run coverage locally with the new tooling
cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The `--fail-under-lines` flag used by `cargo-llvm-cov` measures line coverage, which is semantically equivalent to the line-based threshold enforced by `cargo-tarpaulin`'s `--fail-under`. Reviewers should confirm the 30% threshold remains appropriate given the improved accuracy of the new tool (which may report slightly different numbers due to elimination of false negatives).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement (describe below)

`taiki-e/install-action` uses pre-built binaries and GitHub Actions caching, making the install step significantly faster than `cargo install cargo-tarpaulin` which compiles from source on every CI run.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a CI-only change with no impact on the library API, CLI behaviour, or end users.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping `cargo-tarpaulin`: Rejected because it consistently produces false negatives on `.await?` expressions, leading to inaccurate coverage metrics for async-heavy code.
- Using `grcov`: Considered but `cargo-llvm-cov` offers a simpler integration path with direct `--codecov` output format support and active maintenance.

**Known Limitations:**
- LLVM-based coverage requires the `llvm-tools-preview` rustup component, which is already installed by the existing `rustup component add llvm-tools-preview` step in the workflow.