### PR TITLE
feat(atlassian): add custom field support to JIRA issue fetch

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -61,6 +61,43 @@ pub struct JiraIssue {
 
     /// Labels.
     pub labels: Vec<String>,
+
+    /// Custom fields populated on the issue. Non-empty only when the fetch
+    /// was made with [`FieldSelection::Named`] or [`FieldSelection::All`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_fields: Vec<JiraCustomField>,
+}
+
+/// Selector for which fields to request when fetching a JIRA issue.
+#[derive(Debug, Clone, Default)]
+pub enum FieldSelection {
+    /// Only the standard fields omni-dev tracks (summary, description,
+    /// status, issuetype, assignee, priority, labels).
+    #[default]
+    Standard,
+
+    /// Standard fields plus the named custom fields. Each entry may be a
+    /// field ID (e.g., `customfield_19300`) or a human name (e.g.,
+    /// `Acceptance Criteria`); the REST API accepts either.
+    Named(Vec<String>),
+
+    /// Every field populated on the issue, including all custom fields.
+    All,
+}
+
+/// A JIRA custom field value keyed by both its stable ID and human name.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraCustomField {
+    /// Field ID (e.g., "customfield_19300"). Stable across renames.
+    pub id: String,
+
+    /// Human-readable field name (e.g., "Acceptance Criteria"). Falls back
+    /// to `id` when the API did not return `expand=names`.
+    pub name: String,
+
+    /// Raw field value as returned by the API (ADF JSON, option object,
+    /// scalar, etc.).
+    pub value: serde_json::Value,
 }
 
 /// Response from the JIRA `/myself` endpoint.
