### PR TITLE
feat(cli, lib): add Datadog integration scaffold and authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Datadog Integration — Scaffold & Auth** ([#619](https://github.com/rust-works/omni-dev/issues/619)): New `omni-dev datadog` command tree exposing read-only Datadog API access. This first slice ships the authentication surface: `datadog auth login` (interactive credential prompt), `datadog auth logout` (removes credentials from `~/.omni-dev/settings.json`), and `datadog auth status` (verifies credentials via `/api/v1/validate`). Credentials live in the shared `env` map under `DATADOG_API_KEY`, `DATADOG_APP_KEY`, and `DATADOG_SITE`; environment variables override stored settings. The underlying `DatadogClient` in `src/datadog/client.rs` handles 429 responses with `Retry-After` and Datadog-specific `X-RateLimit-Reset` awareness, and surfaces `X-RateLimit-*` headers in error output when retries are exhausted. No new crate dependencies.
+
 ## [0.23.1] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ omni-dev atlassian confluence create page.md --space ENG --title "New Page"
 omni-dev atlassian convert to-adf input.md
 ```
 
+### 📊 Datadog Integration (read-only)
+
+Authenticate against the Datadog API. Subsequent slices add metrics, monitor,
+dashboard, and logs subcommands.
+
+```bash
+# Configure Datadog API credentials (prompts for API key, APP key, and site)
+omni-dev datadog auth login
+
+# Verify the credentials by calling /api/v1/validate
+omni-dev datadog auth status
+
+# Remove Datadog credentials from ~/.omni-dev/settings.json
+omni-dev datadog auth logout
+```
+
+`DATADOG_SITE` defaults to `datadoghq.com`. Other regions (`datadoghq.eu`,
+`us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ddog-gov.com`)
+are recognised without warning. Environment variables `DATADOG_API_KEY`,
+`DATADOG_APP_KEY`, `DATADOG_SITE` override the stored settings.
+
 ### ✏️ Manual Amendment
 
 ```bash
@@ -473,6 +494,8 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 - **Atlassian Credentials** (for JIRA/Confluence features): Instance URL, email, and
   [API token](https://id.atlassian.com/manage-profile/security/api-tokens)
   - Configure with: `omni-dev atlassian auth login`
+- **Datadog Credentials** (for Datadog features): API key, application key, and site
+  - Configure with: `omni-dev datadog auth login`
 - **Git**: Any modern version
 
 ### AI backend selection

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ omni-dev datadog auth logout
 are recognised without warning. Environment variables `DATADOG_API_KEY`,
 `DATADOG_APP_KEY`, `DATADOG_SITE` override the stored settings.
 
+For on-prem or proxied Datadog installs, set `DATADOG_API_URL` to the full
+API base URL (e.g. `https://datadog.corp.example`) — it overrides the
+site-derived URL entirely.
+
 ### ✏️ Manual Amendment
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ pub mod ai;
 pub mod atlassian;
 pub mod commands;
 pub mod config;
+pub mod datadog;
 pub mod git;
 pub mod help;
 
@@ -75,6 +76,8 @@ pub enum Commands {
     Config(config::ConfigCommand),
     /// Atlassian: JIRA and Confluence operations.
     Atlassian(atlassian::AtlassianCommand),
+    /// Datadog: read-only API operations.
+    Datadog(datadog::DatadogCommand),
     /// Displays comprehensive help for all commands.
     #[command(name = "help-all")]
     HelpAll(help::HelpCommand),
@@ -106,6 +109,7 @@ impl Cli {
             Commands::Git(git_cmd) => git_cmd.execute().await,
             Commands::Commands(commands_cmd) => commands_cmd.execute(),
             Commands::Atlassian(cmd) => cmd.execute().await,
+            Commands::Datadog(cmd) => cmd.execute().await,
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::HelpAll(help_cmd) => help_cmd.execute(),
         }

--- a/src/cli/datadog.rs
+++ b/src/cli/datadog.rs
@@ -1,0 +1,47 @@
+//! Datadog CLI commands (read-only).
+
+pub(crate) mod auth;
+pub(crate) mod format;
+pub(crate) mod helpers;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Datadog: read-only API operations.
+#[derive(Parser)]
+pub struct DatadogCommand {
+    /// The Datadog subcommand to execute.
+    #[command(subcommand)]
+    pub command: DatadogSubcommands,
+}
+
+/// Datadog subcommands.
+#[derive(Subcommand)]
+pub enum DatadogSubcommands {
+    /// Manages Datadog API credentials.
+    Auth(auth::AuthCommand),
+}
+
+impl DatadogCommand {
+    /// Executes the Datadog command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            DatadogSubcommands::Auth(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datadog_subcommands_auth_variant() {
+        let cmd = DatadogCommand {
+            command: DatadogSubcommands::Auth(auth::AuthCommand {
+                command: auth::AuthSubcommands::Status(auth::StatusCommand),
+            }),
+        };
+        assert!(matches!(cmd.command, DatadogSubcommands::Auth(_)));
+    }
+}

--- a/src/cli/datadog.rs
+++ b/src/cli/datadog.rs
@@ -32,8 +32,10 @@ impl DatadogCommand {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::datadog::test_support::{with_empty_home, EnvGuard};
 
     #[test]
     fn datadog_subcommands_auth_variant() {
@@ -43,5 +45,17 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, DatadogSubcommands::Auth(_)));
+    }
+
+    #[tokio::test]
+    async fn datadog_command_dispatches_auth_logout() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        let cmd = DatadogCommand {
+            command: DatadogSubcommands::Auth(auth::AuthCommand {
+                command: auth::AuthSubcommands::Logout(auth::LogoutCommand),
+            }),
+        };
+        cmd.execute().await.unwrap();
     }
 }

--- a/src/cli/datadog/auth.rs
+++ b/src/cli/datadog/auth.rs
@@ -170,7 +170,7 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE};
+    use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_API_URL, DATADOG_APP_KEY, DATADOG_SITE};
     use crate::datadog::test_support::{with_empty_home, EnvGuard};
 
     #[test]
@@ -343,6 +343,67 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("403"));
         assert!(msg.contains("Forbidden"));
+    }
+
+    // ── StatusCommand::execute end-to-end via DATADOG_API_URL ─────
+
+    fn write_settings(dir: &std::path::Path, site: &str) {
+        let omni_dir = dir.join(".omni-dev");
+        fs::create_dir_all(&omni_dir).unwrap();
+        let json = format!(
+            r#"{{"env":{{"DATADOG_API_KEY":"api","DATADOG_APP_KEY":"app","DATADOG_SITE":"{site}"}}}}"#
+        );
+        fs::write(omni_dir.join("settings.json"), json).unwrap();
+    }
+
+    #[tokio::test]
+    async fn status_command_execute_success_via_api_url_override() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .and(wiremock::matchers::header("DD-API-KEY", "api"))
+            .and(wiremock::matchers::header("DD-APPLICATION-KEY", "app"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"valid": true})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+        write_settings(dir.path(), "datadoghq.com");
+        std::env::set_var(DATADOG_API_URL, server.uri());
+
+        StatusCommand.execute().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn status_command_execute_propagates_api_errors() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+        write_settings(dir.path(), "datadoghq.com");
+        std::env::set_var(DATADOG_API_URL, server.uri());
+
+        let err = StatusCommand.execute().await.unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn status_command_execute_errors_when_credentials_missing() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+
+        let err = StatusCommand.execute().await.unwrap_err();
+        assert!(err.to_string().contains("not configured"));
     }
 
     #[tokio::test]

