### PR TITLE
feat(claude): add claude-cli subprocess AI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,17 @@ The project includes a comprehensive model registry system:
 - **Configuration Commands**: Use `omni-dev config models show` to view available models
 - **Dynamic Limits**: Token limits are automatically applied based on model specifications
 
+### AI Backend Dispatch
+Backends are selected inside `src/claude/client.rs::create_default_claude_client` in this order:
+
+1. `OMNI_DEV_AI_BACKEND=claude-cli` (or `--ai-backend claude-cli`) → `ClaudeCliAiClient` in `src/claude/ai/claude_cli.rs`. Shells out to `claude -p` in a locked-down sandbox (tools disabled, MCP blocked, settings skipped, fresh temp cwd, scrubbed env). Uses JSON output format and parses the `is_error`/`api_error_status`/`result` envelope. `--beta-header` is ignored for this backend.
+2. `USE_OLLAMA=true` → `OpenAiAiClient::new_ollama`.
+3. `USE_OPENAI=true` → `OpenAiAiClient::new_openai`.
+4. `CLAUDE_CODE_USE_BEDROCK=true` → `BedrockAiClient`.
+5. Default → `ClaudeAiClient` (direct Anthropic API).
+
+Preflight (`src/utils/preflight.rs`) mirrors this switch and must change in lock-step when adding backends.
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ Preflight (`src/utils/preflight.rs`) mirrors this switch and must change in lock
 
 **Escape hatch.** `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true` or `--claude-cli-allow-tools` removes the `--tools ""` flag from the subprocess argv, letting the nested session use Read/Edit/Write/Bash/Glob/Grep. Other sandbox flags (`--strict-mcp-config`, `--setting-sources ""`, `--disable-slash-commands`, `--no-session-persistence`, temp cwd, scrubbed env) still apply. A warning is logged every time the escape hatch is active. See `ClaudeCliAiClient::run` for the warn site.
 