@@ -486,6 +523,79 @@ pub struct JiraWorklogList {
 struct JiraIssueResponse {
     key: String,
     fields: JiraIssueFields,
+}
+
+/// Flexible deserialization target for `GET /rest/api/3/issue/{key}` that
+/// retains every field value as raw JSON so custom fields can be extracted.
+#[derive(Deserialize)]
+struct JiraIssueEnvelope {
+    key: String,
+    #[serde(default)]
+    fields: std::collections::BTreeMap<String, serde_json::Value>,
+    #[serde(default)]
+    names: std::collections::BTreeMap<String, String>,
+}
+
+impl JiraIssueEnvelope {
+    fn into_issue(self, selection: &FieldSelection) -> JiraIssue {
+        let Self {
+            key,
+            mut fields,
+            names,
+        } = self;
+
+        let description_adf = fields.remove("description").filter(|v| !v.is_null());
+        let summary = fields
+            .remove("summary")
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        let status = extract_named_field(fields.remove("status"));
+        let issue_type = extract_named_field(fields.remove("issuetype"));
+        let assignee = extract_display_name(fields.remove("assignee"));
+        let priority = extract_named_field(fields.remove("priority"));
+        let labels = fields
+            .remove("labels")
+            .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok())
+            .unwrap_or_default();
+
+        let collect_customs = !matches!(selection, FieldSelection::Standard);
+        let custom_fields = if collect_customs {
+            fields
+                .into_iter()
+                .filter(|(_, value)| !value.is_null())
+                .map(|(id, value)| {
+                    let name = names.get(&id).cloned().unwrap_or_else(|| id.clone());
+                    JiraCustomField { id, name, value }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        JiraIssue {
+            key,
+            summary,
+            description_adf,
+            status,
+            issue_type,
+            assignee,
+            priority,
+            labels,
+            custom_fields,
+        }
+    }
+}
+
+fn extract_named_field(value: Option<serde_json::Value>) -> Option<String> {
+    value
+        .and_then(|v| v.get("name").cloned())
+        .and_then(|n| n.as_str().map(str::to_string))
+}
+
+fn extract_display_name(value: Option<serde_json::Value>) -> Option<String> {
+    value
+        .and_then(|v| v.get("displayName").cloned())
+        .and_then(|n| n.as_str().map(str::to_string))
 }
 
 #[derive(Deserialize)]
@@ -1065,6 +1175,7 @@ mod tests {
             assignee: Some("Alice".to_string()),
             priority: Some("High".to_string()),
             labels: vec!["backend".to_string()],
+            custom_fields: Vec::new(),
         };
         assert_eq!(issue.key, "TEST-1");
         assert_eq!(issue.labels.len(), 1);
@@ -1430,6 +1541,175 @@ mod tests {
         let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
         let err = client.get_issue("NOPE-1").await.unwrap_err();
         assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn get_issue_with_fields_named_populates_custom_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        let issue_json = serde_json::json!({
+            "key": "ACCS-1",
+            "fields": {
+                "summary": "S",
+                "description": null,
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+                "assignee": null,
+                "priority": null,
+                "labels": [],
+                "customfield_19300": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [{"type": "paragraph", "content": [{"type": "text", "text": "AC"}]}]
+                }
+            },
+            "names": {
+                "customfield_19300": "Acceptance Criteria"
+            }
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::query_param("expand", "names,schema"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&issue_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let issue = client
+            .get_issue_with_fields(
+                "ACCS-1",
+                FieldSelection::Named(vec!["customfield_19300".to_string()]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(issue.key, "ACCS-1");
+        assert_eq!(issue.custom_fields.len(), 1);
+        let cf = &issue.custom_fields[0];
+        assert_eq!(cf.id, "customfield_19300");
+        assert_eq!(cf.name, "Acceptance Criteria");
+        assert_eq!(cf.value["type"], "doc");
+    }
+
+    #[tokio::test]
+    async fn get_issue_with_fields_standard_omits_custom_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        let issue_json = serde_json::json!({
+            "key": "ACCS-1",
+            "fields": {
+                "summary": "S",
+                "description": null,
+                "status": null,
+                "issuetype": null,
+                "assignee": null,
+                "priority": null,
+                "labels": [],
+                "customfield_19300": {"value": "Unplanned"}
+            },
+            "names": {
+                "customfield_19300": "Planned / Unplanned Work"
+            }
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&issue_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let issue = client
+            .get_issue_with_fields("ACCS-1", FieldSelection::Standard)
+            .await
+            .unwrap();
+
+        assert!(issue.custom_fields.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_issue_with_fields_all_uses_star_param() {
+        let server = wiremock::MockServer::start().await;
+
+        let issue_json = serde_json::json!({
+            "key": "ACCS-1",
+            "fields": {
+                "summary": "S",
+                "description": null,
+                "status": null,
+                "issuetype": null,
+                "assignee": null,
+                "priority": null,
+                "labels": [],
+                "customfield_10001": {"value": "Unplanned"},
+                "customfield_10002": 42
+            },
+            "names": {
+                "customfield_10001": "Planned / Unplanned Work",
+                "customfield_10002": "Story points"
+            }
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::query_param("fields", "*all"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&issue_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let issue = client
+            .get_issue_with_fields("ACCS-1", FieldSelection::All)
+            .await
+            .unwrap();
+
+        assert_eq!(issue.custom_fields.len(), 2);
+        let names: Vec<&str> = issue
+            .custom_fields
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert!(names.contains(&"Planned / Unplanned Work"));
+        assert!(names.contains(&"Story points"));
+    }
+
+    #[tokio::test]
+    async fn get_issue_with_fields_falls_back_to_id_when_names_missing() {
+        let server = wiremock::MockServer::start().await;
+
+        let issue_json = serde_json::json!({
+            "key": "ACCS-1",
+            "fields": {
+                "summary": "S",
+                "description": null,
+                "status": null,
+                "issuetype": null,
+                "assignee": null,
+                "priority": null,
+                "labels": [],
+                "customfield_99999": "raw"
+            }
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&issue_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let issue = client
+            .get_issue_with_fields("ACCS-1", FieldSelection::All)
+            .await
+            .unwrap();
+
+        assert_eq!(issue.custom_fields.len(), 1);
+        assert_eq!(issue.custom_fields[0].name, "customfield_99999");
     }
 
     #[tokio::test]
@@ -4832,16 +5112,53 @@ impl AtlassianClient {
         tokio::time::sleep(Duration::from_secs(delay)).await;
     }
 
-    /// Fetches a JIRA issue by key.
+    /// Fetches a JIRA issue by key with only the standard fields.
+    ///
+    /// Thin shim over [`Self::get_issue_with_fields`] with
+    /// [`FieldSelection::Standard`]. Preserved for callers that do not need
+    /// custom field data.
     pub async fn get_issue(&self, key: &str) -> Result<JiraIssue> {
-        let url = format!(
-            "{}/rest/api/3/issue/{}?fields=summary,description,status,issuetype,assignee,priority,labels",
-            self.instance_url, key
-        );
+        self.get_issue_with_fields(key, FieldSelection::Standard)
+            .await
+    }
+
+    /// Fetches a JIRA issue by key with the given field selection.
+    ///
+    /// Always requests `expand=names,schema` so human-readable field names
+    /// and type metadata are available for rendering custom fields. When
+    /// `selection` is [`FieldSelection::Standard`], `custom_fields` on the
+    /// returned issue will be empty.
+    pub async fn get_issue_with_fields(
+        &self,
+        key: &str,
+        selection: FieldSelection,
+    ) -> Result<JiraIssue> {
+        const STANDARD_FIELDS: &str =
+            "summary,description,status,issuetype,assignee,priority,labels";
+
+        let fields_param = match &selection {
+            FieldSelection::Standard => STANDARD_FIELDS.to_string(),
+            FieldSelection::Named(names) => {
+                let mut parts: Vec<&str> = STANDARD_FIELDS.split(',').collect();
+                parts.extend(names.iter().map(String::as_str));
+                parts.join(",")
+            }
+            FieldSelection::All => "*all".to_string(),
+        };
+
+        let base = format!("{}/rest/api/3/issue/{}", self.instance_url, key);
+        let url = reqwest::Url::parse_with_params(
+            &base,
+            &[
+                ("fields", fields_param.as_str()),
+                ("expand", "names,schema"),
+            ],
+        )
+        .context("Failed to build JIRA issue URL")?;
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header("Authorization", &self.auth_header)
             .header("Accept", "application/json")
             .send()
@@ -4854,21 +5171,12 @@ impl AtlassianClient {
             return Err(AtlassianError::ApiRequestFailed { status, body }.into());
         }
 
-        let issue_response: JiraIssueResponse = response
+        let envelope: JiraIssueEnvelope = response
             .json()
             .await
             .context("Failed to parse JIRA issue response")?;
 
-        Ok(JiraIssue {
-            key: issue_response.key,
-            summary: issue_response.fields.summary.unwrap_or_default(),
-            description_adf: issue_response.fields.description,
-            status: issue_response.fields.status.and_then(|s| s.name),
-            issue_type: issue_response.fields.issuetype.and_then(|t| t.name),
-            assignee: issue_response.fields.assignee.and_then(|a| a.display_name),
-            priority: issue_response.fields.priority.and_then(|p| p.name),
-            labels: issue_response.fields.labels,
-        })
+        Ok(envelope.into_issue(&selection))
     }
 
     /// Updates a JIRA issue's description and optionally its summary.
@@ -5246,6 +5554,7 @@ impl AtlassianClient {
                     assignee: r.fields.assignee.and_then(|a| a.display_name),
                     priority: r.fields.priority.and_then(|p| p.name),
                     labels: r.fields.labels,
+                    custom_fields: Vec::new(),
                 });
             }
 
@@ -5526,6 +5835,7 @@ impl AtlassianClient {
                     assignee: r.fields.assignee.and_then(|a| a.display_name),
                     priority: r.fields.priority.and_then(|p| p.name),
                     labels: r.fields.labels,
+                    custom_fields: Vec::new(),
                 });
             }
 
@@ -5665,6 +5975,7 @@ impl AtlassianClient {
                     assignee: r.fields.assignee.and_then(|a| a.display_name),
                     priority: r.fields.priority.and_then(|p| p.name),
                     labels: r.fields.labels,
+                    custom_fields: Vec::new(),
                 });
             }
 

--- a/src/atlassian/document.rs
+++ b/src/atlassian/document.rs
@@ -11,12 +11,15 @@
 //! Markdown body content here.
 //! ```
 
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::api::{ContentItem, ContentMetadata};
-use crate::atlassian::client::JiraIssue;
+use crate::atlassian::client::{JiraCustomField, JiraIssue};
 use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::error::AtlassianError;
 
@@ -81,6 +84,14 @@ pub struct JiraFrontmatter {
     /// Labels applied to the issue.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
+
+    /// Scalar custom field values keyed by human-readable field name.
+    ///
+    /// Populated when the issue was fetched with `--fields` or
+    /// `--all-fields`. Rich-text (ADF) custom fields are rendered into the
+    /// document body as extra sections instead.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub custom_fields: BTreeMap<String, serde_yaml::Value>,
 }
 
 /// Confluence-specific frontmatter fields.
@@ -157,14 +168,25 @@ pub fn validate_issue_key(key: &str) -> Result<()> {
 }
 
 /// Converts a [`JiraIssue`] into a [`JfmDocument`] with YAML frontmatter.
+///
+/// Custom fields present on the issue are partitioned: rich-text (ADF)
+/// fields become additional JFM sections appended to the body (prefixed
+/// with an HTML-comment tag so the `write` round-trip can identify them),
+/// while scalar fields are serialized into the frontmatter's
+/// `custom_fields` map keyed by human-readable name.
 pub fn issue_to_jfm_document(issue: &JiraIssue, instance_url: &str) -> Result<JfmDocument> {
-    let body = if let Some(ref adf_value) = issue.description_adf {
+    let mut body = if let Some(ref adf_value) = issue.description_adf {
         let adf_doc: AdfDocument =
             serde_json::from_value(adf_value.clone()).context("Failed to parse ADF description")?;
         adf_to_markdown(&adf_doc)?
     } else {
         String::new()
     };
+
+    let mut custom_scalars: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
+    for field in &issue.custom_fields {
+        render_custom_field(field, &mut body, &mut custom_scalars)?;
+    }
 
     Ok(JfmDocument {
         frontmatter: JfmFrontmatter::Jira(JiraFrontmatter {
@@ -177,9 +199,100 @@ pub fn issue_to_jfm_document(issue: &JiraIssue, instance_url: &str) -> Result<Jf
             assignee: issue.assignee.clone(),
             priority: issue.priority.clone(),
             labels: issue.labels.clone(),
+            custom_fields: custom_scalars,
         }),
         body,
     })
+}
+
+/// Renders a single custom field into either the body (rich text) or the
+/// frontmatter scalar map.
+fn render_custom_field(
+    field: &JiraCustomField,
+    body: &mut String,
+    scalars: &mut BTreeMap<String, serde_yaml::Value>,
+) -> Result<()> {
+    if is_adf_document(&field.value) {
+        let adf_doc: AdfDocument = serde_json::from_value(field.value.clone())
+            .with_context(|| format!("Failed to parse ADF value for {}", field.id))?;
+        let section_md = adf_to_markdown(&adf_doc)?;
+        append_custom_section(body, field, &section_md);
+    } else if let Some(scalar) = extract_custom_field_scalar(&field.value) {
+        scalars.insert(field.name.clone(), scalar);
+    }
+    // Otherwise the field is null or an unrecognized shape — omit it.
+    Ok(())
+}
+
+/// Appends a rich-text custom field to the body as a tagged section.
+fn append_custom_section(body: &mut String, field: &JiraCustomField, section_md: &str) {
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    if !body.is_empty() {
+        body.push('\n');
+    }
+    let _ = write!(
+        body,
+        "---\n<!-- field: {} ({}) -->\n\n{}",
+        field.name, field.id, section_md
+    );
+    if !body.ends_with('\n') {
+        body.push('\n');
+    }
+}
+
+/// Returns `true` if `value` has the shape of an Atlassian Document Format
+/// document (`{"type":"doc","version":_,"content":[...]}`).
+fn is_adf_document(value: &serde_json::Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    obj.get("type").and_then(|t| t.as_str()) == Some("doc")
+        && obj.contains_key("version")
+        && obj.contains_key("content")
+}
+
+/// Converts a custom field's raw JSON value into a scalar YAML
+/// representation suitable for frontmatter serialization.
+///
+/// - Option/select objects (`{self, value, id}`) collapse to their
+///   `value` string.
+/// - User-picker objects collapse to their `displayName`.
+/// - Arrays recurse per element, dropping null/unknown entries.
+/// - Primitives (bool/number/string) pass through unchanged.
+/// - Unknown objects pass through as a structured YAML mapping.
+/// - Null returns `None`.
+fn extract_custom_field_scalar(value: &serde_json::Value) -> Option<serde_yaml::Value> {
+    use serde_json::Value as J;
+    match value {
+        J::Null => None,
+        J::Bool(_) | J::Number(_) | J::String(_) => json_to_yaml(value),
+        J::Array(items) => {
+            let extracted: Vec<_> = items
+                .iter()
+                .filter_map(extract_custom_field_scalar)
+                .collect();
+            if extracted.is_empty() {
+                None
+            } else {
+                Some(serde_yaml::Value::Sequence(extracted))
+            }
+        }
+        J::Object(map) => {
+            if let Some(v) = map.get("value").and_then(|v| v.as_str()) {
+                Some(serde_yaml::Value::String(v.to_string()))
+            } else if let Some(name) = map.get("displayName").and_then(|v| v.as_str()) {
+                Some(serde_yaml::Value::String(name.to_string()))
+            } else {
+                json_to_yaml(value)
+            }
+        }
+    }
+}
+
+fn json_to_yaml(value: &serde_json::Value) -> Option<serde_yaml::Value> {
+    serde_yaml::to_value(value).ok()
 }
 
 /// Converts a [`ContentItem`] into a [`JfmDocument`] with YAML frontmatter.
@@ -212,6 +325,7 @@ pub fn content_item_to_document(item: &ContentItem, instance_url: &str) -> Resul
             assignee: assignee.clone(),
             priority: priority.clone(),
             labels: labels.clone(),
+            custom_fields: BTreeMap::new(),
         }),
         ContentMetadata::Confluence {
             space_key,
@@ -365,6 +479,7 @@ mod tests {
                 assignee: None,
                 priority: None,
                 labels: vec![],
+                custom_fields: BTreeMap::new(),
             }),
             body: "Description here.".to_string(),
         };
@@ -389,6 +504,7 @@ mod tests {
                 assignee: None,
                 priority: None,
                 labels: vec!["test".to_string()],
+                custom_fields: BTreeMap::new(),
             }),
             body: "# Heading\n\nSome text.\n".to_string(),
         };
@@ -445,6 +561,7 @@ mod tests {
             assignee: Some("Alice".to_string()),
             priority: Some("High".to_string()),
             labels: vec!["backend".to_string()],
+            custom_fields: Vec::new(),
         }
     }
 
@@ -483,6 +600,7 @@ mod tests {
             assignee: None,
             priority: None,
             labels: vec![],
+            custom_fields: Vec::new(),
         };
         let doc = issue_to_jfm_document(&issue, "https://test.atlassian.net").unwrap();
         assert_eq!(doc.frontmatter.instance(), "https://test.atlassian.net");
@@ -518,6 +636,7 @@ mod tests {
                 assignee: None,
                 priority: None,
                 labels: vec![],
+                custom_fields: BTreeMap::new(),
             }),
             body: String::new(),
         };
@@ -526,6 +645,218 @@ mod tests {
         assert!(!output.contains("status:"));
         assert!(!output.contains("issue_type:"));
         assert!(!output.contains("labels:"));
+    }
+
+    // ── Custom field helpers ────────────────────────────────────────
+
+    #[test]
+    fn is_adf_document_detects_doc_shape() {
+        let adf = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": []}]
+        });
+        assert!(is_adf_document(&adf));
+    }
+
+    #[test]
+    fn is_adf_document_rejects_scalar_and_other_objects() {
+        assert!(!is_adf_document(&serde_json::json!("string")));
+        assert!(!is_adf_document(&serde_json::json!(42)));
+        assert!(!is_adf_document(&serde_json::json!({"type": "option"})));
+        assert!(!is_adf_document(&serde_json::json!({
+            "type": "doc", "version": 1
+        })));
+    }
+
+    #[test]
+    fn extract_scalar_passes_through_primitives() {
+        assert_eq!(
+            extract_custom_field_scalar(&serde_json::json!(7)),
+            Some(serde_yaml::Value::from(7_i64))
+        );
+        assert_eq!(
+            extract_custom_field_scalar(&serde_json::json!("hello")),
+            Some(serde_yaml::Value::String("hello".to_string()))
+        );
+        assert_eq!(
+            extract_custom_field_scalar(&serde_json::json!(true)),
+            Some(serde_yaml::Value::Bool(true))
+        );
+        assert_eq!(extract_custom_field_scalar(&serde_json::Value::Null), None);
+    }
+
+    #[test]
+    fn extract_scalar_collapses_option_object_to_value_string() {
+        let value = serde_json::json!({
+            "self": "https://example.atlassian.net/rest/api/3/customFieldOption/12345",
+            "value": "Unplanned",
+            "id": "12345"
+        });
+        assert_eq!(
+            extract_custom_field_scalar(&value),
+            Some(serde_yaml::Value::String("Unplanned".to_string()))
+        );
+    }
+
+    #[test]
+    fn extract_scalar_collapses_user_object_to_display_name() {
+        let value = serde_json::json!({
+            "accountId": "abc123",
+            "displayName": "Alice",
+            "emailAddress": "alice@example.com"
+        });
+        assert_eq!(
+            extract_custom_field_scalar(&value),
+            Some(serde_yaml::Value::String("Alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn extract_scalar_recurses_into_arrays_and_drops_nulls() {
+        let value = serde_json::json!([
+            {"value": "A"},
+            null,
+            {"displayName": "Bob"},
+            42
+        ]);
+        let extracted = extract_custom_field_scalar(&value).unwrap();
+        assert_eq!(
+            extracted,
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("A".to_string()),
+                serde_yaml::Value::String("Bob".to_string()),
+                serde_yaml::Value::from(42_i64),
+            ])
+        );
+    }
+
+    #[test]
+    fn extract_scalar_empty_array_returns_none() {
+        let value = serde_json::json!([null, null]);
+        assert_eq!(extract_custom_field_scalar(&value), None);
+    }
+
+    #[test]
+    fn issue_with_scalar_custom_field_goes_to_frontmatter() {
+        let issue = JiraIssue {
+            key: "ACCS-1".to_string(),
+            summary: "S".to_string(),
+            description_adf: None,
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: vec![JiraCustomField {
+                id: "customfield_10001".to_string(),
+                name: "Planned / Unplanned Work".to_string(),
+                value: serde_json::json!({"value": "Unplanned", "id": "42"}),
+            }],
+        };
+        let doc = issue_to_jfm_document(&issue, "https://org.atlassian.net").unwrap();
+        let rendered = doc.render().unwrap();
+        assert!(rendered.contains("custom_fields:"));
+        assert!(rendered.contains("Planned / Unplanned Work"));
+        assert!(rendered.contains("Unplanned"));
+        assert!(!rendered.contains("<!-- field:"));
+    }
+
+    #[test]
+    fn issue_with_adf_custom_field_becomes_body_section() {
+        let adf_value = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Criterion one"}]
+            }]
+        });
+        let issue = JiraIssue {
+            key: "ACCS-1".to_string(),
+            summary: "S".to_string(),
+            description_adf: None,
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: vec![JiraCustomField {
+                id: "customfield_19300".to_string(),
+                name: "Acceptance Criteria".to_string(),
+                value: adf_value,
+            }],
+        };
+        let doc = issue_to_jfm_document(&issue, "https://org.atlassian.net").unwrap();
+        let rendered = doc.render().unwrap();
+        assert!(rendered.contains("<!-- field: Acceptance Criteria (customfield_19300) -->"));
+        assert!(rendered.contains("Criterion one"));
+        assert!(!rendered.contains("custom_fields:"));
+    }
+
+    #[test]
+    fn issue_with_mixed_custom_fields() {
+        let adf_value = serde_json::json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "AC body"}]}]
+        });
+        let issue = JiraIssue {
+            key: "ACCS-1".to_string(),
+            summary: "S".to_string(),
+            description_adf: Some(serde_json::json!({
+                "type": "doc",
+                "version": 1,
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Main"}]}]
+            })),
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: vec![
+                JiraCustomField {
+                    id: "customfield_19300".to_string(),
+                    name: "Acceptance Criteria".to_string(),
+                    value: adf_value,
+                },
+                JiraCustomField {
+                    id: "customfield_10001".to_string(),
+                    name: "Sprint Label".to_string(),
+                    value: serde_json::json!("Q1"),
+                },
+            ],
+        };
+        let doc = issue_to_jfm_document(&issue, "https://org.atlassian.net").unwrap();
+        let rendered = doc.render().unwrap();
+        assert!(rendered.contains("custom_fields:"));
+        assert!(rendered.contains("Sprint Label: Q1"));
+        assert!(rendered.contains("Main"));
+        assert!(rendered.contains("<!-- field: Acceptance Criteria"));
+        assert!(rendered.contains("AC body"));
+    }
+
+    #[test]
+    fn issue_with_null_custom_field_is_omitted() {
+        let issue = JiraIssue {
+            key: "ACCS-1".to_string(),
+            summary: "S".to_string(),
+            description_adf: None,
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: vec![JiraCustomField {
+                id: "customfield_99".to_string(),
+                name: "Empty Field".to_string(),
+                value: serde_json::Value::Null,
+            }],
+        };
+        let doc = issue_to_jfm_document(&issue, "https://org.atlassian.net").unwrap();
+        let rendered = doc.render().unwrap();
+        assert!(!rendered.contains("custom_fields:"));
+        assert!(!rendered.contains("Empty Field"));
     }
 
     // ── Confluence frontmatter tests ───���─────────────────────────────

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -407,6 +407,7 @@ mod tests {
             assignee: None,
             priority: None,
             labels: vec![],
+            custom_fields: vec![],
         }
     }
 

