### PR TITLE
fix(atlassian): handle null ADF input in convert and helpers commands

### DIFF
--- a/src/atlassian/adf.rs
+++ b/src/atlassian/adf.rs
@@ -29,6 +29,23 @@ impl AdfDocument {
             content: Vec::new(),
         }
     }
+
+    /// Parses ADF JSON, treating a top-level `null` as an empty document.
+    ///
+    /// The Jira REST API returns `description: null` for issues with no
+    /// description. This helper accepts that as equivalent to the canonical
+    /// empty ADF document so that `jira read --format adf` output can be piped
+    /// into `convert from-adf` without a pre-filter.
+    pub fn from_json_str(input: &str) -> anyhow::Result<Self> {
+        use anyhow::Context;
+
+        let value: serde_json::Value =
+            serde_json::from_str(input).context("Failed to parse ADF JSON input")?;
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        serde_json::from_value(value).context("Failed to parse ADF JSON input")
+    }
 }
 
 impl Default for AdfDocument {
@@ -1501,5 +1518,41 @@ mod tests {
         assert_eq!(deserialized.mark_type, "border");
         assert_eq!(deserialized.attrs.as_ref().unwrap()["color"], "#ff000033");
         assert_eq!(deserialized.attrs.as_ref().unwrap()["size"], 2);
+    }
+
+    #[test]
+    fn from_json_str_null_yields_empty_document() {
+        let doc = AdfDocument::from_json_str("null").unwrap();
+        assert_eq!(doc, AdfDocument::default());
+    }
+
+    #[test]
+    fn from_json_str_whitespace_null_yields_empty_document() {
+        let doc = AdfDocument::from_json_str("  null\n").unwrap();
+        assert_eq!(doc, AdfDocument::default());
+    }
+
+    #[test]
+    fn from_json_str_empty_doc_roundtrips() {
+        let doc = AdfDocument::from_json_str(r#"{"version":1,"type":"doc","content":[]}"#).unwrap();
+        assert_eq!(doc, AdfDocument::default());
+    }
+
+    #[test]
+    fn from_json_str_populated_doc() {
+        let input = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}"#;
+        let doc = AdfDocument::from_json_str(input).unwrap();
+        assert_eq!(doc.content.len(), 1);
+        assert_eq!(doc.content[0].node_type, "paragraph");
+    }
+
+    #[test]
+    fn from_json_str_invalid_json_errors() {
+        assert!(AdfDocument::from_json_str("not json").is_err());
+    }
+
+    #[test]
+    fn from_json_str_wrong_shape_errors() {
+        assert!(AdfDocument::from_json_str(r#"{"foo":"bar"}"#).is_err());
     }
 }

--- a/src/cli/atlassian/convert.rs
+++ b/src/cli/atlassian/convert.rs
@@ -83,8 +83,7 @@ impl FromAdfCommand {
         use crate::atlassian::convert::{adf_to_markdown_with_options, RenderOptions};
 
         let input = read_input(self.file.as_deref())?;
-        let doc: AdfDocument =
-            serde_json::from_str(&input).context("Failed to parse ADF JSON input")?;
+        let doc = AdfDocument::from_json_str(&input)?;
 
         let opts = RenderOptions {
             strip_local_ids: self.strip_local_ids,
@@ -184,6 +183,19 @@ mod tests {
             strip_local_ids: false,
         };
         assert!(cmd.execute().is_err());
+    }
+
+    #[test]
+    fn from_adf_null_input_succeeds() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("null.json");
+        fs::write(&file_path, "null").unwrap();
+
+        let cmd = FromAdfCommand {
+            file: Some(file_path.to_str().unwrap().to_string()),
+            strip_local_ids: false,
+        };
+        assert!(cmd.execute().is_ok());
     }
 
     #[test]

--- a/src/cli/atlassian/helpers.rs
+++ b/src/cli/atlassian/helpers.rs
@@ -57,8 +57,7 @@ pub fn prepare_write(file: Option<&str>, format: &ContentFormat) -> Result<(AdfD
             Ok((adf, title))
         }
         ContentFormat::Adf => {
-            let adf: AdfDocument =
-                serde_json::from_str(&input).context("Failed to parse ADF JSON input")?;
+            let adf = AdfDocument::from_json_str(&input)?;
             Ok((adf, String::new()))
         }
     }
@@ -510,6 +509,19 @@ mod tests {
 
         let result = prepare_write(Some(file_path.to_str().unwrap()), &ContentFormat::Adf);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn prepare_write_null_adf_input_yields_empty_doc() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("null.json");
+        fs::write(&file_path, "null").unwrap();
+
+        let (adf, title) =
+            prepare_write(Some(file_path.to_str().unwrap()), &ContentFormat::Adf).unwrap();
+
+        assert_eq!(adf, AdfDocument::default());
+        assert!(title.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a bug where `convert from-adf` and the `prepare_write` helper would panic or return an unhelpful error when given `null` as ADF JSON input. The Jira REST API returns `"description": null` for issues that have no description, meaning that piping `jira read --format adf` output directly into `convert from-adf` would fail without a pre-filter step. This fix makes `null` ADF input equivalent to an empty ADF document, eliminating the need for any pre-processing when consuming Jira API output.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #591

## Changes Made

**Core Changes:**
- Added `AdfDocument::from_json_str()` method in `src/atlassian/adf.rs` that parses ADF JSON and treats a top-level `null` value as an empty document, delegating to `serde_json` for all other inputs
- Updated `FromAdfCommand::execute()` in `src/cli/atlassian/convert.rs` to use `AdfDocument::from_json_str()` instead of a raw `serde_json::from_str` call
- Updated `prepare_write()` in `src/cli/atlassian/helpers.rs` to use `AdfDocument::from_json_str()` instead of a raw `serde_json::from_str` call

**Testing:**
- Added 6 unit tests for `AdfDocument::from_json_str()` covering: `null` input, whitespace-padded `null`, empty document round-trip, populated document, invalid JSON, and wrong-shaped JSON
- Added integration test `from_adf_null_input_succeeds` in `convert.rs` verifying the CLI command succeeds when given a file containing `null`
- Added integration test `prepare_write_null_adf_input_yields_empty_doc` in `helpers.rs` verifying `prepare_write` returns an empty `AdfDocument` and empty title for `null` ADF input

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new/affected tests
cargo test from_json_str
cargo test from_adf_null_input_succeeds
cargo test prepare_write_null_adf_input_yields_empty_doc

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `from_json_str` correctly propagates parse errors for invalid JSON and wrong-shaped objects while silently accepting `null`
- [x] Backward compatibility — all previously valid ADF input continues to work identically; only the `null` case is newly handled

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive fix. Existing ADF input that was previously accepted continues to work identically. The only behavioural change is that `null` input, which previously produced an error, now produces an empty document.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Requiring callers to strip `null` values before passing to the converter — rejected because it places the burden on every consumer of the Jira API output rather than fixing it once at the parsing layer.
- Treating `null` as an error with a more descriptive message — rejected because `null` is a valid, meaningful Jira API response (no description set) and should be handled gracefully rather than surfaced as a failure.