### PR TITLE
fix(git): trim whitespace from scope parts in multi-scope validation

### DIFF
--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -709,7 +709,7 @@ impl CommitInfoForAI {
 
                 // Deterministic scope validity check
                 if !valid_scopes.is_empty() {
-                    let scope_parts: Vec<&str> = scope.split(',').collect();
+                    let scope_parts: Vec<&str> = scope.split(',').map(str::trim).collect();
                     let all_valid = scope_parts
                         .iter()
                         .all(|part| valid_scopes.iter().any(|s| s.name == *part));
@@ -1273,6 +1273,23 @@ mod tests {
             .pre_validated_checks
             .iter()
             .any(|c| c.contains("multi-scope")),);
+    }
+
+    #[test]
+    fn pre_validation_multi_scope_with_spaces() {
+        let scopes = vec![
+            make_scope_def("cli", &["src/cli/**"]),
+            make_scope_def("lib", &["src/lib/**"]),
+        ];
+        let mut info = make_commit_info_for_ai("feat(cli, lib): add something");
+        info.run_pre_validation_checks(&scopes);
+        assert!(
+            info.pre_validated_checks
+                .iter()
+                .any(|c| c.contains("Scope validity verified")),
+            "expected scope validity check for spaced multi-scope, got: {:?}",
+            info.pre_validated_checks
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes a bug in the conventional commit scope validation logic where multi-scope commit messages using spaces after commas (e.g., `feat(cli, lib): ...`) would incorrectly fail the scope validity check. The root cause was that `scope.split(',')` produced scope parts with leading/trailing whitespace, which did not match the trimmed scope names in the valid scopes list.

Adding `.map(str::trim)` to the scope splitting logic ensures that each scope part is compared without surrounding whitespace, making `feat(cli, lib): ...` and `feat(cli,lib): ...` both pass validation correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #626

## Changes Made

**Core Changes:**
- Modified `CommitInfoForAI` scope validation in `src/git/commit.rs` to apply `.map(str::trim)` when splitting comma-separated scope strings, so each part is whitespace-trimmed before being matched against the valid scopes list

**Testing:**
- Added `pre_validation_multi_scope_with_spaces` test in `src/git/commit.rs` to cover the case of spaced multi-scope input (`feat(cli, lib): add something`), asserting that the "Scope validity verified" check is present in `pre_validated_checks`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the relevant module tests
cargo test git::commit

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling
- [x] Backward compatibility

The change is minimal and surgical — only one line in the production path is modified (the `.map(str::trim)` addition). The behaviour for single-scope and no-whitespace multi-scope inputs is unchanged.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Normalising the scope string before splitting (e.g., stripping all spaces): rejected in favour of the more targeted per-part trim, which preserves any intentional spacing within scope names while cleanly handling delimiter whitespace.