### PR TITLE
feat(atlassian): implement custom field write support for JIRA issues

### DIFF
--- a/src/atlassian.rs
+++ b/src/atlassian.rs
@@ -11,6 +11,7 @@ pub mod auth;
 pub mod client;
 pub mod confluence_api;
 pub mod convert;
+pub mod custom_fields;
 pub mod directive;
 pub mod document;
 pub mod error;

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -100,6 +100,48 @@ pub struct JiraCustomField {
     pub value: serde_json::Value,
 }
 
+/// Metadata returned by `GET /rest/api/3/issue/{key}/editmeta`.
+///
+/// Scoped to fields on the issue's screen, so names are unambiguous for a
+/// given issue even when multiple custom fields share a display name
+/// globally.
+#[derive(Debug, Clone, Default)]
+pub struct EditMeta {
+    /// Field metadata keyed by field ID (e.g., `customfield_19300`).
+    pub fields: std::collections::BTreeMap<String, EditMetaField>,
+}
+
+/// A single field descriptor from the editmeta response.
+#[derive(Debug, Clone)]
+pub struct EditMetaField {
+    /// Human-readable field name.
+    pub name: String,
+
+    /// Schema describing the field's wire type.
+    pub schema: EditMetaSchema,
+}
+
+/// Schema type information for an editable field.
+#[derive(Debug, Clone)]
+pub struct EditMetaSchema {
+    /// Base type: `string`, `number`, `option`, `array`, `user`, `date`, etc.
+    pub kind: String,
+
+    /// For custom fields: the plugin type URI, e.g.
+    /// `com.atlassian.jira.plugin.system.customfieldtypes:textarea`.
+    pub custom: Option<String>,
+}
+
+impl EditMetaField {
+    /// Returns `true` when the field is a rich-text (ADF) custom field.
+    pub fn is_adf_rich_text(&self) -> bool {
+        matches!(
+            self.schema.custom.as_deref(),
+            Some("com.atlassian.jira.plugin.system.customfieldtypes:textarea")
+        )
+    }
+}
+
 /// Response from the JIRA `/myself` endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JiraUser {