--- a/src/cli/datadog/auth.rs
+++ b/src/cli/datadog/auth.rs
@@ -1,0 +1,268 @@
+//! CLI commands for Datadog credential management.
+
+use std::io::{self, Write};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use serde::Deserialize;
+
+use crate::datadog::auth::{self, DatadogCredentials, DEFAULT_SITE};
+use crate::datadog::client::DatadogClient;
+
+/// Manages Datadog API credentials.
+#[derive(Parser)]
+pub struct AuthCommand {
+    /// The auth subcommand to execute.
+    #[command(subcommand)]
+    pub command: AuthSubcommands,
+}
+
+/// Auth subcommands.
+#[derive(Subcommand)]
+pub enum AuthSubcommands {
+    /// Configures Datadog API credentials interactively.
+    Login(LoginCommand),
+    /// Removes Datadog API credentials from settings.json.
+    Logout(LogoutCommand),
+    /// Shows the current authentication status.
+    Status(StatusCommand),
+}
+
+impl AuthCommand {
+    /// Executes the auth command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            AuthSubcommands::Login(cmd) => cmd.execute(),
+            AuthSubcommands::Logout(cmd) => cmd.execute(),
+            AuthSubcommands::Status(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Configures Datadog API credentials.
+#[derive(Parser)]
+pub struct LoginCommand;
+
+impl LoginCommand {
+    /// Prompts the user for credentials and saves them.
+    pub fn execute(self) -> Result<()> {
+        println!("Configure Datadog API credentials\n");
+
+        let api_key = prompt("API key: ")?;
+        if api_key.is_empty() {
+            anyhow::bail!("API key is required");
+        }
+
+        let app_key = prompt("Application key: ")?;
+        if app_key.is_empty() {
+            anyhow::bail!("Application key is required");
+        }
+
+        let site_raw = prompt(&format!("Site [default: {DEFAULT_SITE}]: "))?;
+        let site = if site_raw.is_empty() {
+            DEFAULT_SITE.to_string()
+        } else {
+            auth::normalize_site(&site_raw)
+        };
+
+        let credentials = DatadogCredentials {
+            api_key,
+            app_key,
+            site: site.clone(),
+        };
+
+        auth::save_credentials(&credentials)?;
+        println!("\nCredentials saved to ~/.omni-dev/settings.json");
+        println!("  Site: {site}");
+        println!("\nRun `omni-dev datadog auth status` to verify.");
+
+        Ok(())
+    }
+}
+
+/// Removes Datadog API credentials.
+#[derive(Parser)]
+pub struct LogoutCommand;
+
+impl LogoutCommand {
+    /// Removes Datadog credential keys from settings.json.
+    pub fn execute(self) -> Result<()> {
+        let removed = auth::remove_credentials()?;
+        if removed {
+            println!("Datadog credentials removed from ~/.omni-dev/settings.json");
+        } else {
+            println!("No Datadog credentials were configured.");
+        }
+        Ok(())
+    }
+}
+
+/// Shows the current authentication status.
+#[derive(Parser)]
+pub struct StatusCommand;
+
+impl StatusCommand {
+    /// Verifies credentials by calling `/api/v1/validate`.
+    pub async fn execute(self) -> Result<()> {
+        let credentials = auth::load_credentials()?;
+        let site = credentials.site.clone();
+        let client = DatadogClient::from_credentials(&credentials)?;
+        run_auth_status(&client, &site).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ValidateResponse {
+    #[serde(default)]
+    valid: bool,
+}
+
+/// Calls `/api/v1/validate` and reports whether the API+APP key pair is accepted.
+async fn run_auth_status(client: &DatadogClient, site: &str) -> Result<()> {
+    println!("Checking Datadog authentication for site '{site}'...");
+
+    let url = format!("{}/api/v1/validate", client.base_url());
+    let response = client.get_json(&url).await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(DatadogClient::response_to_error(response).await.into());
+    }
+
+    let validate: ValidateResponse = response
+        .json()
+        .await
+        .context("Failed to parse /api/v1/validate response")?;
+
+    if validate.valid {
+        println!("Authenticated successfully.");
+    } else {
+        println!("Datadog reported credentials as invalid.");
+    }
+    println!("Site: {site}");
+    println!("Base URL: {}", client.base_url());
+
+    Ok(())
+}
+
+/// Prompts the user for input on a single line.
+fn prompt(message: &str) -> Result<String> {
+    print!("{message}");
+    io::stdout().flush().context("Failed to flush stdout")?;
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .context("Failed to read user input")?;
+
+    Ok(input.trim().to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_command_login_dispatch() {
+        let cmd = AuthCommand {
+            command: AuthSubcommands::Login(LoginCommand),
+        };
+        assert!(matches!(cmd.command, AuthSubcommands::Login(_)));
+    }
+
+    #[test]
+    fn auth_command_logout_dispatch() {
+        let cmd = AuthCommand {
+            command: AuthSubcommands::Logout(LogoutCommand),
+        };
+        assert!(matches!(cmd.command, AuthSubcommands::Logout(_)));
+    }
+
+    #[test]
+    fn auth_command_status_dispatch() {
+        let cmd = AuthCommand {
+            command: AuthSubcommands::Status(StatusCommand),
+        };
+        assert!(matches!(cmd.command, AuthSubcommands::Status(_)));
+    }
+
+    // ── run_auth_status ────────────────────────────────────────────
+
+    fn mock_client(base_url: &str) -> DatadogClient {
+        DatadogClient::new(base_url, "api", "app").unwrap()
+    }
+
+    #[tokio::test]
+    async fn run_auth_status_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .and(wiremock::matchers::header("DD-API-KEY", "api"))
+            .and(wiremock::matchers::header("DD-APPLICATION-KEY", "app"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"valid": true})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(run_auth_status(&client, "datadoghq.com").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_auth_status_valid_false_still_ok() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"valid": false})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(run_auth_status(&client, "datadoghq.com").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_auth_status_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_auth_status(&client, "datadoghq.com").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("Forbidden"));
+    }
+
+    #[tokio::test]
+    async fn run_auth_status_surfaces_rate_limit_on_exhausted_retries() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v1/validate"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .append_header("X-RateLimit-Remaining", "0")
+                    .append_header("X-RateLimit-Reset", "3")
+                    .set_body_string("slow down"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_auth_status(&client, "datadoghq.com").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("429"));
+        assert!(msg.contains("rate-limit"));
+    }
+}

--- a/src/cli/datadog/auth.rs
+++ b/src/cli/datadog/auth.rs
@@ -47,37 +47,43 @@ impl LoginCommand {
     /// Prompts the user for credentials and saves them.
     pub fn execute(self) -> Result<()> {
         println!("Configure Datadog API credentials\n");
-
         let api_key = prompt("API key: ")?;
-        if api_key.is_empty() {
-            anyhow::bail!("API key is required");
-        }
-
         let app_key = prompt("Application key: ")?;
-        if app_key.is_empty() {
-            anyhow::bail!("Application key is required");
-        }
-
         let site_raw = prompt(&format!("Site [default: {DEFAULT_SITE}]: "))?;
-        let site = if site_raw.is_empty() {
-            DEFAULT_SITE.to_string()
-        } else {
-            auth::normalize_site(&site_raw)
-        };
-
-        let credentials = DatadogCredentials {
-            api_key,
-            app_key,
-            site: site.clone(),
-        };
-
-        auth::save_credentials(&credentials)?;
-        println!("\nCredentials saved to ~/.omni-dev/settings.json");
-        println!("  Site: {site}");
-        println!("\nRun `omni-dev datadog auth status` to verify.");
-
-        Ok(())
+        run_login(&api_key, &app_key, &site_raw)
     }
+}
+
+/// Validates credentials and persists them to `~/.omni-dev/settings.json`.
+///
+/// Extracted from [`LoginCommand::execute`] so the input-validation and
+/// site-normalisation branches are reachable from tests without mocking
+/// stdin.
+fn run_login(api_key: &str, app_key: &str, site_raw: &str) -> Result<()> {
+    if api_key.is_empty() {
+        anyhow::bail!("API key is required");
+    }
+    if app_key.is_empty() {
+        anyhow::bail!("Application key is required");
+    }
+    let site = if site_raw.is_empty() {
+        DEFAULT_SITE.to_string()
+    } else {
+        auth::normalize_site(site_raw)
+    };
+
+    let credentials = DatadogCredentials {
+        api_key: api_key.to_string(),
+        app_key: app_key.to_string(),
+        site: site.clone(),
+    };
+
+    auth::save_credentials(&credentials)?;
+    println!("\nCredentials saved to ~/.omni-dev/settings.json");
+    println!("  Site: {site}");
+    println!("\nRun `omni-dev datadog auth status` to verify.");
+
+    Ok(())
 }
 
 /// Removes Datadog API credentials.
@@ -161,7 +167,11 @@ fn prompt(message: &str) -> Result<String> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::fs;
+
     use super::*;
+    use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE};
+    use crate::datadog::test_support::{with_empty_home, EnvGuard};
 
     #[test]
     fn auth_command_login_dispatch() {
@@ -191,6 +201,97 @@ mod tests {
 
     fn mock_client(base_url: &str) -> DatadogClient {
         DatadogClient::new(base_url, "api", "app").unwrap()
+    }
+
+    // ── run_login ──────────────────────────────────────────────────
+
+    #[test]
+    fn run_login_rejects_empty_api_key() {
+        let err = run_login("", "app", "").unwrap_err();
+        assert!(err.to_string().contains("API key"));
+    }
+
+    #[test]
+    fn run_login_rejects_empty_app_key() {
+        let err = run_login("api", "", "").unwrap_err();
+        assert!(err.to_string().contains("Application key"));
+    }
+
+    #[test]
+    fn run_login_defaults_site_when_blank_and_persists() {
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+
+        run_login("api-1", "app-1", "").unwrap();
+
+        let content =
+            fs::read_to_string(dir.path().join(".omni-dev").join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(val["env"]["DATADOG_API_KEY"], "api-1");
+        assert_eq!(val["env"]["DATADOG_APP_KEY"], "app-1");
+        assert_eq!(val["env"]["DATADOG_SITE"], DEFAULT_SITE);
+    }
+
+    #[test]
+    fn run_login_normalises_provided_site() {
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+
+        run_login("api", "app", "https://api.us5.datadoghq.com/").unwrap();
+
+        let content =
+            fs::read_to_string(dir.path().join(".omni-dev").join("settings.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(val["env"]["DATADOG_SITE"], "us5.datadoghq.com");
+    }
+
+    // ── LogoutCommand::execute ────────────────────────────────────
+
+    #[test]
+    fn logout_command_removes_credentials_when_present() {
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+        let omni_dir = dir.path().join(".omni-dev");
+        fs::create_dir_all(&omni_dir).unwrap();
+        fs::write(
+            omni_dir.join("settings.json"),
+            r#"{"env": {
+                "DATADOG_API_KEY": "a",
+                "DATADOG_APP_KEY": "b",
+                "DATADOG_SITE": "datadoghq.com",
+                "OTHER": "keep"
+            }}"#,
+        )
+        .unwrap();
+
+        LogoutCommand.execute().unwrap();
+
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(omni_dir.join("settings.json")).unwrap())
+                .unwrap();
+        assert!(val["env"].get(DATADOG_API_KEY).is_none());
+        assert!(val["env"].get(DATADOG_APP_KEY).is_none());
+        assert!(val["env"].get(DATADOG_SITE).is_none());
+        assert_eq!(val["env"]["OTHER"], "keep");
+    }
+
+    #[test]
+    fn logout_command_is_idempotent_when_no_credentials() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        LogoutCommand.execute().unwrap();
+    }
+
+    // ── AuthCommand::execute dispatch ─────────────────────────────
+
+    #[tokio::test]
+    async fn auth_command_dispatches_logout() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        let cmd = AuthCommand {
+            command: AuthSubcommands::Logout(LogoutCommand),
+        };
+        cmd.execute().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/cli/datadog/format.rs
+++ b/src/cli/datadog/format.rs
@@ -1,0 +1,231 @@
+//! Shared format types for Datadog CLI commands.
+//!
+//! Duplicated from [`crate::cli::atlassian::format`] intentionally: promoting
+//! to a shared module requires decoupling the `JsonlSerialize` trait from
+//! Atlassian-specific types, which is out of scope for the Datadog slice.
+//! Follow-up: file to extract a shared `src/cli/format.rs`.
+//!
+//! Items are unused in slice 1 (auth-only); they become live once the
+//! metrics / monitor / dashboard / logs subcommands land.
+#![allow(dead_code)]
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::Serialize;
+
+/// Display format for list/table commands.
+#[derive(Clone, Debug, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable table.
+    #[default]
+    Table,
+    /// JSON.
+    Json,
+    /// YAML (single document).
+    Yaml,
+    /// YAML stream (`---`-separated multi-document).
+    Yamls,
+    /// JSON Lines: one compact JSON object per line, streaming-friendly.
+    Jsonl,
+}
+
+/// Writes a value as newline-terminated JSON Lines.
+///
+/// For collection-like types, implementations emit one JSON object per
+/// contained item. For scalar types, implementations emit the value as a
+/// single JSON line.
+pub trait JsonlSerialize {
+    /// Writes the value as JSONL to `out`, newline-terminated.
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()>;
+}
+
+/// Writes each item in an iterator as a single compact JSON line.
+pub fn write_items_jsonl<'a, I, T>(items: I, out: &mut dyn Write) -> Result<()>
+where
+    I: IntoIterator<Item = &'a T>,
+    T: Serialize + 'a,
+{
+    for item in items {
+        let line = serde_json::to_string(item).context("Failed to serialize as JSON")?;
+        writeln!(out, "{line}").context("Failed to write JSONL line")?;
+    }
+    Ok(())
+}
+
+/// Writes a single serializable value as one compact JSON line.
+pub fn write_scalar_jsonl<T: Serialize>(item: &T, out: &mut dyn Write) -> Result<()> {
+    let line = serde_json::to_string(item).context("Failed to serialize as JSON")?;
+    writeln!(out, "{line}").context("Failed to write JSONL line")?;
+    Ok(())
+}
+
+impl<T: Serialize> JsonlSerialize for Vec<T> {
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
+        write_items_jsonl(self.iter(), out)
+    }
+}
+
+/// Writes `data` to `out` in the requested format.
+///
+/// Returns `Ok(true)` when `data` was written (json/yaml/yamls/jsonl),
+/// `Ok(false)` when `format` is `Table` (the caller is expected to render
+/// its own table).
+pub fn write_output<T: Serialize + JsonlSerialize>(
+    data: &T,
+    format: &OutputFormat,
+    out: &mut dyn Write,
+) -> Result<bool> {
+    match format {
+        OutputFormat::Table => Ok(false),
+        OutputFormat::Json => {
+            let rendered =
+                serde_json::to_string_pretty(data).context("Failed to serialize as JSON")?;
+            writeln!(out, "{rendered}").context("Failed to write JSON output")?;
+            Ok(true)
+        }
+        OutputFormat::Yaml => {
+            let rendered = serde_yaml::to_string(data).context("Failed to serialize as YAML")?;
+            write!(out, "{rendered}").context("Failed to write YAML output")?;
+            Ok(true)
+        }
+        OutputFormat::Yamls => {
+            let rendered = format_yaml_stream(data)?;
+            write!(out, "{rendered}").context("Failed to write YAML stream output")?;
+            Ok(true)
+        }
+        OutputFormat::Jsonl => {
+            data.write_jsonl(out)?;
+            Ok(true)
+        }
+    }
+}
+
+/// Serializes a single YAML value as one `---`-prefixed document.
+fn yaml_stream_doc(value: &serde_yaml::Value) -> Result<String> {
+    let s = serde_yaml::to_string(value).context("Failed to serialize YAML stream item")?;
+    Ok(format!("---\n{s}"))
+}
+
+/// Serializes data as a YAML multi-document stream.
+fn format_yaml_stream<T: Serialize>(data: &T) -> Result<String> {
+    match serde_yaml::to_value(data).context("Failed to serialize as YAML stream")? {
+        serde_yaml::Value::Sequence(items) => items.iter().map(yaml_stream_doc).collect(),
+        other => yaml_stream_doc(&other),
+    }
+}
+
+/// Serializes data in the requested output format to stdout.
+pub fn output_as<T: Serialize + JsonlSerialize>(data: &T, format: &OutputFormat) -> Result<bool> {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    write_output(data, format, &mut handle)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_default_is_table() {
+        assert!(matches!(OutputFormat::default(), OutputFormat::Table));
+    }
+
+    #[test]
+    fn output_debug_format() {
+        assert_eq!(format!("{:?}", OutputFormat::Jsonl), "Jsonl");
+    }
+
+    #[test]
+    fn output_clone() {
+        let f = OutputFormat::Json.clone();
+        assert!(matches!(f, OutputFormat::Json));
+    }
+
+    #[test]
+    fn write_output_table_returns_false_and_writes_nothing() {
+        let data = vec![1_i32, 2];
+        let mut buf = Vec::new();
+        let wrote = write_output(&data, &OutputFormat::Table, &mut buf).unwrap();
+        assert!(!wrote);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn write_output_json_emits_pretty_array() {
+        let data = vec![1_i32, 2, 3];
+        let mut buf = Vec::new();
+        let wrote = write_output(&data, &OutputFormat::Json, &mut buf).unwrap();
+        assert!(wrote);
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.starts_with('['));
+        assert!(out.ends_with("]\n"));
+    }
+
+    #[test]
+    fn write_output_yaml_emits_list() {
+        let data = vec![1_i32, 2];
+        let mut buf = Vec::new();
+        write_output(&data, &OutputFormat::Yaml, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "- 1\n- 2\n");
+    }
+
+    #[test]
+    fn write_output_yamls_emits_stream() {
+        let data = vec![1_i32, 2];
+        let mut buf = Vec::new();
+        write_output(&data, &OutputFormat::Yamls, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "---\n1\n---\n2\n");
+    }
+
+    #[test]
+    fn write_output_jsonl_emits_one_line_per_item() {
+        let data = vec![1_i32, 2, 3];
+        let mut buf = Vec::new();
+        write_output(&data, &OutputFormat::Jsonl, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "1\n2\n3\n");
+    }
+
+    #[test]
+    fn output_as_table_returns_false() {
+        let data: Vec<i32> = vec![];
+        assert!(!output_as(&data, &OutputFormat::Table).unwrap());
+    }
+
+    #[test]
+    fn output_as_json_returns_true() {
+        let data: Vec<i32> = vec![];
+        assert!(output_as(&data, &OutputFormat::Json).unwrap());
+    }
+
+    #[test]
+    fn write_items_jsonl_over_slice() {
+        let data = [10_i32, 20];
+        let mut buf = Vec::new();
+        write_items_jsonl(data.iter(), &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "10\n20\n");
+    }
+
+    #[test]
+    fn write_scalar_jsonl_emits_one_line() {
+        #[derive(Serialize)]
+        struct Scalar {
+            name: &'static str,
+        }
+        let mut buf = Vec::new();
+        write_scalar_jsonl(&Scalar { name: "solo" }, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "{\"name\":\"solo\"}\n");
+    }
+
+    #[test]
+    fn yaml_stream_non_sequence_emits_single_doc() {
+        #[derive(Serialize)]
+        struct S {
+            key: &'static str,
+        }
+        let out = format_yaml_stream(&S { key: "v" }).unwrap();
+        assert_eq!(out, "---\nkey: v\n");
+    }
+}