--- a/src/cli/atlassian/helpers.rs
+++ b/src/cli/atlassian/helpers.rs
@@ -8,9 +8,9 @@ use anyhow::{Context, Result};
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::api::AtlassianApi;
 use crate::atlassian::auth;
-use crate::atlassian::client::AtlassianClient;
+use crate::atlassian::client::{AtlassianClient, FieldSelection};
 use crate::atlassian::convert::markdown_to_adf;
-use crate::atlassian::document::{content_item_to_document, JfmDocument};
+use crate::atlassian::document::{content_item_to_document, issue_to_jfm_document, JfmDocument};
 
 use super::format::ContentFormat;
 
@@ -33,6 +33,49 @@ pub async fn run_read(
         }
         ContentFormat::Jfm => {
             let doc = content_item_to_document(&item, instance_url)?;
+            let rendered = doc.render()?;
+            output_text(&rendered, output)?;
+
+            if let Some(path) = output {
+                eprintln!("Saved to: {path}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Fetches a JIRA issue with the given field selection and outputs it.
+///
+/// JIRA-specific path used when `--fields` or `--all-fields` is set. Calls
+/// [`AtlassianClient::get_issue_with_fields`] directly rather than the
+/// generic [`AtlassianApi`] trait, since `ContentItem` does not carry
+/// custom field data.
+pub async fn run_read_jira_with_fields(
+    key: &str,
+    output: Option<&str>,
+    format: &ContentFormat,
+    selection: FieldSelection,
+    client: &AtlassianClient,
+    instance_url: &str,
+) -> Result<()> {
+    let issue = client.get_issue_with_fields(key, selection).await?;
+
+    match format {
+        ContentFormat::Adf => {
+            let mut fields = serde_json::Map::new();
+            if let Some(desc) = &issue.description_adf {
+                fields.insert("description".to_string(), desc.clone());
+            }
+            for cf in &issue.custom_fields {
+                fields.insert(cf.id.clone(), cf.value.clone());
+            }
+            let json = serde_json::to_string_pretty(&serde_json::Value::Object(fields))
+                .context("Failed to serialize fields as JSON")?;
+            output_text(&json, output)?;
+        }
+        ContentFormat::Jfm => {
+            let doc = issue_to_jfm_document(&issue, instance_url)?;
             let rendered = doc.render()?;
             output_text(&rendered, output)?;
 
@@ -710,5 +753,150 @@ mod tests {
         let adf = AdfDocument::new();
         let result = print_create_dry_run("PROJ", "Task", "Add feature", &adf, &[]);
         assert!(result.is_ok());
+    }
+
+    // ── run_read_jira_with_fields ──────────────────────────────────
+
+    async fn setup_jira_fields_mock() -> (wiremock::MockServer, AtlassianClient) {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "key": "ACCS-1",
+                    "fields": {
+                        "summary": "Custom field issue",
+                        "description": {
+                            "type": "doc",
+                            "version": 1,
+                            "content": [{
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Main description"}]
+                            }]
+                        },
+                        "status": {"name": "Open"},
+                        "issuetype": {"name": "Bug"},
+                        "assignee": null,
+                        "priority": null,
+                        "labels": [],
+                        "customfield_19300": {
+                            "type": "doc",
+                            "version": 1,
+                            "content": [{
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Criterion body"}]
+                            }]
+                        },
+                        "customfield_10001": {"value": "Unplanned"}
+                    },
+                    "names": {
+                        "customfield_19300": "Acceptance Criteria",
+                        "customfield_10001": "Planned / Unplanned Work"
+                    }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        (server, client)
+    }
+
+    #[tokio::test]
+    async fn run_read_jira_with_fields_jfm_emits_scalars_and_sections() {
+        let (_server, client) = setup_jira_fields_mock().await;
+        let instance_url = client.instance_url().to_string();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let out_path = temp_dir.path().join("issue.md");
+
+        run_read_jira_with_fields(
+            "ACCS-1",
+            Some(out_path.to_str().unwrap()),
+            &ContentFormat::Jfm,
+            FieldSelection::All,
+            &client,
+            &instance_url,
+        )
+        .await
+        .unwrap();
+
+        let rendered = fs::read_to_string(&out_path).unwrap();
+        assert!(rendered.contains("key: ACCS-1"));
+        assert!(rendered.contains("custom_fields:"));
+        assert!(rendered.contains("Planned / Unplanned Work"));
+        assert!(rendered.contains("Unplanned"));
+        assert!(rendered.contains("Main description"));
+        assert!(rendered.contains("<!-- field: Acceptance Criteria (customfield_19300) -->"));
+        assert!(rendered.contains("Criterion body"));
+    }
+
+    #[tokio::test]
+    async fn run_read_jira_with_fields_adf_emits_field_map_json() {
+        let (_server, client) = setup_jira_fields_mock().await;
+        let instance_url = client.instance_url().to_string();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let out_path = temp_dir.path().join("issue.json");
+
+        run_read_jira_with_fields(
+            "ACCS-1",
+            Some(out_path.to_str().unwrap()),
+            &ContentFormat::Adf,
+            FieldSelection::All,
+            &client,
+            &instance_url,
+        )
+        .await
+        .unwrap();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&out_path).unwrap()).unwrap();
+        assert_eq!(json["description"]["type"], "doc");
+        assert_eq!(json["customfield_19300"]["type"], "doc");
+        assert_eq!(json["customfield_10001"]["value"], "Unplanned");
+    }
+
+    #[tokio::test]
+    async fn run_read_jira_with_fields_jfm_to_stdout() {
+        let (_server, client) = setup_jira_fields_mock().await;
+        let instance_url = client.instance_url().to_string();
+
+        let result = run_read_jira_with_fields(
+            "ACCS-1",
+            None,
+            &ContentFormat::Jfm,
+            FieldSelection::Named(vec!["Acceptance Criteria".to_string()]),
+            &client,
+            &instance_url,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_read_jira_with_fields_propagates_client_errors() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/NOPE-1"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let instance_url = client.instance_url().to_string();
+
+        let err = run_read_jira_with_fields(
+            "NOPE-1",
+            None,
+            &ContentFormat::Jfm,
+            FieldSelection::All,
+            &client,
+            &instance_url,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("404"));
     }
 }

--- a/src/cli/atlassian/jira/board.rs
+++ b/src/cli/atlassian/jira/board.rs
@@ -283,6 +283,7 @@ mod tests {
             assignee: assignee.map(String::from),
             priority: None,
             labels: vec![],
+            custom_fields: vec![],
         }
     }
 

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -109,6 +109,8 @@ mod tests {
                 key: "PROJ-1".to_string(),
                 output: None,
                 format: ContentFormat::Jfm,
+                fields: vec![],
+                all_fields: false,
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::Read(_)));

--- a/src/cli/atlassian/jira/read.rs
+++ b/src/cli/atlassian/jira/read.rs
@@ -3,9 +3,10 @@
 use anyhow::Result;
 use clap::Parser;
 
+use crate::atlassian::client::FieldSelection;
 use crate::atlassian::jira_api::JiraApi;
 use crate::cli::atlassian::format::ContentFormat;
-use crate::cli::atlassian::helpers::{create_client, run_read};
+use crate::cli::atlassian::helpers::{create_client, run_read, run_read_jira_with_fields};
 
 /// Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON.
 #[derive(Parser)]
@@ -20,22 +21,52 @@ pub struct ReadCommand {
     /// Output format.
     #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
     pub format: ContentFormat,
+
+    /// Custom fields to include (comma-separated). Each entry may be a
+    /// field ID (e.g. `customfield_19300`) or a human name (e.g.
+    /// `"Acceptance Criteria"`).
+    #[arg(long, value_delimiter = ',')]
+    pub fields: Vec<String>,
+
+    /// Include every custom field populated on the issue.
+    #[arg(long, conflicts_with = "fields")]
+    pub all_fields: bool,
 }
 
 impl ReadCommand {
     /// Fetches the issue and outputs it.
     pub async fn execute(self) -> Result<()> {
         let (client, instance_url) = create_client()?;
-        let api = JiraApi::new(client);
 
-        run_read(
-            &self.key,
-            self.output.as_deref(),
-            &self.format,
-            &api,
-            &instance_url,
-        )
-        .await
+        let selection = if self.all_fields {
+            Some(FieldSelection::All)
+        } else if !self.fields.is_empty() {
+            Some(FieldSelection::Named(self.fields.clone()))
+        } else {
+            None
+        };
+
+        if let Some(sel) = selection {
+            run_read_jira_with_fields(
+                &self.key,
+                self.output.as_deref(),
+                &self.format,
+                sel,
+                &client,
+                &instance_url,
+            )
+            .await
+        } else {
+            let api = JiraApi::new(client);
+            run_read(
+                &self.key,
+                self.output.as_deref(),
+                &self.format,
+                &api,
+                &instance_url,
+            )
+            .await
+        }
     }
 }
 
@@ -50,6 +81,8 @@ mod tests {
             key: "PROJ-42".to_string(),
             output: Some("out.md".to_string()),
             format: ContentFormat::Adf,
+            fields: vec![],
+            all_fields: false,
         };
         assert_eq!(cmd.key, "PROJ-42");
         assert_eq!(cmd.output.as_deref(), Some("out.md"));
@@ -62,8 +95,36 @@ mod tests {
             key: "PROJ-1".to_string(),
             output: None,
             format: ContentFormat::default(),
+            fields: vec![],
+            all_fields: false,
         };
         assert!(matches!(cmd.format, ContentFormat::Jfm));
         assert!(cmd.output.is_none());
+        assert!(cmd.fields.is_empty());
+        assert!(!cmd.all_fields);
+    }
+
+    #[test]
+    fn read_command_with_field_selection() {
+        let cmd = ReadCommand {
+            key: "PROJ-9".to_string(),
+            output: None,
+            format: ContentFormat::Jfm,
+            fields: vec!["customfield_19300".to_string(), "Sprint".to_string()],
+            all_fields: false,
+        };
+        assert_eq!(cmd.fields.len(), 2);
+    }
+
+    #[test]
+    fn read_command_all_fields() {
+        let cmd = ReadCommand {
+            key: "PROJ-9".to_string(),
+            output: None,
+            format: ContentFormat::Jfm,
+            fields: vec![],
+            all_fields: true,
+        };
+        assert!(cmd.all_fields);
     }
 }