@@ -596,6 +638,28 @@ fn extract_display_name(value: Option<serde_json::Value>) -> Option<String> {
     value
         .and_then(|v| v.get("displayName").cloned())
         .and_then(|n| n.as_str().map(str::to_string))
+}
+
+#[derive(Deserialize)]
+struct JiraEditMetaResponse {
+    #[serde(default)]
+    fields: std::collections::BTreeMap<String, JiraEditMetaField>,
+}
+
+#[derive(Deserialize)]
+struct JiraEditMetaField {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    schema: Option<JiraEditMetaSchemaRaw>,
+}
+
+#[derive(Deserialize)]
+struct JiraEditMetaSchemaRaw {
+    #[serde(rename = "type", default)]
+    kind: Option<String>,
+    #[serde(default)]
+    custom: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1675,6 +1739,130 @@ mod tests {
             .collect();
         assert!(names.contains(&"Planned / Unplanned Work"));
         assert!(names.contains(&"Story points"));
+    }
+
+    #[tokio::test]
+    async fn get_editmeta_parses_field_schema() {
+        let server = wiremock::MockServer::start().await;
+
+        let editmeta_json = serde_json::json!({
+            "fields": {
+                "customfield_19300": {
+                    "name": "Acceptance Criteria",
+                    "schema": {
+                        "type": "string",
+                        "custom": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+                        "customId": 19300
+                    }
+                },
+                "customfield_10001": {
+                    "name": "Planned / Unplanned Work",
+                    "schema": {
+                        "type": "option",
+                        "custom": "com.atlassian.jira.plugin.system.customfieldtypes:select",
+                        "customId": 10001
+                    }
+                }
+            }
+        });
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/ACCS-1/editmeta",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(&editmeta_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let meta = client.get_editmeta("ACCS-1").await.unwrap();
+
+        assert_eq!(meta.fields.len(), 2);
+        let ac = meta.fields.get("customfield_19300").unwrap();
+        assert_eq!(ac.name, "Acceptance Criteria");
+        assert!(ac.is_adf_rich_text());
+        let opt = meta.fields.get("customfield_10001").unwrap();
+        assert_eq!(opt.schema.kind, "option");
+        assert!(!opt.is_adf_rich_text());
+    }
+
+    #[tokio::test]
+    async fn get_editmeta_api_error_surfaces_status() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/NOPE-1/editmeta",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_editmeta("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn update_issue_with_custom_fields_merges_into_payload() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "description": {"version": 1, "type": "doc", "content": []},
+                    "summary": "New title",
+                    "customfield_10001": {"value": "Unplanned"},
+                    "customfield_19300": {
+                        "type": "doc",
+                        "version": 1,
+                        "content": [{"type": "paragraph"}]
+                    }
+                }
+            })))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let mut custom = std::collections::BTreeMap::new();
+        custom.insert(
+            "customfield_10001".to_string(),
+            serde_json::json!({"value": "Unplanned"}),
+        );
+        custom.insert(
+            "customfield_19300".to_string(),
+            serde_json::json!({"type": "doc", "version": 1, "content": [{"type": "paragraph"}]}),
+        );
+        let result = client
+            .update_issue_with_custom_fields("ACCS-1", &adf, Some("New title"), &custom)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn update_issue_shim_sends_no_custom_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "description": {"version": 1, "type": "doc", "content": []}
+                }
+            })))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        client.update_issue("ACCS-1", &adf, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -5180,11 +5368,32 @@ impl AtlassianClient {
     }
 
     /// Updates a JIRA issue's description and optionally its summary.
+    ///
+    /// Thin shim over [`Self::update_issue_with_custom_fields`] that sends no
+    /// custom field changes.
     pub async fn update_issue(
         &self,
         key: &str,
         description_adf: &AdfDocument,
         summary: Option<&str>,
+    ) -> Result<()> {
+        self.update_issue_with_custom_fields(
+            key,
+            description_adf,
+            summary,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+    }
+
+    /// Updates a JIRA issue's description, optionally its summary, and any
+    /// custom fields keyed by stable ID (e.g., `customfield_19300`).
+    pub async fn update_issue_with_custom_fields(
+        &self,
+        key: &str,
+        description_adf: &AdfDocument,
+        summary: Option<&str>,
+        custom_fields: &std::collections::BTreeMap<String, serde_json::Value>,
     ) -> Result<()> {
         let url = format!("{}/rest/api/3/issue/{}", self.instance_url, key);
 
@@ -5198,6 +5407,9 @@ impl AtlassianClient {
                 "summary".to_string(),
                 serde_json::Value::String(summary_text.to_string()),
             );
+        }
+        for (id, value) in custom_fields {
+            fields.insert(id.clone(), value.clone());
         }
 
         let body = serde_json::json!({ "fields": fields });
@@ -5219,6 +5431,60 @@ impl AtlassianClient {
         }
 
         Ok(())
+    }
+
+    /// Fetches editable field metadata scoped to an issue's edit screen.
+    ///
+    /// `GET /rest/api/3/issue/{key}/editmeta` returns only fields on the
+    /// issue's screen, so field names are unambiguous even when multiple
+    /// custom fields share a display name globally.
+    pub async fn get_editmeta(&self, key: &str) -> Result<EditMeta> {
+        let url = format!("{}/rest/api/3/issue/{}/editmeta", self.instance_url, key);
+
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .context("Failed to send editmeta request to JIRA API")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let raw: JiraEditMetaResponse = response
+            .json()
+            .await
+            .context("Failed to parse JIRA editmeta response")?;
+
+        let fields = raw
+            .fields
+            .into_iter()
+            .map(|(id, field)| {
+                let schema = field.schema.map_or_else(
+                    || EditMetaSchema {
+                        kind: String::new(),
+                        custom: None,
+                    },
+                    |s| EditMetaSchema {
+                        kind: s.kind.unwrap_or_default(),
+                        custom: s.custom,
+                    },
+                );
+                (
+                    id,
+                    EditMetaField {
+                        name: field.name.unwrap_or_default(),
+                        schema,
+                    },
+                )
+            })
+            .collect();
+        Ok(EditMeta { fields })
     }
 
     /// Creates a new JIRA issue.

--- a/src/atlassian/custom_fields.rs
+++ b/src/atlassian/custom_fields.rs
@@ -1,0 +1,522 @@
+//! Resolves frontmatter custom field values and body sections to a JIRA
+//! `fields` payload for write operations.
+//!
+//! Input:
+//! - Frontmatter scalar map keyed by human name (from `custom_fields:` in JFM).
+//! - Body sections parsed via [`crate::atlassian::document::split_custom_sections`].
+//! - [`EditMeta`] fetched for the target issue (or create target).
+//!
+//! Output: `{ field_id -> api_json }` ready to be merged into a PUT/POST.
+
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::atlassian::client::{EditMeta, EditMetaField};
+use crate::atlassian::convert::markdown_to_adf;
+use crate::atlassian::document::CustomFieldSection;
+
+/// Plugin type URI for the rich-text "textarea" custom field. Used as the
+/// discriminator for dispatch in tests and elsewhere that distinguishes
+/// rich-text custom fields from scalar ones.
+#[cfg(test)]
+const CUSTOM_TEXTAREA: &str = "com.atlassian.jira.plugin.system.customfieldtypes:textarea";
+
+/// Resolves a mixed set of frontmatter scalars and body sections into an
+/// API-ready custom field map keyed by stable field ID.
+///
+/// - **Scalars** are dispatched by schema: option/radiobutton fields become
+///   `{"value": "..."}`, textfield/number/date pass through, rich-text
+///   fields are rejected (must use a body section instead).
+/// - **Sections** must reference rich-text fields; their markdown is
+///   converted to ADF via [`markdown_to_adf`].
+///
+/// Field names are looked up in [`EditMeta`]; entries already formatted as
+/// `customfield_<digits>` bypass the lookup. An unknown or ambiguous name
+/// produces an error naming the available editable fields.
+pub fn resolve_custom_fields(
+    scalars: &BTreeMap<String, serde_yaml::Value>,
+    sections: &[CustomFieldSection],
+    editmeta: &EditMeta,
+) -> Result<BTreeMap<String, serde_json::Value>> {
+    let mut out: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+
+    for (key, value) in scalars {
+        let (id, field) = lookup_field(editmeta, key)?;
+        if field.is_adf_rich_text() {
+            bail!(
+                "Field '{}' ({}) is a rich-text field; set it via a `<!-- field: {} ({}) -->` section in the body, not as a scalar in frontmatter",
+                field.name, id, field.name, id
+            );
+        }
+        let payload = scalar_to_api_value(value, field).with_context(|| {
+            format!(
+                "Failed to convert custom field '{}' ({}) to API value",
+                field.name, id
+            )
+        })?;
+        out.insert(id, payload);
+    }
+
+    for section in sections {
+        let (id, field) = resolve_section_field(editmeta, section)?;
+        if !field.is_adf_rich_text() {
+            bail!(
+                "Field '{}' ({}) is not a rich-text field; put scalar values in `custom_fields:` frontmatter instead of a body section",
+                field.name, id
+            );
+        }
+        let adf = markdown_to_adf(&section.body).with_context(|| {
+            format!(
+                "Failed to convert body for custom field '{}' ({}) to ADF",
+                field.name, id
+            )
+        })?;
+        let value =
+            serde_json::to_value(&adf).context("Failed to serialize custom field ADF document")?;
+        out.insert(id, value);
+    }
+
+    Ok(out)
+}
+
+/// Looks up a field by id-or-name, preferring exact `customfield_<id>`
+/// matches before falling back to a name lookup.
+fn lookup_field<'a>(editmeta: &'a EditMeta, key: &str) -> Result<(String, &'a EditMetaField)> {
+    if looks_like_field_id(key) {
+        if let Some(field) = editmeta.fields.get(key) {
+            return Ok((key.to_string(), field));
+        }
+        // Fall through to name lookup in case the caller named a field
+        // literally "customfield_something".
+    }
+
+    let matches: Vec<_> = editmeta
+        .fields
+        .iter()
+        .filter(|(_, f)| f.name == key)
+        .collect();
+
+    match matches.as_slice() {
+        [] => {
+            let candidates = editmeta
+                .fields
+                .iter()
+                .map(|(id, f)| format!("  {id}  {}", f.name))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(anyhow!(
+                "Unknown custom field '{key}'. Available editable fields on this issue:\n{candidates}"
+            ))
+        }
+        [(id, field)] => Ok(((*id).clone(), field)),
+        multi => {
+            let ids: Vec<_> = multi.iter().map(|(id, _)| id.as_str()).collect();
+            Err(anyhow!(
+                "Ambiguous custom field '{key}' matches multiple IDs: {}",
+                ids.join(", ")
+            ))
+        }
+    }
+}
+
+/// Resolves a body section's tag (which carries both name and id) against
+/// editmeta, trusting the id when both are present.
+fn resolve_section_field<'a>(
+    editmeta: &'a EditMeta,
+    section: &CustomFieldSection,
+) -> Result<(String, &'a EditMetaField)> {
+    if let Some(field) = editmeta.fields.get(&section.id) {
+        return Ok((section.id.clone(), field));
+    }
+    lookup_field(editmeta, &section.name)
+}
+
+fn looks_like_field_id(s: &str) -> bool {
+    s.starts_with("customfield_") && s[12..].chars().all(|c| c.is_ascii_digit())
+}
+
+/// Dispatches a scalar YAML value to the API shape expected for a given
+/// field schema.
+fn scalar_to_api_value(
+    value: &serde_yaml::Value,
+    field: &EditMetaField,
+) -> Result<serde_json::Value> {
+    let kind = field.schema.kind.as_str();
+    let custom = field.schema.custom.as_deref();
+    match (kind, custom) {
+        ("option", _) | ("string", Some("com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons")) => {
+            let s = yaml_as_string(value).with_context(|| {
+                format!("expected a string for option field '{}'", field.name)
+            })?;
+            Ok(serde_json::json!({ "value": s }))
+        }
+        ("array", _) => {
+            let seq = value.as_sequence().ok_or_else(|| {
+                anyhow!("expected a sequence for array field '{}'", field.name)
+            })?;
+            let items: Vec<serde_json::Value> = seq
+                .iter()
+                .map(|v| {
+                    let s = yaml_as_string(v).with_context(|| {
+                        format!(
+                            "expected a string array element for field '{}'",
+                            field.name
+                        )
+                    })?;
+                    Ok(serde_json::json!({ "value": s }))
+                })
+                .collect::<Result<_>>()?;
+            Ok(serde_json::Value::Array(items))
+        }
+        ("string" | "number" | "date" | "datetime", _) => yaml_to_json(value),
+        (other, _) => Err(anyhow!(
+            "Unsupported field type '{other}' for '{}'; custom field writes currently support option, textfield, number, date, and array-of-options",
+            field.name
+        )),
+    }
+}
+
+fn yaml_as_string(value: &serde_yaml::Value) -> Result<String> {
+    match value {
+        serde_yaml::Value::String(s) => Ok(s.clone()),
+        serde_yaml::Value::Bool(b) => Ok(b.to_string()),
+        serde_yaml::Value::Number(n) => Ok(n.to_string()),
+        _ => Err(anyhow!("expected a scalar string value")),
+    }
+}
+
+fn yaml_to_json(value: &serde_yaml::Value) -> Result<serde_json::Value> {
+    let s = serde_yaml::to_string(value).context("Failed to convert YAML to JSON")?;
+    serde_json::to_value(serde_yaml::from_str::<serde_json::Value>(&s)?)
+        .context("Failed to convert YAML value to JSON")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::{EditMetaField, EditMetaSchema};
+
+    fn meta(entries: &[(&str, &str, &str, Option<&str>)]) -> EditMeta {
+        let mut fields = BTreeMap::new();
+        for (id, name, kind, custom) in entries {
+            fields.insert(
+                (*id).to_string(),
+                EditMetaField {
+                    name: (*name).to_string(),
+                    schema: EditMetaSchema {
+                        kind: (*kind).to_string(),
+                        custom: custom.map(str::to_string),
+                    },
+                },
+            );
+        }
+        EditMeta { fields }
+    }
+
+    #[test]
+    fn scalar_option_field_wraps_in_value_object() {
+        let editmeta = meta(&[(
+            "customfield_10001",
+            "Planned / Unplanned Work",
+            "option",
+            Some("com.atlassian.jira.plugin.system.customfieldtypes:select"),
+        )]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Planned / Unplanned Work".to_string(),
+            serde_yaml::Value::String("Unplanned".to_string()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_10001").unwrap(),
+            &serde_json::json!({ "value": "Unplanned" })
+        );
+    }
+
+    #[test]
+    fn scalar_radiobutton_wraps_in_value_object() {
+        let editmeta = meta(&[(
+            "customfield_10002",
+            "Risk",
+            "string",
+            Some("com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons"),
+        )]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Risk".to_string(),
+            serde_yaml::Value::String("High".to_string()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_10002").unwrap(),
+            &serde_json::json!({ "value": "High" })
+        );
+    }
+
+    #[test]
+    fn scalar_number_field_passes_through() {
+        let editmeta = meta(&[(
+            "customfield_10003",
+            "Story points",
+            "number",
+            Some("com.atlassian.jira.plugin.system.customfieldtypes:float"),
+        )]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Story points".to_string(),
+            serde_yaml::Value::Number(8.into()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(out.get("customfield_10003").unwrap(), &serde_json::json!(8));
+    }
+
+    #[test]
+    fn scalar_array_option_field_wraps_each_item() {
+        let editmeta = meta(&[("customfield_10004", "Components", "array", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Components".to_string(),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("backend".to_string()),
+                serde_yaml::Value::String("auth".to_string()),
+            ]),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_10004").unwrap(),
+            &serde_json::json!([{"value": "backend"}, {"value": "auth"}])
+        );
+    }
+
+    #[test]
+    fn scalar_to_rich_text_field_errors() {
+        let editmeta = meta(&[(
+            "customfield_19300",
+            "Acceptance Criteria",
+            "string",
+            Some(CUSTOM_TEXTAREA),
+        )]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Acceptance Criteria".to_string(),
+            serde_yaml::Value::String("just text".to_string()),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(err.to_string().contains("rich-text field"));
+    }
+
+    #[test]
+    fn rich_text_section_becomes_adf_payload() {
+        let editmeta = meta(&[(
+            "customfield_19300",
+            "Acceptance Criteria",
+            "string",
+            Some(CUSTOM_TEXTAREA),
+        )]);
+        let sections = [CustomFieldSection {
+            name: "Acceptance Criteria".to_string(),
+            id: "customfield_19300".to_string(),
+            body: "- Item one\n- Item two".to_string(),
+        }];
+        let out = resolve_custom_fields(&BTreeMap::new(), &sections, &editmeta).unwrap();
+        let value = out.get("customfield_19300").unwrap();
+        assert_eq!(value["type"], "doc");
+        assert_eq!(value["version"], 1);
+        assert!(value["content"].is_array());
+    }
+
+    #[test]
+    fn section_pointing_at_non_rich_text_field_errors() {
+        let editmeta = meta(&[("customfield_10001", "Priority Flag", "option", None)]);
+        let sections = [CustomFieldSection {
+            name: "Priority Flag".to_string(),
+            id: "customfield_10001".to_string(),
+            body: "Some text".to_string(),
+        }];
+        let err = resolve_custom_fields(&BTreeMap::new(), &sections, &editmeta).unwrap_err();
+        assert!(err.to_string().contains("not a rich-text field"));
+    }
+
+    #[test]
+    fn unknown_field_name_errors_with_suggestions() {
+        let editmeta = meta(&[
+            ("customfield_1", "Alpha", "string", None),
+            ("customfield_2", "Beta", "string", None),
+        ]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert("Gamma".to_string(), serde_yaml::Value::from("x"));
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown custom field 'Gamma'"));
+        assert!(msg.contains("Alpha"));
+        assert!(msg.contains("Beta"));
+    }
+
+    #[test]
+    fn field_id_bypasses_name_lookup() {
+        let editmeta = meta(&[(
+            "customfield_10001",
+            "Planned / Unplanned Work",
+            "option",
+            None,
+        )]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "customfield_10001".to_string(),
+            serde_yaml::Value::String("Unplanned".to_string()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_10001").unwrap(),
+            &serde_json::json!({ "value": "Unplanned" })
+        );
+    }
+
+    #[test]
+    fn ambiguous_field_name_errors_listing_ids() {
+        let editmeta = meta(&[
+            ("customfield_1", "Duplicate", "string", None),
+            ("customfield_2", "Duplicate", "string", None),
+        ]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert("Duplicate".to_string(), serde_yaml::Value::from("x"));
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Ambiguous"));
+        assert!(msg.contains("customfield_1"));
+        assert!(msg.contains("customfield_2"));
+    }
+
+    #[test]
+    fn array_field_requires_sequence_value() {
+        let editmeta = meta(&[("customfield_10004", "Components", "array", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Components".to_string(),
+            serde_yaml::Value::String("not-a-sequence".to_string()),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(format!("{err:#}").contains("expected a sequence"));
+    }
+
+    #[test]
+    fn array_element_must_be_scalar_string() {
+        let editmeta = meta(&[("customfield_10004", "Components", "array", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Components".to_string(),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("nested".to_string()),
+            ])]),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(format!("{err:#}").contains("expected a scalar string value"));
+    }
+
+    #[test]
+    fn unsupported_schema_type_errors_with_field_name() {
+        let editmeta = meta(&[("customfield_20000", "Reporter", "user", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert("Reporter".to_string(), serde_yaml::Value::from("alice"));
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Unsupported field type 'user'"));
+        assert!(msg.contains("Reporter"));
+    }
+
+    #[test]
+    fn option_field_accepts_bool_and_number_scalars() {
+        let editmeta = meta(&[
+            (
+                "customfield_bool",
+                "Toggle",
+                "option",
+                Some("com.atlassian.jira.plugin.system.customfieldtypes:select"),
+            ),
+            (
+                "customfield_num",
+                "Number choice",
+                "option",
+                Some("com.atlassian.jira.plugin.system.customfieldtypes:select"),
+            ),
+        ]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert("Toggle".to_string(), serde_yaml::Value::Bool(true));
+        scalars.insert(
+            "Number choice".to_string(),
+            serde_yaml::Value::Number(3.into()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_bool").unwrap(),
+            &serde_json::json!({"value": "true"})
+        );
+        assert_eq!(
+            out.get("customfield_num").unwrap(),
+            &serde_json::json!({"value": "3"})
+        );
+    }
+
+    #[test]
+    fn option_field_rejects_non_scalar_value() {
+        let editmeta = meta(&[("customfield_opt", "Opt", "option", None)]);
+        let mut mapping = serde_yaml::Mapping::new();
+        mapping.insert(serde_yaml::Value::from("k"), serde_yaml::Value::from("v"));
+        let mut scalars = BTreeMap::new();
+        scalars.insert("Opt".to_string(), serde_yaml::Value::Mapping(mapping));
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(format!("{err:#}").contains("expected a scalar string value"));
+    }
+
+    #[test]
+    fn section_with_stale_id_falls_back_to_name_lookup() {
+        // editmeta has the field under a new id; the section tag carries an
+        // older id. Resolver should fall back to name lookup and find it.
+        let editmeta = meta(&[(
+            "customfield_NEW",
+            "Acceptance Criteria",
+            "string",
+            Some(CUSTOM_TEXTAREA),
+        )]);
+        let sections = [CustomFieldSection {
+            name: "Acceptance Criteria".to_string(),
+            id: "customfield_OLD".to_string(),
+            body: "body".to_string(),
+        }];
+        let out = resolve_custom_fields(&BTreeMap::new(), &sections, &editmeta).unwrap();
+        assert!(out.contains_key("customfield_NEW"));
+        assert!(!out.contains_key("customfield_OLD"));
+    }
+
+    #[test]
+    fn field_id_that_does_not_exist_falls_through_to_name_lookup() {
+        // A `customfield_<digits>` key that isn't in editmeta should still
+        // try a name lookup before erroring.
+        let editmeta = meta(&[("customfield_ACTUAL", "My Field", "string", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert("customfield_999".to_string(), serde_yaml::Value::from("x"));
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(err.to_string().contains("Unknown custom field"));
+    }
+
+    #[test]
+    fn section_prefers_tag_id_over_name_lookup() {
+        // Name "Acceptance Criteria" matches two different IDs globally, but
+        // the section tag carries a specific ID so no ambiguity error.
+        let editmeta = meta(&[(
+            "customfield_19300",
+            "Acceptance Criteria",
+            "string",
+            Some(CUSTOM_TEXTAREA),
+        )]);
+        let sections = [CustomFieldSection {
+            name: "Acceptance Criteria".to_string(),
+            id: "customfield_19300".to_string(),
+            body: "body".to_string(),
+        }];
+        let out = resolve_custom_fields(&BTreeMap::new(), &sections, &editmeta).unwrap();
+        assert!(out.contains_key("customfield_19300"));
+    }
+}

--- a/src/atlassian/document.rs
+++ b/src/atlassian/document.rs
@@ -155,6 +155,15 @@ impl JfmFrontmatter {
             Self::Confluence(_) => "confluence",
         }
     }
+
+    /// Returns the JIRA custom field scalar map, or `None` when the
+    /// frontmatter is not a JIRA variant.
+    pub fn jira_custom_fields(&self) -> Option<&BTreeMap<String, serde_yaml::Value>> {
+        match self {
+            Self::Jira(fm) => Some(&fm.custom_fields),
+            Self::Confluence(_) => None,
+        }
+    }
 }
 
 /// Validates that a string looks like a JIRA issue key (e.g., "PROJ-123").
@@ -240,6 +249,122 @@ fn append_custom_section(body: &mut String, field: &JiraCustomField, section_md:
     if !body.ends_with('\n') {
         body.push('\n');
     }
+}
+
+/// A single rich-text custom field section parsed out of a JFM body.
+///
+/// Emitted by [`issue_to_jfm_document`] via [`append_custom_section`] and
+/// recovered by [`JfmDocument::split_custom_sections`] so the write path
+/// can round-trip a field through `markdown_to_adf` for upload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomFieldSection {
+    /// Human-readable field name captured from the `<!-- field: Name (id) -->` tag.
+    pub name: String,
+
+    /// Stable field ID captured from the tag (e.g., `customfield_19300`).
+    pub id: String,
+
+    /// Markdown body of the section (no trailing newline guarantees).
+    pub body: String,
+}
+
+/// Splits a JFM body into the primary body and any trailing custom-field
+/// sections.
+///
+/// Recognizes the separator emitted by [`append_custom_section`]: a line
+/// containing only `---` followed by a line matching
+/// `<!-- field: <name> (<id>) -->`. Everything before the first such
+/// separator is the primary body; each subsequent separator starts a new
+/// section whose content runs up to the next separator (or end of input).
+pub(crate) fn split_custom_sections(body: &str) -> (String, Vec<CustomFieldSection>) {
+    // (marker_start, content_start, name, id)
+    let mut markers: Vec<(usize, usize, String, String)> = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < body.len() {
+        let Some(marker_start) = find_next_marker(body, cursor) else {
+            break;
+        };
+
+        // Require exactly "---" on its own line, followed by "\n" (or "\r\n").
+        let after_dashes = marker_start + 3;
+        let after_nl = if body[after_dashes..].starts_with("\r\n") {
+            after_dashes + 2
+        } else if body[after_dashes..].starts_with('\n') {
+            after_dashes + 1
+        } else {
+            cursor = after_dashes;
+            continue;
+        };
+
+        if let Some((name, id, content_start)) = parse_field_tag_line(body, after_nl) {
+            markers.push((marker_start, content_start, name, id));
+            cursor = content_start;
+        } else {
+            cursor = after_nl;
+        }
+    }
+
+    if markers.is_empty() {
+        return (body.to_string(), Vec::new());
+    }
+
+    let first_marker = markers[0].0;
+    let main_body = body[..first_marker].trim_end_matches('\n').to_string();
+
+    let mut sections = Vec::with_capacity(markers.len());
+    for i in 0..markers.len() {
+        let (_marker, content_start, name, id) = &markers[i];
+        let content_end = markers.get(i + 1).map_or(body.len(), |next| next.0);
+        let raw = &body[*content_start..content_end];
+        let trimmed = raw.trim_matches('\n').to_string();
+        sections.push(CustomFieldSection {
+            name: name.clone(),
+            id: id.clone(),
+            body: trimmed,
+        });
+    }
+
+    (main_body, sections)
+}
+
+/// Finds the next line-anchored `---` at or after `from`. A marker is
+/// either at the very start of `body` or preceded by a newline.
+fn find_next_marker(body: &str, from: usize) -> Option<usize> {
+    if from == 0 && body.starts_with("---") {
+        return Some(0);
+    }
+    body[from..]
+        .find("\n---")
+        .map(|rel| from + rel + 1)
+        .filter(|p| *p + 3 <= body.len())
+}
+
+/// Parses an HTML-comment field tag at `start` and returns
+/// `(name, id, content_start)` where `content_start` is the byte offset
+/// immediately after the comment line's newline.
+fn parse_field_tag_line(body: &str, start: usize) -> Option<(String, String, usize)> {
+    let rest = body.get(start..)?;
+    let line_end = rest.find('\n').unwrap_or(rest.len());
+    let line = rest[..line_end].trim_end_matches('\r');
+
+    let after_open = line.strip_prefix("<!--")?.trim_start();
+    let after_field = after_open.strip_prefix("field:")?.trim_start();
+    let close_idx = after_field.rfind("-->")?;
+    let inner = after_field[..close_idx].trim_end();
+
+    let paren_open = inner.rfind('(')?;
+    let name = inner[..paren_open].trim().to_string();
+    let rest_part = inner.get(paren_open + 1..)?;
+    let paren_close = rest_part.rfind(')')?;
+    let id = rest_part[..paren_close].trim().to_string();
+
+    if name.is_empty() || id.is_empty() {
+        return None;
+    }
+
+    let next_line_start = (start + line_end + 1).min(body.len());
+    Some((name, id, next_line_start))
 }
 
 /// Returns `true` if `value` has the shape of an Atlassian Document Format
@@ -404,6 +529,15 @@ impl JfmDocument {
         }
 
         Ok(output)
+    }
+
+    /// Splits the body into the primary markdown and any trailing custom-field
+    /// sections emitted by the custom-field-aware read path.
+    ///
+    /// Non-destructive — returns owned strings and leaves `self.body`
+    /// unchanged so `render()` continues to produce a lossless round-trip.
+    pub fn split_custom_sections(&self) -> (String, Vec<CustomFieldSection>) {
+        split_custom_sections(&self.body)
     }
 }
 
@@ -649,6 +783,80 @@ mod tests {
 
     // ── Custom field helpers ────────────────────────────────────────
 
+    // ── append_custom_section ───────────────────────────────────────
+
+    #[test]
+    fn append_custom_section_adds_leading_newline_when_body_unterminated() {
+        let mut body = String::from("No trailing newline");
+        let field = JiraCustomField {
+            id: "customfield_1".to_string(),
+            name: "AC".to_string(),
+            value: serde_json::Value::Null,
+        };
+        append_custom_section(&mut body, &field, "section body");
+        assert!(body.starts_with("No trailing newline\n\n---\n"));
+        assert!(body.ends_with('\n'));
+    }
+
+    #[test]
+    fn append_custom_section_terminates_body_when_section_lacks_newline() {
+        let mut body = String::from("Main body\n");
+        let field = JiraCustomField {
+            id: "customfield_1".to_string(),
+            name: "AC".to_string(),
+            value: serde_json::Value::Null,
+        };
+        append_custom_section(&mut body, &field, "no-trailing-nl");
+        assert!(body.ends_with("no-trailing-nl\n"));
+    }
+
+    #[test]
+    fn append_custom_section_into_empty_body_has_no_leading_blank_line() {
+        let mut body = String::new();
+        let field = JiraCustomField {
+            id: "customfield_1".to_string(),
+            name: "AC".to_string(),
+            value: serde_json::Value::Null,
+        };
+        append_custom_section(&mut body, &field, "s\n");
+        assert!(body.starts_with("---\n<!-- field: AC (customfield_1) -->\n\ns\n"));
+    }
+
+    #[test]
+    fn jira_custom_fields_returns_none_for_confluence_frontmatter() {
+        let fm = JfmFrontmatter::Confluence(ConfluenceFrontmatter {
+            instance: "https://org.atlassian.net".to_string(),
+            page_id: "1".to_string(),
+            title: "t".to_string(),
+            space_key: "X".to_string(),
+            status: None,
+            version: None,
+            parent_id: None,
+        });
+        assert!(fm.jira_custom_fields().is_none());
+    }
+
+    #[test]
+    fn jira_custom_fields_returns_scalars_for_jira_frontmatter() {
+        let mut custom = BTreeMap::new();
+        custom.insert("K".to_string(), serde_yaml::Value::from("V"));
+        let fm = JfmFrontmatter::Jira(JiraFrontmatter {
+            instance: "https://org.atlassian.net".to_string(),
+            key: "X-1".to_string(),
+            project: None,
+            summary: "s".to_string(),
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: custom,
+        });
+        let got = fm.jira_custom_fields().unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got.get("K").unwrap(), &serde_yaml::Value::from("V"));
+    }
+
     #[test]
     fn is_adf_document_detects_doc_shape() {
         let adf = serde_json::json!({
@@ -834,6 +1042,124 @@ mod tests {
         assert!(rendered.contains("Main"));
         assert!(rendered.contains("<!-- field: Acceptance Criteria"));
         assert!(rendered.contains("AC body"));
+    }
+
+    // ── split_custom_sections ──────────────────────────────────────
+
+    #[test]
+    fn split_custom_sections_no_sections_returns_body_unchanged() {
+        let (body, sections) = split_custom_sections("Hello world\n\nMore text\n");
+        assert_eq!(body, "Hello world\n\nMore text\n");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn split_custom_sections_extracts_single_section() {
+        let input = "Main body\n\n---\n<!-- field: Acceptance Criteria (customfield_19300) -->\n\n- Item 1\n- Item 2\n";
+        let (body, sections) = split_custom_sections(input);
+        assert_eq!(body, "Main body");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].name, "Acceptance Criteria");
+        assert_eq!(sections[0].id, "customfield_19300");
+        assert_eq!(sections[0].body, "- Item 1\n- Item 2");
+    }
+
+    #[test]
+    fn split_custom_sections_extracts_multiple_sections() {
+        let input = "Main\n\n---\n<!-- field: AC (customfield_1) -->\n\nAC body\n\n---\n<!-- field: Notes (customfield_2) -->\n\nNotes body\n";
+        let (body, sections) = split_custom_sections(input);
+        assert_eq!(body, "Main");
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].id, "customfield_1");
+        assert_eq!(sections[0].body, "AC body");
+        assert_eq!(sections[1].id, "customfield_2");
+        assert_eq!(sections[1].body, "Notes body");
+    }
+
+    #[test]
+    fn split_custom_sections_preserves_triple_dashes_inside_body() {
+        // A `---` without the follow-up comment tag is just content, not a
+        // section separator.
+        let input =
+            "Before\n\n---\n\nStill body\n\n---\n<!-- field: AC (customfield_1) -->\n\nSection\n";
+        let (body, sections) = split_custom_sections(input);
+        assert!(body.contains("Still body"));
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].body, "Section");
+    }
+
+    #[test]
+    fn split_custom_sections_body_starting_with_marker() {
+        let input = "---\n<!-- field: AC (customfield_1) -->\n\nSection body\n";
+        let (body, sections) = split_custom_sections(input);
+        assert!(body.is_empty());
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].id, "customfield_1");
+        assert_eq!(sections[0].body, "Section body");
+    }
+
+    #[test]
+    fn split_custom_sections_rejects_dash_sequence_without_newline() {
+        // `---foo` on a line is not a valid marker.
+        let input = "Before\n---foo\nMore\n---\n<!-- field: AC (customfield_1) -->\n\nS\n";
+        let (body, sections) = split_custom_sections(input);
+        assert!(body.contains("---foo"));
+        assert!(body.contains("More"));
+        assert_eq!(sections.len(), 1);
+    }
+
+    #[test]
+    fn split_custom_sections_handles_crlf_line_endings() {
+        let input = "Main\r\n\r\n---\r\n<!-- field: AC (customfield_1) -->\r\n\r\nSection\r\n";
+        let (_body, sections) = split_custom_sections(input);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].name, "AC");
+        assert_eq!(sections[0].id, "customfield_1");
+    }
+
+    #[test]
+    fn split_custom_sections_rejects_malformed_field_tag() {
+        // The `---` is present and line-anchored, but the next line is not a
+        // proper `<!-- field: Name (id) -->` tag, so the section is treated
+        // as plain body content.
+        let input = "Before\n\n---\n<!-- not a field tag -->\n\nStill body\n";
+        let (body, sections) = split_custom_sections(input);
+        assert!(body.contains("<!-- not a field tag -->"));
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn split_custom_sections_roundtrips_through_render() {
+        let issue = JiraIssue {
+            key: "TEST-1".to_string(),
+            summary: "S".to_string(),
+            description_adf: Some(serde_json::json!({
+                "type": "doc", "version": 1,
+                "content": [{"type":"paragraph","content":[{"type":"text","text":"Main"}]}]
+            })),
+            status: None,
+            issue_type: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: vec![JiraCustomField {
+                id: "customfield_19300".to_string(),
+                name: "Acceptance Criteria".to_string(),
+                value: serde_json::json!({
+                    "type": "doc", "version": 1,
+                    "content": [{"type":"paragraph","content":[{"type":"text","text":"AC line"}]}]
+                }),
+            }],
+        };
+        let doc = issue_to_jfm_document(&issue, "https://org.atlassian.net").unwrap();
+        let rendered = doc.render().unwrap();
+        let reparsed = JfmDocument::parse(&rendered).unwrap();
+        let (body, sections) = reparsed.split_custom_sections();
+        assert!(body.contains("Main"));
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].id, "customfield_19300");
+        assert_eq!(sections[0].name, "Acceptance Criteria");
+        assert!(sections[0].body.contains("AC line"));
     }
 
     #[test]

--- a/src/cli/atlassian/helpers.rs
+++ b/src/cli/atlassian/helpers.rs
@@ -173,6 +173,75 @@ pub async fn run_write(
     Ok(())
 }
 
+/// Confirms and pushes content (description, title, and custom fields) to
+/// a JIRA issue via [`AtlassianClient::update_issue_with_custom_fields`].
+///
+/// Used by the JIRA write path when custom fields are present. Goes direct
+/// to the client rather than through [`AtlassianApi`] since the trait does
+/// not model custom fields.
+pub async fn run_write_jira_with_resolved_fields(
+    key: &str,
+    adf: &AdfDocument,
+    title: &str,
+    force: bool,
+    custom_fields: &std::collections::BTreeMap<String, serde_json::Value>,
+    client: &AtlassianClient,
+) -> Result<()> {
+    if !force {
+        println!("About to update {key}:");
+        if !title.is_empty() {
+            println!("  Title: {title}");
+        }
+        if !custom_fields.is_empty() {
+            println!("  Custom fields: {}", custom_fields.len());
+        }
+        print!("\nApply changes? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut answer = String::new();
+        io::stdin().read_line(&mut answer)?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let title_ref = if title.is_empty() { None } else { Some(title) };
+
+    client
+        .update_issue_with_custom_fields(key, adf, title_ref, custom_fields)
+        .await?;
+    println!("Updated {key} successfully.");
+
+    Ok(())
+}
+
+/// Prints a dry-run summary including the resolved custom fields payload.
+pub fn print_jira_dry_run_with_custom_fields(
+    key: &str,
+    adf: &AdfDocument,
+    title: &str,
+    scalars: &std::collections::BTreeMap<String, serde_yaml::Value>,
+    sections: &[crate::atlassian::document::CustomFieldSection],
+) -> Result<()> {
+    print_dry_run(key, adf, title)?;
+    if !scalars.is_empty() {
+        println!("\nCustom field scalars (frontmatter):");
+        for (name, value) in scalars {
+            let rendered =
+                serde_yaml::to_string(value).context("Failed to serialize scalar as YAML")?;
+            println!("  {name}: {}", rendered.trim());
+        }
+    }
+    if !sections.is_empty() {
+        println!("\nCustom field sections (body):");
+        for section in sections {
+            println!("  - {} ({})", section.name, section.id);
+        }
+    }
+    Ok(())
+}
+
 /// Interactive fetch-edit-push cycle.
 pub async fn run_edit(id: &str, api: &dyn AtlassianApi, instance_url: &str) -> Result<()> {
     use tracing::debug;
@@ -872,6 +941,94 @@ mod tests {
             &instance_url,
         )
         .await;
+        assert!(result.is_ok());
+    }
+
+    // ── run_write_jira_with_resolved_fields ────────────────────────
+
+    #[tokio::test]
+    async fn run_write_jira_with_resolved_fields_force_applies_payload() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "description": {"version": 1, "type": "doc", "content": []},
+                    "summary": "New",
+                    "customfield_10001": {"value": "Unplanned"}
+                }
+            })))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let mut custom = std::collections::BTreeMap::new();
+        custom.insert(
+            "customfield_10001".to_string(),
+            serde_json::json!({"value": "Unplanned"}),
+        );
+
+        let result =
+            run_write_jira_with_resolved_fields("ACCS-1", &adf, "New", true, &custom, &client)
+                .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_write_jira_with_resolved_fields_empty_title_sends_no_summary() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/ACCS-1"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "description": {"version": 1, "type": "doc", "content": []},
+                    "customfield_10001": 42
+                }
+            })))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let mut custom = std::collections::BTreeMap::new();
+        custom.insert("customfield_10001".to_string(), serde_json::json!(42));
+
+        run_write_jira_with_resolved_fields("ACCS-1", &adf, "", true, &custom, &client)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn print_jira_dry_run_with_scalars_and_sections() {
+        use crate::atlassian::document::CustomFieldSection;
+        let adf = AdfDocument::new();
+        let mut scalars = std::collections::BTreeMap::new();
+        scalars.insert(
+            "Planned / Unplanned Work".to_string(),
+            serde_yaml::Value::String("Unplanned".to_string()),
+        );
+        let sections = [CustomFieldSection {
+            name: "Acceptance Criteria".to_string(),
+            id: "customfield_19300".to_string(),
+            body: "- item".to_string(),
+        }];
+        let result =
+            print_jira_dry_run_with_custom_fields("ACCS-1", &adf, "T", &scalars, &sections);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn print_jira_dry_run_without_extras_still_prints_description() {
+        let adf = AdfDocument::new();
+        let scalars = std::collections::BTreeMap::new();
+        let result = print_jira_dry_run_with_custom_fields("ACCS-1", &adf, "", &scalars, &[]);
         assert!(result.is_ok());
     }
 

--- a/src/cli/atlassian/jira/write.rs
+++ b/src/cli/atlassian/jira/write.rs
@@ -3,9 +3,15 @@
 use anyhow::Result;
 use clap::Parser;
 
+use crate::atlassian::convert::markdown_to_adf;
+use crate::atlassian::custom_fields::resolve_custom_fields;
+use crate::atlassian::document::JfmDocument;
 use crate::atlassian::jira_api::JiraApi;
 use crate::cli::atlassian::format::ContentFormat;
-use crate::cli::atlassian::helpers::{create_client, prepare_write, run_write};
+use crate::cli::atlassian::helpers::{
+    create_client, prepare_write, print_dry_run, print_jira_dry_run_with_custom_fields, read_input,
+    run_write, run_write_jira_with_resolved_fields,
+};
 
 /// Pushes content to a JIRA issue.
 #[derive(Parser)]
@@ -32,16 +38,48 @@ pub struct WriteCommand {
 impl WriteCommand {
     /// Reads input and pushes to the JIRA issue.
     pub async fn execute(self) -> Result<()> {
-        let (adf, title) = prepare_write(self.file.as_deref(), &self.format)?;
+        if matches!(self.format, ContentFormat::Adf) {
+            let (adf, title) = prepare_write(self.file.as_deref(), &self.format)?;
+            if self.dry_run {
+                return print_dry_run(&self.key, &adf, &title);
+            }
+            let (client, _instance_url) = create_client()?;
+            let api = JiraApi::new(client);
+            return run_write(&self.key, &adf, &title, self.force, &api).await;
+        }
+
+        // JFM path: may carry custom fields in frontmatter or body sections.
+        let input = read_input(self.file.as_deref())?;
+        let doc = JfmDocument::parse(&input)?;
+        let (body_md, sections) = doc.split_custom_sections();
+        let scalars = doc
+            .frontmatter
+            .jira_custom_fields()
+            .cloned()
+            .unwrap_or_default();
+        let body_adf = markdown_to_adf(&body_md)?;
+        let title = doc.frontmatter.title().to_string();
 
         if self.dry_run {
-            return crate::cli::atlassian::helpers::print_dry_run(&self.key, &adf, &title);
+            return print_jira_dry_run_with_custom_fields(
+                &self.key, &body_adf, &title, &scalars, &sections,
+            );
         }
 
         let (client, _instance_url) = create_client()?;
-        let api = JiraApi::new(client);
 
-        run_write(&self.key, &adf, &title, self.force, &api).await
+        if scalars.is_empty() && sections.is_empty() {
+            let api = JiraApi::new(client);
+            return run_write(&self.key, &body_adf, &title, self.force, &api).await;
+        }
+
+        let editmeta = client.get_editmeta(&self.key).await?;
+        let resolved = resolve_custom_fields(&scalars, &sections, &editmeta)?;
+
+        run_write_jira_with_resolved_fields(
+            &self.key, &body_adf, &title, self.force, &resolved, &client,
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds end-to-end support for writing custom fields when pushing content to JIRA issues via the JFM write path. Users can now specify custom field values either as scalar values in JFM frontmatter (under `custom_fields:`) or as rich-text body sections delimited by `---` / `<!-- field: Name (id) -->` markers. The write command fetches editable field metadata from JIRA's `editmeta` API to validate and convert field values to the correct wire format before sending the PUT request.

Previously, the `jira write` command could only update the issue description and summary. This change unlocks the ability to update any custom field visible on the issue's edit screen — option/select, radio-button, array-of-options, number, date, and rich-text (ADF textarea) fields — from a single JFM document.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Relates to #594

## Changes Made

**Core Client (`src/atlassian/client.rs`):**
- Added `EditMeta`, `EditMetaField`, and `EditMetaSchema` public types describing editable field metadata
- Added `EditMetaField::is_adf_rich_text()` helper that checks for the `textarea` plugin type URI
- Added `get_editmeta(key)` method that calls `GET /rest/api/3/issue/{key}/editmeta` and maps the raw response into `EditMeta`
- Added `update_issue_with_custom_fields(key, adf, summary, custom_fields)` that merges arbitrary `BTreeMap<String, serde_json::Value>` entries into the PUT request body
- Refactored `update_issue` as a zero-custom-fields shim over the new method (no behavioral change for existing callers)

**Custom Field Resolution (`src/atlassian/custom_fields.rs` — new file):**
- Added `resolve_custom_fields(scalars, sections, editmeta)` that maps frontmatter scalar values and body sections to an API-ready `{ field_id -> json }` map
- Field lookup supports both stable `customfield_<digits>` IDs (bypass name lookup) and human-readable names (case-sensitive, error on ambiguity)
- Schema-aware dispatch: `option`/`radiobutton` → `{"value": "..."}`, `array` → `[{"value": "..."}, ...]`, `number`/`date`/`string` → pass-through, `textarea` → reject scalar (must use body section)
- Body sections are converted to ADF via `markdown_to_adf`; non-rich-text fields reject body sections with a descriptive error
- Unknown field names produce an error listing all available editable fields on the issue

**Document Parsing (`src/atlassian/document.rs`):**
- Added `CustomFieldSection` struct holding `name`, `id`, and `body` for a parsed body section
- Added `split_custom_sections(body)` free function that locates `---` + `<!-- field: Name (id) -->` separator markers and splits the body into a primary markdown string plus a `Vec<CustomFieldSection>`
- Added `JfmDocument::split_custom_sections()` convenience method wrapping the above
- Added `JfmFrontmatter::jira_custom_fields()` accessor returning the JIRA frontmatter's `custom_fields` map (or `None` for Confluence)

**CLI Helpers (`src/cli/atlassian/helpers.rs`):**
- Added `run_write_jira_with_resolved_fields(key, adf, title, force, custom_fields, client)` that prompts the user (unless `--force`) and calls `update_issue_with_custom_fields`
- Added `print_jira_dry_run_with_custom_fields(key, adf, title, scalars, sections)` that prints a dry-run summary including custom field scalars and section names

**Write Command (`src/cli/atlassian/jira/write.rs`):**
- Updated `WriteCommand::execute` to branch on content format: ADF follows the existing path unchanged; JFM now parses the document, splits custom sections, reads frontmatter scalars, and routes through the new custom-field write helpers when fields are present

**Testing:**
- Added `get_editmeta_parses_field_schema` and `get_editmeta_api_error_surfaces_status` integration tests in `client.rs` using wiremock
- Added `update_issue_with_custom_fields_merges_into_payload` and `update_issue_shim_sends_no_custom_fields` integration tests verifying HTTP body correctness
- Added 11 unit tests in `custom_fields.rs` covering all schema dispatch paths, unknown/ambiguous field errors, ID bypass, and section ID preference
- Added 5 unit tests in `document.rs` covering section extraction edge cases and a full render → parse → split round-trip
- Added 4 tests in `helpers.rs` covering force-apply, empty-title, and dry-run printing paths

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (wiremock HTTP mocking for `get_editmeta` and `update_issue_with_custom_fields`)

**Manual Testing:**
- [x] Tested happy path scenarios (option field, rich-text section, number field)
- [x] Tested error/edge cases (unknown field name, scalar to rich-text field, body section to non-rich-text field)
- [x] Backward compatibility verified — ADF write path and `update_issue` callers are unaffected

### Test Commands
```bash
# Core test suite
cargo test

# Run only the Atlassian-related tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `update_issue` is now a shim; `get_editmeta` is a new API call on every JFM write with custom fields
- [x] Error handling — field lookup errors name available fields; schema mismatch errors give actionable guidance
- [x] Backward compatibility — JFM writes without any `custom_fields:` frontmatter or body sections still go through the existing `JiraApi` trait path

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] Potential performance impact — JFM writes that include custom fields now make one additional HTTP request (`GET /editmeta`) before the PUT. Writes without custom fields are unaffected.

## Security Considerations

- [x] No security implications — custom field values come from the local JFM file authored by the user; no new external input surfaces are introduced.

## Breaking Changes

None. `update_issue` retains its existing signature and behavior. The ADF write path in `WriteCommand::execute` is unchanged. JFM writes without custom fields continue to use the existing `JiraApi` trait path.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Extend `resolve_custom_fields` to support `user` picker fields (currently unsupported with a clear error)
- Add `create_issue_with_custom_fields` to support custom fields on issue creation, not just updates
- Consider caching `editmeta` per session to avoid repeated requests when writing multiple issues

**Known Limitations:**
- Multi-select (`array`) fields currently assume all items are `{"value": "..."}` objects; cascading select and label arrays may need additional schema handling
- `user` and `group` picker fields are not yet supported and will return an unsupported-type error