--- a/src/cli/datadog/helpers.rs
+++ b/src/cli/datadog/helpers.rs
@@ -18,3 +18,42 @@ pub fn create_client() -> Result<(DatadogClient, String)> {
     let client = DatadogClient::from_credentials(&credentials)?;
     Ok((client, site))
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::datadog::test_support::{with_empty_home, EnvGuard};
+
+    #[test]
+    fn create_client_reads_from_settings_file() {
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+        let omni_dir = dir.path().join(".omni-dev");
+        fs::create_dir_all(&omni_dir).unwrap();
+        fs::write(
+            omni_dir.join("settings.json"),
+            r#"{"env": {
+                "DATADOG_API_KEY": "api",
+                "DATADOG_APP_KEY": "app",
+                "DATADOG_SITE": "us5.datadoghq.com"
+            }}"#,
+        )
+        .unwrap();
+
+        let (client, site) = create_client().unwrap();
+        assert_eq!(site, "us5.datadoghq.com");
+        assert_eq!(client.base_url(), "https://api.us5.datadoghq.com");
+    }
+
+    #[test]
+    fn create_client_errors_when_credentials_missing() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+
+        let err = create_client().unwrap_err();
+        assert!(err.to_string().contains("not configured"));
+    }
+}

--- a/src/cli/datadog/helpers.rs
+++ b/src/cli/datadog/helpers.rs
@@ -1,0 +1,20 @@
+//! Shared helpers for Datadog CLI commands.
+//!
+//! `create_client` is unused in slice 1 (the auth status command builds its
+//! own client so it can report the site separately); it becomes live with
+//! the first endpoint subcommand.
+#![allow(dead_code)]
+
+use anyhow::Result;
+
+use crate::datadog::auth;
+use crate::datadog::client::DatadogClient;
+
+/// Creates an authenticated Datadog API client, returning the client and
+/// the configured site identifier.
+pub fn create_client() -> Result<(DatadogClient, String)> {
+    let credentials = auth::load_credentials()?;
+    let site = credentials.site.clone();
+    let client = DatadogClient::from_credentials(&credentials)?;
+    Ok((client, site))
+}

--- a/src/datadog.rs
+++ b/src/datadog.rs
@@ -9,3 +9,6 @@ pub mod client;
 pub mod error;
 pub mod time;
 pub mod types;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/src/datadog.rs
+++ b/src/datadog.rs
@@ -1,0 +1,11 @@
+//! Datadog API integration: read-only HTTP client and helpers.
+//!
+//! Provides a thin `reqwest` wrapper around the Datadog REST APIs for
+//! metrics, monitors, dashboards, and logs. Phase 1 covers authentication
+//! only; endpoint families land in subsequent slices.
+
+pub mod auth;
+pub mod client;
+pub mod error;
+pub mod time;
+pub mod types;

--- a/src/datadog/auth.rs
+++ b/src/datadog/auth.rs
@@ -21,6 +21,14 @@ pub const DATADOG_APP_KEY: &str = "DATADOG_APP_KEY";
 /// Environment variable / settings key for the Datadog site (e.g. `datadoghq.com`).
 pub const DATADOG_SITE: &str = "DATADOG_SITE";
 
+/// Environment variable / settings key for an explicit Datadog API base URL.
+///
+/// When set, overrides [`DATADOG_SITE`] entirely — the client uses this URL
+/// verbatim instead of deriving `https://api.{site}`. Useful for:
+/// - Tests that point at a wiremock server (e.g. `http://127.0.0.1:PORT`).
+/// - On-prem / proxied Datadog installs that don't match `api.{site}`.
+pub const DATADOG_API_URL: &str = "DATADOG_API_URL";
+
 /// Default Datadog site when none is configured (US1 region).
 pub const DEFAULT_SITE: &str = "datadoghq.com";
 

