### PR TITLE
feat(atlassian): add --set-field flag and custom field support for jira create and write

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -663,6 +663,24 @@ struct JiraEditMetaSchemaRaw {
 }
 
 #[derive(Deserialize)]
+struct JiraCreateMetaResponse {
+    #[serde(default)]
+    projects: Vec<JiraCreateMetaProject>,
+}
+
+#[derive(Deserialize)]
+struct JiraCreateMetaProject {
+    #[serde(default)]
+    issuetypes: Vec<JiraCreateMetaIssueType>,
+}
+
+#[derive(Deserialize)]
+struct JiraCreateMetaIssueType {
+    #[serde(default)]
+    fields: std::collections::BTreeMap<String, JiraEditMetaField>,
+}
+
+#[derive(Deserialize)]
 struct JiraIssueFields {
     summary: Option<String>,
     description: Option<serde_json::Value>,
@@ -2148,6 +2166,153 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn create_issue_with_custom_fields_merges_into_payload() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "project": {"key": "PROJ"},
+                    "issuetype": {"name": "Task"},
+                    "summary": "Test",
+                    "customfield_10001": {"value": "Unplanned"}
+                }
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "key": "PROJ-100",
+                    "self": "https://org.atlassian.net/rest/api/3/issue/100"
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let mut custom = std::collections::BTreeMap::new();
+        custom.insert(
+            "customfield_10001".to_string(),
+            serde_json::json!({"value": "Unplanned"}),
+        );
+        let result = client
+            .create_issue_with_custom_fields("PROJ", "Task", "Test", None, &[], &custom)
+            .await
+            .unwrap();
+        assert_eq!(result.key, "PROJ-100");
+    }
+
+    #[tokio::test]
+    async fn create_issue_shim_sends_no_custom_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "project": {"key": "PROJ"},
+                    "issuetype": {"name": "Task"},
+                    "summary": "Test"
+                }
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "key": "PROJ-100",
+                    "self": "https://org.atlassian.net/rest/api/3/issue/100"
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        client
+            .create_issue("PROJ", "Task", "Test", None, &[])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_createmeta_parses_nested_fields() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/createmeta"))
+            .and(wiremock::matchers::query_param("projectKeys", "PROJ"))
+            .and(wiremock::matchers::query_param("issuetypeNames", "Task"))
+            .and(wiremock::matchers::query_param(
+                "expand",
+                "projects.issuetypes.fields",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "projects": [{
+                        "key": "PROJ",
+                        "issuetypes": [{
+                            "name": "Task",
+                            "fields": {
+                                "customfield_10001": {
+                                    "name": "Planned / Unplanned Work",
+                                    "schema": {
+                                        "type": "option",
+                                        "custom": "com.atlassian.jira.plugin.system.customfieldtypes:select",
+                                        "customId": 10001
+                                    }
+                                }
+                            }
+                        }]
+                    }]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let meta = client.get_createmeta("PROJ", "Task").await.unwrap();
+        assert_eq!(meta.fields.len(), 1);
+        let field = meta.fields.get("customfield_10001").unwrap();
+        assert_eq!(field.name, "Planned / Unplanned Work");
+        assert_eq!(field.schema.kind, "option");
+    }
+
+    #[tokio::test]
+    async fn get_createmeta_empty_projects_returns_empty_meta() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/createmeta"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "projects": []
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let meta = client.get_createmeta("PROJ", "Task").await.unwrap();
+        assert!(meta.fields.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_createmeta_api_error_surfaces_status() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/createmeta"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_createmeta("NOPE", "Task").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
     }
 
     #[tokio::test]
@@ -5488,6 +5653,9 @@ impl AtlassianClient {
     }
 
     /// Creates a new JIRA issue.
+    ///
+    /// Thin shim over [`Self::create_issue_with_custom_fields`] that sends no
+    /// custom field values.
     pub async fn create_issue(
         &self,
         project_key: &str,
@@ -5495,6 +5663,28 @@ impl AtlassianClient {
         summary: &str,
         description_adf: Option<&AdfDocument>,
         labels: &[String],
+    ) -> Result<JiraCreatedIssue> {
+        self.create_issue_with_custom_fields(
+            project_key,
+            issue_type,
+            summary,
+            description_adf,
+            labels,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+    }
+
+    /// Creates a new JIRA issue with standard fields and any custom fields
+    /// keyed by stable ID (e.g., `customfield_19300`).
+    pub async fn create_issue_with_custom_fields(
+        &self,
+        project_key: &str,
+        issue_type: &str,
+        summary: &str,
+        description_adf: Option<&AdfDocument>,
+        labels: &[String],
+        custom_fields: &std::collections::BTreeMap<String, serde_json::Value>,
     ) -> Result<JiraCreatedIssue> {
         let url = format!("{}/rest/api/3/issue", self.instance_url);
 
@@ -5520,6 +5710,9 @@ impl AtlassianClient {
         if !labels.is_empty() {
             fields.insert("labels".to_string(), serde_json::to_value(labels)?);
         }
+        for (id, value) in custom_fields {
+            fields.insert(id.clone(), value.clone());
+        }
 
         let body = serde_json::json!({ "fields": fields });
 
@@ -5544,6 +5737,77 @@ impl AtlassianClient {
             id: create_response.id,
             self_url: create_response.self_url,
         })
+    }
+
+    /// Fetches field metadata for creating a JIRA issue of a given project
+    /// and issue type.
+    ///
+    /// `GET /rest/api/3/issue/createmeta?projectKeys={p}&issuetypeNames={t}&expand=projects.issuetypes.fields`
+    /// returns fields on the create screen, which is the write-time source
+    /// of truth for custom-field resolution prior to issue creation.
+    pub async fn get_createmeta(&self, project_key: &str, issue_type: &str) -> Result<EditMeta> {
+        let base = format!("{}/rest/api/3/issue/createmeta", self.instance_url);
+        let url = reqwest::Url::parse_with_params(
+            &base,
+            &[
+                ("projectKeys", project_key),
+                ("issuetypeNames", issue_type),
+                ("expand", "projects.issuetypes.fields"),
+            ],
+        )
+        .context("Failed to build JIRA createmeta URL")?;
+
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", &self.auth_header)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .context("Failed to send createmeta request to JIRA API")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let raw: JiraCreateMetaResponse = response
+            .json()
+            .await
+            .context("Failed to parse JIRA createmeta response")?;
+
+        let Some(project) = raw.projects.into_iter().next() else {
+            return Ok(EditMeta::default());
+        };
+        let Some(issuetype) = project.issuetypes.into_iter().next() else {
+            return Ok(EditMeta::default());
+        };
+
+        let fields = issuetype
+            .fields
+            .into_iter()
+            .map(|(id, field)| {
+                let schema = field.schema.map_or_else(
+                    || EditMetaSchema {
+                        kind: String::new(),
+                        custom: None,
+                    },
+                    |s| EditMetaSchema {
+                        kind: s.kind.unwrap_or_default(),
+                        custom: s.custom,
+                    },
+                );
+                (
+                    id,
+                    EditMetaField {
+                        name: field.name.unwrap_or_default(),
+                        schema,
+                    },
+                )
+            })
+            .collect();
+        Ok(EditMeta { fields })
     }
 
     /// Lists comments on a JIRA issue with auto-pagination.

--- a/src/atlassian/custom_fields.rs
+++ b/src/atlassian/custom_fields.rs
@@ -192,6 +192,37 @@ fn yaml_to_json(value: &serde_yaml::Value) -> Result<serde_json::Value> {
         .context("Failed to convert YAML value to JSON")
 }
 
+/// Parses a `--set-field NAME=VALUE` argument into a `(name, value)` pair.
+///
+/// The value is parsed as YAML when possible so `--set-field "Points=8"`
+/// becomes a number and `--set-field "Enabled=true"` becomes a bool.
+/// Values that fail to parse as YAML fall back to plain strings.
+pub fn parse_set_field(input: &str) -> Result<(String, serde_yaml::Value)> {
+    let (name, value) = input
+        .split_once('=')
+        .ok_or_else(|| anyhow!("expected --set-field \"NAME=VALUE\", got '{input}'"))?;
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        bail!("--set-field requires a non-empty name before '='");
+    }
+    let yaml_value = serde_yaml::from_str::<serde_yaml::Value>(value)
+        .unwrap_or_else(|_| serde_yaml::Value::String(value.to_string()));
+    Ok((name, yaml_value))
+}
+
+/// Merges CLI `--set-field` overrides into a frontmatter scalar map,
+/// with CLI overriding frontmatter on name conflicts.
+pub fn merge_set_field_overrides(
+    frontmatter: BTreeMap<String, serde_yaml::Value>,
+    overrides: Vec<(String, serde_yaml::Value)>,
+) -> BTreeMap<String, serde_yaml::Value> {
+    let mut merged = frontmatter;
+    for (name, value) in overrides {
+        merged.insert(name, value);
+    }
+    merged
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -499,6 +530,92 @@ mod tests {
         scalars.insert("customfield_999".to_string(), serde_yaml::Value::from("x"));
         let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
         assert!(err.to_string().contains("Unknown custom field"));
+    }
+
+    // ── parse_set_field / merge_set_field_overrides ─────────────────
+
+    #[test]
+    fn parse_set_field_bare_string_value() {
+        let (name, value) = parse_set_field("Status=Open").unwrap();
+        assert_eq!(name, "Status");
+        assert_eq!(value, serde_yaml::Value::String("Open".to_string()));
+    }
+
+    #[test]
+    fn parse_set_field_numeric_value_becomes_number() {
+        let (_name, value) = parse_set_field("Points=8").unwrap();
+        assert_eq!(value, serde_yaml::Value::Number(8.into()));
+    }
+
+    #[test]
+    fn parse_set_field_bool_value_becomes_bool() {
+        let (_name, value) = parse_set_field("Enabled=true").unwrap();
+        assert_eq!(value, serde_yaml::Value::Bool(true));
+    }
+
+    #[test]
+    fn parse_set_field_preserves_spaces_in_name() {
+        let (name, value) = parse_set_field("Planned / Unplanned Work=Unplanned").unwrap();
+        assert_eq!(name, "Planned / Unplanned Work");
+        assert_eq!(value, serde_yaml::Value::String("Unplanned".to_string()));
+    }
+
+    #[test]
+    fn parse_set_field_equals_in_value_preserved() {
+        // Only the FIRST `=` splits name from value.
+        let (name, value) = parse_set_field("Formula=a=b+c").unwrap();
+        assert_eq!(name, "Formula");
+        assert_eq!(value, serde_yaml::Value::String("a=b+c".to_string()));
+    }
+
+    #[test]
+    fn parse_set_field_requires_equals() {
+        let err = parse_set_field("just-a-name").unwrap_err();
+        assert!(err.to_string().contains("expected --set-field"));
+    }
+
+    #[test]
+    fn parse_set_field_empty_name_errors() {
+        let err = parse_set_field("=value").unwrap_err();
+        assert!(err.to_string().contains("non-empty name"));
+    }
+
+    #[test]
+    fn merge_set_field_overrides_cli_wins() {
+        let mut frontmatter = BTreeMap::new();
+        frontmatter.insert(
+            "Priority".to_string(),
+            serde_yaml::Value::String("Low".to_string()),
+        );
+        frontmatter.insert(
+            "Keep".to_string(),
+            serde_yaml::Value::String("from-fm".to_string()),
+        );
+        let overrides = vec![(
+            "Priority".to_string(),
+            serde_yaml::Value::String("High".to_string()),
+        )];
+        let merged = merge_set_field_overrides(frontmatter, overrides);
+        assert_eq!(
+            merged.get("Priority"),
+            Some(&serde_yaml::Value::String("High".to_string()))
+        );
+        assert_eq!(
+            merged.get("Keep"),
+            Some(&serde_yaml::Value::String("from-fm".to_string()))
+        );
+    }
+
+    #[test]
+    fn merge_set_field_overrides_with_empty_overrides_preserves_frontmatter() {
+        let mut frontmatter = BTreeMap::new();
+        frontmatter.insert("K".to_string(), serde_yaml::Value::from("v"));
+        let merged = merge_set_field_overrides(frontmatter, vec![]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(
+            merged.get("K"),
+            Some(&serde_yaml::Value::String("v".to_string()))
+        );
     }
 
     #[test]

--- a/src/cli/atlassian/jira/create.rs
+++ b/src/cli/atlassian/jira/create.rs
@@ -1,12 +1,17 @@
 //! CLI command for creating JIRA issues.
 
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result};
 use clap::Parser;
 
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::client::AtlassianClient;
 use crate::atlassian::convert::markdown_to_adf;
-use crate::atlassian::document::{JfmDocument, JfmFrontmatter};
+use crate::atlassian::custom_fields::{
+    merge_set_field_overrides, parse_set_field, resolve_custom_fields,
+};
+use crate::atlassian::document::{CustomFieldSection, JfmDocument, JfmFrontmatter};
 use crate::cli::atlassian::format::ContentFormat;
 use crate::cli::atlassian::helpers::{create_client, print_create_dry_run, read_input};
 
@@ -32,6 +37,13 @@ pub struct CreateCommand {
     #[arg(long)]
     pub summary: Option<String>,
 
+    /// Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used
+    /// multiple times. Values are parsed as YAML scalars (numbers, bools)
+    /// when possible, falling back to strings. Overrides values from the
+    /// frontmatter `custom_fields:` map for the same name.
+    #[arg(long = "set-field", value_name = "NAME=VALUE")]
+    pub set_fields: Vec<String>,
+
     /// Shows what would be sent without creating.
     #[arg(long)]
     pub dry_run: bool,
@@ -45,6 +57,8 @@ struct CreateParams {
     summary: String,
     labels: Vec<String>,
     adf: AdfDocument,
+    custom_scalars: BTreeMap<String, serde_yaml::Value>,
+    custom_sections: Vec<CustomFieldSection>,
 }
 
 impl CreateCommand {
@@ -68,19 +82,36 @@ impl CreateCommand {
 
     /// Resolves creation parameters from input file and CLI flags.
     fn resolve_params(&self) -> Result<CreateParams> {
+        let overrides = self
+            .set_fields
+            .iter()
+            .map(|s| parse_set_field(s))
+            .collect::<Result<Vec<_>>>()?;
         match self.format {
-            ContentFormat::Jfm => self.resolve_from_jfm(),
-            ContentFormat::Adf => self.resolve_from_adf(),
+            ContentFormat::Jfm => self.resolve_from_jfm(overrides),
+            ContentFormat::Adf => {
+                if !overrides.is_empty() {
+                    anyhow::bail!(
+                        "--set-field is only supported with --format jfm; ADF input takes a raw payload"
+                    );
+                }
+                self.resolve_from_adf()
+            }
         }
     }
 
     /// Resolves parameters from JFM input, with CLI flags as overrides.
-    fn resolve_from_jfm(&self) -> Result<CreateParams> {
+    fn resolve_from_jfm(
+        &self,
+        overrides: Vec<(String, serde_yaml::Value)>,
+    ) -> Result<CreateParams> {
         let input = read_input(self.file.as_deref())?;
         let doc = JfmDocument::parse(&input)?;
-        let adf = markdown_to_adf(&doc.body)?;
+        let (body_md, custom_sections) = doc.split_custom_sections();
+        let adf = markdown_to_adf(&body_md)?;
 
-        let (fm_project, fm_issue_type, fm_summary, fm_labels) = match &doc.frontmatter {
+        let (fm_project, fm_issue_type, fm_summary, fm_labels, fm_scalars) = match &doc.frontmatter
+        {
             JfmFrontmatter::Jira(fm) => {
                 // Derive project from key if project field is absent
                 let project = fm.project.clone().or_else(|| {
@@ -95,6 +126,7 @@ impl CreateCommand {
                     fm.issue_type.clone(),
                     Some(fm.summary.clone()),
                     fm.labels.clone(),
+                    fm.custom_fields.clone(),
                 )
             }
             JfmFrontmatter::Confluence(_) => {
@@ -116,12 +148,16 @@ impl CreateCommand {
             anyhow::anyhow!("Summary is required (use --summary or set in frontmatter)")
         })?;
 
+        let custom_scalars = merge_set_field_overrides(fm_scalars, overrides);
+
         Ok(CreateParams {
             project,
             issue_type,
             summary,
             labels: fm_labels,
             adf,
+            custom_scalars,
+            custom_sections,
         })
     }
 
@@ -149,19 +185,35 @@ impl CreateCommand {
             summary,
             labels: vec![],
             adf,
+            custom_scalars: BTreeMap::new(),
+            custom_sections: Vec::new(),
         })
     }
 }
 
 /// Creates a JIRA issue from resolved parameters.
+///
+/// Fast path when no custom fields are requested: one POST to
+/// `/rest/api/3/issue`. With custom fields, fetches `createmeta` to resolve
+/// human names to IDs and dispatch values by schema before sending.
 async fn run_create(client: &AtlassianClient, params: &CreateParams) -> Result<()> {
+    let custom_fields = if params.custom_scalars.is_empty() && params.custom_sections.is_empty() {
+        BTreeMap::new()
+    } else {
+        let createmeta = client
+            .get_createmeta(&params.project, &params.issue_type)
+            .await?;
+        resolve_custom_fields(&params.custom_scalars, &params.custom_sections, &createmeta)?
+    };
+
     let result = client
-        .create_issue(
+        .create_issue_with_custom_fields(
             &params.project,
             &params.issue_type,
             &params.summary,
             Some(&params.adf),
             &params.labels,
+            &custom_fields,
         )
         .await?;
 
@@ -183,6 +235,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
         assert!(cmd.file.is_none());
@@ -203,6 +256,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -226,6 +280,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -246,6 +301,7 @@ mod tests {
             project: Some("NEW".to_string()),
             r#type: Some("Story".to_string()),
             summary: Some("New Title".to_string()),
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -268,6 +324,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -288,6 +345,7 @@ mod tests {
             project: Some("PROJ".to_string()),
             r#type: Some("Bug".to_string()),
             summary: Some("Fix it".to_string()),
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -310,6 +368,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: Some("Title".to_string()),
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -330,6 +389,7 @@ mod tests {
             project: Some("PROJ".to_string()),
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -350,6 +410,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -370,6 +431,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: true,
         };
 
@@ -391,6 +453,7 @@ mod tests {
             project: Some("PROJ".to_string()),
             r#type: None,
             summary: Some("Test".to_string()),
+            set_fields: vec![],
             dry_run: true,
         };
 
@@ -412,6 +475,7 @@ mod tests {
             project: None,
             r#type: None,
             summary: None,
+            set_fields: vec![],
             dry_run: false,
         };
 
@@ -432,6 +496,8 @@ mod tests {
             summary: "Test issue".to_string(),
             labels: vec![],
             adf: AdfDocument::new(),
+            custom_scalars: BTreeMap::new(),
+            custom_sections: Vec::new(),
         }
     }
 
@@ -464,5 +530,154 @@ mod tests {
         let client = mock_client(&server.uri());
         let err = run_create(&client, &sample_params()).await.unwrap_err();
         assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn run_create_with_custom_scalar_fetches_createmeta_and_merges_payload() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/issue/createmeta"))
+            .and(wiremock::matchers::query_param("projectKeys", "PROJ"))
+            .and(wiremock::matchers::query_param("issuetypeNames", "Task"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "projects": [{
+                    "issuetypes": [{
+                        "fields": {
+                            "customfield_10001": {
+                                "name": "Planned / Unplanned Work",
+                                "schema": {
+                                    "type": "option",
+                                    "custom": "com.atlassian.jira.plugin.system.customfieldtypes:select"
+                                }
+                            }
+                        }
+                    }]
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "fields": {
+                    "project": {"key": "PROJ"},
+                    "issuetype": {"name": "Task"},
+                    "summary": "Test issue",
+                    "description": {"version": 1, "type": "doc", "content": []},
+                    "customfield_10001": {"value": "Unplanned"}
+                }
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "key": "PROJ-100",
+                    "self": "https://org.atlassian.net/rest/api/3/issue/100"
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let mut params = sample_params();
+        params.custom_scalars.insert(
+            "Planned / Unplanned Work".to_string(),
+            serde_yaml::Value::String("Unplanned".to_string()),
+        );
+        run_create(&client, &params).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_create_without_custom_fields_skips_createmeta_call() {
+        // If no custom fields are requested, create must not hit
+        // /rest/api/3/issue/createmeta — only the POST to /issue.
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/issue"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "key": "PROJ-100",
+                    "self": "https://org.atlassian.net/rest/api/3/issue/100"
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // createmeta mock expects exactly 0 hits — wiremock will fail the
+        // test if any unmatched GET lands.
+        let client = mock_client(&server.uri());
+        run_create(&client, &sample_params()).await.unwrap();
+    }
+
+    #[test]
+    fn resolve_from_jfm_with_set_field_overrides_frontmatter() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("issue.md");
+        let content = "---\ntype: jira\ninstance: https://org.atlassian.net\nproject: PROJ\nsummary: T\ncustom_fields:\n  Priority: Low\n---\n\nBody\n";
+        fs::write(&file_path, content).unwrap();
+
+        let cmd = CreateCommand {
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+            project: None,
+            r#type: None,
+            summary: None,
+            set_fields: vec!["Priority=High".to_string()],
+            dry_run: false,
+        };
+
+        let params = cmd.resolve_params().unwrap();
+        assert_eq!(
+            params.custom_scalars.get("Priority"),
+            Some(&serde_yaml::Value::String("High".to_string()))
+        );
+    }
+
+    #[test]
+    fn invalid_set_field_syntax_errors_during_resolve() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("issue.md");
+        let content = "---\ntype: jira\ninstance: https://org.atlassian.net\nproject: PROJ\nsummary: T\n---\n\nBody\n";
+        fs::write(&file_path, content).unwrap();
+
+        let cmd = CreateCommand {
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+            project: None,
+            r#type: None,
+            summary: None,
+            set_fields: vec!["no-equals".to_string()],
+            dry_run: false,
+        };
+
+        let err = cmd.resolve_params().unwrap_err();
+        assert!(err.to_string().contains("expected --set-field"));
+    }
+
+    #[test]
+    fn resolve_from_adf_rejects_set_field() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("body.json");
+        let adf_json = r#"{"version":1,"type":"doc","content":[]}"#;
+        fs::write(&file_path, adf_json).unwrap();
+
+        let cmd = CreateCommand {
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Adf,
+            project: Some("PROJ".to_string()),
+            r#type: None,
+            summary: Some("T".to_string()),
+            set_fields: vec!["Priority=High".to_string()],
+            dry_run: false,
+        };
+
+        let err = cmd.resolve_params().unwrap_err();
+        assert!(err.to_string().contains("--set-field is only supported"));
     }
 }

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -123,6 +123,7 @@ mod tests {
                 key: "PROJ-1".to_string(),
                 file: None,
                 format: ContentFormat::Jfm,
+                set_fields: vec![],
                 force: false,
                 dry_run: false,
             }),
@@ -149,6 +150,7 @@ mod tests {
                 project: Some("PROJ".to_string()),
                 r#type: None,
                 summary: Some("Test".to_string()),
+                set_fields: vec![],
                 dry_run: false,
             }),
         };

--- a/src/cli/atlassian/jira/write.rs
+++ b/src/cli/atlassian/jira/write.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::atlassian::convert::markdown_to_adf;
-use crate::atlassian::custom_fields::resolve_custom_fields;
+use crate::atlassian::custom_fields::{
+    merge_set_field_overrides, parse_set_field, resolve_custom_fields,
+};
 use crate::atlassian::document::JfmDocument;
 use crate::atlassian::jira_api::JiraApi;
 use crate::cli::atlassian::format::ContentFormat;
@@ -26,6 +28,13 @@ pub struct WriteCommand {
     #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
     pub format: ContentFormat,
 
+    /// Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used
+    /// multiple times. Values are parsed as YAML scalars (numbers, bools)
+    /// when possible, falling back to strings. Overrides values from the
+    /// frontmatter `custom_fields:` map for the same name.
+    #[arg(long = "set-field", value_name = "NAME=VALUE")]
+    pub set_fields: Vec<String>,
+
     /// Skips the confirmation prompt.
     #[arg(long)]
     pub force: bool,
@@ -38,7 +47,18 @@ pub struct WriteCommand {
 impl WriteCommand {
     /// Reads input and pushes to the JIRA issue.
     pub async fn execute(self) -> Result<()> {
+        let overrides = self
+            .set_fields
+            .iter()
+            .map(|s| parse_set_field(s))
+            .collect::<Result<Vec<_>>>()?;
+
         if matches!(self.format, ContentFormat::Adf) {
+            if !overrides.is_empty() {
+                anyhow::bail!(
+                    "--set-field is only supported with --format jfm; ADF writes take a raw payload"
+                );
+            }
             let (adf, title) = prepare_write(self.file.as_deref(), &self.format)?;
             if self.dry_run {
                 return print_dry_run(&self.key, &adf, &title);
@@ -52,11 +72,12 @@ impl WriteCommand {
         let input = read_input(self.file.as_deref())?;
         let doc = JfmDocument::parse(&input)?;
         let (body_md, sections) = doc.split_custom_sections();
-        let scalars = doc
+        let frontmatter_scalars = doc
             .frontmatter
             .jira_custom_fields()
             .cloned()
             .unwrap_or_default();
+        let scalars = merge_set_field_overrides(frontmatter_scalars, overrides);
         let body_adf = markdown_to_adf(&body_md)?;
         let title = doc.frontmatter.title().to_string();
 
@@ -95,6 +116,7 @@ mod tests {
             key: "PROJ-1".to_string(),
             file: Some("input.md".to_string()),
             format: ContentFormat::Jfm,
+            set_fields: vec![],
             force: true,
             dry_run: false,
         };
@@ -114,6 +136,7 @@ mod tests {
             key: "PROJ-1".to_string(),
             file: Some(file_path.to_str().unwrap().to_string()),
             format: ContentFormat::Jfm,
+            set_fields: vec![],
             force: false,
             dry_run: true,
         };
@@ -121,6 +144,65 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let result = rt.block_on(cmd.execute());
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_field_with_adf_format_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("issue.json");
+        fs::write(&file_path, r#"{"version":1,"type":"doc","content":[]}"#).unwrap();
+
+        let cmd = WriteCommand {
+            key: "PROJ-1".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Adf,
+            set_fields: vec!["Priority=High".to_string()],
+            force: true,
+            dry_run: true,
+        };
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(cmd.execute()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("--set-field is only supported with --format jfm"));
+    }
+
+    #[test]
+    fn invalid_set_field_syntax_errors() {
+        let cmd = WriteCommand {
+            key: "PROJ-1".to_string(),
+            file: None,
+            format: ContentFormat::Jfm,
+            set_fields: vec!["no-equals-sign".to_string()],
+            force: true,
+            dry_run: true,
+        };
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(cmd.execute()).unwrap_err();
+        assert!(err.to_string().contains("expected --set-field"));
+    }
+
+    #[test]
+    fn dry_run_with_set_field_prints_custom_fields() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("issue.md");
+        let content =
+            "---\ntype: jira\ninstance: https://org.atlassian.net\nkey: PROJ-1\nsummary: T\n---\n\nBody\n";
+        fs::write(&file_path, content).unwrap();
+
+        let cmd = WriteCommand {
+            key: "PROJ-1".to_string(),
+            file: Some(file_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+            set_fields: vec!["Priority=High".to_string()],
+            force: false,
+            dry_run: true,
+        };
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert!(rt.block_on(cmd.execute()).is_ok());
     }
 
     #[test]
@@ -134,6 +216,7 @@ mod tests {
             key: "PROJ-1".to_string(),
             file: Some(file_path.to_str().unwrap().to_string()),
             format: ContentFormat::Adf,
+            set_fields: vec![],
             force: false,
             dry_run: true,
         };

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -803,12 +803,13 @@ Arguments:
   [FILE]  Input file containing JFM markdown or ADF JSON (reads from stdin if omitted or "-")
 
 Options:
-      --format <FORMAT>    Input format [default: jfm] [possible values: jfm, adf]
-      --project <PROJECT>  Project key (e.g., "PROJ"). Overrides frontmatter
-      --type <TYPE>        Issue type (e.g., "Task", "Bug", "Story"). Overrides frontmatter
-      --summary <SUMMARY>  Issue summary/title. Overrides frontmatter
-      --dry-run            Shows what would be sent without creating
-  -h, --help               Print help (see more with '--help')
+      --format <FORMAT>         Input format [default: jfm] [possible values: jfm, adf]
+      --project <PROJECT>       Project key (e.g., "PROJ"). Overrides frontmatter
+      --type <TYPE>             Issue type (e.g., "Task", "Bug", "Story"). Overrides frontmatter
+      --summary <SUMMARY>       Issue summary/title. Overrides frontmatter
+      --set-field <NAME=VALUE>  Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used multiple times. Values are parsed as YAML scalars (numbers, bools) when possible, falling back to strings. Overrides values from the frontmatter `custom_fields:` map for the same name
+      --dry-run                 Shows what would be sent without creating
+  -h, --help                    Print help (see more with '--help')
 
 
 ================================================================================
@@ -1315,10 +1316,11 @@ Arguments:
   [FILE]  Input file (reads from stdin if omitted or "-")
 
 Options:
-      --format <FORMAT>  Input format [default: jfm] [possible values: jfm, adf]
-      --force            Skips the confirmation prompt
-      --dry-run          Shows what would change without writing
-  -h, --help             Print help (see more with '--help')
+      --format <FORMAT>         Input format [default: jfm] [possible values: jfm, adf]
+      --set-field <NAME=VALUE>  Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used multiple times. Values are parsed as YAML scalars (numbers, bools) when possible, falling back to strings. Overrides values from the frontmatter `custom_fields:` map for the same name
+      --force                   Skips the confirmation prompt
+      --dry-run                 Shows what would change without writing
+  -h, --help                    Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR extends the JIRA `create` and `write` CLI commands with a `--set-field NAME=VALUE` flag that allows inline custom field overrides directly from the command line. CLI-provided values take precedence over any matching `custom_fields:` entries in the document frontmatter.

Previously, custom fields could only be set via frontmatter in JFM documents. This change allows users to override or supplement custom fields without modifying the source file — useful for scripting, CI pipelines, or one-off field adjustments.

**Example usage:**
```bash
# Set a custom field when creating an issue
omni-dev jira create issue.md --set-field "Priority=High" --set-field "Points=8"

# Override frontmatter custom fields when writing
omni-dev jira write PROJ-123 issue.md --set-field "Planned / Unplanned Work=Unplanned"
```

Values are parsed as YAML scalars: `--set-field "Points=8"` becomes the integer `8`, `--set-field "Enabled=true"` becomes a boolean, and everything else falls back to a string. The `--set-field` flag is rejected when `--format adf` is used, as ADF takes a raw payload that cannot be merged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #594

## Changes Made

**Core Changes (`src/atlassian/`):**
- Added `parse_set_field(input: &str)` helper in `custom_fields.rs` that splits on the first `=` and coerces the value via `serde_yaml`, falling back to a plain string
- Added `merge_set_field_overrides(frontmatter, overrides)` in `custom_fields.rs` that merges CLI overrides onto frontmatter scalars with CLI winning on name conflicts
- Added `create_issue_with_custom_fields()` method on `AtlassianClient` that accepts a `BTreeMap<String, serde_json::Value>` of pre-resolved field IDs and merges them into the issue creation payload
- Refactored `create_issue()` as a thin shim over `create_issue_with_custom_fields()` with an empty map (no behavioral change)
- Added `get_createmeta()` on `AtlassianClient` to fetch field metadata from `GET /rest/api/3/issue/createmeta` and deserialize into an `EditMeta`; returns empty meta when the project or issue type is absent
- Added `JiraCreateMetaResponse`, `JiraCreateMetaProject`, and `JiraCreateMetaIssueType` internal deserialization structs

**CLI Changes (`src/cli/atlassian/jira/`):**
- Added `--set-field <NAME=VALUE>` argument (repeatable) to `CreateCommand` in `create.rs`
- Added `--set-field <NAME=VALUE>` argument (repeatable) to `WriteCommand` in `write.rs`
- Updated `run_create()` with fast-path optimization: skips `createmeta` call entirely when no custom fields are requested; fetches metadata and resolves field IDs only when custom fields are present
- Rejected `--set-field` with `--format adf` in both `create` and `write` commands with clear error messages
- Extended `CreateParams` struct with `custom_scalars` and `custom_sections` fields
- Updated `resolve_from_jfm()` to accept CLI overrides and merge them over frontmatter values

**Snapshot Updates:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to reflect the new `--set-field` option in both `create` and `write` help text

**Testing:**
- Unit tests for `parse_set_field`: bare string, numeric, bool, spaces in name, `=` in value, missing `=`, empty name
- Unit tests for `merge_set_field_overrides`: CLI wins on conflict, empty overrides preserves frontmatter
- Integration tests for `AtlassianClient::create_issue_with_custom_fields`: payload merging verified against mock server
- Integration tests for `AtlassianClient::create_issue` (shim): confirms no custom fields are sent
- Integration tests for `AtlassianClient::get_createmeta`: nested field parsing, empty projects fallback, API error (404) surfacing
- Integration tests for `run_create`: custom scalar triggers `createmeta` fetch and correct payload; no custom fields skips `createmeta` call entirely
- Unit tests for `resolve_from_jfm` CLI override precedence and ADF rejection of `--set-field`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for all new paths (parse, merge, client methods, CLI integration)
- [x] Integration tests use `wiremock` mock server to validate HTTP payloads precisely

**Manual Testing:**
- [x] Tested happy path scenarios (scalar string, number, bool custom field values)
- [x] Tested error/edge cases (`--set-field` with ADF format rejected, missing `=` rejected, empty name rejected)
- [x] Backward compatibility verified (`create_issue` shim sends identical payload as before)

### Test Commands
```bash
# Core test suite
cargo test

# Run atlassian-specific tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `create_issue` is now a shim over `create_issue_with_custom_fields`; confirm the shim passes an empty map cleanly
- [x] Error handling — `--set-field` with `--format adf` produces a clear error in both `create` and `write`
- [x] Performance impact — fast-path skips `createmeta` HTTP call when no custom fields are present
- [x] Backward compatibility — existing callers of `create_issue` are unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Potential performance impact (describe below)

When custom fields are used, `run_create` makes an additional `GET /rest/api/3/issue/createmeta` request before the `POST /rest/api/3/issue`. This is intentional and necessary for name-to-ID resolution. The fast-path optimization ensures this extra request is never made when no custom fields are requested, so existing workflows have zero performance impact.

## Security Considerations

- [x] No security implications

The `--set-field` values are parsed as YAML scalars and then serialized to JSON before being sent to the JIRA API. No shell interpolation or unsafe deserialization is performed. Values go through the same path as frontmatter custom fields.

## Breaking Changes

None. `create_issue` retains its existing signature and behavior; `create_issue_with_custom_fields` is a new additive method. All CLI flags are additive.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `--set-field` flag currently only supports scalar values (strings, numbers, bools). Structured values (e.g., option objects like `{"value": "Unplanned"}`) are resolved automatically via `createmeta` schema lookup. Future work could support JSON-valued `--set-field` arguments for advanced use cases.

**Known Limitations:**
- `--set-field` is not supported with `--format adf` in either `create` or `write`, as ADF input is a raw JSON payload with no merging semantics.

**Alternatives Considered:**
- Accepting JSON directly in `--set-field` was considered but would make simple cases (e.g., `--set-field "Priority=High"`) unnecessarily verbose. YAML scalar parsing provides a good balance between convenience and type fidelity.