--- a/src/cli/atlassian/jira/search.rs
+++ b/src/cli/atlassian/jira/search.rs
@@ -170,6 +170,7 @@ mod tests {
             assignee: assignee.map(String::from),
             priority: None,
             labels: vec![],
+            custom_fields: vec![],
         }
     }
 

--- a/src/cli/atlassian/jira/sprint.rs
+++ b/src/cli/atlassian/jira/sprint.rs
@@ -468,6 +468,7 @@ mod tests {
             assignee: assignee.map(String::from),
             priority: None,
             labels: vec![],
+            custom_fields: vec![],
         }
     }
 

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1042,6 +1042,8 @@ Arguments:
 Options:
   -o, --output <OUTPUT>  Output file (writes to stdout if omitted)
       --format <FORMAT>  Output format [default: jfm] [possible values: jfm, adf]
+      --fields <FIELDS>  Custom fields to include (comma-separated). Each entry may be a field ID (e.g. `customfield_19300`) or a human name (e.g. `"Acceptance Criteria"`)
+      --all-fields       Include every custom field populated on the issue
   -h, --help             Print help (see more with '--help')
 
 


### PR DESCRIPTION
## Description

This PR extends the JIRA issue client and `jira read` command to support fetching custom fields alongside the standard fields. Previously, only a fixed set of standard fields (summary, description, status, issuetype, assignee, priority, labels) were retrieved. Users can now request specific named custom fields or all custom fields populated on an issue, with rich-text (ADF) fields rendered as additional body sections and scalar fields serialized into the frontmatter.