+**Spending cap.** `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=<amount>` or `--claude-cli-max-budget-usd <amount>` forwards to `claude -p --max-budget-usd`, aborting the nested session if it exceeds the cap. Every invocation logs `total_cost_usd` from the JSON envelope at INFO level regardless of cap, for cost observability. Non-positive / non-finite values are silently treated as no cap. See `ClaudeCliAiClient::run` for the log site and the post-response warn when cost exceeds the configured cap.
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Backends are selected inside `src/claude/client.rs::create_default_claude_client
 
 Preflight (`src/utils/preflight.rs`) mirrors this switch and must change in lock-step when adding backends.
 
+**Escape hatch.** `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true` or `--claude-cli-allow-tools` removes the `--tools ""` flag from the subprocess argv, letting the nested session use Read/Edit/Write/Bash/Glob/Grep. Other sandbox flags (`--strict-mcp-config`, `--setting-sources ""`, `--disable-slash-commands`, `--no-session-persistence`, temp cwd, scrubbed env) still apply. A warning is logged every time the escape hatch is active. See `ClaudeCliAiClient::run` for the warn site.
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,60 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
   - Configure with: `omni-dev atlassian auth login`
 - **Git**: Any modern version
 
+### AI backend selection
+
+By default, `omni-dev` calls the Anthropic API (or Bedrock/OpenAI/Ollama via
+the `USE_*`/`CLAUDE_CODE_USE_BEDROCK` env vars). As an alternative, you can
+route AI calls through an already-authenticated
+[Claude Code CLI](https://github.com/anthropics/claude-code) session, avoiding
+the need for a separate API key:
+
+```bash
+# Per-invocation flag:
+omni-dev --ai-backend claude-cli git commit message twiddle <range>
+
+# Or set persistently:
+export OMNI_DEV_AI_BACKEND=claude-cli
+```
+
+The flag takes precedence over the environment variable.
+
+**Model selection** follows the precedence chain
+`--model` → `CLAUDE_MODEL` → `CLAUDE_CODE_MODEL` → `ANTHROPIC_MODEL` → registry
+default. Short aliases (`sonnet`, `opus`, `haiku`) and full identifiers
+(`claude-sonnet-4-6`) are both accepted and forwarded verbatim to
+`claude -p --model`.
+
+**Sandboxing guarantees.** The `claude -p` subprocess is locked down so it
+behaves as a pure prompt→completion service, not a nested agent with
+filesystem or shell access:
+
+- Built-in tools disabled (`--tools ""`).
+- MCP servers blocked (`--strict-mcp-config` with no config).
+- User/project/local settings ignored (`--setting-sources ""`).
+- Slash commands / skills disabled.
+- Session persistence disabled.
+- Subprocess runs in a fresh temp directory (not your repo root).
+- Environment is scrubbed of `CLAUDE_PROJECT_DIR`, `CLAUDE_CODE_*`, and
+  `CLAUDE_PROJECT_*` before spawn.
+
+**Cost baseline.** Because the `claude -p` session still loads a small system
+prompt, each invocation has a floor cost (~$0.007 Haiku, ~$0.03 Sonnet,
+~$0.15 Opus) before any user content. Back-to-back calls within one hour hit
+the prompt cache and are much cheaper. If you pay per token, compare against
+the default HTTP backend which has no such floor.
+
+**Overrides.** Optional environment variables:
+
+- `OMNI_DEV_CLAUDE_CLI_BIN` — path to the `claude` binary (default: resolved
+  from `PATH`).
+- `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS` — subprocess timeout (default: 600).
+- `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES` — stdout cap in bytes (default:
+  4 MiB).
+
+The `--beta-header` flag is ignored with this backend (the CLI's `--betas`
+flag is API-key-user-only and has different semantics).
+
 ## 🐛 Debugging
 
 For troubleshooting and detailed logging, use the `RUST_LOG` environment variable:

--- a/README.md
+++ b/README.md
@@ -525,9 +525,33 @@ the default HTTP backend which has no such floor.
 - `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS` — subprocess timeout (default: 600).
 - `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES` — stdout cap in bytes (default:
   4 MiB).
+- `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS` — **escape hatch** (default: disabled).
+  See below.
 
 The `--beta-header` flag is ignored with this backend (the CLI's `--betas`
 flag is API-key-user-only and has different semantics).
+
+#### Escape hatch: `--claude-cli-allow-tools`
+
+By default the nested `claude -p` session is run with `--tools ""` and
+cannot read, edit, or execute anything on your system. For deliberately
+tool-capable use cases, you can weaken the sandbox:
+
+```bash
+omni-dev --ai-backend claude-cli --claude-cli-allow-tools git branch create pr
+# or:
+export OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true
+```
+
+**When enabled**, the nested session uses the CLI's default tool set
+(Read / Edit / Write / Bash / Glob / Grep, plus any MCP servers configured in
+your `~/.claude/settings.json`). This means the session can access your
+repository and run commands. Only enable it when you want that behaviour.
+When active, omni-dev logs a warning on every invocation.
+
+`--strict-mcp-config` and `--setting-sources ""` still apply, so MCP servers
+won't auto-load unless you explicitly allow them via further flags in a
+future slice.
 
 ## 🐛 Debugging
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ the default HTTP backend which has no such floor.
   4 MiB).
 - `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS` — **escape hatch** (default: disabled).
   See below.
+- `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD` — per-invocation spending cap in USD
+  (default: none). See below.
 
 The `--beta-header` flag is ignored with this backend (the CLI's `--betas`
 flag is API-key-user-only and has different semantics).
@@ -552,6 +554,26 @@ When active, omni-dev logs a warning on every invocation.
 `--strict-mcp-config` and `--setting-sources ""` still apply, so MCP servers
 won't auto-load unless you explicitly allow them via further flags in a
 future slice.
+
+#### Spending cap: `--claude-cli-max-budget-usd`
+
+Pass a per-invocation spending cap in USD:
+
+```bash
+omni-dev --ai-backend claude-cli --claude-cli-max-budget-usd 0.50 \
+  git commit message twiddle HEAD~3..HEAD
+# or:
+export OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=0.50
+```
+
+The value is forwarded to `claude -p --max-budget-usd`. If the nested
+session exceeds the cap, it aborts with an error rather than running away
+with cost. Regardless of whether a cap is set, each invocation's
+`total_cost_usd` is logged at INFO level for observability — run with
+`RUST_LOG=omni_dev=info` to see it.
+
+The cap is ignored when `--ai-backend` is not `claude-cli`. Non-positive,
+non-finite, or non-numeric values are silently treated as no cap.
 
 ## 🐛 Debugging
 

--- a/src/claude/ai.rs
+++ b/src/claude/ai.rs
@@ -2,6 +2,7 @@
 
 pub mod bedrock;
 pub mod claude;
+pub mod claude_cli;
 pub mod openai;
 
 use std::future::Future;

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -1,0 +1,994 @@
+//! Claude Code CLI subprocess AI client.
+//!
+//! Shells out to `claude -p` in a locked-down sandbox so users with an
+//! authenticated Claude Code session can reuse it without provisioning a
+//! separate API key.
+//!
+//! Sandboxing:
+//! - `--tools ""` disables built-in tools.
+//! - `--strict-mcp-config` (with no accompanying `--mcp-config`) blocks MCP
+//!   server pickup from user settings.
+//! - `--setting-sources ""` skips user / project / local settings discovery.
+//! - `--disable-slash-commands` blocks skills.
+//! - `--no-session-persistence` avoids writing session state to disk.
+//! - Subprocess runs with cwd set to a fresh temp directory.
+//! - Environment inherits from the parent, then removes `CLAUDE_PROJECT_DIR`,
+//!   any `CLAUDE_CODE_*`, and any `CLAUDE_PROJECT_*` vars that could re-scope
+//!   the nested session.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+
+use super::{AiClient, AiClientMetadata};
+use crate::claude::error::ClaudeError;
+
+/// Default subprocess timeout.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Default stdout cap (4 MiB).
+pub(crate) const DEFAULT_STDOUT_CAP: usize = 4 * 1024 * 1024;
+
+/// Default binary name.
+pub(crate) const DEFAULT_BINARY: &str = "claude";
+
+/// Env var overriding [`DEFAULT_TIMEOUT`] (value: seconds).
+pub(crate) const TIMEOUT_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS";
+
+/// Env var overriding [`DEFAULT_STDOUT_CAP`] (value: bytes).
+pub(crate) const STDOUT_CAP_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES";
+
+/// Env var overriding [`DEFAULT_BINARY`] (value: path to the `claude` binary).
+pub(crate) const BINARY_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_BIN";
+
+/// Defence-in-depth suffix appended to the caller's system prompt.
+///
+/// Even with tools disabled at runtime, the model "knows" Claude Code tools
+/// exist and will sometimes emit XML `<function_calls>` tags in the output.
+/// This instruction cleanly suppresses that behaviour.
+pub(crate) const TOOL_SUPPRESSION_SUFFIX: &str =
+    "\n\nYou have no tools available in this session. \
+Do not emit function_calls XML or attempt any tool invocation. Output only the requested content.";
+
+/// Env var prefixes to remove from the subprocess environment.
+const SCRUBBED_ENV_PREFIXES: &[&str] = &["CLAUDE_CODE_", "CLAUDE_PROJECT_"];
+
+/// Exact env var names to remove from the subprocess environment.
+const SCRUBBED_ENV_EXACT: &[&str] = &["CLAUDE_PROJECT_DIR"];
+
+/// Subset of the `claude -p --output-format json` envelope we care about.
+///
+/// `claude -p` emits a single JSON object on stdout. Additional fields
+/// (`session_id`, `usage`, etc.) are ignored.
+#[derive(Deserialize)]
+struct JsonOutput {
+    #[serde(default)]
+    is_error: bool,
+    #[serde(default)]
+    api_error_status: Option<i64>,
+    #[serde(default)]
+    result: String,
+}
+
+/// Claude Code CLI subprocess AI client.
+pub struct ClaudeCliAiClient {
+    /// Model identifier (alias like `sonnet` or full ID like
+    /// `claude-sonnet-4-6`). Forwarded verbatim to `claude -p --model`.
+    model: String,
+    /// Subprocess timeout.
+    timeout: Duration,
+    /// Maximum bytes of stdout to accept before erroring.
+    stdout_cap: usize,
+    /// When true, skip `--tools ""` (escape hatch for future tool-enabled
+    /// use cases). Off by default.
+    allow_tools: bool,
+    /// Path to the `claude` binary (defaults to `claude` on PATH).
+    binary_path: PathBuf,
+}
+
+impl ClaudeCliAiClient {
+    /// Creates a client with defaults from environment variables (or the
+    /// compiled-in defaults when unset).
+    #[must_use]
+    pub fn new(model: String) -> Self {
+        Self::new_with_config(
+            model,
+            Self::timeout_from_env(),
+            Self::stdout_cap_from_env(),
+            false,
+            Self::binary_from_env(),
+        )
+    }
+
+    /// Creates a client with explicit configuration. Primarily for tests.
+    #[must_use]
+    pub fn new_with_config(
+        model: String,
+        timeout: Duration,
+        stdout_cap: usize,
+        allow_tools: bool,
+        binary_path: PathBuf,
+    ) -> Self {
+        Self {
+            model,
+            timeout,
+            stdout_cap,
+            allow_tools,
+            binary_path,
+        }
+    }
+
+    fn timeout_from_env() -> Duration {
+        crate::utils::settings::get_env_var(TIMEOUT_ENV_VAR)
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map_or(DEFAULT_TIMEOUT, Duration::from_secs)
+    }
+
+    fn stdout_cap_from_env() -> usize {
+        crate::utils::settings::get_env_var(STDOUT_CAP_ENV_VAR)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_STDOUT_CAP)
+    }
+
+    fn binary_from_env() -> PathBuf {
+        crate::utils::settings::get_env_var(BINARY_ENV_VAR)
+            .ok()
+            .map_or_else(|| PathBuf::from(DEFAULT_BINARY), PathBuf::from)
+    }
+
+    /// Builds the subprocess [`Command`] without spawning.
+    ///
+    /// Broken out so tests can inspect the argv / env / cwd via
+    /// `Command::get_args`, `get_envs`, `get_current_dir` without running
+    /// a subprocess.
+    pub(crate) fn build_command(&self, system_prompt: &str, cwd: &Path) -> Command {
+        let mut cmd = Command::new(&self.binary_path);
+        cmd.arg("-p")
+            .arg("--model")
+            .arg(&self.model)
+            .arg("--output-format")
+            .arg("json")
+            .arg("--permission-mode")
+            .arg("default")
+            .arg("--no-session-persistence")
+            .arg("--disable-slash-commands")
+            .arg("--strict-mcp-config")
+            .arg("--setting-sources")
+            .arg("")
+            .arg("--system-prompt")
+            .arg(system_prompt);
+
+        if !self.allow_tools {
+            cmd.arg("--tools").arg("");
+        }
+
+        cmd.current_dir(cwd);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        // Scrub risky env vars rather than clearing wholesale. Clearing the
+        // env breaks the Node runtime inside `claude` (needs HOME, PATH,
+        // possibly DYLD_* / homebrew PATH entries on macOS).
+        for (k, _) in std::env::vars() {
+            if SCRUBBED_ENV_EXACT.contains(&k.as_str())
+                || SCRUBBED_ENV_PREFIXES.iter().any(|p| k.starts_with(p))
+            {
+                cmd.env_remove(&k);
+            }
+        }
+
+        cmd
+    }
+
+    async fn run(&self, system_prompt: &str, user_prompt: &str) -> Result<String> {
+        let combined_system = format!("{system_prompt}{TOOL_SUPPRESSION_SUFFIX}");
+
+        let temp_dir = tempfile::TempDir::new()
+            .context("Failed to create temp directory for claude subprocess")?;
+
+        let mut cmd = self.build_command(&combined_system, temp_dir.path());
+
+        info!(
+            binary = %self.binary_path.display(),
+            model = %self.model,
+            timeout_secs = self.timeout.as_secs(),
+            "Spawning claude -p subprocess"
+        );
+
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow::Error::from(ClaudeError::SubprocessBinaryMissing(
+                    self.binary_path.display().to_string(),
+                ))
+            } else {
+                anyhow::Error::from(ClaudeError::SubprocessSpawnFailed(e.to_string()))
+            }
+        })?;
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Failed to capture claude subprocess stdin"))?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Failed to capture claude subprocess stdout"))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("Failed to capture claude subprocess stderr"))?;
+
+        let cap = self.stdout_cap;
+        let prompt_bytes = user_prompt.to_owned();
+
+        // Concurrently: write stdin, read capped stdout, read stderr.
+        // Wrapped in a timeout; on timeout we kill and reap the child.
+        let io_result = tokio::time::timeout(self.timeout, async {
+            let write_task = async move {
+                // A child that exits before reading all our input will close
+                // its stdin pipe, so subsequent writes get EPIPE. Treat that
+                // as a soft signal — the child has already decided its fate
+                // and we want to surface the real diagnosis from its exit
+                // status and stdout/stderr, not a misleading "broken pipe".
+                match stdin.write_all(prompt_bytes.as_bytes()).await {
+                    Ok(()) => {}
+                    Err(e) if is_pipe_closed(&e) => {
+                        debug!("claude subprocess closed stdin before prompt fully written");
+                        return Ok::<(), anyhow::Error>(());
+                    }
+                    Err(e) => {
+                        return Err(anyhow::Error::from(e)
+                            .context("Failed to write prompt to claude subprocess stdin"));
+                    }
+                }
+                match stdin.shutdown().await {
+                    Ok(()) => {}
+                    Err(e) if is_pipe_closed(&e) => {
+                        debug!("claude subprocess stdin already closed at shutdown");
+                    }
+                    Err(e) => {
+                        return Err(anyhow::Error::from(e)
+                            .context("Failed to close claude subprocess stdin"));
+                    }
+                }
+                Ok::<(), anyhow::Error>(())
+            };
+            let read_stdout_task = read_capped(&mut stdout, cap);
+            let read_stderr_task = async {
+                let mut buf = Vec::new();
+                // stderr read is best-effort; ignore errors.
+                let _ = stderr.read_to_end(&mut buf).await;
+                Ok::<Vec<u8>, anyhow::Error>(buf)
+            };
+
+            let ((), stdout_bytes, stderr_bytes) =
+                tokio::try_join!(write_task, read_stdout_task, read_stderr_task)?;
+            Ok::<_, anyhow::Error>((stdout_bytes, stderr_bytes))
+        })
+        .await;
+
+        let (stdout_bytes, stderr_bytes) = match io_result {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(e);
+            }
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(ClaudeError::SubprocessTimeout {
+                    secs: self.timeout.as_secs(),
+                }
+                .into());
+            }
+        };
+
+        let status = child
+            .wait()
+            .await
+            .context("Failed to wait for claude subprocess")?;
+        let stderr_text = String::from_utf8_lossy(&stderr_bytes).to_string();
+
+        debug!(
+            exit_status = ?status,
+            stdout_bytes = stdout_bytes.len(),
+            stderr_bytes = stderr_bytes.len(),
+            "claude -p subprocess finished"
+        );
+
+        // Try to parse the JSON envelope. claude -p emits one JSON object on
+        // stdout even on API errors (with is_error=true); argparse-level
+        // failures go to stderr and produce no JSON.
+        let envelope: JsonOutput = match serde_json::from_slice::<JsonOutput>(&stdout_bytes) {
+            Ok(env) => env,
+            Err(e) => {
+                let stdout_text = String::from_utf8_lossy(&stdout_bytes);
+                return Err(ClaudeError::SubprocessJsonParseFailed(format!(
+                    "{e}; exit_status={status}; stdout={stdout_text}; stderr={stderr_text}"
+                ))
+                .into());
+            }
+        };
+
+        if envelope.is_error {
+            return Err(map_api_error(&envelope, &stderr_text));
+        }
+
+        if !status.success() {
+            return Err(ClaudeError::ApiRequestFailed(format!(
+                "claude -p exited with non-zero status ({status}); stderr={stderr_text}"
+            ))
+            .into());
+        }
+
+        let result = strip_wrapping_code_fence(&envelope.result);
+        super::log_response_success("Claude CLI", &Ok(result.clone()));
+        Ok(result)
+    }
+}
+
+/// Strips a single outer markdown code fence wrapping the entire response.
+///
+/// `claude -p` tends to wrap structured outputs (YAML, JSON) in a top-level
+/// ``` ```yaml ... ``` ``` block even when the prompt didn't ask for it. Some
+/// downstream parsers in this crate (e.g. `parse_pr_response`) expect bare
+/// YAML and do not tolerate that wrapper.
+///
+/// Conservative rules:
+/// - Only strips if the *entire* trimmed response is wrapped in one fence.
+/// - Leaves internal fences (e.g. inside a multi-line `description`) alone.
+/// - Returns the trimmed-original on any ambiguity.
+fn strip_wrapping_code_fence(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let Some(after_open) = trimmed.strip_prefix("```") else {
+        return trimmed.to_string();
+    };
+    // Drop optional language tag on the same line as the opening fence.
+    let body = match after_open.find('\n') {
+        Some(i) => &after_open[i + 1..],
+        None => return trimmed.to_string(),
+    };
+    let Some(without_trailing) = body.trim_end().strip_suffix("```") else {
+        return trimmed.to_string();
+    };
+    // Bail out if there's another fence inside — the content may legitimately
+    // contain its own fenced blocks (e.g. a PR description).
+    if without_trailing.contains("```") {
+        return trimmed.to_string();
+    }
+    without_trailing.trim_end().to_string()
+}
+
+impl AiClient for ClaudeCliAiClient {
+    fn send_request<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        Box::pin(async move {
+            debug!(
+                system_prompt_len = system_prompt.len(),
+                user_prompt_len = user_prompt.len(),
+                model = %self.model,
+                "Preparing claude -p subprocess request"
+            );
+            self.run(system_prompt, user_prompt).await
+        })
+    }
+
+    fn get_metadata(&self) -> AiClientMetadata {
+        // Resolve aliases (sonnet/opus/haiku) to concrete registry IDs for
+        // token-budget math; keep the original alias in the reported model
+        // string so users see what they asked for.
+        let effective_id = resolve_alias(&self.model);
+        let (max_context_length, max_response_length) =
+            super::registry_model_limits(&effective_id, &None);
+
+        AiClientMetadata {
+            provider: "Claude CLI".to_string(),
+            model: self.model.clone(),
+            max_context_length,
+            max_response_length,
+            active_beta: None,
+        }
+    }
+}
+
+/// Maps `claude -p` alias names to concrete API identifiers for the model
+/// registry lookup. Unknown names pass through unchanged.
+fn resolve_alias(model: &str) -> String {
+    match model {
+        "haiku" => "claude-haiku-4-5-20251001".to_string(),
+        "sonnet" => "claude-sonnet-4-6".to_string(),
+        "opus" => "claude-opus-4-6".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Converts a `claude -p` error envelope into a typed error.
+fn map_api_error(env: &JsonOutput, stderr: &str) -> anyhow::Error {
+    let status = env.api_error_status;
+    let msg = &env.result;
+    match status {
+        Some(401 | 403) => ClaudeError::ApiRequestFailed(format!(
+            "claude -p authentication failed ({status:?}): {msg}; stderr={stderr}"
+        ))
+        .into(),
+        Some(404) => {
+            ClaudeError::ApiRequestFailed(format!("claude -p reported unknown model (404): {msg}"))
+                .into()
+        }
+        Some(429) => ClaudeError::RateLimitExceeded.into(),
+        Some(code) if (500..=599).contains(&code) => ClaudeError::ApiRequestFailed(format!(
+            "claude -p transient API error ({code}): {msg}; stderr={stderr}"
+        ))
+        .into(),
+        _ => ClaudeError::ApiRequestFailed(format!(
+            "claude -p reported error (api_error_status={status:?}): {msg}; stderr={stderr}"
+        ))
+        .into(),
+    }
+}
+
+/// Returns true if `err` indicates the peer closed the pipe.
+fn is_pipe_closed(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+    )
+}
+
+/// Reads from `reader` until EOF, erroring if output exceeds `cap` bytes.
+async fn read_capped<R>(reader: &mut R, cap: usize) -> Result<Vec<u8>>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut buf = Vec::with_capacity(4096.min(cap));
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = reader
+            .read(&mut chunk)
+            .await
+            .context("Failed to read claude subprocess stdout")?;
+        if n == 0 {
+            break;
+        }
+        if buf.len().saturating_add(n) > cap {
+            warn!(cap, "claude subprocess stdout exceeded cap");
+            return Err(ClaudeError::SubprocessOutputTooLarge { limit: cap }.into());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    Ok(buf)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use tempfile::TempDir;
+
+    fn client_with_defaults(model: &str) -> ClaudeCliAiClient {
+        ClaudeCliAiClient::new_with_config(
+            model.to_string(),
+            DEFAULT_TIMEOUT,
+            DEFAULT_STDOUT_CAP,
+            false,
+            PathBuf::from("claude"),
+        )
+    }
+
+    fn args_of(cmd: &Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn build_command_includes_sandbox_flags() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys-prompt", tmp.path());
+        let args = args_of(&cmd);
+
+        assert!(args.contains(&"-p".to_string()), "missing -p: {args:?}");
+        assert!(
+            args.contains(&"--model".to_string()) && args.contains(&"sonnet".to_string()),
+            "missing --model sonnet: {args:?}"
+        );
+        assert!(
+            args.contains(&"--output-format".to_string()) && args.contains(&"json".to_string()),
+            "missing --output-format json: {args:?}"
+        );
+        assert!(
+            args.contains(&"--tools".to_string()),
+            "missing --tools: {args:?}"
+        );
+        assert!(
+            args.contains(&"--strict-mcp-config".to_string()),
+            "missing --strict-mcp-config: {args:?}"
+        );
+        assert!(
+            args.contains(&"--setting-sources".to_string()),
+            "missing --setting-sources: {args:?}"
+        );
+        assert!(
+            args.contains(&"--disable-slash-commands".to_string()),
+            "missing --disable-slash-commands: {args:?}"
+        );
+        assert!(
+            args.contains(&"--no-session-persistence".to_string()),
+            "missing --no-session-persistence: {args:?}"
+        );
+        assert!(
+            args.contains(&"--permission-mode".to_string())
+                && args.contains(&"default".to_string()),
+            "missing --permission-mode default: {args:?}"
+        );
+        assert!(
+            args.contains(&"--system-prompt".to_string()),
+            "missing --system-prompt: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_command_does_not_include_add_dir() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        assert!(
+            !args.contains(&"--add-dir".to_string()),
+            "must not pass --add-dir: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--mcp-config".to_string()),
+            "must not pass --mcp-config (strict-mcp-config with no config = lockdown)"
+        );
+    }
+
+    #[test]
+    fn build_command_uses_temp_cwd_not_parent() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        assert_eq!(
+            cmd.as_std().get_current_dir().map(Path::to_path_buf),
+            Some(tmp.path().to_path_buf())
+        );
+    }
+
+    #[test]
+    fn build_command_appends_tool_suppression_in_system_prompt() {
+        // The run() method appends the suffix before calling build_command.
+        // build_command itself takes the system prompt verbatim, so we
+        // verify the argv just echoes what we pass in.
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let with_suffix = format!("my system prompt{TOOL_SUPPRESSION_SUFFIX}");
+        let cmd = cli.build_command(&with_suffix, tmp.path());
+        let args = args_of(&cmd);
+        let sys_idx = args
+            .iter()
+            .position(|a| a == "--system-prompt")
+            .expect("--system-prompt present");
+        let sys_val = &args[sys_idx + 1];
+        assert!(
+            sys_val.contains("Do not emit function_calls XML"),
+            "system prompt should contain tool-suppression instruction: {sys_val}"
+        );
+    }
+
+    #[test]
+    fn build_command_scrubs_claude_project_env() {
+        std::env::set_var("CLAUDE_PROJECT_DIR", "/should/not/leak");
+        std::env::set_var("CLAUDE_CODE_ENTRYPOINT", "cli");
+        std::env::set_var("CLAUDE_PROJECT_SOMETHING", "x");
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+
+        // env_remove entries show up as (key, None) in get_envs.
+        let env: Vec<_> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| (k.to_string_lossy().into_owned(), v.map(OsStr::to_os_string)))
+            .collect();
+
+        let was_removed = |key: &str| -> bool { env.iter().any(|(k, v)| k == key && v.is_none()) };
+
+        assert!(
+            was_removed("CLAUDE_PROJECT_DIR"),
+            "CLAUDE_PROJECT_DIR should be scrubbed: {env:?}"
+        );
+        assert!(
+            was_removed("CLAUDE_CODE_ENTRYPOINT"),
+            "CLAUDE_CODE_ENTRYPOINT should be scrubbed: {env:?}"
+        );
+        assert!(
+            was_removed("CLAUDE_PROJECT_SOMETHING"),
+            "CLAUDE_PROJECT_SOMETHING should be scrubbed: {env:?}"
+        );
+
+        std::env::remove_var("CLAUDE_PROJECT_DIR");
+        std::env::remove_var("CLAUDE_CODE_ENTRYPOINT");
+        std::env::remove_var("CLAUDE_PROJECT_SOMETHING");
+    }
+
+    #[test]
+    fn build_command_with_allow_tools_omits_tools_flag() {
+        let cli = ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            DEFAULT_TIMEOUT,
+            DEFAULT_STDOUT_CAP,
+            true,
+            PathBuf::from("claude"),
+        );
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        // --tools flag should be absent when allow_tools=true (lets the
+        // CLI use its default tool set).
+        assert!(
+            !args.contains(&"--tools".to_string()),
+            "allow_tools=true should not pass --tools: {args:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_alias_known() {
+        assert_eq!(resolve_alias("haiku"), "claude-haiku-4-5-20251001");
+        assert_eq!(resolve_alias("sonnet"), "claude-sonnet-4-6");
+        assert_eq!(resolve_alias("opus"), "claude-opus-4-6");
+    }
+
+    #[test]
+    fn resolve_alias_passthrough() {
+        assert_eq!(resolve_alias("claude-sonnet-4-6"), "claude-sonnet-4-6");
+        assert_eq!(
+            resolve_alias("claude-haiku-4-5-20251001"),
+            "claude-haiku-4-5-20251001"
+        );
+    }
+
+    #[test]
+    fn metadata_has_claude_cli_provider() {
+        let cli = client_with_defaults("sonnet");
+        let meta = cli.get_metadata();
+        assert_eq!(meta.provider, "Claude CLI");
+        assert_eq!(meta.model, "sonnet");
+        assert!(meta.max_context_length > 0);
+        assert!(meta.max_response_length > 0);
+        assert!(meta.active_beta.is_none());
+    }
+
+    #[test]
+    fn metadata_prompt_style_is_claude() {
+        use crate::claude::ai::PromptStyle;
+        let cli = client_with_defaults("sonnet");
+        assert_eq!(cli.get_metadata().prompt_style(), PromptStyle::Claude);
+    }
+
+    #[test]
+    fn strip_fence_removes_yaml_wrapping() {
+        let raw = "```yaml\namendments: []\n```";
+        assert_eq!(strip_wrapping_code_fence(raw), "amendments: []");
+    }
+
+    #[test]
+    fn strip_fence_removes_bare_wrapping() {
+        let raw = "```\nsome text\n```";
+        assert_eq!(strip_wrapping_code_fence(raw), "some text");
+    }
+
+    #[test]
+    fn strip_fence_preserves_bare_content() {
+        let raw = "amendments:\n  - hash: abc";
+        assert_eq!(strip_wrapping_code_fence(raw), raw);
+    }
+
+    #[test]
+    fn strip_fence_preserves_content_with_internal_fences() {
+        // A PR description may legitimately embed a ```rust block; we must
+        // not mangle it.
+        let raw = "title: PR title\ndescription: |\n  Here is code:\n  ```rust\n  fn x() {}\n  ```\n  Done.";
+        assert_eq!(strip_wrapping_code_fence(raw), raw);
+    }
+
+    #[test]
+    fn strip_fence_with_wrapper_around_internal_fences_is_left_alone() {
+        // If the response is wrapped AND contains internal fences, we bail
+        // out — ambiguity between a legitimate wrapper and a response whose
+        // first character just happens to be a fence.
+        let raw = "```markdown\nouter\n```rust\nfn x() {}\n```\nmore\n```";
+        assert_eq!(strip_wrapping_code_fence(raw), raw);
+    }
+
+    #[test]
+    fn strip_fence_trims_outer_whitespace() {
+        let raw = "\n\n```yaml\namendments: []\n```\n\n";
+        assert_eq!(strip_wrapping_code_fence(raw), "amendments: []");
+    }
+
+    #[tokio::test]
+    async fn spawn_missing_binary_yields_typed_error() {
+        let cli = ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            DEFAULT_TIMEOUT,
+            DEFAULT_STDOUT_CAP,
+            false,
+            PathBuf::from("/nonexistent/path/to/claude-binary-xyz"),
+        );
+        let err = cli
+            .run("sys", "user")
+            .await
+            .expect_err("expected missing-binary error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("Subprocess binary not found"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn runaway_output_yields_timeout_or_cap_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // GNU `yes` on Linux errors on any unknown flag (including our
+        // leading `-p`), so we can't use it as a stand-in. Instead write
+        // a tiny shell-script shim that ignores argv and floods stdout.
+        let tmp = TempDir::new().unwrap();
+        let shim = tmp.path().join("runaway-claude");
+        std::fs::write(&shim, "#!/bin/sh\nwhile true; do printf 'y\\n'; done\n").unwrap();
+        let mut perms = std::fs::metadata(&shim).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&shim, perms).unwrap();
+
+        let cli = ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            Duration::from_secs(1),
+            64 * 1024,
+            false,
+            shim,
+        );
+        let err = cli
+            .run("sys", "user")
+            .await
+            .expect_err("expected timeout or size-cap error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("timed out") || chain.contains("output exceeded"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_json_output_yields_typed_error() {
+        // /bin/echo prints its args and exits 0 — produces no valid JSON.
+        let cli = ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            DEFAULT_TIMEOUT,
+            DEFAULT_STDOUT_CAP,
+            false,
+            PathBuf::from("/bin/echo"),
+        );
+        let err = cli
+            .run("sys", "user")
+            .await
+            .expect_err("expected JSON parse error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("invalid JSON output"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    // ── End-to-end run() tests via shell-script shims ───────────────
+
+    /// Writes a shell-script shim that drains stdin, emits `body` on
+    /// stdout, and exits with `exit_code`. Returns the shim path.
+    #[cfg(unix)]
+    fn make_shim(tmp: &TempDir, body: &str, exit_code: i32) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let shim = tmp.path().join("claude-shim");
+        // `cat > /dev/null` drains stdin so the parent's write completes
+        // cleanly rather than hitting EPIPE. `printf %s` avoids backslash
+        // interpretation. The heredoc uses a quoted terminator so JSON
+        // braces and quotes pass through unchanged.
+        let script = format!(
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{}'\nexit {}\n",
+            body.replace('\'', "'\\''"),
+            exit_code
+        );
+        std::fs::write(&shim, script).unwrap();
+        let mut perms = std::fs::metadata(&shim).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&shim, perms).unwrap();
+        shim
+    }
+
+    #[cfg(unix)]
+    fn client_with_shim(shim: PathBuf) -> ClaudeCliAiClient {
+        ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            Duration::from_secs(10),
+            DEFAULT_STDOUT_CAP,
+            false,
+            shim,
+        )
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn success_returns_result_field() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(&tmp, r#"{"is_error":false,"result":"hello from shim"}"#, 0);
+        let out = client_with_shim(shim).run("sys", "user").await.unwrap();
+        assert_eq!(out, "hello from shim");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn success_strips_top_level_yaml_fence() {
+        let tmp = TempDir::new().unwrap();
+        // `result` field is itself JSON-escaped; the wrapped content is
+        // ```yaml\namendments: []\n```
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":false,"result":"```yaml\namendments: []\n```"}"#,
+            0,
+        );
+        let out = client_with_shim(shim).run("sys", "user").await.unwrap();
+        assert_eq!(out, "amendments: []");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_401_maps_to_auth_failure() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"api_error_status":401,"result":"unauthorized"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected auth error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("authentication failed"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_403_maps_to_auth_failure() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"api_error_status":403,"result":"forbidden"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected auth error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("authentication failed"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_404_maps_to_unknown_model() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"api_error_status":404,"result":"model not found"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected unknown-model error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("unknown model"), "unexpected error: {chain}");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_429_maps_to_rate_limit() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"api_error_status":429,"result":"too many"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected rate-limit error");
+        let downcast = err
+            .downcast_ref::<ClaudeError>()
+            .expect("error should be ClaudeError");
+        assert!(matches!(downcast, ClaudeError::RateLimitExceeded));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_500_maps_to_transient() {
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"api_error_status":503,"result":"upstream unavailable"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected transient error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("transient API error"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn is_error_unknown_status_maps_to_generic() {
+        let tmp = TempDir::new().unwrap();
+        // No api_error_status → falls through to the generic arm.
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":true,"result":"something went wrong"}"#,
+            0,
+        );
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected generic error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("reported error"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn non_zero_exit_with_clean_json_still_errors() {
+        // is_error=false but process exits 1 — surfaced as a distinct
+        // error so the user sees the unexpected exit status.
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(&tmp, r#"{"is_error":false,"result":"ok"}"#, 1);
+        let err = client_with_shim(shim)
+            .run("sys", "user")
+            .await
+            .expect_err("expected exit-status error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("non-zero status"),
+            "unexpected error: {chain}"
+        );
+    }
+}

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -49,6 +49,14 @@ pub(crate) const STDOUT_CAP_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTE
 /// Env var overriding [`DEFAULT_BINARY`] (value: path to the `claude` binary).
 pub(crate) const BINARY_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_BIN";
 
+/// Env var enabling the tool-access escape hatch.
+///
+/// When set to `true` / `1` / `yes`, the nested `claude -p` session is
+/// allowed to use its default tool set (file-system access, shell, etc.)
+/// instead of being run with `--tools ""`. **This weakens the sandbox and
+/// should only be used for deliberately tool-capable use cases.**
+pub(crate) const ALLOW_TOOLS_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS";
+
 /// Defence-in-depth suffix appended to the caller's system prompt.
 ///
 /// Even with tools disabled at runtime, the model "knows" Claude Code tools
@@ -103,7 +111,7 @@ impl ClaudeCliAiClient {
             model,
             Self::timeout_from_env(),
             Self::stdout_cap_from_env(),
-            false,
+            Self::allow_tools_from_env(),
             Self::binary_from_env(),
         )
     }
@@ -144,6 +152,15 @@ impl ClaudeCliAiClient {
         crate::utils::settings::get_env_var(BINARY_ENV_VAR)
             .ok()
             .map_or_else(|| PathBuf::from(DEFAULT_BINARY), PathBuf::from)
+    }
+
+    /// Reads [`ALLOW_TOOLS_ENV_VAR`] and returns whether the tool-access
+    /// escape hatch is enabled. Accepts `true` / `1` / `yes` (case-insensitive);
+    /// everything else (including unset) means disabled.
+    fn allow_tools_from_env() -> bool {
+        crate::utils::settings::get_env_var(ALLOW_TOOLS_ENV_VAR)
+            .ok()
+            .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
     }
 
     /// Builds the subprocess [`Command`] without spawning.
@@ -199,9 +216,19 @@ impl ClaudeCliAiClient {
 
         let mut cmd = self.build_command(&combined_system, temp_dir.path());
 
+        if self.allow_tools {
+            warn!(
+                "claude -p sandbox weakened: tool-access escape hatch is enabled \
+                 (--claude-cli-allow-tools / OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS). \
+                 The nested session can now read, edit, and execute against the \
+                 environment it inherits."
+            );
+        }
+
         info!(
             binary = %self.binary_path.display(),
             model = %self.model,
+            allow_tools = self.allow_tools,
             timeout_secs = self.timeout.as_secs(),
             "Spawning claude -p subprocess"
         );
@@ -646,6 +673,109 @@ mod tests {
         assert!(
             !args.contains(&"--tools".to_string()),
             "allow_tools=true should not pass --tools: {args:?}"
+        );
+    }
+
+    /// Test-scoped mutex + guard to serialise env-mutating escape-hatch
+    /// tests. Separate from other modules' locks on purpose — these tests
+    /// only touch `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS`.
+    static ALLOW_TOOLS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct AllowToolsEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Option<String>,
+    }
+
+    impl AllowToolsEnvGuard {
+        fn new() -> Self {
+            let lock = ALLOW_TOOLS_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let saved = std::env::var(ALLOW_TOOLS_ENV_VAR).ok();
+            std::env::remove_var(ALLOW_TOOLS_ENV_VAR);
+            Self { _lock: lock, saved }
+        }
+
+        fn set(&self, value: &str) {
+            std::env::set_var(ALLOW_TOOLS_ENV_VAR, value);
+        }
+    }
+
+    impl Drop for AllowToolsEnvGuard {
+        fn drop(&mut self) {
+            match self.saved.take() {
+                Some(v) => std::env::set_var(ALLOW_TOOLS_ENV_VAR, v),
+                None => std::env::remove_var(ALLOW_TOOLS_ENV_VAR),
+            }
+        }
+    }
+
+    #[test]
+    fn allow_tools_from_env_defaults_to_false_when_unset() {
+        let _g = AllowToolsEnvGuard::new();
+        assert!(!ClaudeCliAiClient::allow_tools_from_env());
+    }
+
+    #[test]
+    fn allow_tools_from_env_true() {
+        let g = AllowToolsEnvGuard::new();
+        g.set("true");
+        assert!(ClaudeCliAiClient::allow_tools_from_env());
+    }
+
+    #[test]
+    fn allow_tools_from_env_true_case_insensitive_and_trimmed() {
+        let g = AllowToolsEnvGuard::new();
+        g.set("  TRUE  ");
+        assert!(ClaudeCliAiClient::allow_tools_from_env());
+    }
+
+    #[test]
+    fn allow_tools_from_env_one_and_yes_accepted() {
+        let g = AllowToolsEnvGuard::new();
+        g.set("1");
+        assert!(ClaudeCliAiClient::allow_tools_from_env());
+        g.set("yes");
+        assert!(ClaudeCliAiClient::allow_tools_from_env());
+    }
+
+    #[test]
+    fn allow_tools_from_env_other_values_are_false() {
+        let g = AllowToolsEnvGuard::new();
+        for v in ["false", "0", "no", "off", "TRUE1", "YES!", ""] {
+            g.set(v);
+            assert!(
+                !ClaudeCliAiClient::allow_tools_from_env(),
+                "value {v:?} should not enable the escape hatch"
+            );
+        }
+    }
+
+    #[test]
+    fn new_picks_up_allow_tools_env_var() {
+        let g = AllowToolsEnvGuard::new();
+        g.set("true");
+        let cli = ClaudeCliAiClient::new("sonnet".to_string());
+        // Verify via build_command — allow_tools=true omits --tools.
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        assert!(
+            !args.contains(&"--tools".to_string()),
+            "ALLOW_TOOLS=true should omit --tools in argv: {args:?}"
+        );
+    }
+
+    #[test]
+    fn new_defaults_to_tools_disabled_when_env_unset() {
+        let _g = AllowToolsEnvGuard::new();
+        let cli = ClaudeCliAiClient::new("sonnet".to_string());
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        assert!(
+            args.contains(&"--tools".to_string()),
+            "default (no env) must include --tools \"\": {args:?}"
         );
     }
 

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -57,6 +57,13 @@ pub(crate) const BINARY_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_BIN";
 /// should only be used for deliberately tool-capable use cases.**
 pub(crate) const ALLOW_TOOLS_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS";
 
+/// Env var setting a per-invocation spending cap in USD.
+///
+/// Forwarded to `claude -p --max-budget-usd <amount>`. When the subprocess
+/// exceeds this budget it aborts with an error rather than running away
+/// with cost. Accepts floating-point dollar amounts (e.g. `0.50`).
+pub(crate) const MAX_BUDGET_ENV_VAR: &str = "OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD";
+
 /// Defence-in-depth suffix appended to the caller's system prompt.
 ///
 /// Even with tools disabled at runtime, the model "knows" Claude Code tools
@@ -84,6 +91,11 @@ struct JsonOutput {
     api_error_status: Option<i64>,
     #[serde(default)]
     result: String,
+    /// Total billed cost for this invocation in USD (inclusive of cache
+    /// creation, input and output tokens). Surfaced via tracing for cost
+    /// observability regardless of budget cap.
+    #[serde(default)]
+    total_cost_usd: Option<f64>,
 }
 
 /// Claude Code CLI subprocess AI client.
@@ -100,6 +112,9 @@ pub struct ClaudeCliAiClient {
     allow_tools: bool,
     /// Path to the `claude` binary (defaults to `claude` on PATH).
     binary_path: PathBuf,
+    /// Optional per-invocation spending cap in USD (forwarded to
+    /// `claude -p --max-budget-usd`). `None` means no explicit cap.
+    max_budget_usd: Option<f64>,
 }
 
 impl ClaudeCliAiClient {
@@ -114,9 +129,14 @@ impl ClaudeCliAiClient {
             Self::allow_tools_from_env(),
             Self::binary_from_env(),
         )
+        .with_max_budget_usd(Self::max_budget_from_env())
     }
 
     /// Creates a client with explicit configuration. Primarily for tests.
+    ///
+    /// `max_budget_usd` is set separately via [`with_max_budget_usd`] so
+    /// that existing callers of this constructor do not need to update
+    /// when new optional knobs are added.
     #[must_use]
     pub fn new_with_config(
         model: String,
@@ -131,7 +151,15 @@ impl ClaudeCliAiClient {
             stdout_cap,
             allow_tools,
             binary_path,
+            max_budget_usd: None,
         }
+    }
+
+    /// Sets the per-invocation spending cap. Builder-style for ergonomics.
+    #[must_use]
+    pub fn with_max_budget_usd(mut self, budget: Option<f64>) -> Self {
+        self.max_budget_usd = budget;
+        self
     }
 
     fn timeout_from_env() -> Duration {
@@ -163,6 +191,15 @@ impl ClaudeCliAiClient {
             .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
     }
 
+    /// Reads [`MAX_BUDGET_ENV_VAR`] and returns the parsed spending cap.
+    /// Returns `None` when unset or unparseable.
+    fn max_budget_from_env() -> Option<f64> {
+        crate::utils::settings::get_env_var(MAX_BUDGET_ENV_VAR)
+            .ok()
+            .and_then(|v| v.trim().parse::<f64>().ok())
+            .filter(|v| v.is_finite() && *v > 0.0)
+    }
+
     /// Builds the subprocess [`Command`] without spawning.
     ///
     /// Broken out so tests can inspect the argv / env / cwd via
@@ -187,6 +224,13 @@ impl ClaudeCliAiClient {
 
         if !self.allow_tools {
             cmd.arg("--tools").arg("");
+        }
+
+        if let Some(budget) = self.max_budget_usd {
+            // claude -p expects a decimal dollar amount; use a stable
+            // format that round-trips through its parser (no locale
+            // formatting, no scientific notation).
+            cmd.arg("--max-budget-usd").arg(format!("{budget}"));
         }
 
         cmd.current_dir(cwd);
@@ -348,6 +392,29 @@ impl ClaudeCliAiClient {
                 .into());
             }
         };
+
+        // Cost observability: log the total billed cost whenever the CLI
+        // reports one, regardless of success / failure. Users running at
+        // scale need this to understand spending.
+        if let Some(cost) = envelope.total_cost_usd {
+            info!(
+                total_cost_usd = cost,
+                max_budget_usd = ?self.max_budget_usd,
+                model = %self.model,
+                "claude -p invocation cost"
+            );
+            if let Some(budget) = self.max_budget_usd {
+                if cost > budget {
+                    // claude -p enforces the cap itself, but warn in case
+                    // its enforcement differs from ours.
+                    warn!(
+                        total_cost_usd = cost,
+                        max_budget_usd = budget,
+                        "claude -p reported cost above the configured budget cap"
+                    );
+                }
+            }
+        }
 
         if envelope.is_error {
             return Err(map_api_error(&envelope, &stderr_text));
@@ -777,6 +844,155 @@ mod tests {
             args.contains(&"--tools".to_string()),
             "default (no env) must include --tools \"\": {args:?}"
         );
+    }
+
+    // ── Budget cap tests (MAX_BUDGET_ENV_VAR / with_max_budget_usd) ──
+
+    static MAX_BUDGET_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct MaxBudgetEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Option<String>,
+    }
+
+    impl MaxBudgetEnvGuard {
+        fn new() -> Self {
+            let lock = MAX_BUDGET_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let saved = std::env::var(MAX_BUDGET_ENV_VAR).ok();
+            std::env::remove_var(MAX_BUDGET_ENV_VAR);
+            Self { _lock: lock, saved }
+        }
+
+        fn set(&self, value: &str) {
+            std::env::set_var(MAX_BUDGET_ENV_VAR, value);
+        }
+    }
+
+    impl Drop for MaxBudgetEnvGuard {
+        fn drop(&mut self) {
+            match self.saved.take() {
+                Some(v) => std::env::set_var(MAX_BUDGET_ENV_VAR, v),
+                None => std::env::remove_var(MAX_BUDGET_ENV_VAR),
+            }
+        }
+    }
+
+    #[test]
+    fn max_budget_from_env_unset_is_none() {
+        let _g = MaxBudgetEnvGuard::new();
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+    }
+
+    #[test]
+    fn max_budget_from_env_parses_decimal() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("0.50");
+        assert_eq!(ClaudeCliAiClient::max_budget_from_env(), Some(0.50));
+        g.set("2.5");
+        assert_eq!(ClaudeCliAiClient::max_budget_from_env(), Some(2.5));
+    }
+
+    #[test]
+    fn max_budget_from_env_trims_whitespace() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("  1.25  ");
+        assert_eq!(ClaudeCliAiClient::max_budget_from_env(), Some(1.25));
+    }
+
+    #[test]
+    fn max_budget_from_env_rejects_non_positive() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("0");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+        g.set("-1.0");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+    }
+
+    #[test]
+    fn max_budget_from_env_rejects_non_finite() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("nan");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+        g.set("inf");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+    }
+
+    #[test]
+    fn max_budget_from_env_rejects_garbage() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("five dollars");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+        g.set("");
+        assert!(ClaudeCliAiClient::max_budget_from_env().is_none());
+    }
+
+    #[test]
+    fn build_command_omits_max_budget_when_unset() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        assert!(
+            !args.contains(&"--max-budget-usd".to_string()),
+            "no budget → argv must omit --max-budget-usd: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_command_includes_max_budget_when_set() {
+        let cli = client_with_defaults("sonnet").with_max_budget_usd(Some(0.50));
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        let idx = args
+            .iter()
+            .position(|a| a == "--max-budget-usd")
+            .expect("argv should contain --max-budget-usd");
+        assert_eq!(args[idx + 1], "0.5");
+    }
+
+    #[test]
+    fn new_picks_up_max_budget_env_var() {
+        let g = MaxBudgetEnvGuard::new();
+        g.set("1.25");
+        let cli = ClaudeCliAiClient::new("sonnet".to_string());
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        let idx = args
+            .iter()
+            .position(|a| a == "--max-budget-usd")
+            .expect("argv should contain --max-budget-usd when env set");
+        assert_eq!(args[idx + 1], "1.25");
+    }
+
+    #[test]
+    fn with_max_budget_usd_none_clears_budget() {
+        let cli = client_with_defaults("sonnet")
+            .with_max_budget_usd(Some(1.0))
+            .with_max_budget_usd(None);
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command("sys", tmp.path());
+        let args = args_of(&cmd);
+        assert!(!args.contains(&"--max-budget-usd".to_string()));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn cost_is_extracted_from_json_envelope_and_run_succeeds() {
+        // Verifies the JSON envelope's total_cost_usd is parsed without
+        // error and the happy path still returns the result.
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(
+            &tmp,
+            r#"{"is_error":false,"result":"ok","total_cost_usd":0.0123}"#,
+            0,
+        );
+        let cli = client_with_shim(shim).with_max_budget_usd(Some(1.0));
+        let out = cli.run("sys", "user").await.unwrap();
+        assert_eq!(out, "ok");
     }
 
     #[test]

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -1,7 +1,7 @@
 //! Claude client for commit message improvement.
 
 use anyhow::{Context, Result};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::claude::token_budget::TokenBudget;
 use crate::claude::{ai::bedrock::BedrockAiClient, ai::claude::ClaudeAiClient};
@@ -1496,8 +1496,41 @@ pub fn create_default_claude_client(
     model: Option<String>,
     beta_header: Option<(String, String)>,
 ) -> Result<ClaudeClient> {
+    use crate::claude::ai::claude_cli::ClaudeCliAiClient;
     use crate::claude::ai::openai::OpenAiAiClient;
     use crate::utils::settings::{get_env_var, get_env_vars};
+
+    // `claude -p` subprocess backend takes precedence when requested — it
+    // reuses an existing Claude Code auth session and is the only backend
+    // that accepts short model aliases (sonnet/opus/haiku), so it must
+    // short-circuit before `validate_beta_header` runs below.
+    let ai_backend = get_env_var("OMNI_DEV_AI_BACKEND").ok();
+    let use_claude_cli = ai_backend
+        .as_deref()
+        .is_some_and(|v| matches!(v, "claude-cli" | "claude_cli"));
+
+    if use_claude_cli {
+        if beta_header.is_some() {
+            warn!(
+                "--beta-header is ignored when OMNI_DEV_AI_BACKEND=claude-cli \
+                 (the CLI's --betas flag has different semantics and is not forwarded)"
+            );
+        }
+        let registry = crate::claude::model_config::get_model_registry();
+        let cli_model = model
+            .or_else(|| get_env_var("CLAUDE_MODEL").ok())
+            .or_else(|| get_env_var("CLAUDE_CODE_MODEL").ok())
+            .or_else(|| get_env_var("ANTHROPIC_MODEL").ok())
+            .unwrap_or_else(|| {
+                registry
+                    .get_default_model("claude")
+                    .unwrap_or("claude-sonnet-4-6")
+                    .to_string()
+            });
+        debug!(model = %cli_model, "Creating claude -p subprocess client");
+        let ai_client = ClaudeCliAiClient::new(cli_model);
+        return Ok(ClaudeClient::new(Box::new(ai_client)));
+    }
 
     // Check if we should use OpenAI-compatible API (OpenAI or Ollama)
     let use_openai = get_env_var("USE_OPENAI").is_ok_and(|val| val == "true");
@@ -3498,5 +3531,123 @@ mod tests {
         assert_eq!(result.unwrap().amendments.len(), 1);
         assert_eq!(response_handle.remaining(), 0);
         assert_eq!(prompt_handle.request_count(), 3, "all 3 attempts used");
+    }
+
+    // ── create_default_claude_client factory ───────────────────────
+
+    /// Serialises env-mutating factory tests in this module.
+    static FACTORY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct FactoryEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl FactoryEnvGuard {
+        fn new(keys: &[&'static str]) -> Self {
+            let lock = FACTORY_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let saved = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            for k in keys {
+                std::env::remove_var(k);
+            }
+            Self { _lock: lock, saved }
+        }
+
+        fn set(&self, key: &str, value: &str) {
+            std::env::set_var(key, value);
+        }
+    }
+
+    impl Drop for FactoryEnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in self.saved.drain(..) {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn factory_claude_cli_backend_dispatches_to_claude_cli_client() {
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_MODEL",
+            "CLAUDE_CODE_MODEL",
+            "ANTHROPIC_MODEL",
+        ]);
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+
+        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.provider, "Claude CLI");
+        // Default model falls through to the registry's claude default.
+        assert_eq!(metadata.model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn factory_claude_cli_backend_honours_model_precedence() {
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_MODEL",
+            "CLAUDE_CODE_MODEL",
+            "ANTHROPIC_MODEL",
+        ]);
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+        guard.set("CLAUDE_CODE_MODEL", "opus");
+        // CLAUDE_MODEL has higher precedence than CLAUDE_CODE_MODEL.
+        guard.set("CLAUDE_MODEL", "haiku");
+
+        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.provider, "Claude CLI");
+        assert_eq!(metadata.model, "haiku");
+    }
+
+    #[test]
+    fn factory_claude_cli_backend_explicit_model_wins_over_env() {
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_MODEL",
+            "CLAUDE_CODE_MODEL",
+            "ANTHROPIC_MODEL",
+        ]);
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+        guard.set("CLAUDE_MODEL", "haiku");
+
+        let client = create_default_claude_client(Some("opus".to_string()), None)
+            .expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.model, "opus");
+    }
+
+    #[test]
+    fn factory_claude_cli_backend_accepts_underscore_alias() {
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_MODEL",
+            "CLAUDE_CODE_MODEL",
+            "ANTHROPIC_MODEL",
+        ]);
+        guard.set("OMNI_DEV_AI_BACKEND", "claude_cli");
+
+        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.provider, "Claude CLI");
     }
 }

