### PR TITLE
feat(cli): add skills status command and YAML output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Claude Skills Status** ([#558](https://github.com/rust-works/omni-dev/issues/558)): New `ai claude skills status` subcommand reports the symlinks and managed exclude-block entries left behind by prior `sync` runs, with `--worktrees` to aggregate across every worktree and `--format {text,yaml}` for machine-readable output
+- **Claude Skills YAML Output** ([#558](https://github.com/rust-works/omni-dev/issues/558)): `ai claude skills sync` and `ai claude skills clean` now accept `--format {text,yaml}` (default `text`), producing a structured YAML report when invoked with `--format yaml`
+
+### Changed
+- **Claude Skills Exclude File Format** ([#558](https://github.com/rust-works/omni-dev/issues/558)): Entries in `.git/info/exclude` written by `sync` are now wrapped in a managed `# BEGIN omni-dev-skills (managed — do not edit)` / `# END omni-dev-skills` block so that `clean` can reverse the operation precisely. Clean break: bare `.claude/skills/*/` lines written by earlier builds are not recognised by the new `clean` and must be removed manually
+
 ## [0.22.0] - 2026-04-19
 
 ### Added

--- a/src/cli/ai/claude/skills/clean.rs
+++ b/src/cli/ai/claude/skills/clean.rs
@@ -1,17 +1,18 @@
-//! Clean command — removes symlinks previously created by `skills sync`.
+//! Clean command — removes symlinks and the managed exclude block created by `sync`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use serde::Serialize;
 
 use super::common::{
-    exclude_entry_for, exclude_file_for, list_worktrees, remove_exclude_entries, resolve_toplevel,
+    exclude_file_for, list_worktrees, remove_skills_block, resolve_toplevel, OutputFormat,
     SKILLS_SUBPATH,
 };
 
-/// Removes skill symlinks and associated exclude entries from one or more targets.
+/// Removes skill symlinks and the managed exclude block from one or more targets.
 #[derive(Parser)]
 pub struct CleanCommand {
     /// Target repository or worktree to clean. Defaults to the current working directory.
@@ -25,6 +26,10 @@ pub struct CleanCommand {
     /// Preview the changes without deleting symlinks or modifying the exclude file.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(super) format: OutputFormat,
 }
 
 impl CleanCommand {
@@ -44,19 +49,20 @@ impl CleanCommand {
         }
 
         let report = run_clean(&targets, self.dry_run)?;
-        print_report(&report, self.dry_run);
+        print_report(&report, self.dry_run, self.format)?;
         Ok(())
     }
 }
 
 /// Outcome of a clean run.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub(super) struct CleanReport {
     pub actions: Vec<CleanAction>,
 }
 
 /// Individual action produced by the clean operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub(super) enum CleanAction {
     Unlinked {
         link: PathBuf,
@@ -85,54 +91,21 @@ pub(super) fn run_clean(targets: &[PathBuf], dry_run: bool) -> Result<CleanRepor
 
 fn clean_target(target_root: &Path, dry_run: bool, report: &mut CleanReport) -> Result<()> {
     let skills_dir = target_root.join(SKILLS_SUBPATH);
-    if !skills_dir.exists() {
-        return Ok(());
+
+    if skills_dir.exists() {
+        remove_skill_symlinks(&skills_dir, dry_run, report)?;
     }
 
-    let mut removed_names = Vec::new();
-    let entries = fs::read_dir(&skills_dir)
-        .with_context(|| format!("Failed to read {}", skills_dir.display()))?;
-    for entry in entries {
-        let entry =
-            entry.with_context(|| format!("Failed to read entry in {}", skills_dir.display()))?;
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        let name = name.to_string();
-        let meta = fs::symlink_metadata(&path)
-            .with_context(|| format!("Failed to inspect {}", path.display()))?;
-        if meta.file_type().is_symlink() {
-            if !dry_run {
-                fs::remove_file(&path)
-                    .with_context(|| format!("Failed to remove symlink {}", path.display()))?;
-            }
-            report.actions.push(CleanAction::Unlinked { link: path });
-            removed_names.push(name);
-        } else {
-            let reason = if meta.is_dir() {
-                "real directory".to_string()
-            } else {
-                "real file".to_string()
-            };
-            report.actions.push(CleanAction::Preserved { path, reason });
-        }
+    let exclude_file = exclude_file_for(target_root)?;
+    let removed = remove_skills_block(&exclude_file, dry_run)?;
+    for entry in removed {
+        report.actions.push(CleanAction::ExcludeRemoved {
+            exclude_file: exclude_file.clone(),
+            entry,
+        });
     }
 
-    if !removed_names.is_empty() {
-        let exclude_file = exclude_file_for(target_root)?;
-        let entries_to_remove: Vec<String> =
-            removed_names.iter().map(|n| exclude_entry_for(n)).collect();
-        let removed = remove_exclude_entries(&exclude_file, &entries_to_remove, dry_run)?;
-        for entry in removed {
-            report.actions.push(CleanAction::ExcludeRemoved {
-                exclude_file: exclude_file.clone(),
-                entry,
-            });
-        }
-    }
-
-    if !dry_run && is_empty_dir(&skills_dir)? {
+    if !dry_run && skills_dir.exists() && is_empty_dir(&skills_dir)? {
         fs::remove_dir(&skills_dir)
             .with_context(|| format!("Failed to remove empty {}", skills_dir.display()))?;
         report
@@ -143,13 +116,68 @@ fn clean_target(target_root: &Path, dry_run: bool, report: &mut CleanReport) -> 
     Ok(())
 }
 
+fn remove_skill_symlinks(skills_dir: &Path, dry_run: bool, report: &mut CleanReport) -> Result<()> {
+    let entries = fs::read_dir(skills_dir)
+        .with_context(|| format!("Failed to read {}", skills_dir.display()))?;
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry in {}", skills_dir.display()))?;
+        let path = entry.path();
+        if path.file_name().and_then(|n| n.to_str()).is_none() {
+            continue;
+        }
+        let meta = fs::symlink_metadata(&path)
+            .with_context(|| format!("Failed to inspect {}", path.display()))?;
+        if meta.file_type().is_symlink() {
+            if !dry_run {
+                fs::remove_file(&path)
+                    .with_context(|| format!("Failed to remove symlink {}", path.display()))?;
+            }
+            report.actions.push(CleanAction::Unlinked { link: path });
+        } else {
+            let reason = if meta.is_dir() {
+                "real directory".to_string()
+            } else {
+                "real file".to_string()
+            };
+            report.actions.push(CleanAction::Preserved { path, reason });
+        }
+    }
+    Ok(())
+}
+
 fn is_empty_dir(dir: &Path) -> Result<bool> {
     let mut iter =
         fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?;
     Ok(iter.next().is_none())
 }
 
-fn print_report(report: &CleanReport, dry_run: bool) {
+#[derive(Serialize)]
+struct CleanOutput<'a> {
+    dry_run: bool,
+    actions: &'a [CleanAction],
+}
+
+fn print_report(report: &CleanReport, dry_run: bool, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Text => {
+            print_report_text(report, dry_run);
+            Ok(())
+        }
+        OutputFormat::Yaml => {
+            let output = CleanOutput {
+                dry_run,
+                actions: &report.actions,
+            };
+            let yaml = serde_yaml::to_string(&output)
+                .context("Failed to serialize clean report as YAML")?;
+            print!("{yaml}");
+            Ok(())
+        }
+    }
+}
+
+fn print_report_text(report: &CleanReport, dry_run: bool) {
     let prefix = if dry_run { "[dry-run] " } else { "" };
     for action in &report.actions {
         match action {
@@ -180,6 +208,8 @@ fn print_report(report: &CleanReport, dry_run: bool) {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    use super::super::common::{BLOCK_BEGIN, BLOCK_END};
 
     use tempfile::TempDir;
 
@@ -217,8 +247,20 @@ mod tests {
         }
     }
 
+    fn write_block(exclude: &Path, entries: &[&str]) {
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let mut content = format!("{BLOCK_BEGIN}\n");
+        for e in entries {
+            content.push_str(e);
+            content.push('\n');
+        }
+        content.push_str(BLOCK_END);
+        content.push('\n');
+        fs::write(exclude, content).unwrap();
+    }
+
     #[test]
-    fn run_clean_removes_symlinks_and_exclude_entries() {
+    fn run_clean_removes_symlinks_and_exclude_block() {
         let src_tmp = tempdir();
         let tgt_tmp = tempdir();
         make_source_skills(src_tmp.path(), &["alpha"]);
@@ -231,7 +273,8 @@ mod tests {
         )
         .unwrap();
         let exclude_path = tgt_tmp.path().join(".git/info/exclude");
-        fs::write(&exclude_path, "# comment\n.claude/skills/alpha/\n").unwrap();
+        let pre_content = format!("# comment\n{BLOCK_BEGIN}\n.claude/skills/alpha/\n{BLOCK_END}\n");
+        fs::write(&exclude_path, &pre_content).unwrap();
 
         let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
         let unlinks = report
@@ -249,8 +292,8 @@ mod tests {
         assert!(!target_skills_dir.join("alpha").exists());
         let content = fs::read_to_string(&exclude_path).unwrap();
         assert!(content.contains("# comment"));
+        assert!(!content.contains(BLOCK_BEGIN));
         assert!(!content.contains(".claude/skills/alpha/"));
-        // Directory should be removed since it was left empty.
         assert!(report
             .actions
             .iter()
@@ -272,7 +315,6 @@ mod tests {
             .iter()
             .any(|a| matches!(a, CleanAction::Preserved { .. })));
         assert!(target_skills_dir.join("keepme").join("SKILL.md").exists());
-        // Directory should NOT be removed because it still holds a real dir.
         assert!(target_skills_dir.exists());
     }
 
@@ -290,17 +332,34 @@ mod tests {
         )
         .unwrap();
         let exclude_path = tgt_tmp.path().join(".git/info/exclude");
-        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+        write_block(&exclude_path, &[".claude/skills/alpha/"]);
+        let pre_content = fs::read_to_string(&exclude_path).unwrap();
 
         let report = run_clean(&[tgt_tmp.path().to_path_buf()], true).unwrap();
         assert!(!report.actions.is_empty());
         assert!(target_skills_dir.join("alpha").exists());
         let content = fs::read_to_string(&exclude_path).unwrap();
-        assert!(content.contains(".claude/skills/alpha/"));
+        assert_eq!(content, pre_content);
     }
 
     #[test]
-    fn run_clean_missing_skills_dir_is_noop() {
+    fn run_clean_missing_skills_dir_still_removes_block() {
+        let tgt_tmp = tempdir();
+        init_repo(tgt_tmp.path());
+        let exclude_path = tgt_tmp.path().join(".git/info/exclude");
+        write_block(&exclude_path, &[".claude/skills/alpha/"]);
+
+        let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
+        assert!(report
+            .actions
+            .iter()
+            .any(|a| matches!(a, CleanAction::ExcludeRemoved { .. })));
+        let content = fs::read_to_string(&exclude_path).unwrap();
+        assert!(!content.contains(BLOCK_BEGIN));
+    }
+
+    #[test]
+    fn run_clean_no_residue_is_noop() {
         let tgt_tmp = tempdir();
         init_repo(tgt_tmp.path());
         let report = run_clean(&[tgt_tmp.path().to_path_buf()], false).unwrap();
@@ -309,7 +368,6 @@ mod tests {
 
     #[test]
     fn run_clean_preserves_real_file_reports_file_reason() {
-        // Exercises the `real file` branch of the preserved reason.
         let tgt_tmp = tempdir();
         init_repo(tgt_tmp.path());
         let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
@@ -342,18 +400,19 @@ mod tests {
         )
         .unwrap();
         let exclude_path = tgt_tmp.path().join(".git/info/exclude");
-        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+        write_block(&exclude_path, &[".claude/skills/alpha/"]);
 
         let cmd = CleanCommand {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
 
         assert!(!target_skills_dir.join("alpha").exists());
         let content = fs::read_to_string(&exclude_path).unwrap();
-        assert!(!content.contains(".claude/skills/alpha/"));
+        assert!(!content.contains(BLOCK_BEGIN));
     }
 
     #[test]
@@ -364,7 +423,6 @@ mod tests {
         init_repo(tgt_tmp.path());
         let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills_dir).unwrap();
-        // One symlink + one real file so both Unlinked and Preserved actions print.
         symlink(
             &src_tmp.path().join(SKILLS_SUBPATH).join("alpha"),
             &target_skills_dir.join("alpha"),
@@ -372,22 +430,21 @@ mod tests {
         .unwrap();
         fs::write(target_skills_dir.join("keep.txt"), "keep").unwrap();
         let exclude_path = tgt_tmp.path().join(".git/info/exclude");
-        fs::write(&exclude_path, ".claude/skills/alpha/\n").unwrap();
+        write_block(&exclude_path, &[".claude/skills/alpha/"]);
 
         let cmd = CleanCommand {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: true,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
-        // Dry-run: nothing changed.
         assert!(target_skills_dir.join("alpha").exists());
         assert!(target_skills_dir.join("keep.txt").exists());
     }
 
     #[test]
     fn execute_directory_removed_branch() {
-        // After removing the only symlink, DirectoryRemoved should print.
         let src_tmp = tempdir();
         let tgt_tmp = tempdir();
         make_source_skills(src_tmp.path(), &["alpha"]);
@@ -404,6 +461,7 @@ mod tests {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
         assert!(!target_skills_dir.exists());
@@ -457,7 +515,6 @@ mod tests {
 
         let result = run_clean(&[tgt.path().to_path_buf()], false);
 
-        // Restore writable perms so TempDir cleanup succeeds.
         let mut perms = fs::metadata(&target_skills_dir).unwrap().permissions();
         perms.set_mode(0o700);
         fs::set_permissions(&target_skills_dir, perms).unwrap();
@@ -469,8 +526,6 @@ mod tests {
         );
     }
 
-    // APFS rejects non-UTF-8 filenames, so this test is Linux-only. CI's
-    // tarpaulin job runs on Linux and exercises the to_str()-returns-None branch.
     #[cfg(target_os = "linux")]
     #[test]
     fn run_clean_skips_directory_with_non_utf8_name() {
@@ -484,7 +539,6 @@ mod tests {
         let bad = OsStr::from_bytes(b"bad\xffname");
         fs::create_dir_all(target_skills_dir.join(bad)).unwrap();
 
-        // Should not error and should not record an action for the bad entry.
         let report = run_clean(&[tgt.path().to_path_buf()], false).unwrap();
         assert!(
             report
@@ -514,7 +568,6 @@ mod tests {
             .unwrap();
         assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
 
-        // Pre-install symlinks in both worktrees by hand.
         for root in [tgt_main.path(), linked.as_path()] {
             let skills_dir = root.join(SKILLS_SUBPATH);
             fs::create_dir_all(&skills_dir).unwrap();
@@ -529,10 +582,89 @@ mod tests {
             target: Some(tgt_main.path().to_path_buf()),
             worktrees: true,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
 
         assert!(!tgt_main.path().join(SKILLS_SUBPATH).exists());
         assert!(!linked.join(SKILLS_SUBPATH).exists());
+    }
+
+    #[test]
+    fn execute_yaml_format_serializes_report() {
+        let src = tempdir();
+        let tgt = tempdir();
+        make_source_skills(src.path(), &["alpha"]);
+        init_repo(tgt.path());
+        let target_skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&target_skills_dir).unwrap();
+        symlink(
+            &src.path().join(SKILLS_SUBPATH).join("alpha"),
+            &target_skills_dir.join("alpha"),
+        )
+        .unwrap();
+
+        let cmd = CleanCommand {
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+            format: OutputFormat::Yaml,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn print_report_text_covers_all_action_variants_and_both_prefixes() {
+        let report = CleanReport {
+            actions: vec![
+                CleanAction::Unlinked {
+                    link: PathBuf::from("/a"),
+                },
+                CleanAction::Preserved {
+                    path: PathBuf::from("/b"),
+                    reason: "real file".to_string(),
+                },
+                CleanAction::ExcludeRemoved {
+                    exclude_file: PathBuf::from("/c/.git/info/exclude"),
+                    entry: ".claude/skills/x/".to_string(),
+                },
+                CleanAction::DirectoryRemoved {
+                    path: PathBuf::from("/d"),
+                },
+            ],
+        };
+        print_report_text(&report, false);
+        print_report_text(&report, true);
+    }
+
+    #[test]
+    fn print_report_yaml_serializes_all_action_variants() {
+        let report = CleanReport {
+            actions: vec![
+                CleanAction::Unlinked {
+                    link: PathBuf::from("/a"),
+                },
+                CleanAction::Preserved {
+                    path: PathBuf::from("/b"),
+                    reason: "real file".to_string(),
+                },
+                CleanAction::ExcludeRemoved {
+                    exclude_file: PathBuf::from("/c"),
+                    entry: ".claude/skills/x/".to_string(),
+                },
+                CleanAction::DirectoryRemoved {
+                    path: PathBuf::from("/d"),
+                },
+            ],
+        };
+        let output = CleanOutput {
+            dry_run: false,
+            actions: &report.actions,
+        };
+        let yaml = serde_yaml::to_string(&output).unwrap();
+        assert!(yaml.contains("type: unlinked"));
+        assert!(yaml.contains("type: preserved"));
+        assert!(yaml.contains("type: exclude_removed"));
+        assert!(yaml.contains("type: directory_removed"));
     }
 }

--- a/src/cli/ai/claude/skills/common.rs
+++ b/src/cli/ai/claude/skills/common.rs
@@ -1,16 +1,37 @@
-//! Shared helpers for skills sync and clean commands.
+//! Shared helpers for skills sync, clean, and status commands.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::Serialize;
 
 /// Skills directory name relative to a repository or worktree root.
 pub(super) const SKILLS_SUBPATH: &str = ".claude/skills";
 
 /// Prefix used for entries written to `.git/info/exclude`.
 pub(super) const EXCLUDE_PREFIX: &str = ".claude/skills/";
+
+/// Opening marker for the managed block inside `.git/info/exclude`. Changing
+/// this string would orphan blocks written by prior versions — forward
+/// compatibility commitment.
+pub(super) const BLOCK_BEGIN: &str = "# BEGIN omni-dev-skills (managed — do not edit)";
+
+/// Closing marker for the managed block inside `.git/info/exclude`.
+pub(super) const BLOCK_END: &str = "# END omni-dev-skills";
+
+/// Output format shared by `sync`, `clean`, and `status`.
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum OutputFormat {
+    /// Human-readable lines, one per action.
+    #[default]
+    Text,
+    /// Machine-readable YAML document.
+    Yaml,
+}
 
 /// Runs `git rev-parse --show-toplevel` from `path` and returns the absolute root.
 pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
@@ -121,94 +142,148 @@ pub(super) fn exclude_entry_for(skill_name: &str) -> String {
     format!("{EXCLUDE_PREFIX}{skill_name}/")
 }
 
-/// Appends missing entries to `exclude_file`, returning the list of added entries.
+/// Upserts the managed skills block inside `.git/info/exclude`.
 ///
-/// If `dry_run` is true the file is not modified but the would-be additions are
-/// still reported.
-pub(super) fn add_exclude_entries(
+/// Foreign lines outside the block are preserved verbatim. Hand-edits inside
+/// the block are not preserved — the block is rewritten with the union of its
+/// existing entries and `entries`. Returns the entries newly added.
+pub(super) fn upsert_skills_block(
     exclude_file: &Path,
     entries: &[String],
     dry_run: bool,
 ) -> Result<Vec<String>> {
-    let existing = read_exclude_lines(exclude_file)?;
-    let mut additions = Vec::new();
+    let content = read_existing_content(exclude_file)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let block = find_block(&lines);
+
+    let existing: Vec<String> = match &block {
+        Some(b) => lines[b.begin + 1..b.end]
+            .iter()
+            .filter(|l| **l != BLOCK_BEGIN && **l != BLOCK_END)
+            .map(|&s| s.to_string())
+            .collect(),
+        None => Vec::new(),
+    };
+
+    let mut additions: Vec<String> = Vec::new();
     for entry in entries {
-        if !existing.iter().any(|line| line == entry) {
+        if !existing.iter().any(|e| e == entry) && !additions.iter().any(|e| e == entry) {
             additions.push(entry.clone());
         }
     }
+
     if additions.is_empty() || dry_run {
         return Ok(additions);
     }
+
+    let mut out_lines: Vec<String> = Vec::new();
+    if let Some(b) = block {
+        out_lines.extend(lines[..b.begin].iter().map(|&s| s.to_string()));
+        out_lines.push(BLOCK_BEGIN.to_string());
+        out_lines.extend(existing.iter().cloned());
+        out_lines.extend(additions.iter().cloned());
+        out_lines.push(BLOCK_END.to_string());
+        out_lines.extend(lines[b.end + 1..].iter().map(|&s| s.to_string()));
+    } else {
+        out_lines.extend(lines.iter().map(|&s| s.to_string()));
+        out_lines.push(BLOCK_BEGIN.to_string());
+        out_lines.extend(additions.iter().cloned());
+        out_lines.push(BLOCK_END.to_string());
+    }
+
+    write_exclude_file(exclude_file, &out_lines)?;
+    Ok(additions)
+}
+
+/// Removes the managed skills block from `.git/info/exclude` entirely.
+///
+/// Returns every line that was inside the block. Foreign lines outside the
+/// block are preserved. No-op (returning empty) if the file or block is absent.
+pub(super) fn remove_skills_block(exclude_file: &Path, dry_run: bool) -> Result<Vec<String>> {
+    if !exclude_file.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(exclude_file)
+        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
+    let lines: Vec<&str> = content.lines().collect();
+    let Some(block) = find_block(&lines) else {
+        return Ok(Vec::new());
+    };
+    let removed: Vec<String> = lines[block.begin + 1..block.end]
+        .iter()
+        .map(|&s| s.to_string())
+        .collect();
+
+    if dry_run {
+        return Ok(removed);
+    }
+
+    let mut out_lines: Vec<String> = Vec::new();
+    out_lines.extend(lines[..block.begin].iter().map(|&s| s.to_string()));
+    out_lines.extend(lines[block.end + 1..].iter().map(|&s| s.to_string()));
+
+    write_exclude_file(exclude_file, &out_lines)?;
+    Ok(removed)
+}
+
+/// Reads the entries currently inside the managed skills block, if any.
+pub(super) fn read_skills_block_entries(exclude_file: &Path) -> Result<Vec<String>> {
+    if !exclude_file.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(exclude_file)
+        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
+    let lines: Vec<&str> = content.lines().collect();
+    let Some(block) = find_block(&lines) else {
+        return Ok(Vec::new());
+    };
+    Ok(lines[block.begin + 1..block.end]
+        .iter()
+        .map(|&s| s.to_string())
+        .collect())
+}
+
+struct BlockBounds {
+    begin: usize,
+    end: usize,
+}
+
+fn find_block(lines: &[&str]) -> Option<BlockBounds> {
+    let begin = lines.iter().position(|l| *l == BLOCK_BEGIN)?;
+    let end_offset = lines[begin + 1..].iter().position(|l| *l == BLOCK_END)?;
+    Some(BlockBounds {
+        begin,
+        end: begin + 1 + end_offset,
+    })
+}
+
+fn read_existing_content(exclude_file: &Path) -> Result<String> {
+    if exclude_file.exists() {
+        fs::read_to_string(exclude_file)
+            .with_context(|| format!("Failed to read {}", exclude_file.display()))
+    } else {
+        Ok(String::new())
+    }
+}
+
+fn write_exclude_file(exclude_file: &Path, lines: &[String]) -> Result<()> {
     if let Some(parent) = exclude_file.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create {}", parent.display()))?;
     }
-    let mut content = if exclude_file.exists() {
-        fs::read_to_string(exclude_file)
-            .with_context(|| format!("Failed to read {}", exclude_file.display()))?
-    } else {
+    let output = if lines.is_empty() {
         String::new()
+    } else {
+        let mut s = lines.join("\n");
+        s.push('\n');
+        s
     };
-    if !content.is_empty() && !content.ends_with('\n') {
-        content.push('\n');
-    }
-    for entry in &additions {
-        content.push_str(entry);
-        content.push('\n');
-    }
-    fs::write(exclude_file, content)
-        .with_context(|| format!("Failed to write {}", exclude_file.display()))?;
-    Ok(additions)
-}
-
-/// Removes matching entries from `exclude_file`, returning the list removed.
-///
-/// Entries are matched by exact line content. If `dry_run` is true the file is
-/// not modified.
-pub(super) fn remove_exclude_entries(
-    exclude_file: &Path,
-    entries: &[String],
-    dry_run: bool,
-) -> Result<Vec<String>> {
-    if !exclude_file.exists() {
-        return Ok(Vec::new());
-    }
-    let content = fs::read_to_string(exclude_file)
-        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
-    let trailing_newline = content.ends_with('\n');
-    let mut removed = Vec::new();
-    let mut kept = Vec::new();
-    for line in content.lines() {
-        if entries.iter().any(|e| e == line) {
-            removed.push(line.to_string());
-        } else {
-            kept.push(line.to_string());
-        }
-    }
-    if removed.is_empty() || dry_run {
-        return Ok(removed);
-    }
-    let mut new_content = kept.join("\n");
-    if trailing_newline && !new_content.is_empty() {
-        new_content.push('\n');
-    }
-    fs::write(exclude_file, new_content)
-        .with_context(|| format!("Failed to write {}", exclude_file.display()))?;
-    Ok(removed)
+    fs::write(exclude_file, output)
+        .with_context(|| format!("Failed to write {}", exclude_file.display()))
 }
 
 fn ctx_spawn_failure(command: &str, path: &Path) -> String {
     format!("Failed to run {command} in {}", path.display())
-}
-
-fn read_exclude_lines(exclude_file: &Path) -> Result<Vec<String>> {
-    if !exclude_file.exists() {
-        return Ok(Vec::new());
-    }
-    let content = fs::read_to_string(exclude_file)
-        .with_context(|| format!("Failed to read {}", exclude_file.display()))?;
-    Ok(content.lines().map(ToString::to_string).collect())
 }
 
 #[cfg(test)]
@@ -264,8 +339,6 @@ mod tests {
     fn resolve_toplevel_returns_repo_root() {
         let dir = tempdir();
         init_repo(dir.path());
-        // Canonicalize because macOS /var -> /private/var, while `git init` returns
-        // the canonical form.
         let expected = fs::canonicalize(dir.path()).unwrap();
         let result = resolve_toplevel(dir.path()).unwrap();
         assert_eq!(fs::canonicalize(result).unwrap(), expected);
@@ -284,8 +357,6 @@ mod tests {
 
     #[test]
     fn resolve_toplevel_outside_repo_fails() {
-        // Use the system temp dir (not the in-repo `tmp/`) so git cannot find a
-        // parent repository from this path.
         let dir = TempDir::new().unwrap();
         let err = resolve_toplevel(dir.path()).unwrap_err().to_string();
         assert!(
@@ -299,9 +370,7 @@ mod tests {
         let dir = tempdir();
         init_repo(dir.path());
         let common = resolve_git_common_dir(dir.path()).unwrap();
-        // Path should end in `.git` and point into the repo.
         assert!(common.ends_with(".git"), "got {}", common.display());
-        assert!(common.join("info").exists() || !common.join("info").exists());
     }
 
     #[test]
@@ -319,7 +388,6 @@ mod tests {
         assert!(status.status.success(), "git worktree add: {status:?}");
 
         let common = resolve_git_common_dir(&linked).unwrap();
-        // The common dir of the linked worktree should be the main repo's `.git`.
         let main_git = fs::canonicalize(main.path().join(".git")).unwrap();
         assert_eq!(fs::canonicalize(&common).unwrap(), main_git);
     }
@@ -374,8 +442,6 @@ mod tests {
         );
     }
 
-    // APFS rejects non-UTF-8 filenames, so this test is Linux-only. CI's
-    // tarpaulin job runs on Linux and exercises the to_str()-returns-None branch.
     #[cfg(target_os = "linux")]
     #[test]
     fn enumerate_skills_skips_directory_with_non_utf8_name() {
@@ -385,9 +451,7 @@ mod tests {
         let dir = tempdir();
         let skills = dir.path().join("skills");
         fs::create_dir_all(&skills).unwrap();
-        // Valid UTF-8 entry that should be returned.
         fs::create_dir_all(skills.join("alpha")).unwrap();
-        // Invalid UTF-8 byte sequence — exercises the `to_str()` None branch.
         let bad = OsStr::from_bytes(b"bad\xffname");
         fs::create_dir_all(skills.join(bad)).unwrap();
 
@@ -449,7 +513,6 @@ mod tests {
         fs::create_dir_all(skills_dir.join("charlie")).unwrap();
         fs::create_dir_all(skills_dir.join("alpha")).unwrap();
         fs::create_dir_all(skills_dir.join("bravo")).unwrap();
-        // A stray file should be ignored.
         fs::write(skills_dir.join("README.md"), "hi").unwrap();
         let result = enumerate_skills(&skills_dir).unwrap();
         let names: Vec<_> = result.iter().map(|(n, _)| n.clone()).collect();
@@ -457,59 +520,298 @@ mod tests {
     }
 
     #[test]
-    fn add_exclude_entries_creates_file_and_appends() {
+    fn upsert_skills_block_creates_block_when_absent() {
         let dir = tempdir();
         let exclude = dir.path().join("info").join("exclude");
-        let added = add_exclude_entries(
+        let added = upsert_skills_block(
             &exclude,
             &[exclude_entry_for("review"), exclude_entry_for("init")],
             false,
         )
         .unwrap();
-        assert_eq!(added.len(), 2);
+        assert_eq!(
+            added,
+            vec![
+                ".claude/skills/review/".to_string(),
+                ".claude/skills/init/".to_string()
+            ]
+        );
         let content = fs::read_to_string(&exclude).unwrap();
-        assert!(content.contains(".claude/skills/review/"));
-        assert!(content.contains(".claude/skills/init/"));
+        let expected =
+            format!("{BLOCK_BEGIN}\n.claude/skills/review/\n.claude/skills/init/\n{BLOCK_END}\n");
+        assert_eq!(content, expected);
     }
 
     #[test]
-    fn add_exclude_entries_does_not_duplicate() {
+    fn upsert_skills_block_appends_to_existing_block() {
         let dir = tempdir();
         let exclude = dir.path().join("info").join("exclude");
-        let first = add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
-        assert_eq!(first, vec![".claude/skills/review/".to_string()]);
-        let second = add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
-        assert!(second.is_empty());
+        upsert_skills_block(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let added = upsert_skills_block(&exclude, &[exclude_entry_for("init")], false).unwrap();
+        assert_eq!(added, vec![".claude/skills/init/".to_string()]);
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.contains(".claude/skills/review/"));
+        assert!(content.contains(".claude/skills/init/"));
+        assert_eq!(content.matches(BLOCK_BEGIN).count(), 1);
+        assert_eq!(content.matches(BLOCK_END).count(), 1);
+    }
+
+    #[test]
+    fn upsert_skills_block_does_not_duplicate() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        upsert_skills_block(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let added = upsert_skills_block(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        assert!(added.is_empty());
         let content = fs::read_to_string(&exclude).unwrap();
         assert_eq!(content.matches(".claude/skills/review/").count(), 1);
     }
 
     #[test]
-    fn add_exclude_entries_dry_run_does_not_write() {
+    fn upsert_skills_block_dry_run_does_not_write() {
         let dir = tempdir();
         let exclude = dir.path().join("info").join("exclude");
-        let added = add_exclude_entries(&exclude, &[exclude_entry_for("review")], true).unwrap();
-        assert_eq!(added.len(), 1);
+        let added = upsert_skills_block(&exclude, &[exclude_entry_for("review")], true).unwrap();
+        assert_eq!(added, vec![".claude/skills/review/".to_string()]);
         assert!(!exclude.exists());
     }
 
     #[test]
-    fn add_exclude_entries_preserves_existing_content() {
+    fn upsert_skills_block_preserves_foreign_lines_before_and_after() {
         let dir = tempdir();
         let exclude = dir.path().join("info").join("exclude");
         fs::create_dir_all(exclude.parent().unwrap()).unwrap();
-        fs::write(&exclude, "# comments\n*.tmp\n").unwrap();
-        add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let original = format!(
+            "# user comment\n*.tmp\n{BLOCK_BEGIN}\n.claude/skills/review/\n{BLOCK_END}\n*.log\n"
+        );
+        fs::write(&exclude, &original).unwrap();
+        upsert_skills_block(&exclude, &[exclude_entry_for("init")], false).unwrap();
         let content = fs::read_to_string(&exclude).unwrap();
-        assert!(content.contains("# comments"));
-        assert!(content.contains("*.tmp"));
+        assert!(content.starts_with("# user comment\n*.tmp\n"));
+        assert!(content.ends_with("*.log\n"));
         assert!(content.contains(".claude/skills/review/"));
+        assert!(content.contains(".claude/skills/init/"));
+    }
+
+    #[test]
+    fn upsert_skills_block_returns_empty_when_input_empty() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let added = upsert_skills_block(&exclude, &[], false).unwrap();
+        assert!(added.is_empty());
+        assert!(!exclude.exists());
+    }
+
+    #[test]
+    fn upsert_skills_block_dedupes_within_input() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let added = upsert_skills_block(
+            &exclude,
+            &[exclude_entry_for("review"), exclude_entry_for("review")],
+            false,
+        )
+        .unwrap();
+        assert_eq!(added.len(), 1);
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(content.matches(".claude/skills/review/").count(), 1);
+    }
+
+    #[test]
+    fn upsert_skills_block_appends_after_foreign_lines_in_new_file() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, "*.log\n").unwrap();
+        upsert_skills_block(&exclude, &[exclude_entry_for("review")], false).unwrap();
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert!(content.starts_with("*.log\n"));
+        assert!(content.contains(BLOCK_BEGIN));
+        assert!(content.ends_with(&format!("{BLOCK_END}\n")));
+    }
+
+    #[test]
+    fn upsert_skills_block_propagates_create_dir_all_failure() {
+        let dir = tempdir();
+        let parent_path = dir.path().join("info");
+        fs::write(&parent_path, "block").unwrap();
+        let exclude = parent_path.join("exclude");
+        let err = upsert_skills_block(&exclude, &[exclude_entry_for("a")], false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Failed to create"), "unexpected error: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upsert_skills_block_propagates_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir();
+        let info = dir.path().join("info");
+        fs::create_dir_all(&info).unwrap();
+        let exclude = info.join("exclude");
+        let mut perms = fs::metadata(&info).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&info, perms).unwrap();
+
+        let result = upsert_skills_block(&exclude, &[exclude_entry_for("a")], false);
+
+        let mut perms = fs::metadata(&info).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&info, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to write"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn remove_skills_block_removes_block_and_reports_entries() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let content = format!(
+            "# comment\n*.tmp\n{BLOCK_BEGIN}\n.claude/skills/review/\n.claude/skills/init/\n{BLOCK_END}\n"
+        );
+        fs::write(&exclude, &content).unwrap();
+
+        let removed = remove_skills_block(&exclude, false).unwrap();
+        assert_eq!(
+            removed,
+            vec![
+                ".claude/skills/review/".to_string(),
+                ".claude/skills/init/".to_string()
+            ]
+        );
+        let new_content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(new_content, "# comment\n*.tmp\n");
+    }
+
+    #[test]
+    fn remove_skills_block_missing_file_is_noop() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let removed = remove_skills_block(&exclude, false).unwrap();
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn remove_skills_block_missing_block_is_noop() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, "# comment\n*.tmp\n").unwrap();
+        let removed = remove_skills_block(&exclude, false).unwrap();
+        assert!(removed.is_empty());
+        let content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(content, "# comment\n*.tmp\n");
+    }
+
+    #[test]
+    fn remove_skills_block_dry_run_does_not_modify() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let content = format!("{BLOCK_BEGIN}\n.claude/skills/review/\n{BLOCK_END}\n");
+        fs::write(&exclude, &content).unwrap();
+        let removed = remove_skills_block(&exclude, true).unwrap();
+        assert_eq!(removed, vec![".claude/skills/review/".to_string()]);
+        assert_eq!(fs::read_to_string(&exclude).unwrap(), content);
+    }
+
+    #[test]
+    fn remove_skills_block_empties_file_when_only_block_present() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let content = format!("{BLOCK_BEGIN}\n.claude/skills/review/\n{BLOCK_END}\n");
+        fs::write(&exclude, &content).unwrap();
+        remove_skills_block(&exclude, false).unwrap();
+        let new_content = fs::read_to_string(&exclude).unwrap();
+        assert_eq!(new_content, "");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_skills_block_propagates_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir();
+        let info = dir.path().join("info");
+        fs::create_dir_all(&info).unwrap();
+        let exclude = info.join("exclude");
+        fs::write(
+            &exclude,
+            format!("{BLOCK_BEGIN}\n.claude/skills/a/\n{BLOCK_END}\n"),
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&exclude).unwrap().permissions();
+        perms.set_mode(0o400);
+        fs::set_permissions(&exclude, perms).unwrap();
+
+        let result = remove_skills_block(&exclude, false);
+
+        let mut perms = fs::metadata(&exclude).unwrap().permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(&exclude, perms).unwrap();
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Failed to write"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn read_skills_block_entries_returns_entries() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let content = format!(
+            "# comment\n{BLOCK_BEGIN}\n.claude/skills/alpha/\n.claude/skills/bravo/\n{BLOCK_END}\n"
+        );
+        fs::write(&exclude, content).unwrap();
+        let entries = read_skills_block_entries(&exclude).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                ".claude/skills/alpha/".to_string(),
+                ".claude/skills/bravo/".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn read_skills_block_entries_missing_file_returns_empty() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        let entries = read_skills_block_entries(&exclude).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn read_skills_block_entries_missing_block_returns_empty() {
+        let dir = tempdir();
+        let exclude = dir.path().join("info").join("exclude");
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        fs::write(&exclude, "*.log\n").unwrap();
+        let entries = read_skills_block_entries(&exclude).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn find_block_requires_both_markers() {
+        let only_begin = vec![BLOCK_BEGIN, ".claude/skills/a/"];
+        assert!(find_block(&only_begin).is_none());
+        let only_end = vec!["foo", BLOCK_END];
+        assert!(find_block(&only_end).is_none());
+    }
+
+    #[test]
+    fn find_block_returns_none_for_reversed_markers() {
+        let reversed = vec![BLOCK_END, "middle", BLOCK_BEGIN];
+        assert!(find_block(&reversed).is_none());
     }
 
     #[test]
     fn resolve_toplevel_propagates_spawn_failure() {
-        // current_dir() pointing at a non-existent path causes Command::spawn
-        // itself to fail (chdir-before-exec), exercising the with_context arm.
         let err = resolve_toplevel(Path::new("/this/path/should/not/exist/skills_test_spawn"))
             .unwrap_err()
             .to_string();
@@ -529,127 +831,5 @@ mod tests {
             err.contains("Failed to run git rev-parse --git-common-dir"),
             "unexpected error: {err}"
         );
-    }
-
-    #[test]
-    fn add_exclude_entries_propagates_create_dir_all_failure() {
-        // Place a regular file where the exclude file's parent should be — so
-        // create_dir_all on the parent path fails.
-        let dir = tempdir();
-        let parent_path = dir.path().join("info");
-        fs::write(&parent_path, "block").unwrap();
-        let exclude = parent_path.join("exclude");
-
-        let err = add_exclude_entries(&exclude, &[exclude_entry_for("a")], false)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("Failed to create"), "unexpected error: {err}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn add_exclude_entries_propagates_write_failure() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempdir();
-        let info = dir.path().join("info");
-        fs::create_dir_all(&info).unwrap();
-        let exclude = info.join("exclude");
-        // Read-only parent — fs::write fails with EACCES.
-        let mut perms = fs::metadata(&info).unwrap().permissions();
-        perms.set_mode(0o500);
-        fs::set_permissions(&info, perms).unwrap();
-
-        let result = add_exclude_entries(&exclude, &[exclude_entry_for("a")], false);
-
-        let mut perms = fs::metadata(&info).unwrap().permissions();
-        perms.set_mode(0o700);
-        fs::set_permissions(&info, perms).unwrap();
-
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("Failed to write"), "unexpected error: {err}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn remove_exclude_entries_propagates_write_failure() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempdir();
-        let info = dir.path().join("info");
-        fs::create_dir_all(&info).unwrap();
-        let exclude = info.join("exclude");
-        fs::write(&exclude, ".claude/skills/a/\n").unwrap();
-        // Make the file itself read-only so fs::write to overwrite it fails.
-        let mut perms = fs::metadata(&exclude).unwrap().permissions();
-        perms.set_mode(0o400);
-        fs::set_permissions(&exclude, perms).unwrap();
-
-        let result = remove_exclude_entries(&exclude, &[exclude_entry_for("a")], false);
-
-        let mut perms = fs::metadata(&exclude).unwrap().permissions();
-        perms.set_mode(0o600);
-        fs::set_permissions(&exclude, perms).unwrap();
-
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("Failed to write"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn add_exclude_entries_appends_newline_when_existing_lacks_one() {
-        // Existing content has no trailing newline — exercises the
-        // `content.push('\n')` branch.
-        let dir = tempdir();
-        let exclude = dir.path().join("info").join("exclude");
-        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
-        fs::write(&exclude, "*.log").unwrap();
-        add_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
-        let content = fs::read_to_string(&exclude).unwrap();
-        assert_eq!(content, "*.log\n.claude/skills/review/\n");
-    }
-
-    #[test]
-    fn remove_exclude_entries_removes_matching_lines() {
-        let dir = tempdir();
-        let exclude = dir.path().join("info").join("exclude");
-        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
-        fs::write(
-            &exclude,
-            "# comments\n*.tmp\n.claude/skills/review/\n.claude/skills/init/\n",
-        )
-        .unwrap();
-        let removed = remove_exclude_entries(
-            &exclude,
-            &[exclude_entry_for("review"), exclude_entry_for("init")],
-            false,
-        )
-        .unwrap();
-        assert_eq!(removed.len(), 2);
-        let content = fs::read_to_string(&exclude).unwrap();
-        assert!(content.contains("# comments"));
-        assert!(content.contains("*.tmp"));
-        assert!(!content.contains(".claude/skills/"));
-    }
-
-    #[test]
-    fn remove_exclude_entries_missing_file_is_noop() {
-        let dir = tempdir();
-        let exclude = dir.path().join("info").join("exclude");
-        let removed =
-            remove_exclude_entries(&exclude, &[exclude_entry_for("review")], false).unwrap();
-        assert!(removed.is_empty());
-    }
-
-    #[test]
-    fn remove_exclude_entries_dry_run_does_not_modify() {
-        let dir = tempdir();
-        let exclude = dir.path().join("info").join("exclude");
-        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
-        fs::write(&exclude, ".claude/skills/review/\n").unwrap();
-        let removed =
-            remove_exclude_entries(&exclude, &[exclude_entry_for("review")], true).unwrap();
-        assert_eq!(removed.len(), 1);
-        let content = fs::read_to_string(&exclude).unwrap();
-        assert!(content.contains(".claude/skills/review/"));
     }
 }

--- a/src/cli/ai/claude/skills/mod.rs
+++ b/src/cli/ai/claude/skills/mod.rs
@@ -2,6 +2,7 @@
 
 mod clean;
 mod common;
+mod status;
 mod sync;
 
 use anyhow::Result;
@@ -20,8 +21,10 @@ pub struct SkillsCommand {
 pub enum SkillsSubcommands {
     /// Syncs skills from a source repository into one or more targets.
     Sync(sync::SyncCommand),
-    /// Removes skill symlinks previously created by `sync`.
+    /// Removes skill symlinks and managed exclude block previously created by `sync`.
     Clean(clean::CleanCommand),
+    /// Reports residue left by `sync` — symlinks and managed exclude-block entries.
+    Status(status::StatusCommand),
 }
 
 impl SkillsCommand {
@@ -30,6 +33,7 @@ impl SkillsCommand {
         match self.command {
             SkillsSubcommands::Sync(cmd) => cmd.execute(),
             SkillsSubcommands::Clean(cmd) => cmd.execute(),
+            SkillsSubcommands::Status(cmd) => cmd.execute(),
         }
     }
 }
@@ -44,6 +48,8 @@ mod tests {
     use std::process::Command;
 
     use tempfile::TempDir;
+
+    use common::OutputFormat;
 
     fn tempdir() -> TempDir {
         fs::create_dir_all("tmp").ok();
@@ -71,6 +77,7 @@ mod tests {
                 target: Some(tgt.path().to_path_buf()),
                 worktrees: false,
                 dry_run: false,
+                format: OutputFormat::Text,
             }),
         };
         cmd.execute().unwrap();
@@ -87,6 +94,22 @@ mod tests {
                 target: Some(tgt.path().to_path_buf()),
                 worktrees: false,
                 dry_run: false,
+                format: OutputFormat::Text,
+            }),
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn dispatch_status() {
+        let tgt = tempdir();
+        init_repo(tgt.path());
+
+        let cmd = SkillsCommand {
+            command: SkillsSubcommands::Status(status::StatusCommand {
+                target: Some(tgt.path().to_path_buf()),
+                worktrees: false,
+                format: OutputFormat::Text,
             }),
         };
         cmd.execute().unwrap();

--- a/src/cli/ai/claude/skills/status.rs
+++ b/src/cli/ai/claude/skills/status.rs
@@ -1,0 +1,482 @@
+//! Status command — reports skill symlinks and managed exclude-block residue.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Serialize;
+
+use super::common::{
+    exclude_file_for, list_worktrees, read_skills_block_entries, resolve_toplevel, OutputFormat,
+    SKILLS_SUBPATH,
+};
+
+/// Reports what `sync` has left behind in the current target (and optionally all worktrees).
+#[derive(Parser)]
+pub struct StatusCommand {
+    /// Target repository or worktree to inspect. Defaults to the current working directory.
+    #[arg(long, value_name = "PATH")]
+    pub target: Option<PathBuf>,
+
+    /// Also inspect every worktree belonging to the target repository.
+    #[arg(long)]
+    pub worktrees: bool,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(super) format: OutputFormat,
+}
+
+impl StatusCommand {
+    /// Executes the status command.
+    pub fn execute(self) -> Result<()> {
+        let cwd = std::env::current_dir().context("Failed to determine current directory")?;
+        let target_seed = self.target.clone().unwrap_or(cwd);
+        let target_root = resolve_toplevel(&target_seed)?;
+
+        let mut targets = vec![target_root.clone()];
+        if self.worktrees {
+            for wt in list_worktrees(&target_root)? {
+                if !targets.iter().any(|t| t == &wt) {
+                    targets.push(wt);
+                }
+            }
+        }
+
+        let report = run_status(&targets)?;
+        print_report(&report, self.format)?;
+        Ok(())
+    }
+}
+
+/// Outcome of a status run across one or more target roots.
+#[derive(Debug, Default, Serialize)]
+pub(super) struct StatusReport {
+    pub targets: Vec<TargetStatus>,
+}
+
+impl StatusReport {
+    fn is_empty(&self) -> bool {
+        self.targets
+            .iter()
+            .all(|t| t.symlinks.is_empty() && t.exclude_entries.is_empty())
+    }
+}
+
+/// Residue found inside a single target root.
+#[derive(Debug, Serialize)]
+pub(super) struct TargetStatus {
+    pub root: PathBuf,
+    pub symlinks: Vec<SymlinkInfo>,
+    pub exclude_file: PathBuf,
+    pub exclude_entries: Vec<String>,
+}
+
+/// A single symlink inside a target's `.claude/skills/` directory.
+#[derive(Debug, Serialize)]
+pub(super) struct SymlinkInfo {
+    pub path: PathBuf,
+    pub points_to: PathBuf,
+}
+
+/// Inspects every supplied target and collects any residue from prior syncs.
+pub(super) fn run_status(targets: &[PathBuf]) -> Result<StatusReport> {
+    let mut report = StatusReport::default();
+    for target_root in targets {
+        report.targets.push(collect_target_status(target_root)?);
+    }
+    Ok(report)
+}
+
+fn collect_target_status(target_root: &Path) -> Result<TargetStatus> {
+    let skills_dir = target_root.join(SKILLS_SUBPATH);
+    let symlinks = if skills_dir.exists() {
+        collect_symlinks(&skills_dir)?
+    } else {
+        Vec::new()
+    };
+    let exclude_file = exclude_file_for(target_root)?;
+    let exclude_entries = read_skills_block_entries(&exclude_file)?;
+    Ok(TargetStatus {
+        root: target_root.to_path_buf(),
+        symlinks,
+        exclude_file,
+        exclude_entries,
+    })
+}
+
+fn collect_symlinks(skills_dir: &Path) -> Result<Vec<SymlinkInfo>> {
+    let mut out = Vec::new();
+    let entries = fs::read_dir(skills_dir)
+        .with_context(|| format!("Failed to read {}", skills_dir.display()))?;
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry in {}", skills_dir.display()))?;
+        let path = entry.path();
+        let meta = fs::symlink_metadata(&path)
+            .with_context(|| format!("Failed to inspect {}", path.display()))?;
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let points_to = fs::read_link(&path)
+            .with_context(|| format!("Failed to read link {}", path.display()))?;
+        out.push(SymlinkInfo { path, points_to });
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+#[derive(Serialize)]
+struct StatusOutput<'a> {
+    targets: &'a [TargetStatus],
+}
+
+fn print_report(report: &StatusReport, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Text => {
+            if report.is_empty() {
+                return Ok(());
+            }
+            print_report_text(report);
+            Ok(())
+        }
+        OutputFormat::Yaml => {
+            let output = StatusOutput {
+                targets: &report.targets,
+            };
+            let yaml = serde_yaml::to_string(&output)
+                .context("Failed to serialize status report as YAML")?;
+            print!("{yaml}");
+            Ok(())
+        }
+    }
+}
+
+fn print_report_text(report: &StatusReport) {
+    let mut first = true;
+    for target in &report.targets {
+        if target.symlinks.is_empty() && target.exclude_entries.is_empty() {
+            continue;
+        }
+        if !first {
+            println!();
+        }
+        first = false;
+        println!("{}", target.root.display());
+        if !target.symlinks.is_empty() {
+            println!("  symlinks:");
+            for link in &target.symlinks {
+                println!(
+                    "    {} -> {}",
+                    link.path.display(),
+                    link.points_to.display()
+                );
+            }
+        }
+        if !target.exclude_entries.is_empty() {
+            println!("  exclude block ({}):", target.exclude_file.display());
+            for entry in &target.exclude_entries {
+                println!("    {entry}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use super::super::common::{BLOCK_BEGIN, BLOCK_END};
+
+    use tempfile::TempDir;
+
+    fn tempdir() -> TempDir {
+        std::fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(dir)
+            .output()
+            .expect("git init failed to spawn");
+        assert!(status.status.success(), "git init failed: {status:?}");
+    }
+
+    fn init_repo_with_commit(dir: &Path) {
+        init_repo(dir);
+        fs::write(dir.join("README.md"), "readme").unwrap();
+        let add = std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=x@x",
+                "-c",
+                "user.name=x",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(commit.status.success());
+    }
+
+    #[cfg(unix)]
+    fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
+    fn write_block(exclude: &Path, entries: &[&str]) {
+        fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        let mut content = format!("{BLOCK_BEGIN}\n");
+        for e in entries {
+            content.push_str(e);
+            content.push('\n');
+        }
+        content.push_str(BLOCK_END);
+        content.push('\n');
+        fs::write(exclude, content).unwrap();
+    }
+
+    #[test]
+    fn run_status_reports_symlinks_and_block_entries() {
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let source_skill = src.path().join("alpha");
+        fs::create_dir_all(&source_skill).unwrap();
+        let skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills_dir).unwrap();
+        symlink(&source_skill, &skills_dir.join("alpha")).unwrap();
+        write_block(
+            &tgt.path().join(".git/info/exclude"),
+            &[".claude/skills/alpha/"],
+        );
+
+        let report = run_status(&[tgt.path().to_path_buf()]).unwrap();
+        assert_eq!(report.targets.len(), 1);
+        let t = &report.targets[0];
+        assert_eq!(t.symlinks.len(), 1);
+        assert_eq!(t.symlinks[0].path, skills_dir.join("alpha"));
+        assert_eq!(t.symlinks[0].points_to, source_skill);
+        assert_eq!(t.exclude_entries, vec![".claude/skills/alpha/".to_string()]);
+    }
+
+    #[test]
+    fn run_status_empty_repo_is_empty() {
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let report = run_status(&[tgt.path().to_path_buf()]).unwrap();
+        assert!(report.is_empty());
+        assert_eq!(report.targets.len(), 1);
+        assert!(report.targets[0].symlinks.is_empty());
+        assert!(report.targets[0].exclude_entries.is_empty());
+    }
+
+    #[test]
+    fn run_status_skips_real_files_in_skills_dir() {
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(skills_dir.join("README.md"), "hi").unwrap();
+        fs::create_dir_all(skills_dir.join("real-skill")).unwrap();
+
+        let report = run_status(&[tgt.path().to_path_buf()]).unwrap();
+        assert!(report.targets[0].symlinks.is_empty());
+    }
+
+    #[test]
+    fn execute_target_defaults_to_cwd_is_quiet_on_clean_repo() {
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let cmd = StatusCommand {
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            format: OutputFormat::Text,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn execute_text_output_prints_residue() {
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let source_skill = src.path().join("alpha");
+        fs::create_dir_all(&source_skill).unwrap();
+        let skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills_dir).unwrap();
+        symlink(&source_skill, &skills_dir.join("alpha")).unwrap();
+        write_block(
+            &tgt.path().join(".git/info/exclude"),
+            &[".claude/skills/alpha/"],
+        );
+
+        let cmd = StatusCommand {
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            format: OutputFormat::Text,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn execute_yaml_format_serializes_report() {
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(tgt.path());
+        let source_skill = src.path().join("alpha");
+        fs::create_dir_all(&source_skill).unwrap();
+        let skills_dir = tgt.path().join(SKILLS_SUBPATH);
+        fs::create_dir_all(&skills_dir).unwrap();
+        symlink(&source_skill, &skills_dir.join("alpha")).unwrap();
+        write_block(
+            &tgt.path().join(".git/info/exclude"),
+            &[".claude/skills/alpha/"],
+        );
+
+        let cmd = StatusCommand {
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            format: OutputFormat::Yaml,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn execute_with_worktrees_aggregates_all_worktrees() {
+        let tgt_main = tempdir();
+        let wt_parent = tempdir();
+        let linked = wt_parent.path().join("linked");
+
+        init_repo_with_commit(tgt_main.path());
+        let add_wt = std::process::Command::new("git")
+            .args(["worktree", "add", "-q"])
+            .arg(&linked)
+            .current_dir(tgt_main.path())
+            .output()
+            .unwrap();
+        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+
+        let src = tempdir();
+        let source_skill = src.path().join("alpha");
+        fs::create_dir_all(&source_skill).unwrap();
+        for root in [tgt_main.path(), linked.as_path()] {
+            let skills_dir = root.join(SKILLS_SUBPATH);
+            fs::create_dir_all(&skills_dir).unwrap();
+            symlink(&source_skill, &skills_dir.join("alpha")).unwrap();
+        }
+        write_block(
+            &tgt_main.path().join(".git/info/exclude"),
+            &[".claude/skills/alpha/"],
+        );
+
+        let cmd = StatusCommand {
+            target: Some(tgt_main.path().to_path_buf()),
+            worktrees: true,
+            format: OutputFormat::Text,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn print_report_yaml_serializes_fields() {
+        let report = StatusReport {
+            targets: vec![TargetStatus {
+                root: PathBuf::from("/repo"),
+                symlinks: vec![SymlinkInfo {
+                    path: PathBuf::from("/repo/.claude/skills/alpha"),
+                    points_to: PathBuf::from("/src/.claude/skills/alpha"),
+                }],
+                exclude_file: PathBuf::from("/repo/.git/info/exclude"),
+                exclude_entries: vec![".claude/skills/alpha/".to_string()],
+            }],
+        };
+        let output = StatusOutput {
+            targets: &report.targets,
+        };
+        let yaml = serde_yaml::to_string(&output).unwrap();
+        assert!(yaml.contains("root: /repo"));
+        assert!(yaml.contains("points_to:"));
+        assert!(yaml.contains(".claude/skills/alpha/"));
+    }
+
+    #[test]
+    fn print_report_text_covers_multiple_targets_and_mixed_empty() {
+        let report = StatusReport {
+            targets: vec![
+                TargetStatus {
+                    root: PathBuf::from("/empty"),
+                    symlinks: Vec::new(),
+                    exclude_file: PathBuf::from("/empty/.git/info/exclude"),
+                    exclude_entries: Vec::new(),
+                },
+                TargetStatus {
+                    root: PathBuf::from("/only-symlinks"),
+                    symlinks: vec![SymlinkInfo {
+                        path: PathBuf::from("/only-symlinks/.claude/skills/alpha"),
+                        points_to: PathBuf::from("/src/alpha"),
+                    }],
+                    exclude_file: PathBuf::from("/only-symlinks/.git/info/exclude"),
+                    exclude_entries: Vec::new(),
+                },
+                TargetStatus {
+                    root: PathBuf::from("/only-entries"),
+                    symlinks: Vec::new(),
+                    exclude_file: PathBuf::from("/only-entries/.git/info/exclude"),
+                    exclude_entries: vec![".claude/skills/alpha/".to_string()],
+                },
+                TargetStatus {
+                    root: PathBuf::from("/both"),
+                    symlinks: vec![SymlinkInfo {
+                        path: PathBuf::from("/both/.claude/skills/bravo"),
+                        points_to: PathBuf::from("/src/bravo"),
+                    }],
+                    exclude_file: PathBuf::from("/both/.git/info/exclude"),
+                    exclude_entries: vec![".claude/skills/bravo/".to_string()],
+                },
+            ],
+        };
+        print_report_text(&report);
+    }
+
+    #[test]
+    fn status_report_is_empty_only_when_all_targets_empty() {
+        let empty = StatusReport {
+            targets: vec![TargetStatus {
+                root: PathBuf::from("/a"),
+                symlinks: Vec::new(),
+                exclude_file: PathBuf::from("/a/.git/info/exclude"),
+                exclude_entries: Vec::new(),
+            }],
+        };
+        assert!(empty.is_empty());
+
+        let not_empty = StatusReport {
+            targets: vec![TargetStatus {
+                root: PathBuf::from("/a"),
+                symlinks: Vec::new(),
+                exclude_file: PathBuf::from("/a/.git/info/exclude"),
+                exclude_entries: vec![".claude/skills/x/".to_string()],
+            }],
+        };
+        assert!(!not_empty.is_empty());
+    }
+}

--- a/src/cli/ai/claude/skills/sync.rs
+++ b/src/cli/ai/claude/skills/sync.rs
@@ -5,10 +5,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use serde::Serialize;
 
 use super::common::{
-    add_exclude_entries, enumerate_skills, exclude_entry_for, exclude_file_for, list_worktrees,
-    resolve_toplevel, SKILLS_SUBPATH,
+    enumerate_skills, exclude_entry_for, exclude_file_for, list_worktrees, resolve_toplevel,
+    upsert_skills_block, OutputFormat, SKILLS_SUBPATH,
 };
 
 /// Syncs Claude skills from a source repository into one or more target worktrees.
@@ -30,6 +31,10 @@ pub struct SyncCommand {
     /// Preview the changes without creating symlinks or modifying the exclude file.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(super) format: OutputFormat,
 }
 
 impl SyncCommand {
@@ -52,7 +57,7 @@ impl SyncCommand {
         }
 
         let report = run_sync(&source_root, &targets, self.dry_run)?;
-        print_report(&report, self.dry_run);
+        print_report(&report, self.dry_run, self.format)?;
 
         if !report.errors.is_empty() {
             anyhow::bail!(
@@ -65,14 +70,15 @@ impl SyncCommand {
 }
 
 /// Outcome of running a sync operation.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub(super) struct SyncReport {
     pub actions: Vec<SyncAction>,
     pub errors: Vec<SyncError>,
 }
 
 /// Individual action produced by the sync operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub(super) enum SyncAction {
     Linked {
         link: PathBuf,
@@ -93,7 +99,7 @@ pub(super) enum SyncAction {
 
 /// Error describing a skill that could not be synced because a real file or directory
 /// already exists at the target path.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(super) struct SyncError {
     pub target: PathBuf,
     pub reason: String,
@@ -167,7 +173,7 @@ fn sync_to_target(
 
     if !exclude_entries.is_empty() {
         let exclude_file = exclude_file_for(target_root)?;
-        let added = add_exclude_entries(&exclude_file, &exclude_entries, dry_run)?;
+        let added = upsert_skills_block(&exclude_file, &exclude_entries, dry_run)?;
         for entry in added {
             report.actions.push(SyncAction::Excluded {
                 exclude_file: exclude_file.clone(),
@@ -242,7 +248,34 @@ fn paths_equal(a: &Path, b: &Path) -> bool {
         .map_or_else(|| a == b, |(a, b)| a == b)
 }
 
-fn print_report(report: &SyncReport, dry_run: bool) {
+#[derive(Serialize)]
+struct SyncOutput<'a> {
+    dry_run: bool,
+    actions: &'a [SyncAction],
+    errors: &'a [SyncError],
+}
+
+fn print_report(report: &SyncReport, dry_run: bool, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Text => {
+            print_report_text(report, dry_run);
+            Ok(())
+        }
+        OutputFormat::Yaml => {
+            let output = SyncOutput {
+                dry_run,
+                actions: &report.actions,
+                errors: &report.errors,
+            };
+            let yaml = serde_yaml::to_string(&output)
+                .context("Failed to serialize sync report as YAML")?;
+            print!("{yaml}");
+            Ok(())
+        }
+    }
+}
+
+fn print_report_text(report: &SyncReport, dry_run: bool) {
     let prefix = if dry_run { "[dry-run] " } else { "" };
     for action in &report.actions {
         match action {
@@ -284,6 +317,8 @@ fn print_report(report: &SyncReport, dry_run: bool) {
 mod tests {
     use super::*;
 
+    use super::super::common::{BLOCK_BEGIN, BLOCK_END};
+
     use tempfile::TempDir;
 
     fn tempdir() -> TempDir {
@@ -301,8 +336,6 @@ mod tests {
         }
     }
 
-    /// Initialises a real git repository at `dir` so commands like
-    /// `git rev-parse --git-common-dir` work as expected.
     fn init_repo(dir: &Path) {
         let status = std::process::Command::new("git")
             .arg("init")
@@ -317,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    fn run_sync_creates_symlinks_and_exclude_entries() {
+    fn run_sync_creates_symlinks_and_exclude_block() {
         let src_tmp = tempdir();
         let tgt_tmp = tempdir();
         make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
@@ -336,6 +369,8 @@ mod tests {
         }
 
         let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
+        assert!(exclude.contains(BLOCK_BEGIN));
+        assert!(exclude.contains(BLOCK_END));
         assert!(exclude.contains(".claude/skills/alpha/"));
         assert!(exclude.contains(".claude/skills/bravo/"));
     }
@@ -349,7 +384,6 @@ mod tests {
         make_source_skills(other_tmp.path(), &["alpha"]);
         make_fake_repo(tgt_tmp.path());
 
-        // Pre-create a symlink pointing to the "other" source.
         let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills_dir).unwrap();
         create_symlink(
@@ -378,7 +412,6 @@ mod tests {
         make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
         make_fake_repo(tgt_tmp.path());
 
-        // Place a real directory at the target of "alpha".
         let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(target_skills_dir.join("alpha")).unwrap();
         fs::write(target_skills_dir.join("alpha").join("keep.txt"), "keep").unwrap();
@@ -386,12 +419,10 @@ mod tests {
         let report = run_sync(src_tmp.path(), &[tgt_tmp.path().to_path_buf()], false).unwrap();
         assert_eq!(report.errors.len(), 1);
         assert!(report.errors[0].target.ends_with(".claude/skills/alpha"));
-        // bravo should still have been linked
         assert!(fs::symlink_metadata(target_skills_dir.join("bravo"))
             .unwrap()
             .file_type()
             .is_symlink());
-        // alpha's real file should still exist
         assert!(target_skills_dir.join("alpha").join("keep.txt").exists());
     }
 
@@ -425,6 +456,7 @@ mod tests {
 
         let exclude = fs::read_to_string(tgt_tmp.path().join(".git/info/exclude")).unwrap();
         assert_eq!(exclude.matches(".claude/skills/alpha/").count(), 1);
+        assert_eq!(exclude.matches(BLOCK_BEGIN).count(), 1);
     }
 
     #[test]
@@ -441,7 +473,6 @@ mod tests {
             .iter()
             .any(|a| matches!(a, SyncAction::SkippedSameTarget { .. })));
 
-        // Original skill directory must not have been touched or replaced.
         let skill = src_tmp.path().join(SKILLS_SUBPATH).join("alpha");
         let meta = fs::symlink_metadata(&skill).unwrap();
         assert!(meta.is_dir() && !meta.file_type().is_symlink());
@@ -478,8 +509,6 @@ mod tests {
 
     #[test]
     fn paths_equal_falls_back_to_literal_comparison_when_canonicalize_fails() {
-        // Neither path exists so canonicalize returns Err — exercises the
-        // fallback `|| a == b` branch.
         assert!(paths_equal(
             Path::new("/nonexistent/skills/a"),
             Path::new("/nonexistent/skills/a")
@@ -503,6 +532,7 @@ mod tests {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
 
@@ -520,7 +550,6 @@ mod tests {
         init_repo(src_tmp.path());
         init_repo(tgt_tmp.path());
         make_source_skills(src_tmp.path(), &["alpha", "bravo"]);
-        // Pre-create a symlink so "alpha" is reported as Relinked.
         let target_skills_dir = tgt_tmp.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills_dir).unwrap();
         create_symlink(
@@ -534,6 +563,7 @@ mod tests {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: true,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
     }
@@ -545,7 +575,6 @@ mod tests {
         init_repo(src_tmp.path());
         init_repo(tgt_tmp.path());
         make_source_skills(src_tmp.path(), &["alpha"]);
-        // Place a real dir so the sync is blocked.
         fs::create_dir_all(tgt_tmp.path().join(SKILLS_SUBPATH).join("alpha")).unwrap();
 
         let cmd = SyncCommand {
@@ -553,6 +582,7 @@ mod tests {
             target: Some(tgt_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         let err = cmd.execute().unwrap_err().to_string();
         assert!(err.contains("blocked by existing files"));
@@ -560,7 +590,6 @@ mod tests {
 
     #[test]
     fn execute_skipped_same_target_covers_print_branch() {
-        // Exercises the SkippedSameTarget print path via execute.
         let src_tmp = tempdir();
         init_repo(src_tmp.path());
         make_source_skills(src_tmp.path(), &["alpha"]);
@@ -570,11 +599,11 @@ mod tests {
             target: Some(src_tmp.path().to_path_buf()),
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
     }
 
-    /// Initialise a repo with one commit so linked worktrees can be created from it.
     fn init_repo_with_commit(dir: &Path) {
         init_repo(dir);
         fs::write(dir.join("README.md"), "readme").unwrap();
@@ -603,8 +632,6 @@ mod tests {
 
     #[test]
     fn execute_source_defaults_to_cwd() {
-        // Covers the `source.unwrap_or_else(|| cwd.clone())` branch. Uses
-        // dry_run so no filesystem writes occur on the inferred source repo.
         let tgt = tempdir();
         init_repo(tgt.path());
         let cmd = SyncCommand {
@@ -612,15 +639,13 @@ mod tests {
             target: Some(tgt.path().to_path_buf()),
             worktrees: false,
             dry_run: true,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
     }
 
     #[test]
     fn execute_target_defaults_to_source() {
-        // Covers the `target.unwrap_or_else(|| source_root.clone())` branch.
-        // With target == source the run skips with SkippedSameTarget, so no
-        // filesystem writes occur even though dry_run is false.
         let src = tempdir();
         init_repo(src.path());
         make_source_skills(src.path(), &["alpha"]);
@@ -630,9 +655,9 @@ mod tests {
             target: None,
             worktrees: false,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
-        // Source directory must remain a real directory.
         let skill = src.path().join(SKILLS_SUBPATH).join("alpha");
         let meta = fs::symlink_metadata(&skill).unwrap();
         assert!(meta.is_dir() && !meta.file_type().is_symlink());
@@ -651,8 +676,6 @@ mod tests {
 
         let target_skills = tgt.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills).unwrap();
-        // Removing search permission causes lstat on a path inside this dir to
-        // return EACCES (not NotFound), exercising the catch-all error arm.
         let mut perms = fs::metadata(&target_skills).unwrap().permissions();
         perms.set_mode(0o000);
         fs::set_permissions(&target_skills, perms).unwrap();
@@ -683,8 +706,6 @@ mod tests {
         make_source_skills(src.path(), &["alpha"]);
         make_source_skills(other.path(), &["alpha"]);
 
-        // Pre-create a symlink at the target then make the parent read-only so
-        // the subsequent remove_file/create_symlink fails.
         let target_skills = tgt.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills).unwrap();
         create_symlink(
@@ -723,14 +744,12 @@ mod tests {
 
         let target_skills = tgt.path().join(SKILLS_SUBPATH);
         fs::create_dir_all(&target_skills).unwrap();
-        // Make the skills directory read-only so create_symlink within it fails.
         let mut perms = fs::metadata(&target_skills).unwrap().permissions();
         perms.set_mode(0o500);
         fs::set_permissions(&target_skills, perms).unwrap();
 
         let result = run_sync(src.path(), &[tgt.path().to_path_buf()], false);
 
-        // Restore writable perms so TempDir cleanup succeeds.
         let mut perms = fs::metadata(&target_skills).unwrap().permissions();
         perms.set_mode(0o700);
         fs::set_permissions(&target_skills, perms).unwrap();
@@ -744,8 +763,6 @@ mod tests {
 
     #[test]
     fn run_sync_propagates_create_dir_all_failure() {
-        // Place a regular file at `<target>/.claude` so that creating
-        // `<target>/.claude/skills` fails with a context-wrapped error.
         let src = tempdir();
         let tgt = tempdir();
         init_repo(src.path());
@@ -783,6 +800,7 @@ mod tests {
             target: Some(tgt_main.path().to_path_buf()),
             worktrees: true,
             dry_run: false,
+            format: OutputFormat::Text,
         };
         cmd.execute().unwrap();
 
@@ -796,5 +814,91 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+    }
+
+    #[test]
+    fn execute_yaml_format_serializes_report() {
+        let src = tempdir();
+        let tgt = tempdir();
+        init_repo(src.path());
+        init_repo(tgt.path());
+        make_source_skills(src.path(), &["alpha"]);
+
+        let cmd = SyncCommand {
+            source: Some(src.path().to_path_buf()),
+            target: Some(tgt.path().to_path_buf()),
+            worktrees: false,
+            dry_run: false,
+            format: OutputFormat::Yaml,
+        };
+        cmd.execute().unwrap();
+    }
+
+    #[test]
+    fn print_report_text_covers_all_action_variants_and_both_prefixes() {
+        let report = SyncReport {
+            actions: vec![
+                SyncAction::Linked {
+                    link: PathBuf::from("/a"),
+                    points_to: PathBuf::from("/b"),
+                },
+                SyncAction::Relinked {
+                    link: PathBuf::from("/c"),
+                    points_to: PathBuf::from("/d"),
+                },
+                SyncAction::Excluded {
+                    exclude_file: PathBuf::from("/e"),
+                    entry: ".claude/skills/x/".to_string(),
+                },
+                SyncAction::SkippedSameTarget {
+                    target: PathBuf::from("/f"),
+                },
+            ],
+            errors: vec![SyncError {
+                target: PathBuf::from("/g"),
+                reason: "blocked".to_string(),
+            }],
+        };
+        print_report_text(&report, false);
+        print_report_text(&report, true);
+    }
+
+    #[test]
+    fn print_report_yaml_serializes_all_action_variants() {
+        let report = SyncReport {
+            actions: vec![
+                SyncAction::Linked {
+                    link: PathBuf::from("/a"),
+                    points_to: PathBuf::from("/b"),
+                },
+                SyncAction::Relinked {
+                    link: PathBuf::from("/c"),
+                    points_to: PathBuf::from("/d"),
+                },
+                SyncAction::Excluded {
+                    exclude_file: PathBuf::from("/e"),
+                    entry: ".claude/skills/x/".to_string(),
+                },
+                SyncAction::SkippedSameTarget {
+                    target: PathBuf::from("/f"),
+                },
+            ],
+            errors: vec![SyncError {
+                target: PathBuf::from("/g"),
+                reason: "blocked".to_string(),
+            }],
+        };
+        let output = SyncOutput {
+            dry_run: true,
+            actions: &report.actions,
+            errors: &report.errors,
+        };
+        let yaml = serde_yaml::to_string(&output).unwrap();
+        assert!(yaml.contains("dry_run: true"));
+        assert!(yaml.contains("type: linked"));
+        assert!(yaml.contains("type: relinked"));
+        assert!(yaml.contains("type: excluded"));
+        assert!(yaml.contains("type: skipped_same_target"));
+        assert!(yaml.contains("blocked"));
     }
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -122,9 +122,10 @@ Manages Claude Code skills across repositories and worktrees
 Usage: skills <COMMAND>
 
 Commands:
-  sync   Syncs skills from a source repository into one or more targets
-  clean  Removes skill symlinks previously created by `sync`
-  help   Print this message or the help of the given subcommand(s)
+  sync    Syncs skills from a source repository into one or more targets
+  clean   Removes skill symlinks and managed exclude block previously created by `sync`
+  status  Reports residue left by `sync` — symlinks and managed exclude-block entries
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -132,17 +133,33 @@ Options:
 
 ================================================================================
 
-omni-dev ai claude skills clean - Removes skill symlinks previously created by `sync`
+omni-dev ai claude skills clean - Removes skill symlinks and managed exclude block previously created by `sync`
 
-Removes skill symlinks previously created by `sync`
+Removes skill symlinks and managed exclude block previously created by `sync`
 
 Usage: clean [OPTIONS]
 
 Options:
-      --target <PATH>  Target repository or worktree to clean. Defaults to the current working directory
-      --worktrees      Also clean every worktree belonging to the target repository
-      --dry-run        Preview the changes without deleting symlinks or modifying the exclude file
-  -h, --help           Print help
+      --target <PATH>    Target repository or worktree to clean. Defaults to the current working directory
+      --worktrees        Also clean every worktree belonging to the target repository
+      --dry-run          Preview the changes without deleting symlinks or modifying the exclude file
+      --format <FORMAT>  Output format [default: text] [possible values: text, yaml]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev ai claude skills status - Reports residue left by `sync` — symlinks and managed exclude-block entries
+
+Reports residue left by `sync` — symlinks and managed exclude-block entries
+
+Usage: status [OPTIONS]
+
+Options:
+      --target <PATH>    Target repository or worktree to inspect. Defaults to the current working directory
+      --worktrees        Also inspect every worktree belonging to the target repository
+      --format <FORMAT>  Output format [default: text] [possible values: text, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================
@@ -154,11 +171,12 @@ Syncs skills from a source repository into one or more targets
 Usage: sync [OPTIONS]
 
 Options:
-      --source <PATH>  Source repository or worktree containing the canonical `.claude/skills/`. Defaults to the current working directory
-      --target <PATH>  Target repository or worktree to sync into. Defaults to the source repository
-      --worktrees      Also sync to every worktree belonging to the target repository
-      --dry-run        Preview the changes without creating symlinks or modifying the exclude file
-  -h, --help           Print help
+      --source <PATH>    Source repository or worktree containing the canonical `.claude/skills/`. Defaults to the current working directory
+      --target <PATH>    Target repository or worktree to sync into. Defaults to the source repository
+      --worktrees        Also sync to every worktree belonging to the target repository
+      --dry-run          Preview the changes without creating symlinks or modifying the exclude file
+      --format <FORMAT>  Output format [default: text] [possible values: text, yaml]
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements the `ai claude skills status` subcommand and adds `--format {text,yaml}` support to all three skills commands (`sync`, `clean`, `status`). Users can now inspect what residue prior `sync` runs have left behind (symlinks and managed exclude-block entries) without performing any destructive operations.

The PR also migrates `.git/info/exclude` management from bare per-entry lines to a managed block delimited by `# BEGIN omni-dev-skills (managed — do not edit)` / `# END omni-dev-skills` markers, enabling precise reversal by `clean` without touching unrelated user content.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #558

## Changes Made

**Core Changes:**
- Added `src/cli/ai/claude/skills/status.rs` with `StatusCommand` that reports symlinks and managed exclude-block entries left behind by prior `sync` runs, with `--worktrees` to aggregate across every worktree
- Added shared `OutputFormat` enum (`text` | `yaml`) to `common.rs` and wired `--format` flag into `sync`, `clean`, and `status` commands
- Replaced bare per-entry exclude lines with a managed block delimited by `# BEGIN omni-dev-skills (managed — do not edit)` / `# END omni-dev-skills` markers; renamed `add_exclude_entries` → `upsert_skills_block` and `remove_exclude_entries` → `remove_skills_block` to reflect new semantics
- Added `read_skills_block_entries` helper in `common.rs` for the status command to read existing block entries without modifying the file
- Added `find_block` / `BlockBounds` private helpers and extracted `write_exclude_file` to centralise exclude file I/O
- Fixed `clean` to remove the exclude block even when the skills directory is absent, and to attempt directory removal only when `skills_dir` exists
- Derived `Serialize` on `CleanReport`, `CleanAction`, `SyncReport`, `SyncAction`, `SyncError`, and all status types; added typed YAML output structs `CleanOutput`, `SyncOutput`, `StatusOutput`
- Registered `status` module in `mod.rs` and wired `dispatch_status` through `SkillsCommand`

**Documentation:**
- Updated `CHANGELOG.md` with new `status` command, YAML output feature, and breaking change note for the new exclude block format

**Testing:**
- Added `dispatch_status` integration test in `mod.rs`
- Added `run_status_reports_symlinks_and_block_entries`, `run_status_empty_repo_is_empty`, `run_status_skips_real_files_in_skills_dir`, `execute_yaml_format_serializes_report`, `execute_with_worktrees_aggregates_all_worktrees`, `print_report_yaml_serializes_fields`, and `status_report_is_empty_only_when_all_targets_empty` tests in `status.rs`
- Added `upsert_skills_block_*` and `remove_skills_block_*` and `read_skills_block_entries_*` and `find_block_*` unit tests in `common.rs` replacing old `add_exclude_entries_*` / `remove_exclude_entries_*` tests
- Added `execute_yaml_format_serializes_report` and `print_report_yaml_serializes_all_action_variants` tests in both `clean.rs` and `sync.rs`
- Updated all existing tests that construct `CleanCommand` or `SyncCommand` structs to include the new `format` field

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- New `status.rs` module covered by 12 unit/integration tests
- New `common.rs` block management code covered by comprehensive unit tests for all public functions and private helpers

### Test Commands
```bash
# Core test suite
cargo test

# Run skills-specific tests only
cargo test cli::ai::claude::skills

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — bare `.claude/skills/*/` lines written by older builds are **not** recognised by the new `clean` and must be removed manually
- [x] Architecture changes — the managed-block approach in `upsert_skills_block` / `remove_skills_block` replaces the previous line-by-line strategy
- [x] Error handling — `clean` now attempts to remove the exclude block even when the skills directory is missing; ensure the logic handles all absent-file cases

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

**Migration Required:**
1. Entries written to `.git/info/exclude` by previous versions of `ai claude skills sync` were bare lines of the form `.claude/skills/<name>/`. The new `clean` command only removes the managed block and will **not** find or remove these bare lines.
2. After upgrading, run `ai claude skills sync` again to rewrite the exclude file with a managed block, then use `ai claude skills clean` to remove it cleanly.
3. Alternatively, manually remove any bare `.claude/skills/*/` lines from `.git/info/exclude` in affected repositories.

**Backward Compatibility:**
- The `sync` and `clean` commands remain functionally equivalent from a user perspective; the change is purely in how exclude entries are stored in `.git/info/exclude`.
- The new `--format` flag defaults to `text` on all three commands, so existing scripts invoking `sync` or `clean` without `--format` continue to behave identically.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- A migration helper that detects and upgrades bare exclude lines from older builds could reduce friction for users upgrading from pre-block versions.

**Known Limitations:**
- The managed block markers are a forward-compatibility commitment; changing the `BLOCK_BEGIN` / `BLOCK_END` strings in a future release would orphan blocks written by the current version.

**Alternatives Considered:**
- Keeping bare per-entry lines and scanning for them in `clean` was rejected because it makes it impossible to distinguish `sync`-managed lines from user-written entries with the same format.