A new `FieldSelection` enum controls which fields are requested from the JIRA REST API, and a `JiraCustomField` struct carries the stable field ID, human-readable name, and raw JSON value returned by the API. The `get_issue` method is preserved as a thin shim over the new `get_issue_with_fields` for backward compatibility.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Relates to #594

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `FieldSelection` enum with three variants: `Standard` (default, existing behaviour), `Named(Vec<String>)` (specific field IDs or human names), and `All` (every field via `*all`)
- Added `JiraCustomField` struct with `id`, `name`, and `value: serde_json::Value` fields
- Added `custom_fields: Vec<JiraCustomField>` to `JiraIssue` (serialized with `skip_serializing_if = "Vec::is_empty"`)
- Added `JiraIssueEnvelope` deserialization target that captures all fields as raw JSON and a `names` map from `expand=names,schema`
- Added `get_issue_with_fields(&self, key, FieldSelection)` method that builds the correct `fields` query parameter and always requests `expand=names,schema`
- Refactored `get_issue` as a thin shim over `get_issue_with_fields` with `FieldSelection::Standard`
- Added `extract_named_field` and `extract_display_name` helper functions
- Updated all call sites that construct `JiraIssue` directly (search, board, sprint) to initialize `custom_fields: Vec::new()`

**Document Rendering (`src/atlassian/document.rs`):**
- Added `custom_fields: BTreeMap<String, serde_yaml::Value>` to `JiraFrontmatter` (serialized with `skip_serializing_if = "BTreeMap::is_empty"`)
- Updated `issue_to_jfm_document` to partition custom fields: ADF/rich-text fields are appended to the body as tagged sections (`<!-- field: Name (id) -->`), scalar fields go into frontmatter `custom_fields` map
- Added `render_custom_field`, `append_custom_section`, `is_adf_document`, `extract_custom_field_scalar`, and `json_to_yaml` helper functions
- Option/select objects collapse to their `value` string; user-picker objects collapse to `displayName`; arrays recurse per element dropping nulls; unknown objects pass through as structured YAML