--- a/src/claude/error.rs
+++ b/src/claude/error.rs
@@ -44,6 +44,32 @@ pub enum ClaudeError {
     /// Network connectivity error.
     #[error("Network error: {0}")]
     NetworkError(String),
+
+    /// Required subprocess binary is missing from PATH.
+    #[error("Subprocess binary not found: {0}")]
+    SubprocessBinaryMissing(String),
+
+    /// Failed to spawn a subprocess.
+    #[error("Failed to spawn subprocess: {0}")]
+    SubprocessSpawnFailed(String),
+
+    /// Subprocess exceeded the configured timeout.
+    #[error("Subprocess timed out after {secs} seconds")]
+    SubprocessTimeout {
+        /// Timeout that was exceeded, in seconds.
+        secs: u64,
+    },
+
+    /// Subprocess produced more output than the configured cap.
+    #[error("Subprocess output exceeded limit of {limit} bytes")]
+    SubprocessOutputTooLarge {
+        /// Configured stdout cap in bytes.
+        limit: usize,
+    },
+
+    /// Subprocess stdout was not valid JSON.
+    #[error("Subprocess produced invalid JSON output: {0}")]
+    SubprocessJsonParseFailed(String),
 }
 
 // Note: anyhow already has a blanket impl for thiserror::Error types

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI interface for omni-dev.
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 pub mod ai;
 pub mod atlassian;
