### PR TITLE
docs(docs): document git worktree convention using .work/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ lcov.info
 
 # ASCII Cinema demo files (temporary)
 cinema/
+
+# Git worktrees
+/.work/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,9 @@ Common git operations in this project:
 - `git branch -r --contains <commit>` - Check remote branch containment
 - `git status --porcelain` - Get working directory status
 
+### Git Worktrees
+New git worktrees should be created in the `.work/` directory of the current project (e.g., `git worktree add .work/<branch-name> <branch-name>`). The `.work/` directory is gitignored and keeps worktrees scoped to the project rather than scattered across sibling directories.
+
 ## Testing Approach
 
 ### Test Types


### PR DESCRIPTION
## Description

Establishes a project-wide convention for managing git worktrees by defining a standard location (`.work/`) and documenting it in CLAUDE.md. Previously, worktrees might be created in sibling directories or arbitrary locations, making them harder to manage and risking them appearing as untracked files.

This change ensures worktrees are kept scoped to the project directory and ignored by git, providing a consistent and clean development experience when working with multiple branches simultaneously.

## Type of Change
- [x] Documentation update

## Related Issue
No related issue.

## Changes Made

**Core Changes:**
- Added `/.work/` to `.gitignore` to prevent git worktree directories from appearing as untracked files in the main working tree

**Documentation:**
- Added a "Git Worktrees" section to `CLAUDE.md` under the Git Operations area, specifying that new worktrees should be created using `git worktree add .work/<branch-name> <branch-name>`
- Documents the rationale: keeping worktrees scoped to the project rather than scattered across sibling directories

**Testing:**
- No automated tests required for documentation and gitignore changes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- No new tests needed for documentation/gitignore changes

**Manual Testing:**
- [x] Verified `.work/` is correctly ignored by git
- [x] Confirmed worktree created with `git worktree add .work/<branch-name> <branch-name>` is not tracked

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `.gitignore` entry uses an absolute path prefix (`/.work/`) to scope the ignore to the project root only

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. This is a purely additive documentation and gitignore change with no impact on existing functionality.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Could add a helper script or `omni-dev` command to automate worktree creation in the `.work/` directory

**Known Limitations:**
- Existing worktrees created outside `.work/` are unaffected and would need to be manually relocated if desired

**Alternatives Considered:**
- Using `.worktrees/` as the directory name — `.work/` was chosen for brevity and clarity