--- a/src/datadog/auth.rs
+++ b/src/datadog/auth.rs
@@ -1,0 +1,561 @@
+//! Datadog credential management.
+//!
+//! Loads and saves Datadog API credentials from/to the
+//! `~/.omni-dev/settings.json` file using the existing `env` map.
+
+use std::collections::HashMap;
+use std::fs;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::datadog::error::DatadogError;
+use crate::utils::settings::Settings;
+
+/// Environment variable / settings key for the Datadog API key.
+pub const DATADOG_API_KEY: &str = "DATADOG_API_KEY";
+
+/// Environment variable / settings key for the Datadog application key.
+pub const DATADOG_APP_KEY: &str = "DATADOG_APP_KEY";
+
+/// Environment variable / settings key for the Datadog site (e.g. `datadoghq.com`).
+pub const DATADOG_SITE: &str = "DATADOG_SITE";
+
+/// Default Datadog site when none is configured (US1 region).
+pub const DEFAULT_SITE: &str = "datadoghq.com";
+
+/// Datadog sites recognised as non-warning.
+///
+/// Any other value is accepted but logs a warning on [`load_credentials`] —
+/// Datadog adds regions occasionally and rejecting unknown values would
+/// break the CLI on each new region.
+pub const KNOWN_SITES: &[&str] = &[
+    "datadoghq.com",
+    "us3.datadoghq.com",
+    "us5.datadoghq.com",
+    "datadoghq.eu",
+    "ap1.datadoghq.com",
+    "ddog-gov.com",
+];
+
+/// Datadog API credentials.
+#[derive(Debug, Clone)]
+pub struct DatadogCredentials {
+    /// API key (organisation-scoped secret; required for every call).
+    pub api_key: String,
+
+    /// Application key (user-scoped secret; required for every call).
+    pub app_key: String,
+
+    /// Site identifier, e.g. `datadoghq.com`. Determines the base URL.
+    pub site: String,
+}
+
+/// Normalises a user-supplied site string.
+///
+/// Strips any `https://` or `http://` scheme, any `api.` subdomain prefix
+/// (users sometimes paste the full API host), and trailing slashes.
+pub fn normalize_site(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let no_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let no_api = no_scheme.strip_prefix("api.").unwrap_or(no_scheme);
+    no_api.trim_end_matches('/').to_string()
+}
+
+/// Returns the Datadog API base URL for a given site.
+pub fn base_url_for_site(site: &str) -> String {
+    format!("https://api.{}", normalize_site(site))
+}
+
+/// Loads Datadog credentials from environment variables or settings.json.
+///
+/// Environment variables take precedence over the settings file. Emits a
+/// warning on stderr when the configured site is not in [`KNOWN_SITES`].
+pub fn load_credentials() -> Result<DatadogCredentials> {
+    let settings = Settings::load().unwrap_or(Settings {
+        env: HashMap::new(),
+    });
+
+    let api_key = settings
+        .get_env_var(DATADOG_API_KEY)
+        .ok_or(DatadogError::CredentialsNotFound)?;
+    let app_key = settings
+        .get_env_var(DATADOG_APP_KEY)
+        .ok_or(DatadogError::CredentialsNotFound)?;
+    let site = settings
+        .get_env_var(DATADOG_SITE)
+        .map(|s| normalize_site(&s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_SITE.to_string());
+
+    if !KNOWN_SITES.iter().any(|k| *k == site) {
+        eprintln!("warning: Datadog site '{site}' is not a known region; proceeding anyway");
+    }
+
+    Ok(DatadogCredentials {
+        api_key,
+        app_key,
+        site,
+    })
+}
+
+/// Summary of a single Datadog credential scope.
+///
+/// Reports which credential keys are present without exposing their values.
+/// Safe to serialise and return over the MCP surface.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DatadogScopeStatus {
+    /// Scope name (currently always `"default"`; forward-compatible for
+    /// per-instance scopes).
+    pub name: String,
+    /// Whether [`DATADOG_API_KEY`] is present.
+    pub has_api_key: bool,
+    /// Whether [`DATADOG_APP_KEY`] is present.
+    pub has_app_key: bool,
+    /// Configured site (non-secret; normalised). `None` when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site: Option<String>,
+}
+
+/// Aggregate credential status across every known Datadog scope.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AuthStatus {
+    /// One entry per scope. Currently a single default scope; kept as a list
+    /// so future multi-instance support does not require a schema change.
+    pub scopes: Vec<DatadogScopeStatus>,
+}
+
+/// Builds an [`AuthStatus`] from the current settings / environment.
+///
+/// Reports credential presence without leaking any secret values. Safe to
+/// call with no credentials configured.
+pub fn status() -> AuthStatus {
+    let settings = Settings::load().unwrap_or(Settings {
+        env: HashMap::new(),
+    });
+
+    let has_api_key = settings.get_env_var(DATADOG_API_KEY).is_some();
+    let has_app_key = settings.get_env_var(DATADOG_APP_KEY).is_some();
+    let site = settings
+        .get_env_var(DATADOG_SITE)
+        .map(|s| normalize_site(&s))
+        .filter(|s| !s.is_empty());
+
+    AuthStatus {
+        scopes: vec![DatadogScopeStatus {
+            name: "default".to_string(),
+            has_api_key,
+            has_app_key,
+            site,
+        }],
+    }
+}
+
+/// Saves Datadog credentials to `~/.omni-dev/settings.json`.
+///
+/// Reads the existing settings file, merges the three credential keys into
+/// the `env` map, and writes back. Preserves all other settings.
+pub fn save_credentials(credentials: &DatadogCredentials) -> Result<()> {
+    let settings_path = Settings::get_settings_path()?;
+    let mut settings_value = read_or_default_settings(&settings_path)?;
+    ensure_env_object(&mut settings_value);
+
+    let Some(env) = settings_value["env"].as_object_mut() else {
+        anyhow::bail!("Internal error: env key is not an object after initialization");
+    };
+    env.insert(
+        DATADOG_API_KEY.to_string(),
+        serde_json::Value::String(credentials.api_key.clone()),
+    );
+    env.insert(
+        DATADOG_APP_KEY.to_string(),
+        serde_json::Value::String(credentials.app_key.clone()),
+    );
+    env.insert(
+        DATADOG_SITE.to_string(),
+        serde_json::Value::String(credentials.site.clone()),
+    );
+
+    write_settings(&settings_path, &settings_value)
+}
+
+/// Removes Datadog credential keys from `~/.omni-dev/settings.json`.
+///
+/// Leaves all other settings intact. Returns `true` if any Datadog key was
+/// present and removed, `false` when the file was already free of them (or
+/// did not exist).
+pub fn remove_credentials() -> Result<bool> {
+    let settings_path = Settings::get_settings_path()?;
+    if !settings_path.exists() {
+        return Ok(false);
+    }
+    let mut settings_value = read_or_default_settings(&settings_path)?;
+
+    let mut removed = false;
+    if let Some(env) = settings_value
+        .get_mut("env")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        for key in [DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE] {
+            if env.remove(key).is_some() {
+                removed = true;
+            }
+        }
+    }
+
+    if removed {
+        write_settings(&settings_path, &settings_value)?;
+    }
+    Ok(removed)
+}
+
+fn read_or_default_settings(path: &std::path::Path) -> Result<serde_json::Value> {
+    if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", path.display()))
+    } else {
+        Ok(serde_json::json!({}))
+    }
+}
+
+fn ensure_env_object(value: &mut serde_json::Value) {
+    if !value.get("env").is_some_and(serde_json::Value::is_object) {
+        value["env"] = serde_json::json!({});
+    }
+}
+
+fn write_settings(path: &std::path::Path, value: &serde_json::Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    let formatted =
+        serde_json::to_string_pretty(value).context("Failed to serialize settings JSON")?;
+    fs::write(path, formatted).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ── Pure helpers (safe to run in parallel) ─────────────────────────
+
+    #[test]
+    fn normalize_site_strips_scheme_and_api_prefix() {
+        assert_eq!(normalize_site("datadoghq.com"), "datadoghq.com");
+        assert_eq!(normalize_site("https://datadoghq.com"), "datadoghq.com");
+        assert_eq!(normalize_site("http://datadoghq.com"), "datadoghq.com");
+        assert_eq!(normalize_site("api.datadoghq.com"), "datadoghq.com");
+        assert_eq!(normalize_site("https://api.datadoghq.com"), "datadoghq.com");
+        assert_eq!(
+            normalize_site("https://api.us3.datadoghq.com/"),
+            "us3.datadoghq.com"
+        );
+    }
+
+    #[test]
+    fn normalize_site_trims_whitespace() {
+        assert_eq!(normalize_site("  datadoghq.com  "), "datadoghq.com");
+    }
+
+    #[test]
+    fn base_url_for_site_builds_api_host() {
+        assert_eq!(
+            base_url_for_site("datadoghq.com"),
+            "https://api.datadoghq.com"
+        );
+        assert_eq!(
+            base_url_for_site("us5.datadoghq.com"),
+            "https://api.us5.datadoghq.com"
+        );
+        assert_eq!(
+            base_url_for_site("datadoghq.eu"),
+            "https://api.datadoghq.eu"
+        );
+    }
+
+    #[test]
+    fn base_url_normalises_input() {
+        assert_eq!(
+            base_url_for_site("https://api.datadoghq.com/"),
+            "https://api.datadoghq.com"
+        );
+    }
+
+    #[test]
+    fn credentials_struct_clone_and_debug() {
+        let creds = DatadogCredentials {
+            api_key: "a".to_string(),
+            app_key: "b".to_string(),
+            site: "datadoghq.com".to_string(),
+        };
+        let cloned = creds.clone();
+        assert_eq!(cloned.api_key, creds.api_key);
+        assert!(format!("{creds:?}").contains("DatadogCredentials"));
+    }
+
+    #[test]
+    fn constant_key_names() {
+        assert_eq!(DATADOG_API_KEY, "DATADOG_API_KEY");
+        assert_eq!(DATADOG_APP_KEY, "DATADOG_APP_KEY");
+        assert_eq!(DATADOG_SITE, "DATADOG_SITE");
+        assert_eq!(DEFAULT_SITE, "datadoghq.com");
+    }
+
+    #[test]
+    fn known_sites_contains_common_regions() {
+        assert!(KNOWN_SITES.contains(&"datadoghq.com"));
+        assert!(KNOWN_SITES.contains(&"datadoghq.eu"));
+        assert!(KNOWN_SITES.contains(&"us5.datadoghq.com"));
+    }
+
+    // ── Tests that mutate process-wide env ────────────────────────────
+
+    /// Mutex shared by every test that mutates `HOME` and the Datadog
+    /// credential env vars. Serialises those tests against each other so
+    /// parallel execution doesn't race on process-wide env state.
+    static AUTH_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard: snapshots `HOME` + every Datadog credential env var on
+    /// construction and restores them on drop.
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        snapshot: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn take() -> Self {
+            let lock = AUTH_ENV_MUTEX
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let keys = ["HOME", DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE];
+            let snapshot = keys
+                .into_iter()
+                .map(|k| (k, std::env::var(k).ok()))
+                .collect();
+            Self {
+                _lock: lock,
+                snapshot,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.snapshot {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
+        let dir = {
+            std::fs::create_dir_all("tmp").ok();
+            tempfile::TempDir::new_in("tmp").unwrap()
+        };
+        std::env::set_var("HOME", dir.path());
+        std::env::remove_var(DATADOG_API_KEY);
+        std::env::remove_var(DATADOG_APP_KEY);
+        std::env::remove_var(DATADOG_SITE);
+        dir
+    }
+
+    #[test]
+    fn status_reports_all_false_when_nothing_configured() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+
+        let status = status();
+        assert_eq!(status.scopes.len(), 1);
+        let scope = &status.scopes[0];
+        assert_eq!(scope.name, "default");
+        assert!(!scope.has_api_key);
+        assert!(!scope.has_app_key);
+        assert_eq!(scope.site, None);
+    }
+
+    #[test]
+    fn status_reports_presence_flags_without_leaking_secrets() {
+        let guard = EnvGuard::take();
+        let dir = with_empty_home(&guard);
+        let omni_dir = dir.path().join(".omni-dev");
+        fs::create_dir_all(&omni_dir).unwrap();
+        fs::write(
+            omni_dir.join("settings.json"),
+            r#"{"env":{
+                "DATADOG_API_KEY":"sekret-api-do-not-leak",
+                "DATADOG_APP_KEY":"sekret-app-do-not-leak",
+                "DATADOG_SITE":"datadoghq.com"
+            }}"#,
+        )
+        .unwrap();
+
+        let status = status();
+        let scope = &status.scopes[0];
+        assert!(scope.has_api_key);
+        assert!(scope.has_app_key);
+        assert_eq!(scope.site.as_deref(), Some("datadoghq.com"));
+
+        let yaml = serde_yaml::to_string(&status).unwrap();
+        assert!(!yaml.contains("sekret-api-do-not-leak"));
+        assert!(!yaml.contains("sekret-app-do-not-leak"));
+    }
+
+    #[test]
+    fn status_normalises_site_value() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        std::env::set_var(DATADOG_SITE, "https://api.us3.datadoghq.com/");
+
+        let status = status();
+        assert_eq!(status.scopes[0].site.as_deref(), Some("us3.datadoghq.com"));
+    }
+
+    #[test]
+    fn load_credentials_errors_when_api_key_missing() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        std::env::set_var(DATADOG_APP_KEY, "app");
+
+        let err = load_credentials().unwrap_err();
+        assert!(err.to_string().contains("not configured"));
+    }
+
+    #[test]
+    fn load_credentials_defaults_site_when_unset() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        std::env::set_var(DATADOG_API_KEY, "api");
+        std::env::set_var(DATADOG_APP_KEY, "app");
+
+        let creds = load_credentials().unwrap();
+        assert_eq!(creds.site, DEFAULT_SITE);
+    }
+
+    #[test]
+    fn load_credentials_warns_on_unknown_site_but_succeeds() {
+        let guard = EnvGuard::take();
+        let _dir = with_empty_home(&guard);
+        std::env::set_var(DATADOG_API_KEY, "api");
+        std::env::set_var(DATADOG_APP_KEY, "app");
+        std::env::set_var(DATADOG_SITE, "custom.example");
+
+        let creds = load_credentials().unwrap();
+        assert_eq!(creds.site, "custom.example");
+    }
+
+    /// Single test for save + remove credentials to avoid HOME races.
+    /// Covers fresh-file creation, merge-with-existing, and removal.
+    #[test]
+    fn save_then_remove_round_trip() {
+        let _guard = EnvGuard::take();
+
+        // ── Part 1: creates file from scratch ──────────────────────
+        {
+            let temp_dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            std::env::set_var("HOME", temp_dir.path());
+
+            let creds = DatadogCredentials {
+                api_key: "api-1".to_string(),
+                app_key: "app-1".to_string(),
+                site: "datadoghq.com".to_string(),
+            };
+            save_credentials(&creds).unwrap();
+
+            let settings_path = temp_dir.path().join(".omni-dev").join("settings.json");
+            assert!(settings_path.exists());
+            let content = fs::read_to_string(&settings_path).unwrap();
+            let val: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(val["env"]["DATADOG_API_KEY"], "api-1");
+            assert_eq!(val["env"]["DATADOG_APP_KEY"], "app-1");
+            assert_eq!(val["env"]["DATADOG_SITE"], "datadoghq.com");
+        }
+
+        // ── Part 2: merges into existing settings ──────────────────
+        {
+            let temp_dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            let omni_dir = temp_dir.path().join(".omni-dev");
+            fs::create_dir_all(&omni_dir).unwrap();
+            let settings_path = omni_dir.join("settings.json");
+            fs::write(
+                &settings_path,
+                r#"{"env": {"OTHER_KEY": "keep_me"}, "extra": true}"#,
+            )
+            .unwrap();
+
+            std::env::set_var("HOME", temp_dir.path());
+
+            let creds = DatadogCredentials {
+                api_key: "api-2".to_string(),
+                app_key: "app-2".to_string(),
+                site: "datadoghq.eu".to_string(),
+            };
+            save_credentials(&creds).unwrap();
+
+            let val: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+            assert_eq!(val["env"]["OTHER_KEY"], "keep_me");
+            assert_eq!(val["extra"], true);
+            assert_eq!(val["env"]["DATADOG_SITE"], "datadoghq.eu");
+        }
+
+        // ── Part 3: remove clears the three keys, preserves others ─
+        {
+            let temp_dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            let omni_dir = temp_dir.path().join(".omni-dev");
+            fs::create_dir_all(&omni_dir).unwrap();
+            let settings_path = omni_dir.join("settings.json");
+            fs::write(
+                &settings_path,
+                r#"{"env": {
+                    "DATADOG_API_KEY": "a",
+                    "DATADOG_APP_KEY": "b",
+                    "DATADOG_SITE": "datadoghq.com",
+                    "OTHER_KEY": "keep"
+                }}"#,
+            )
+            .unwrap();
+            std::env::set_var("HOME", temp_dir.path());
+
+            let removed = remove_credentials().unwrap();
+            assert!(removed);
+
+            let val: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+            assert!(val["env"].get("DATADOG_API_KEY").is_none());
+            assert!(val["env"].get("DATADOG_APP_KEY").is_none());
+            assert!(val["env"].get("DATADOG_SITE").is_none());
+            assert_eq!(val["env"]["OTHER_KEY"], "keep");
+        }
+
+        // ── Part 4: remove returns false when nothing to remove ────
+        {
+            let temp_dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            std::env::set_var("HOME", temp_dir.path());
+            let removed = remove_credentials().unwrap();
+            assert!(!removed);
+        }
+    }
+}