**CLI (`src/cli/atlassian/jira/read.rs`):**
- Added `--fields <field,...>` argument (comma-separated, accepts field IDs or human names)
- Added `--all-fields` flag (conflicts with `--fields`)
- Updated `ReadCommand::execute` to resolve a `FieldSelection` from the flags and route to either `run_read_jira_with_fields` or the existing `run_read` path

**Helpers (`src/cli/atlassian/helpers.rs`):**
- Added `run_read_jira_with_fields` async function that calls `AtlassianClient::get_issue_with_fields` directly (bypassing the `AtlassianApi` trait since `ContentItem` does not carry custom field data) and handles both ADF and JFM output formats

**Testing:**
- Added 4 integration tests in `client.rs`: named fields populates custom fields, standard omits custom fields, `All` uses `*all` query param, and falls back to field ID when `names` is absent
- Added 11 unit tests in `document.rs` covering `is_adf_document`, `extract_custom_field_scalar` (primitives, option objects, user objects, arrays, empty arrays), and end-to-end round-trips for scalar-only, ADF-only, mixed, and null custom fields
- Added 4 integration tests in `helpers.rs` for `run_read_jira_with_fields` covering JFM output, ADF output, stdout, and error propagation
- Updated existing test fixtures in `format.rs`, `board.rs`, `search.rs`, `sprint.rs`, and `mod.rs` to include `custom_fields: vec![]` in `JiraIssue` literals
- Updated help snapshot in `tests/snapshots/integration_test__help_all_output.snap`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (19 new tests across client, document, and helpers modules)
- [x] Integration tests added using `wiremock` for all three `FieldSelection` variants