@@ -10,12 +10,30 @@ pub mod config;
 pub mod git;
 pub mod help;
 
+/// AI backend selector.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum AiBackend {
+    /// Default backend dispatch (HTTP to Anthropic/Bedrock/OpenAI/Ollama via
+    /// the existing `USE_*` env vars).
+    Default,
+    /// Shell out to the `claude -p` CLI (reuses an existing Claude Code auth
+    /// session). Equivalent to setting `OMNI_DEV_AI_BACKEND=claude-cli`.
+    ClaudeCli,
+}
+
 /// omni-dev: A comprehensive development toolkit.
 #[derive(Parser)]
 #[command(name = "omni-dev")]
 #[command(about = "A comprehensive development toolkit", long_about = None)]
 #[command(version)]
 pub struct Cli {
+    /// Selects the AI backend used by commands that invoke an AI model.
+    ///
+    /// Overrides the `OMNI_DEV_AI_BACKEND` environment variable.
+    #[arg(long, global = true, value_enum)]
+    pub ai_backend: Option<AiBackend>,
+
     /// The main command to execute.
     #[command(subcommand)]
     pub command: Commands,
@@ -42,6 +60,16 @@ pub enum Commands {
 impl Cli {
     /// Executes the CLI command.
     pub async fn execute(self) -> Result<()> {
+        // Propagate --ai-backend to the env var the factory reads. Setting
+        // the env var here (rather than threading an extra argument through
+        // every command) keeps the factory signature stable.
+        if let Some(backend) = self.ai_backend {
+            match backend {
+                AiBackend::Default => std::env::remove_var("OMNI_DEV_AI_BACKEND"),
+                AiBackend::ClaudeCli => std::env::set_var("OMNI_DEV_AI_BACKEND", "claude-cli"),
+            }
+        }
+
         match self.command {
             Commands::Ai(ai_cmd) => ai_cmd.execute().await,
             Commands::Git(git_cmd) => git_cmd.execute().await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,19 @@ pub struct Cli {
     #[arg(long, global = true, value_enum)]
     pub ai_backend: Option<AiBackend>,
 
+    /// Weakens the `claude-cli` sandbox by allowing the nested `claude -p`
+    /// session to use its default tool set (Read/Edit/Write/Bash/Glob/Grep
+    /// and any user-level MCP servers).
+    ///
+    /// **Only use for deliberately tool-capable use cases.** By default the
+    /// nested session runs with `--tools ""` and cannot touch the
+    /// file system. This flag removes that guard. Equivalent to setting
+    /// `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true`.
+    ///
+    /// Ignored when `--ai-backend` is not `claude-cli`.
+    #[arg(long, global = true)]
+    pub claude_cli_allow_tools: bool,
+
     /// The main command to execute.
     #[command(subcommand)]
     pub command: Commands,
@@ -70,6 +83,10 @@ impl Cli {
             }
         }
 
+        if self.claude_cli_allow_tools {
+            std::env::set_var("OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS", "true");
+        }
+
         match self.command {
             Commands::Ai(ai_cmd) => ai_cmd.execute().await,
             Commands::Git(git_cmd) => git_cmd.execute().await,
@@ -78,5 +95,54 @@ impl Cli {
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::HelpAll(help_cmd) => help_cmd.execute(),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ai_backend_claude_cli() {
+        let cli =
+            Cli::try_parse_from(["omni-dev", "--ai-backend", "claude-cli", "help-all"]).unwrap();
+        assert!(matches!(cli.ai_backend, Some(AiBackend::ClaudeCli)));
+        assert!(!cli.claude_cli_allow_tools);
+    }
+
+    #[test]
+    fn parses_ai_backend_default() {
+        let cli = Cli::try_parse_from(["omni-dev", "--ai-backend", "default", "help-all"]).unwrap();
+        assert!(matches!(cli.ai_backend, Some(AiBackend::Default)));
+    }
+
+    #[test]
+    fn parses_ai_backend_absent() {
+        let cli = Cli::try_parse_from(["omni-dev", "help-all"]).unwrap();
+        assert!(cli.ai_backend.is_none());
+        assert!(!cli.claude_cli_allow_tools);
+    }
+
+    #[test]
+    fn parses_claude_cli_allow_tools_flag() {
+        let cli =
+            Cli::try_parse_from(["omni-dev", "--claude-cli-allow-tools", "help-all"]).unwrap();
+        assert!(cli.claude_cli_allow_tools);
+    }
+
+    #[test]
+    fn global_flags_accepted_after_subcommand() {
+        // clap global = true allows the flag before or after the subcommand.
+        let cli = Cli::try_parse_from([
+            "omni-dev",
+            "help-all",
+            "--ai-backend",
+            "claude-cli",
+            "--claude-cli-allow-tools",
+        ])
+        .unwrap();
+        assert!(matches!(cli.ai_backend, Some(AiBackend::ClaudeCli)));
+        assert!(cli.claude_cli_allow_tools);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,16 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub claude_cli_allow_tools: bool,
 
+    /// Per-invocation spending cap in USD for the `claude-cli` backend.
+    ///
+    /// Forwarded to `claude -p --max-budget-usd`. When the nested session
+    /// exceeds this budget it aborts rather than running away with cost.
+    /// Equivalent to setting `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD`.
+    ///
+    /// Ignored when `--ai-backend` is not `claude-cli`.
+    #[arg(long, global = true, value_name = "AMOUNT")]
+    pub claude_cli_max_budget_usd: Option<f64>,
+
     /// The main command to execute.
     #[command(subcommand)]
     pub command: Commands,
@@ -85,6 +95,10 @@ impl Cli {
 
         if self.claude_cli_allow_tools {
             std::env::set_var("OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS", "true");
+        }
+
+        if let Some(budget) = self.claude_cli_max_budget_usd {
+            std::env::set_var("OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD", format!("{budget}"));
         }
 
         match self.command {
@@ -144,5 +158,37 @@ mod tests {
         .unwrap();
         assert!(matches!(cli.ai_backend, Some(AiBackend::ClaudeCli)));
         assert!(cli.claude_cli_allow_tools);
+    }
+
+    #[test]
+    fn parses_max_budget_usd_flag() {
+        let cli = Cli::try_parse_from([
+            "omni-dev",
+            "--claude-cli-max-budget-usd",
+            "0.50",
+            "help-all",
+        ])
+        .unwrap();
+        assert_eq!(cli.claude_cli_max_budget_usd, Some(0.50));
+    }
+
+    #[test]
+    fn max_budget_usd_absent_is_none() {
+        let cli = Cli::try_parse_from(["omni-dev", "help-all"]).unwrap();
+        assert!(cli.claude_cli_max_budget_usd.is_none());
+    }
+
+    #[test]
+    fn max_budget_usd_rejects_non_numeric() {
+        let result = Cli::try_parse_from([
+            "omni-dev",
+            "--claude-cli-max-budget-usd",
+            "cheap",
+            "help-all",
+        ]);
+        let Err(err) = result else {
+            panic!("expected parse error for non-numeric budget");
+        };
+        assert!(err.to_string().contains("invalid"));
     }
 }

--- a/src/utils/preflight.rs
+++ b/src/utils/preflight.rs
@@ -28,6 +28,8 @@ pub enum AiProvider {
     OpenAi,
     /// Local Ollama.
     Ollama,
+    /// `claude -p` subprocess (Claude Code CLI).
+    ClaudeCli,
 }
 
 impl std::fmt::Display for AiProvider {
@@ -37,6 +39,7 @@ impl std::fmt::Display for AiProvider {
             Self::Bedrock => write!(f, "AWS Bedrock"),
             Self::OpenAi => write!(f, "OpenAI API"),
             Self::Ollama => write!(f, "Ollama"),
+            Self::ClaudeCli => write!(f, "Claude Code CLI"),
         }
     }
 }
@@ -48,6 +51,45 @@ impl std::fmt::Display for AiProvider {
 /// require AI to fail fast if credentials are missing.
 pub fn check_ai_credentials(model_override: Option<&str>) -> Result<AiCredentialInfo> {
     use crate::utils::settings::{get_env_var, get_env_vars};
+
+    // The `claude -p` subprocess backend is checked first so it wins over
+    // the existing USE_* flags if multiple are set. Credentials for this
+    // backend live inside the `claude` binary's own auth state, so we just
+    // verify the binary is on PATH.
+    if let Ok(val) = get_env_var("OMNI_DEV_AI_BACKEND") {
+        if matches!(val.as_str(), "claude-cli" | "claude_cli") {
+            let binary =
+                get_env_var("OMNI_DEV_CLAUDE_CLI_BIN").unwrap_or_else(|_| "claude".to_string());
+            let probe = std::process::Command::new(&binary)
+                .arg("--version")
+                .output();
+            match probe {
+                Ok(out) if out.status.success() => {
+                    let registry = get_model_registry();
+                    let model = model_override
+                        .map(String::from)
+                        .or_else(|| get_env_var("CLAUDE_MODEL").ok())
+                        .or_else(|| get_env_var("CLAUDE_CODE_MODEL").ok())
+                        .or_else(|| get_env_var("ANTHROPIC_MODEL").ok())
+                        .unwrap_or_else(|| {
+                            registry
+                                .get_default_model("claude")
+                                .unwrap_or("claude-sonnet-4-6")
+                                .to_string()
+                        });
+                    return Ok(AiCredentialInfo {
+                        provider: AiProvider::ClaudeCli,
+                        model,
+                    });
+                }
+                _ => bail!(
+                    "Claude Code CLI not available at '{binary}'.\n\
+                     Install it from https://github.com/anthropics/claude-code \
+                     or set OMNI_DEV_CLAUDE_CLI_BIN to its path."
+                ),
+            }
+        }
+    }
 
     // Check provider selection flags
     let use_openai = get_env_var("USE_OPENAI").is_ok_and(|val| val == "true");
@@ -335,6 +377,7 @@ mod tests {
         assert_eq!(format!("{}", AiProvider::Bedrock), "AWS Bedrock");
         assert_eq!(format!("{}", AiProvider::OpenAi), "OpenAI API");
         assert_eq!(format!("{}", AiProvider::Ollama), "Ollama");
+        assert_eq!(format!("{}", AiProvider::ClaudeCli), "Claude Code CLI");
     }
 
     #[test]
@@ -422,5 +465,96 @@ mod tests {
 
         let info = check_ai_credentials(Some("claude-opus-4-6")).unwrap();
         assert_eq!(info.model, "claude-opus-4-6");
+    }
+
+    #[cfg(unix)]
+    fn make_version_shim(tmp: &tempfile::TempDir, exit_code: i32) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let shim = tmp.path().join("claude-bin-shim");
+        std::fs::write(
+            &shim,
+            format!("#!/bin/sh\necho 'fake-claude 0.0.0'\nexit {exit_code}\n"),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&shim).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&shim, perms).unwrap();
+        shim
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn claude_cli_backend_uses_version_probe() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let shim = make_version_shim(&tmp, 0);
+
+        let mut guard = EnvGuard::new();
+        guard.remove("USE_OPENAI");
+        guard.remove("USE_OLLAMA");
+        guard.remove("CLAUDE_CODE_USE_BEDROCK");
+        guard.remove("ANTHROPIC_MODEL");
+        guard.remove("CLAUDE_MODEL");
+        guard.remove("CLAUDE_CODE_MODEL");
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+        guard.set("OMNI_DEV_CLAUDE_CLI_BIN", shim.to_str().unwrap());
+
+        let info = check_ai_credentials(None).unwrap();
+        assert_eq!(info.provider, AiProvider::ClaudeCli);
+        assert_eq!(info.model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn claude_cli_backend_uses_model_from_env() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let shim = make_version_shim(&tmp, 0);
+
+        let mut guard = EnvGuard::new();
+        guard.remove("USE_OPENAI");
+        guard.remove("USE_OLLAMA");
+        guard.remove("CLAUDE_CODE_USE_BEDROCK");
+        guard.remove("ANTHROPIC_MODEL");
+        guard.remove("CLAUDE_CODE_MODEL");
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+        guard.set("OMNI_DEV_CLAUDE_CLI_BIN", shim.to_str().unwrap());
+        guard.set("CLAUDE_MODEL", "haiku");
+
+        let info = check_ai_credentials(None).unwrap();
+        assert_eq!(info.provider, AiProvider::ClaudeCli);
+        assert_eq!(info.model, "haiku");
+    }
+
+    #[test]
+    fn claude_cli_backend_missing_binary_fails_preflight() {
+        let mut guard = EnvGuard::new();
+        guard.remove("USE_OPENAI");
+        guard.remove("USE_OLLAMA");
+        guard.remove("CLAUDE_CODE_USE_BEDROCK");
+        guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
+        guard.set("OMNI_DEV_CLAUDE_CLI_BIN", "/nonexistent/claude-binary-xyz");
+
+        let err = check_ai_credentials(None).expect_err("expected missing-binary error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("Claude Code CLI not available"),
+            "unexpected error: {chain}"
+        );
+    }
+
+    #[test]
+    fn claude_cli_backend_accepts_underscore_alias() {
+        // The factory/preflight accept both `claude-cli` and `claude_cli`.
+        // Verify the second spelling routes the same way (missing-binary
+        // path exercises the selector cheaply).
+        let mut guard = EnvGuard::new();
+        guard.remove("USE_OPENAI");
+        guard.remove("USE_OLLAMA");
+        guard.remove("CLAUDE_CODE_USE_BEDROCK");
+        guard.set("OMNI_DEV_AI_BACKEND", "claude_cli");
+        guard.set("OMNI_DEV_CLAUDE_CLI_BIN", "/nonexistent/claude-binary-xyz");
+
+        let err = check_ai_credentials(None).expect_err("expected missing-binary error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("Claude Code CLI not available"));
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -447,6 +447,7 @@ async fn cli_execute_dispatches_git_commit_message_view() {
     use omni_dev::cli::{Cli, Commands};
 
     let cli = Cli {
+        ai_backend: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Commit(CommitCommand {
                 command: CommitSubcommands::Message(MessageCommand {
@@ -468,6 +469,7 @@ async fn cli_execute_dispatches_git_branch_info() {
     use omni_dev::cli::{Cli, Commands};
 
     let cli = Cli {
+        ai_backend: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Branch(BranchCommand {
                 command: BranchSubcommands::Info(InfoCommand { base_branch: None }),
@@ -483,6 +485,7 @@ async fn cli_execute_dispatches_ai_chat() {
     use omni_dev::cli::{Cli, Commands};
 
     let cli = Cli {
+        ai_backend: None,
         command: Commands::Ai(AiCommand {
             command: AiSubcommands::Chat(ChatCommand { model: None }),
         }),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -449,6 +449,7 @@ async fn cli_execute_dispatches_git_commit_message_view() {
     let cli = Cli {
         ai_backend: None,
         claude_cli_allow_tools: false,
+        claude_cli_max_budget_usd: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Commit(CommitCommand {
                 command: CommitSubcommands::Message(MessageCommand {
@@ -472,6 +473,7 @@ async fn cli_execute_dispatches_git_branch_info() {
     let cli = Cli {
         ai_backend: None,
         claude_cli_allow_tools: false,
+        claude_cli_max_budget_usd: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Branch(BranchCommand {
                 command: BranchSubcommands::Info(InfoCommand { base_branch: None }),
@@ -489,6 +491,7 @@ async fn cli_execute_dispatches_ai_chat() {
     let cli = Cli {
         ai_backend: None,
         claude_cli_allow_tools: false,
+        claude_cli_max_budget_usd: None,
         command: Commands::Ai(AiCommand {
             command: AiSubcommands::Chat(ChatCommand { model: None }),
         }),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -448,6 +448,7 @@ async fn cli_execute_dispatches_git_commit_message_view() {
 
     let cli = Cli {
         ai_backend: None,
+        claude_cli_allow_tools: false,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Commit(CommitCommand {
                 command: CommitSubcommands::Message(MessageCommand {
@@ -470,6 +471,7 @@ async fn cli_execute_dispatches_git_branch_info() {
 
     let cli = Cli {
         ai_backend: None,
+        claude_cli_allow_tools: false,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Branch(BranchCommand {
                 command: BranchSubcommands::Info(InfoCommand { base_branch: None }),
@@ -486,6 +488,7 @@ async fn cli_execute_dispatches_ai_chat() {
 
     let cli = Cli {
         ai_backend: None,
+        claude_cli_allow_tools: false,
         command: Commands::Ai(AiCommand {
             command: AiSubcommands::Chat(ChatCommand { model: None }),
         }),

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -19,6 +19,7 @@ Commands:
 
 Options:
       --ai-backend <AI_BACKEND>  Selects the AI backend used by commands that invoke an AI model [possible values: default, claude-cli]
+      --claude-cli-allow-tools   Weakens the `claude-cli` sandbox by allowing the nested `claude -p` session to use its default tool set (Read/Edit/Write/Bash/Glob/Grep and any user-level MCP servers)
   -h, --help                     Print help (see more with '--help')
   -V, --version                  Print version
 

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -18,10 +18,16 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-      --ai-backend <AI_BACKEND>  Selects the AI backend used by commands that invoke an AI model [possible values: default, claude-cli]
-      --claude-cli-allow-tools   Weakens the `claude-cli` sandbox by allowing the nested `claude -p` session to use its default tool set (Read/Edit/Write/Bash/Glob/Grep and any user-level MCP servers)
-  -h, --help                     Print help (see more with '--help')
-  -V, --version                  Print version
+      --ai-backend <AI_BACKEND>
+          Selects the AI backend used by commands that invoke an AI model [possible values: default, claude-cli]
+      --claude-cli-allow-tools
+          Weakens the `claude-cli` sandbox by allowing the nested `claude -p` session to use its default tool set (Read/Edit/Write/Bash/Glob/Grep and any user-level MCP servers)
+      --claude-cli-max-budget-usd <AMOUNT>
+          Per-invocation spending cap in USD for the `claude-cli` backend
+  -h, --help
+          Print help (see more with '--help')
+  -V, --version
+          Print version
 
 
 ================================================================================

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -6,7 +6,7 @@ omni-dev - A comprehensive development toolkit
 
 A comprehensive development toolkit
 
-Usage: omni-dev <COMMAND>
+Usage: omni-dev [OPTIONS] <COMMAND>
 
 Commands:
   ai         AI operations
@@ -18,8 +18,9 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+      --ai-backend <AI_BACKEND>  Selects the AI backend used by commands that invoke an AI model [possible values: default, claude-cli]
+  -h, --help                     Print help (see more with '--help')
+  -V, --version                  Print version
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements a new AI backend that shells out to `claude -p` (Claude Code CLI), allowing users with an existing Claude Code authentication session to use omni-dev without provisioning a separate Anthropic API key.

Users can activate the new backend via a global `--ai-backend claude-cli` flag or by setting `OMNI_DEV_AI_BACKEND=claude-cli`. The subprocess runs in a locked-down sandbox (tools disabled, MCP blocked, settings skipped, fresh temp cwd, scrubbed environment) so it behaves as a pure prompt→completion service rather than a nested agent with filesystem or shell access.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #608

## Changes Made

**Core AI Backend (`src/claude/ai/claude_cli.rs` — new file, ~765 lines):**
- Added `ClaudeCliAiClient` struct implementing `AiClient` by spawning `claude -p` as a subprocess
- Sandbox flags applied: `--tools ""`, `--strict-mcp-config`, `--setting-sources ""`, `--disable-slash-commands`, `--no-session-persistence`, fresh temp cwd
- Environment scrubbed of `CLAUDE_PROJECT_DIR`, `CLAUDE_CODE_*`, and `CLAUDE_PROJECT_*` vars before spawn
- Appends a `TOOL_SUPPRESSION_SUFFIX` to system prompts to prevent spurious `<function_calls>` XML in output
- Parses `claude -p --output-format json` envelope (`is_error`, `api_error_status`, `result`)
- `strip_wrapping_code_fence()` removes outer markdown code fences from structured output (YAML/JSON) before returning to downstream parsers
- `resolve_alias()` maps short names (`sonnet`, `opus`, `haiku`) to concrete registry IDs for token-budget math
- Configurable via env vars: `OMNI_DEV_CLAUDE_CLI_BIN`, `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS`, `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES`

**Backend Dispatch (`src/claude/client.rs`):**
- Updated `create_default_claude_client` to check `OMNI_DEV_AI_BACKEND` first, short-circuiting to `ClaudeCliAiClient` before all other backends
- Model resolution follows precedence: `--model` → `CLAUDE_MODEL` → `CLAUDE_CODE_MODEL` → `ANTHROPIC_MODEL` → registry default
- Emits a warning when `--beta-header` is passed with `claude-cli` backend (not supported)

**Error Handling (`src/claude/error.rs`):**
- Added `SubprocessBinaryMissing(String)` — binary not found on PATH
- Added `SubprocessSpawnFailed(String)` — spawn failed for other reasons
- Added `SubprocessTimeout { secs: u64 }` — exceeded configured timeout
- Added `SubprocessOutputTooLarge { limit: usize }` — stdout cap exceeded
- Added `SubprocessJsonParseFailed(String)` — stdout was not valid JSON

**CLI (`src/cli.rs`):**
- Added `AiBackend` enum (`Default`, `ClaudeCli`) with `ValueEnum` derive for clap
- Added `--ai-backend` global flag on the `Cli` struct (propagated to `OMNI_DEV_AI_BACKEND` env var before command dispatch)

**Preflight Check (`src/utils/preflight.rs`):**
- Added `ClaudeCli` variant to `AiProvider`
- `check_ai_credentials` now checks for `OMNI_DEV_AI_BACKEND=claude-cli` first and verifies the `claude` binary is on PATH via `claude --version`

**Documentation:**
- `README.md`: Added "AI backend selection" section documenting the flag, env var, model selection precedence, sandboxing guarantees, cost baseline, and override env vars
- `CLAUDE.md`: Added "AI Backend Dispatch" section describing backend selection order and the preflight lock-step requirement

**Testing:**
- Updated integration tests in `tests/integration_test.rs` to include the new `ai_backend: None` field in `Cli` struct literals
- Updated `tests/snapshots/integration_test__help_all_output.snap` to reflect new `--ai-backend` flag in CLI help output
- Added 16 unit tests in `src/claude/ai/claude_cli.rs` covering: sandbox flags, env scrubbing, temp cwd, tool suppression, `resolve_alias`, `strip_wrapping_code_fence`, missing binary error, stdout cap/timeout error, and non-JSON output error

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (missing binary, runaway output, non-JSON output)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- New `claude_cli.rs` module: comprehensive unit test coverage including async subprocess error paths
- Existing integration tests updated to remain compatible with new `ai_backend` field

### Test Commands
```bash
# Core test suite
cargo test

# Run claude_cli-specific tests
cargo test claude_cli

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
cargo build --release

# Test backend selection via CLI flag
omni-dev --ai-backend claude-cli git commit message twiddle <range>

# Test backend selection via env var
OMNI_DEV_AI_BACKEND=claude-cli omni-dev git commit message twiddle <range>
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — subprocess env scrubbing in `build_command()` and sandbox flag completeness
- [x] Architecture changes — new `AiBackend` enum in CLI and backend dispatch ordering in `create_default_claude_client`
- [x] Error handling — typed `ClaudeError` variants for all subprocess failure modes
- [x] User experience — `--ai-backend` global flag placement and env var propagation pattern
- [x] Backward compatibility — no existing behavior changes; new backend only activates when explicitly requested

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact on existing backends
- The `claude -p` subprocess backend has an inherent floor cost per invocation (~$0.007 Haiku, ~$0.03 Sonnet, ~$0.15 Opus) due to the CLI's system prompt. Prompt caching applies for back-to-back calls within one hour.

## Security Considerations
- [x] Security improvement (describe below)

The subprocess sandbox provides defence-in-depth against a nested `claude -p` session gaining filesystem or shell access:
- `--tools ""` disables all built-in tools at the CLI level
- `--strict-mcp-config` (with no `--mcp-config`) blocks MCP server pickup from user settings
- `--setting-sources ""` prevents discovery of user/project/local settings
- `--no-session-persistence` avoids writing session state to disk
- Subprocess runs in a fresh temp directory, not the repository root
- `CLAUDE_PROJECT_DIR`, `CLAUDE_CODE_*`, and `CLAUDE_PROJECT_*` env vars are scrubbed before spawn to prevent re-scoping the nested session
- `TOOL_SUPPRESSION_SUFFIX` appended to system prompts suppresses residual `<function_calls>` XML the model may emit despite runtime tool disablement

## Breaking Changes

None. This is a purely additive feature. Existing backends (`ClaudeAiClient`, `BedrockAiClient`, `OpenAiAiClient`) are unaffected. The new backend only activates when `--ai-backend claude-cli` or `OMNI_DEV_AI_BACKEND=claude-cli` is explicitly set.

## Deployment Notes
- [x] No special deployment requirements
- [x] Environment variable changes required — new optional env vars: `OMNI_DEV_AI_BACKEND`, `OMNI_DEV_CLAUDE_CLI_BIN`, `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS`, `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES`

Users who want to use this backend must have the [Claude Code CLI](https://github.com/anthropics/claude-code) installed and authenticated separately.

## Additional Notes

**Future Enhancements:**
- Additional short aliases could be added to `resolve_alias()` as new Claude model families are released
- The `allow_tools` field in `ClaudeCliAiClient` is an escape hatch for potential future tool-enabled use cases

**Known Limitations:**
- `--beta-header` flag is silently ignored (with a warning) when using the `claude-cli` backend, as the CLI's `--betas` flag has different semantics
- The `claude -p` subprocess always loads a small system prompt, resulting in a non-zero floor cost even for trivial requests

**Alternatives Considered:**
- Threading the backend selection through every command's argument struct — rejected in favour of env var propagation to keep the factory signature (`create_default_claude_client`) stable
- Clearing the subprocess environment wholesale — rejected because the Node runtime inside `claude` requires `HOME`, `PATH`, and platform-specific entries (e.g. `DYLD_*` on macOS)