--- a/src/datadog/auth.rs
+++ b/src/datadog/auth.rs
@@ -318,57 +318,7 @@ mod tests {
 
     // ── Tests that mutate process-wide env ────────────────────────────
 
-    /// Mutex shared by every test that mutates `HOME` and the Datadog
-    /// credential env vars. Serialises those tests against each other so
-    /// parallel execution doesn't race on process-wide env state.
-    static AUTH_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// RAII guard: snapshots `HOME` + every Datadog credential env var on
-    /// construction and restores them on drop.
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        snapshot: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn take() -> Self {
-            let lock = AUTH_ENV_MUTEX
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let keys = ["HOME", DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE];
-            let snapshot = keys
-                .into_iter()
-                .map(|k| (k, std::env::var(k).ok()))
-                .collect();
-            Self {
-                _lock: lock,
-                snapshot,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.snapshot {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-    }
-
-    fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
-        let dir = {
-            std::fs::create_dir_all("tmp").ok();
-            tempfile::TempDir::new_in("tmp").unwrap()
-        };
-        std::env::set_var("HOME", dir.path());
-        std::env::remove_var(DATADOG_API_KEY);
-        std::env::remove_var(DATADOG_APP_KEY);
-        std::env::remove_var(DATADOG_SITE);
-        dir
-    }
+    use crate::datadog::test_support::{with_empty_home, EnvGuard};
 
     #[test]
     fn status_reports_all_false_when_nothing_configured() {

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -52,8 +52,15 @@ impl DatadogClient {
     }
 
     /// Creates a client from stored credentials.
+    ///
+    /// Respects `DATADOG_API_URL` as an optional override: when set in the
+    /// process environment it replaces the site-derived base URL. Used for
+    /// tests (wiremock) and on-prem Datadog installs.
     pub fn from_credentials(creds: &DatadogCredentials) -> Result<Self> {
-        let base_url = base_url_for_site(&creds.site);
+        let base_url = std::env::var(crate::datadog::auth::DATADOG_API_URL)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| base_url_for_site(&creds.site));
         Self::new(&base_url, &creds.api_key, &creds.app_key)
     }
 
@@ -203,6 +210,9 @@ mod tests {
 
     #[test]
     fn from_credentials_builds_base_url_from_site() {
+        // EnvGuard serialises with other tests that mutate DATADOG_API_URL.
+        let _guard = crate::datadog::test_support::EnvGuard::take();
+        std::env::remove_var(crate::datadog::auth::DATADOG_API_URL);
         let creds = DatadogCredentials {
             api_key: "api".to_string(),
             app_key: "app".to_string(),
@@ -210,6 +220,35 @@ mod tests {
         };
         let client = DatadogClient::from_credentials(&creds).unwrap();
         assert_eq!(client.base_url(), "https://api.us5.datadoghq.com");
+    }
+
+    #[test]
+    fn from_credentials_honours_api_url_override() {
+        let _guard = crate::datadog::test_support::EnvGuard::take();
+        std::env::set_var(
+            crate::datadog::auth::DATADOG_API_URL,
+            "http://proxy.example:8080",
+        );
+        let creds = DatadogCredentials {
+            api_key: "api".to_string(),
+            app_key: "app".to_string(),
+            site: "us5.datadoghq.com".to_string(),
+        };
+        let client = DatadogClient::from_credentials(&creds).unwrap();
+        assert_eq!(client.base_url(), "http://proxy.example:8080");
+    }
+
+    #[test]
+    fn from_credentials_ignores_empty_api_url_override() {
+        let _guard = crate::datadog::test_support::EnvGuard::take();
+        std::env::set_var(crate::datadog::auth::DATADOG_API_URL, "");
+        let creds = DatadogCredentials {
+            api_key: "api".to_string(),
+            app_key: "app".to_string(),
+            site: "datadoghq.com".to_string(),
+        };
+        let client = DatadogClient::from_credentials(&creds).unwrap();
+        assert_eq!(client.base_url(), "https://api.datadoghq.com");
     }
 
     #[tokio::test]

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -1,0 +1,439 @@
+//! Datadog REST API client.
+//!
+//! Thin `reqwest` wrapper that injects the `DD-API-KEY` and
+//! `DD-APPLICATION-KEY` headers on every request and retries 429 responses
+//! with `Retry-After` / `X-RateLimit-Reset` awareness.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+
+use crate::datadog::auth::{base_url_for_site, DatadogCredentials};
+use crate::datadog::error::DatadogError;
+
+/// HTTP request timeout for Datadog API calls.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum number of retries on HTTP 429 (Too Many Requests).
+const MAX_RETRIES: u32 = 3;
+
+/// Default retry delay when no `Retry-After` / `X-RateLimit-Reset` header
+/// is present. Used as the base for exponential backoff.
+const DEFAULT_RETRY_DELAY_SECS: u64 = 2;
+
+/// HTTP client for Datadog REST APIs.
+pub struct DatadogClient {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    app_key: String,
+}
+
+impl DatadogClient {
+    /// Creates a new Datadog API client.
+    ///
+    /// `base_url` should be the full API host, e.g. `https://api.datadoghq.com`.
+    /// For production use, construct via [`Self::from_credentials`]; tests
+    /// pass a wiremock URL directly.
+    pub fn new(base_url: &str, api_key: &str, app_key: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .context("Failed to build HTTP client")?;
+
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            app_key: app_key.to_string(),
+        })
+    }
+
+    /// Creates a client from stored credentials.
+    pub fn from_credentials(creds: &DatadogCredentials) -> Result<Self> {
+        let base_url = base_url_for_site(&creds.site);
+        Self::new(&base_url, &creds.api_key, &creds.app_key)
+    }
+
+    /// Returns the API base URL (without trailing slash).
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Sends an authenticated GET request and returns the raw response.
+    pub async fn get_json(&self, url: &str) -> Result<reqwest::Response> {
+        for attempt in 0..=MAX_RETRIES {
+            let response = self
+                .client
+                .get(url)
+                .header("DD-API-KEY", &self.api_key)
+                .header("DD-APPLICATION-KEY", &self.app_key)
+                .header("Accept", "application/json")
+                .send()
+                .await
+                .context("Failed to send GET request to Datadog API")?;
+
+            if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
+                return Ok(response);
+            }
+            Self::wait_for_retry(&response, attempt).await;
+        }
+        unreachable!()
+    }
+
+    /// Sends an authenticated POST request with a JSON body and returns the raw response.
+    pub async fn post_json<T: serde::Serialize + Sync + ?Sized>(
+        &self,
+        url: &str,
+        body: &T,
+    ) -> Result<reqwest::Response> {
+        for attempt in 0..=MAX_RETRIES {
+            let response = self
+                .client
+                .post(url)
+                .header("DD-API-KEY", &self.api_key)
+                .header("DD-APPLICATION-KEY", &self.app_key)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .json(body)
+                .send()
+                .await
+                .context("Failed to send POST request to Datadog API")?;
+
+            if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
+                return Ok(response);
+            }
+            Self::wait_for_retry(&response, attempt).await;
+        }
+        unreachable!()
+    }
+
+    /// Consumes a non-success response and turns it into a [`DatadogError`].
+    ///
+    /// For 429 responses, appends a human-readable rate-limit summary
+    /// (extracted from `X-RateLimit-*` headers) to the body, so the caller
+    /// sees why the retry loop gave up.
+    pub async fn response_to_error(response: reqwest::Response) -> DatadogError {
+        let status = response.status().as_u16();
+        let headers = response.headers().clone();
+        let body = response.text().await.unwrap_or_default();
+        let body = if status == 429 {
+            match format_rate_limit(&headers) {
+                Some(suffix) => format!("{body} {suffix}").trim().to_string(),
+                None => body,
+            }
+        } else {
+            body
+        };
+        DatadogError::ApiRequestFailed { status, body }
+    }
+
+    /// Waits before retrying a rate-limited request.
+    ///
+    /// Consults, in order: `Retry-After`, then Datadog's `X-RateLimit-Reset`,
+    /// then exponential backoff (`DEFAULT_RETRY_DELAY_SECS ^ (attempt+1)`).
+    async fn wait_for_retry(response: &reqwest::Response, attempt: u32) {
+        let headers = response.headers();
+        let delay = header_u64(headers, "Retry-After")
+            .or_else(|| header_u64(headers, "X-RateLimit-Reset"))
+            .unwrap_or_else(|| DEFAULT_RETRY_DELAY_SECS.pow(attempt + 1));
+
+        eprintln!(
+            "Rate limited (429). Retrying in {delay}s (attempt {})...",
+            attempt + 1
+        );
+        tokio::time::sleep(Duration::from_secs(delay)).await;
+    }
+}
+
+fn header_u64(headers: &reqwest::header::HeaderMap, name: &str) -> Option<u64> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+}
+
+fn format_rate_limit(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let remaining = headers
+        .get("X-RateLimit-Remaining")
+        .and_then(|v| v.to_str().ok());
+    let reset = headers
+        .get("X-RateLimit-Reset")
+        .and_then(|v| v.to_str().ok());
+    let limit = headers
+        .get("X-RateLimit-Limit")
+        .and_then(|v| v.to_str().ok());
+
+    if remaining.is_none() && reset.is_none() && limit.is_none() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    if let Some(v) = remaining {
+        parts.push(format!("remaining={v}"));
+    }
+    if let Some(v) = limit {
+        parts.push(format!("limit={v}"));
+    }
+    if let Some(v) = reset {
+        parts.push(format!("reset_in={v}s"));
+    }
+    Some(format!("[rate-limit: {}]", parts.join(", ")))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_client_strips_trailing_slash() {
+        let client = DatadogClient::new("https://api.datadoghq.com/", "api", "app").unwrap();
+        assert_eq!(client.base_url(), "https://api.datadoghq.com");
+    }
+
+    #[test]
+    fn new_client_preserves_clean_url() {
+        let client = DatadogClient::new("https://api.datadoghq.com", "api", "app").unwrap();
+        assert_eq!(client.base_url(), "https://api.datadoghq.com");
+    }
+
+    #[test]
+    fn from_credentials_builds_base_url_from_site() {
+        let creds = DatadogCredentials {
+            api_key: "api".to_string(),
+            app_key: "app".to_string(),
+            site: "us5.datadoghq.com".to_string(),
+        };
+        let client = DatadogClient::from_credentials(&creds).unwrap();
+        assert_eq!(client.base_url(), "https://api.us5.datadoghq.com");
+    }
+
+    #[tokio::test]
+    async fn get_json_sends_auth_headers() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .and(wiremock::matchers::header("DD-API-KEY", "my-api"))
+            .and(wiremock::matchers::header("DD-APPLICATION-KEY", "my-app"))
+            .and(wiremock::matchers::header("Accept", "application/json"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "my-api", "my-app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn post_json_sends_body_and_auth() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/test"))
+            .and(wiremock::matchers::header("DD-API-KEY", "my-api"))
+            .and(wiremock::matchers::header("DD-APPLICATION-KEY", "my-app"))
+            .and(wiremock::matchers::header(
+                "Content-Type",
+                "application/json",
+            ))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "query": "hello"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "1"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "my-api", "my-app").unwrap();
+        let body = serde_json::json!({"query": "hello"});
+        let resp = client
+            .post_json(&format!("{}/test", server.uri()), &body)
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn get_json_retries_on_429_via_retry_after() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(wiremock::ResponseTemplate::new(429).append_header("Retry-After", "0"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn get_json_retries_on_429_via_x_ratelimit_reset() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(429).append_header("X-RateLimit-Reset", "0"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn post_json_retries_on_429() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(wiremock::ResponseTemplate::new(429).append_header("Retry-After", "0"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .post_json(
+                &format!("{}/test", server.uri()),
+                &serde_json::json!({"k": "v"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 201);
+    }
+
+    #[tokio::test]
+    async fn get_json_returns_429_after_max_retries() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(wiremock::ResponseTemplate::new(429).append_header("Retry-After", "0"))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 429);
+    }
+
+    #[tokio::test]
+    async fn response_to_error_surfaces_rate_limit_headers_on_429() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .append_header("X-RateLimit-Remaining", "0")
+                    .append_header("X-RateLimit-Reset", "42")
+                    .append_header("X-RateLimit-Limit", "100")
+                    .set_body_string("too many"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        let err = DatadogClient::response_to_error(resp).await;
+        let msg = err.to_string();
+        assert!(msg.contains("429"));
+        assert!(msg.contains("too many"));
+        assert!(msg.contains("remaining=0"));
+        assert!(msg.contains("limit=100"));
+        assert!(msg.contains("reset_in=42s"));
+    }
+
+    #[tokio::test]
+    async fn response_to_error_does_not_add_rate_limit_suffix_on_non_429() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(wiremock::ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        let err = DatadogClient::response_to_error(resp).await;
+        let msg = err.to_string();
+        assert!(msg.contains("401"));
+        assert!(msg.contains("Unauthorized"));
+        assert!(!msg.contains("rate-limit"));
+    }
+
+    #[tokio::test]
+    async fn response_to_error_omits_suffix_when_no_rate_limit_headers() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/test"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(429)
+                    .append_header("Retry-After", "0")
+                    .set_body_string("slow down"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let resp = client
+            .get_json(&format!("{}/test", server.uri()))
+            .await
+            .unwrap();
+        let err = DatadogClient::response_to_error(resp).await;
+        let msg = err.to_string();
+        assert!(msg.contains("slow down"));
+        assert!(!msg.contains("rate-limit"));
+    }
+}

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -23,6 +23,7 @@ const MAX_RETRIES: u32 = 3;
 const DEFAULT_RETRY_DELAY_SECS: u64 = 2;
 
 /// HTTP client for Datadog REST APIs.
+#[derive(Debug)]
 pub struct DatadogClient {
     client: Client,
     base_url: String,

--- a/src/datadog/error.rs
+++ b/src/datadog/error.rs
@@ -1,0 +1,64 @@
+//! Error types for Datadog operations.
+
+use thiserror::Error;
+
+/// Errors that can occur during Datadog operations.
+#[derive(Error, Debug)]
+pub enum DatadogError {
+    /// Datadog credentials are not configured.
+    #[error("Datadog credentials not configured. Run `omni-dev datadog auth login`")]
+    CredentialsNotFound,
+
+    /// A Datadog API request failed.
+    #[error("Datadog API request failed: HTTP {status}: {body}")]
+    ApiRequestFailed {
+        /// HTTP status code.
+        status: u16,
+        /// Response body text, optionally suffixed with rate-limit details
+        /// when the status was 429.
+        body: String,
+    },
+
+    /// The configured Datadog site is invalid.
+    #[error("Invalid Datadog site: {0}")]
+    InvalidSite(String),
+
+    /// A time-range specification could not be parsed.
+    #[error("Invalid time range: {0}")]
+    InvalidTimeRange(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_not_found_display() {
+        let err = DatadogError::CredentialsNotFound;
+        assert!(err.to_string().contains("not configured"));
+        assert!(err.to_string().contains("datadog auth login"));
+    }
+
+    #[test]
+    fn api_request_failed_display() {
+        let err = DatadogError::ApiRequestFailed {
+            status: 401,
+            body: "Unauthorized".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("401"));
+        assert!(msg.contains("Unauthorized"));
+    }
+
+    #[test]
+    fn invalid_site_display() {
+        let err = DatadogError::InvalidSite("weird.example".to_string());
+        assert!(err.to_string().contains("weird.example"));
+    }
+
+    #[test]
+    fn invalid_time_range_display() {
+        let err = DatadogError::InvalidTimeRange("1h30m".to_string());
+        assert!(err.to_string().contains("1h30m"));
+    }
+}

--- a/src/datadog/test_support.rs
+++ b/src/datadog/test_support.rs
@@ -10,7 +10,7 @@
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
-use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE};
+use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_API_URL, DATADOG_APP_KEY, DATADOG_SITE};
 
 /// Process-wide mutex serialising tests that mutate `HOME` and the
 /// Datadog credential environment variables.
@@ -28,7 +28,13 @@ impl EnvGuard {
         let lock = DATADOG_ENV_MUTEX
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
-        let keys = ["HOME", DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE];
+        let keys = [
+            "HOME",
+            DATADOG_API_KEY,
+            DATADOG_APP_KEY,
+            DATADOG_SITE,
+            DATADOG_API_URL,
+        ];
         let snapshot = keys
             .into_iter()
             .map(|k| (k, std::env::var(k).ok()))
@@ -67,5 +73,6 @@ pub(crate) fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
     std::env::remove_var(DATADOG_API_KEY);
     std::env::remove_var(DATADOG_APP_KEY);
     std::env::remove_var(DATADOG_SITE);
+    std::env::remove_var(DATADOG_API_URL);
     dir
 }

--- a/src/datadog/test_support.rs
+++ b/src/datadog/test_support.rs
@@ -1,0 +1,69 @@
+//! Shared test helpers for Datadog unit tests.
+//!
+//! Any test that mutates `HOME` or a `DATADOG_*` environment variable must
+//! acquire [`EnvGuard`] so parallel tests don't race on process-wide state.
+//! Keeping the mutex here (rather than per-module) ensures that tests in
+//! `src/datadog/auth.rs`, `src/cli/datadog/auth.rs`, and
+//! `src/cli/datadog/helpers.rs` all serialise against each other.
+
+#![allow(dead_code, clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use crate::datadog::auth::{DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE};
+
+/// Process-wide mutex serialising tests that mutate `HOME` and the
+/// Datadog credential environment variables.
+static DATADOG_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// RAII guard: snapshots `HOME` + every Datadog credential env var on
+/// construction and restores them on drop.
+pub(crate) struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    snapshot: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    pub(crate) fn take() -> Self {
+        let lock = DATADOG_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let keys = ["HOME", DATADOG_API_KEY, DATADOG_APP_KEY, DATADOG_SITE];
+        let snapshot = keys
+            .into_iter()
+            .map(|k| (k, std::env::var(k).ok()))
+            .collect();
+        Self {
+            _lock: lock,
+            snapshot,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.snapshot {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}
+
+/// Sets `HOME` to a fresh tempdir and clears all `DATADOG_*` env vars.
+///
+/// Returns the tempdir so the caller can populate `.omni-dev/settings.json`
+/// inside it. The guard parameter enforces ordering: callers must hold an
+/// [`EnvGuard`] before invoking this helper.
+pub(crate) fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
+    let dir = {
+        std::fs::create_dir_all("tmp").ok();
+        tempfile::TempDir::new_in("tmp").expect("create tempdir")
+    };
+    std::env::set_var("HOME", dir.path());
+    std::env::remove_var(DATADOG_API_KEY);
+    std::env::remove_var(DATADOG_APP_KEY);
+    std::env::remove_var(DATADOG_SITE);
+    dir
+}

--- a/src/datadog/test_support.rs
+++ b/src/datadog/test_support.rs
@@ -56,11 +56,13 @@ impl Drop for EnvGuard {
 /// Returns the tempdir so the caller can populate `.omni-dev/settings.json`
 /// inside it. The guard parameter enforces ordering: callers must hold an
 /// [`EnvGuard`] before invoking this helper.
+///
+/// Uses `tempfile::tempdir()` (absolute path via `std::env::temp_dir`)
+/// rather than a CWD-relative tempdir so that concurrent tests which
+/// mutate CWD (e.g. `mcp::resources` and `cli::git::view` tests) cannot
+/// race this helper into resolving against the wrong working directory.
 pub(crate) fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
-    let dir = {
-        std::fs::create_dir_all("tmp").ok();
-        tempfile::TempDir::new_in("tmp").expect("create tempdir")
-    };
+    let dir = tempfile::tempdir().expect("create tempdir");
     std::env::set_var("HOME", dir.path());
     std::env::remove_var(DATADOG_API_KEY);
     std::env::remove_var(DATADOG_APP_KEY);

--- a/src/datadog/time.rs
+++ b/src/datadog/time.rs
@@ -1,0 +1,240 @@
+//! Time-range parsing for Datadog CLI commands.
+//!
+//! Accepts three forms:
+//! - Relative shorthand: `{N}{s|m|h|d|w}` (e.g. `15m`, `1h`, `7d`).
+//! - Literal `now`.
+//! - RFC 3339 timestamps (timezone required, e.g. `2026-04-22T10:00:00Z`).
+//! - Unix epoch seconds (non-negative integer).
+//!
+//! All results are returned as epoch seconds (`i64`) — the unit expected
+//! by Datadog v1 query parameters.
+
+use chrono::{DateTime, Utc};
+
+use crate::datadog::error::DatadogError;
+
+/// Parses a single time instant relative to `now`.
+///
+/// Returns Unix epoch seconds. See module docs for accepted syntax.
+pub fn parse_instant(spec: &str, now: DateTime<Utc>) -> Result<i64, DatadogError> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Err(DatadogError::InvalidTimeRange("empty".to_string()));
+    }
+
+    if spec.eq_ignore_ascii_case("now") {
+        return Ok(now.timestamp());
+    }
+
+    if let Some(seconds) = parse_relative(spec) {
+        return Ok(now.timestamp() - seconds as i64);
+    }
+
+    if let Ok(ts) = DateTime::parse_from_rfc3339(spec) {
+        return Ok(ts.timestamp());
+    }
+
+    if let Ok(secs) = spec.parse::<i64>() {
+        if secs >= 0 {
+            return Ok(secs);
+        }
+    }
+
+    Err(DatadogError::InvalidTimeRange(spec.to_string()))
+}
+
+/// Parses a `(from, to)` pair. When `to` is `None`, defaults to `now`.
+pub fn parse_time_range(from: &str, to: Option<&str>) -> Result<(i64, i64), DatadogError> {
+    let now = Utc::now();
+    let from_ts = parse_instant(from, now)?;
+    let to_ts = match to {
+        Some(spec) => parse_instant(spec, now)?,
+        None => now.timestamp(),
+    };
+    if to_ts < from_ts {
+        return Err(DatadogError::InvalidTimeRange(format!(
+            "to ({to_ts}) is before from ({from_ts})"
+        )));
+    }
+    Ok((from_ts, to_ts))
+}
+
+/// Parses `{N}{unit}` shorthand. Returns the number of seconds it represents,
+/// or `None` if the input does not match the shorthand grammar.
+fn parse_relative(spec: &str) -> Option<u64> {
+    let bytes = spec.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    let unit_byte = *bytes.last()?;
+    let unit_seconds: u64 = match unit_byte {
+        b's' => 1,
+        b'm' => 60,
+        b'h' => 60 * 60,
+        b'd' => 24 * 60 * 60,
+        b'w' => 7 * 24 * 60 * 60,
+        _ => return None,
+    };
+    let digits = &spec[..spec.len() - 1];
+    if digits.is_empty() {
+        return None;
+    }
+    let n: u64 = digits.parse().ok()?;
+    n.checked_mul(unit_seconds)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 4, 22, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn parses_now() {
+        assert_eq!(parse_instant("now", now()).unwrap(), now().timestamp());
+    }
+
+    #[test]
+    fn parses_now_case_insensitive() {
+        assert_eq!(parse_instant("NOW", now()).unwrap(), now().timestamp());
+        assert_eq!(parse_instant("Now", now()).unwrap(), now().timestamp());
+    }
+
+    #[test]
+    fn parses_relative_minutes() {
+        assert_eq!(
+            parse_instant("15m", now()).unwrap(),
+            now().timestamp() - 15 * 60
+        );
+    }
+
+    #[test]
+    fn parses_relative_seconds() {
+        assert_eq!(parse_instant("30s", now()).unwrap(), now().timestamp() - 30);
+    }
+
+    #[test]
+    fn parses_relative_hours() {
+        assert_eq!(
+            parse_instant("2h", now()).unwrap(),
+            now().timestamp() - 2 * 60 * 60
+        );
+    }
+
+    #[test]
+    fn parses_relative_days() {
+        assert_eq!(
+            parse_instant("3d", now()).unwrap(),
+            now().timestamp() - 3 * 24 * 60 * 60
+        );
+    }
+
+    #[test]
+    fn parses_relative_weeks() {
+        assert_eq!(
+            parse_instant("1w", now()).unwrap(),
+            now().timestamp() - 7 * 24 * 60 * 60
+        );
+    }
+
+    #[test]
+    fn parses_rfc3339_utc() {
+        let expected = Utc
+            .with_ymd_and_hms(2026, 4, 22, 10, 0, 0)
+            .unwrap()
+            .timestamp();
+        assert_eq!(
+            parse_instant("2026-04-22T10:00:00Z", now()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn parses_rfc3339_with_offset() {
+        let expected = Utc
+            .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+            .unwrap()
+            .timestamp();
+        assert_eq!(
+            parse_instant("2026-04-22T10:00:00+01:00", now()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn parses_epoch_seconds() {
+        assert_eq!(parse_instant("1700000000", now()).unwrap(), 1_700_000_000);
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(parse_instant("", now()).is_err());
+        assert!(parse_instant("   ", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_compound_relative() {
+        assert!(parse_instant("1h30m", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_unit_without_digits() {
+        assert!(parse_instant("h", now()).is_err());
+        assert!(parse_instant("m", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_unit() {
+        assert!(parse_instant("5y", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_negative_epoch() {
+        assert!(parse_instant("-1", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_rfc3339_without_timezone() {
+        assert!(parse_instant("2026-04-22T10:00:00", now()).is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_garbage() {
+        assert!(parse_instant("zzz", now()).is_err());
+    }
+
+    #[test]
+    fn time_range_defaults_to_to_now() {
+        let (from, to) = parse_time_range("1h", None).unwrap();
+        assert!(to - from <= 60 * 60 + 5);
+        assert!(to - from >= 60 * 60 - 5);
+    }
+
+    #[test]
+    fn time_range_explicit_to() {
+        let (from, to) =
+            parse_time_range("2026-04-22T09:00:00Z", Some("2026-04-22T10:00:00Z")).unwrap();
+        assert_eq!(to - from, 60 * 60);
+    }
+
+    #[test]
+    fn time_range_rejects_inverted_range() {
+        let err =
+            parse_time_range("2026-04-22T10:00:00Z", Some("2026-04-22T09:00:00Z")).unwrap_err();
+        assert!(err.to_string().contains("before"));
+    }
+
+    #[test]
+    fn time_range_propagates_from_error() {
+        assert!(parse_time_range("garbage", None).is_err());
+    }
+
+    #[test]
+    fn time_range_propagates_to_error() {
+        assert!(parse_time_range("1h", Some("garbage")).is_err());
+    }
+}

--- a/src/datadog/time.rs
+++ b/src/datadog/time.rs
@@ -62,11 +62,7 @@ pub fn parse_time_range(from: &str, to: Option<&str>) -> Result<(i64, i64), Data
 /// Parses `{N}{unit}` shorthand. Returns the number of seconds it represents,
 /// or `None` if the input does not match the shorthand grammar.
 fn parse_relative(spec: &str) -> Option<u64> {
-    let bytes = spec.as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-    let unit_byte = *bytes.last()?;
+    let unit_byte = *spec.as_bytes().last()?;
     let unit_seconds: u64 = match unit_byte {
         b's' => 1,
         b'm' => 60,

--- a/src/datadog/types.rs
+++ b/src/datadog/types.rs
@@ -1,0 +1,4 @@
+//! Shared response types for the Datadog API.
+//!
+//! Populated in subsequent slices as endpoint families land. Kept as a
+//! module now so `src/datadog.rs` declares a stable set of children.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod atlassian;
 pub mod claude;
 pub mod cli;
 pub mod data;
+pub mod datadog;
 pub mod git;
 #[cfg(feature = "mcp")]
 pub mod mcp;

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -14,6 +14,7 @@ Commands:
   commands   Command template management
   config     Configuration and model information
   atlassian  Atlassian: JIRA and Confluence operations
+  datadog    Datadog: read-only API operations
   help-all   Displays comprehensive help for all commands
   help       Print this message or the help of the given subcommand(s)
 
@@ -1471,6 +1472,76 @@ omni-dev config models show - Shows the embedded models.yaml configuration
 Shows the embedded models.yaml configuration
 
 Usage: show
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev datadog - Datadog: read-only API operations
+
+Datadog: read-only API operations
+
+Usage: datadog <COMMAND>
+
+Commands:
+  auth  Manages Datadog API credentials
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev datadog auth - Manages Datadog API credentials
+
+Manages Datadog API credentials
+
+Usage: auth <COMMAND>
+
+Commands:
+  login   Configures Datadog API credentials interactively
+  logout  Removes Datadog API credentials from settings.json
+  status  Shows the current authentication status
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev datadog auth login - Configures Datadog API credentials interactively
+
+Configures Datadog API credentials interactively
+
+Usage: login
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev datadog auth logout - Removes Datadog API credentials from settings.json
+
+Removes Datadog API credentials from settings.json
+
+Usage: logout
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev datadog auth status - Shows the current authentication status
+
+Shows the current authentication status
+
+Usage: status
 
 Options:
   -h, --help  Print help


### PR DESCRIPTION
## Description

This PR introduces the initial Datadog integration as a new `omni-dev datadog` command tree with read-only API access, resolving [#619](https://github.com/rust-works/omni-dev/issues/619). This is the first slice of the Datadog feature, delivering the complete authentication surface and the underlying HTTP client infrastructure needed by all future Datadog subcommands (metrics, monitors, dashboards, logs).

Credentials are stored in the shared `env` map in `~/.omni-dev/settings.json` under `DATADOG_API_KEY`, `DATADOG_APP_KEY`, and `DATADOG_SITE` (defaulting to `datadoghq.com`). Environment variables override stored settings. No new crate dependencies are introduced.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #619

## Changes Made

**CLI Commands (`src/cli/datadog/`):**
- Added `src/cli/datadog.rs` — `DatadogCommand` and `DatadogSubcommands` wiring for the new `omni-dev datadog` command tree
- Added `src/cli/datadog/auth.rs` — `LoginCommand` (interactive prompt for API key, app key, and site), `LogoutCommand` (removes credentials from settings), and `StatusCommand` (verifies credentials via `/api/v1/validate`)
- Added `src/cli/datadog/format.rs` — `OutputFormat` enum (table/json/yaml/yamls/jsonl) and `JsonlSerialize` trait, mirroring the Atlassian format module; ready for future endpoint subcommands
- Added `src/cli/datadog/helpers.rs` — `create_client()` helper that loads credentials and builds a `DatadogClient`; unused in this slice, live with the first endpoint subcommand
- Updated `src/cli.rs` — registered `DatadogCommand` in the `Commands` enum and `execute()` dispatch

**Library Modules (`src/datadog/`):**
- Added `src/datadog.rs` — module root declaring the five submodules
- Added `src/datadog/auth.rs` — credential load/save/remove backed by `~/.omni-dev/settings.json`, env-var override, site normalisation (strips `https://`, `api.` prefix, trailing slashes), known-region validation with non-fatal warning for unrecognised sites, and secret-safe `AuthStatus`/`DatadogScopeStatus` types for reporting
- Added `src/datadog/client.rs` — `reqwest`-based `DatadogClient` injecting `DD-API-KEY` and `DD-APPLICATION-KEY` headers; retries 429 responses up to 3 times using `Retry-After` → `X-RateLimit-Reset` → exponential backoff priority; surfaces `X-RateLimit-{Remaining,Limit,Reset}` headers in error output when retries are exhausted; supports both GET and POST
- Added `src/datadog/error.rs` — typed `DatadogError` variants: `CredentialsNotFound`, `ApiRequestFailed`, `InvalidSite`, and `InvalidTimeRange`
- Added `src/datadog/time.rs` — time-range parser supporting relative shorthands (`15m`, `1h`, `7d`, `30s`, `1w`), `now` (case-insensitive), RFC 3339 timestamps (timezone required), and non-negative Unix epoch seconds; validates that `to` is not before `from`
- Added `src/datadog/types.rs` — placeholder module for shared response types; populated in subsequent slices
- Updated `src/lib.rs` — exposed `pub mod datadog`

**Documentation:**
- Updated `README.md` with a new "📊 Datadog Integration (read-only)" section covering `auth login`, `auth status`, and `auth logout` commands, site defaults, recognised regions, and environment variable overrides
- Updated `README.md` prerequisites section to list Datadog API key and application key requirements
- Updated `CHANGELOG.md` with a full description of the Datadog integration under `[Unreleased]`

**Testing:**
- Comprehensive unit tests in every new module covering: site normalisation, base URL construction, credential round-trips (create/merge/remove), auth status presence flags without leaking secrets, time parsing (all formats and error cases), HTTP client auth headers, 429 retry behaviour via both `Retry-After` and `X-RateLimit-Reset`, rate-limit header surfacing in error output, and `run_auth_status` happy/error/rate-limit paths using `wiremock`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (auth, client, error, time, format modules all have inline test suites)
- [x] Integration tests for auth status using `wiremock` mock server
- [ ] Performance tests (not applicable for this slice)

**Manual Testing:**
- [x] Tested happy path scenarios (login prompt, status verification, logout)
- [x] Tested error/edge cases (missing credentials, 403 API errors, 429 rate limiting, unknown site)
- [ ] Cross-platform testing (macOS validated; Linux CI covers other platforms)
- [x] Backward compatibility verified (no changes to existing command behaviour)

**Test Coverage:**
- New code coverage: comprehensive inline tests per module; `wiremock`-based async tests for all HTTP paths

### Test Commands
```bash
# Core test suite
cargo test

# Datadog-specific tests only
cargo test datadog

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manual credential flow (requires real Datadog account)
omni-dev datadog auth login
omni-dev datadog auth status
omni-dev datadog auth logout
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — credentials are stored in `~/.omni-dev/settings.json`; `AuthStatus` is designed to never expose secret values; see `src/datadog/auth.rs` `status()` and `DatadogScopeStatus`
- [x] Performance impact — `DatadogClient` retry logic in `src/datadog/client.rs`; exponential backoff and `Retry-After` handling
- [x] Architecture changes — new `datadog` top-level CLI command and library module; `format.rs` is intentionally duplicated from `cli::atlassian::format` pending a future shared extraction
- [x] Error handling — `DatadogError` typed variants; rate-limit header surfacing; non-fatal warning for unknown sites
- [x] Backward compatibility — purely additive; no changes to existing commands or settings schema

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact on existing commands
- [ ] Performance improvement (describe below)
- [x] Potential performance impact (describe below)

New Datadog commands make outbound HTTP calls to `https://api.<site>` with a 30-second timeout. The 429 retry loop uses `Retry-After` / `X-RateLimit-Reset` headers to avoid busy-waiting. No impact on startup time or existing command paths.

## Security Considerations
- [ ] No security implications
- [x] Security improvement (describe below)
- [ ] Potential security impact (describe below)

API keys and application keys are stored in `~/.omni-dev/settings.json` (user-owned file, same pattern as Atlassian credentials). The `AuthStatus` / `DatadogScopeStatus` types explicitly omit secret values — only presence flags (`has_api_key`, `has_app_key`) and the non-secret `site` field are exposed. The test suite includes an assertion that serialised status output does not contain secret values.

## Breaking Changes

None. This is a purely additive feature. No existing commands, settings schema, or APIs are modified.

## Deployment Notes
- [x] No special deployment requirements
- [ ] Database migration required
- [ ] Environment variable changes required
- [ ] Configuration file updates required
- [ ] Service restart required

Users wishing to use the Datadog commands must run `omni-dev datadog auth login` to store credentials. Pre-existing settings files are unaffected.

## Additional Notes

**Future Enhancements:**
- Subsequent slices will add `datadog metrics query`, `datadog monitors list`, `datadog dashboards list`, and `datadog logs search` subcommands using the `DatadogClient` and `OutputFormat` infrastructure introduced here
- `src/cli/datadog/helpers.rs` `create_client()` and `src/cli/datadog/format.rs` become live with the first endpoint subcommand
- A follow-up task is filed to extract a shared `src/cli/format.rs` from the currently duplicated `atlassian::format` and `datadog::format` modules

**Known Limitations:**
- Only US1 (`datadoghq.com`) and five additional known regions are pre-validated; unknown regions emit a stderr warning but are not blocked (future Datadog regions will work automatically)
- `src/datadog/types.rs` is an empty placeholder; populated incrementally as endpoint families land

**Alternatives Considered:**
- Storing credentials in a separate Datadog-specific config file rather than the shared `env` map — rejected to maintain consistency with the Atlassian integration and avoid proliferating config files