**Manual Testing:**
- [x] Tested happy path scenarios (named fields, all fields, standard fallback)
- [x] Tested error/edge cases (missing `names` map, null field values, unrecognized shapes)
- [x] Backward compatibility verified (`get_issue` still works unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Run only atlassian-related tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Example: fetch issue with specific custom field
omni-dev jira read PROJ-123 --fields customfield_19300

# Example: fetch issue with all custom fields
omni-dev jira read PROJ-123 --all-fields

# Example: fetch with multiple named fields
omni-dev jira read PROJ-123 --fields "customfield_19300,Sprint"
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `JiraIssueEnvelope` replaces the old `JiraIssueResponse`/`JiraIssueFields` deserialization path for the `get_issue_with_fields` route; the old structs are retained for search/board/sprint list responses
- [x] Error handling — ADF parse failures for custom fields propagate as errors; null/unrecognized shapes are silently omitted
- [x] Backward compatibility — `get_issue` is unchanged; all existing callers that construct `JiraIssue` directly required a `custom_fields: Vec::new()` addition

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Potential performance impact (describe below)

When `FieldSelection::All` or `FieldSelection::Named` is used, the API request includes `expand=names,schema` and may return significantly more JSON than the standard request. This is expected and intentional — the `Standard` path is unaffected and has no additional overhead.

## Security Considerations
- [x] No security implications

Custom field values are deserialized as raw `serde_json::Value` and serialized out; no credentials or sensitive data handling is involved beyond what the existing JIRA client already does.

## Breaking Changes

None. The `custom_fields` field on `JiraIssue` is `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so existing serialized output is unchanged. The `get_issue` method signature is preserved. All existing callers that construct `JiraIssue` directly were updated to add `custom_fields: Vec::new()`.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `<!-- field: Name (id) -->` tag in the body is designed to allow the `write` command to identify and round-trip custom ADF fields back to JIRA in a future PR
- Additional field type heuristics (e.g., date fields, multi-user pickers) can be added to `extract_custom_field_scalar` without changing the public API

**Known Limitations:**
- Unknown object shapes that are neither option objects nor user-picker objects are passed through as raw YAML mappings, which may not be human-friendly for all field types
- The `run_read_jira_with_fields` helper bypasses the `AtlassianApi` trait because `ContentItem` does not carry custom field data; this is a known design constraint

**Alternatives Considered:**
- Extending `ContentItem` to carry custom fields was considered but rejected as it would require changes to every `AtlassianApi` implementation and spread JIRA-specific concerns into the generic API layer