### PR TITLE
fix(claude, data): require reasoning field before severity in AI issue output

### DIFF
--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -673,11 +673,13 @@ checks:
   - commit: "abc123..."
     passes: false
     issues:
-      - severity: error
+      - reasoning: "Subject is 85 characters, guideline caps at 72. 85 > 72, so this violates the Subject Line rule. Section 'Subject Line' maps to severity 'error'."
+        severity: error
         section: "Subject Line"
         rule: "Keep under 72 characters"
         explanation: "Subject is 85 characters"
-      - severity: warning
+      - reasoning: "Diff shows 142 lines changed. Body Guidelines requires a body for large changes. No body present. Section 'Content' maps to severity 'warning'."
+        severity: warning
         section: "Body Guidelines"
         rule: "Body required for large changes"
         explanation: "142 lines changed but no body provided"
@@ -696,6 +698,11 @@ For commits that pass all checks:
     passes: true
     issues: []
     summary: "Update CI pipeline to run tests in parallel"
+
+CRITICAL — REASONING MUST PRECEDE VERDICT:
+Every issue entry MUST begin with a `reasoning` field, written BEFORE the `severity` field, in the exact field order shown above. The `reasoning` field is where you work out whether the rule is actually violated. Walk through the evidence: what the message says, what the diff or valid-scopes list shows, and whether pre_validated_checks covers it. Only after the reasoning concludes do you commit to a `severity` value.
+
+Do NOT write the severity first and then justify it. Do NOT emit an issue whose `reasoning` concludes the message is valid — if your reasoning finds no violation, omit the issue entirely (or report it at severity `info` if it's merely a style suggestion). The `reasoning` and `severity` fields must be self-consistent; a contradictory issue (e.g., reasoning says "this is valid" but severity is `error`) is a bug in your output.
 
 IMPORTANT:
 - Include ALL commits in the response, whether they pass or fail
@@ -844,7 +851,8 @@ checks:
   - commit: "abc123..."
     passes: true/false
     issues:
-      - severity: error/warning/info
+      - reasoning: "Cross-commit analysis of why this is (or is not) an issue. Work through the evidence before committing to severity."
+        severity: error/warning/info
         section: "Section Name"
         rule: "Rule description"
         explanation: "Why this is an issue"
@@ -853,6 +861,9 @@ checks:
         refined commit message
       explanation: |
         - Reason for refinement
+
+CRITICAL — REASONING MUST PRECEDE VERDICT:
+Every issue entry MUST begin with a `reasoning` field, written BEFORE the `severity` field, in the exact field order shown above. Work through the evidence in `reasoning` first, then commit to `severity`. If your reasoning concludes the finding is valid (not a violation), omit the issue or downgrade to `info`. The `reasoning` and `severity` fields must be self-consistent.
 
 IMPORTANT:
 - Include ALL commits from the input
@@ -1461,6 +1472,50 @@ mod tests {
     fn check_system_prompt_constant_not_empty() {
         assert!(CHECK_SYSTEM_PROMPT.len() > 100);
         assert!(CHECK_SYSTEM_PROMPT.contains("commit message reviewer"));
+    }
+
+    /// Regression guard for #627: in every structural YAML example in `prompt`,
+    /// the `reasoning:` field must appear before the `severity:` field so the
+    /// verdict is conditioned on worked-through reasoning rather than a first
+    /// guess. Returns true only if both fields are present AND ordered
+    /// correctly in the first occurrence.
+    fn reasoning_precedes_severity(prompt: &str) -> bool {
+        match (prompt.find("reasoning:"), prompt.find("severity:")) {
+            (Some(r), Some(s)) => r < s,
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn check_system_prompt_puts_reasoning_before_severity() {
+        assert!(
+            reasoning_precedes_severity(CHECK_SYSTEM_PROMPT),
+            "reasoning field must appear before severity in the YAML template"
+        );
+    }
+
+    #[test]
+    fn check_coherence_prompt_puts_reasoning_before_severity() {
+        assert!(
+            reasoning_precedes_severity(CHECK_COHERENCE_SYSTEM_PROMPT),
+            "reasoning field must appear before severity in the coherence YAML template"
+        );
+    }
+
+    #[test]
+    fn reasoning_precedes_severity_helper_branches() {
+        // Positive: both fields present, correct order.
+        assert!(reasoning_precedes_severity("- reasoning: x\n  severity: y"));
+        // Negative: wrong order.
+        assert!(!reasoning_precedes_severity(
+            "- severity: y\n  reasoning: x"
+        ));
+        // Negative: missing severity.
+        assert!(!reasoning_precedes_severity("- reasoning: x"));
+        // Negative: missing reasoning.
+        assert!(!reasoning_precedes_severity("- severity: y"));
+        // Negative: neither field.
+        assert!(!reasoning_precedes_severity(""));
     }
 
     #[test]

--- a/src/data/check.rs
+++ b/src/data/check.rs
@@ -245,6 +245,12 @@ pub struct AiCommitCheck {
 /// Issue from AI response.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AiIssue {
+    /// Reasoning written before the verdict. Forces think-first ordering so
+    /// `severity` is conditioned on fully-worked-through reasoning instead of
+    /// a first guess. Not surfaced to end users — the concise `explanation`
+    /// is shown instead.
+    #[serde(default)]
+    pub reasoning: Option<String>,
     /// Severity level.
     pub severity: String,
     /// Guideline section.
@@ -456,6 +462,7 @@ mod tests {
             commit: "abc123".to_string(),
             passes: false,
             issues: vec![AiIssue {
+                reasoning: Some("Subject exceeds cap; violates Format rule.".to_string()),
                 severity: "error".to_string(),
                 section: "Format".to_string(),
                 rule: "subject-line".to_string(),
@@ -489,6 +496,40 @@ mod tests {
         let suggestion = result.suggestion.unwrap();
         assert_eq!(suggestion.message, "feat(cli): better message");
         assert_eq!(suggestion.explanation, "improved clarity");
+    }
+
+    #[test]
+    fn ai_issue_deserializes_with_reasoning_field() {
+        // Reasoning-before-severity YAML shape (the intended model output for
+        // issue #627). Parser must accept it and preserve severity correctly.
+        let yaml = r#"
+reasoning: "Scope 'lib' is in the valid scopes list; scope validity check passes. No violation."
+severity: info
+section: "Scope Appropriateness"
+rule: "scope-suggestion"
+explanation: "Consider a narrower scope."
+"#;
+        let issue: AiIssue = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(issue.severity, "info");
+        assert!(issue
+            .reasoning
+            .as_deref()
+            .unwrap()
+            .contains("valid scopes list"));
+    }
+
+    #[test]
+    fn ai_issue_deserializes_without_reasoning_field() {
+        // Older/fallback YAML shape with no reasoning field must still parse.
+        let yaml = r#"
+severity: error
+section: "Subject Line"
+rule: "subject-too-long"
+explanation: "Subject exceeds 72 characters"
+"#;
+        let issue: AiIssue = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(issue.severity, "error");
+        assert!(issue.reasoning.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes issue #627 by enforcing a think-first ordering in the AI commit checker's YAML output: the `reasoning` field must appear before the `severity` field in every issue entry. This ensures that every verdict is conditioned on fully-worked-through reasoning rather than a first guess, improving the quality and consistency of AI-generated commit analysis.

Previously, the AI could emit a `severity` verdict before (or without) articulating its reasoning, leading to potential contradictions between the rationale and the verdict. By requiring `reasoning` to precede `severity` in the YAML structure, the AI is forced to work through the evidence before committing to a verdict.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #627

## Changes Made

**Core Changes:**
- Added `reasoning: Option<String>` field to `AiIssue` struct in `src/data/check.rs` with `#[serde(default)]` so existing YAML without the field continues to deserialize correctly (backward compatible)
- Updated `CHECK_SYSTEM_PROMPT` in `src/claude/prompts.rs` to place `reasoning` before `severity` in every issue example, with an explicit CRITICAL section explaining the required field ordering and the think-first constraint
- Updated `CHECK_COHERENCE_SYSTEM_PROMPT` in `src/claude/prompts.rs` similarly, placing `reasoning` before `severity` and adding a CRITICAL ordering explanation

**Testing:**
- Added `reasoning_precedes_severity` regression-guard helper in `src/claude/prompts.rs` that verifies field ordering in prompt strings
- Added `check_system_prompt_puts_reasoning_before_severity` test asserting the ordering invariant in `CHECK_SYSTEM_PROMPT`
- Added `check_coherence_prompt_puts_reasoning_before_severity` test asserting the ordering invariant in `CHECK_COHERENCE_SYSTEM_PROMPT`
- Added `ai_issue_deserializes_with_reasoning_field` test verifying the new `reasoning`-before-`severity` YAML shape deserializes correctly
- Added `ai_issue_deserializes_without_reasoning_field` test verifying the older YAML shape (no `reasoning` field) still deserializes correctly

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Backward compatibility verified via `ai_issue_deserializes_without_reasoning_field` test

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run prompt ordering regression tests specifically
cargo test check_system_prompt_puts_reasoning_before_severity
cargo test check_coherence_prompt_puts_reasoning_before_severity

# Run AiIssue deserialization tests
cargo test ai_issue_deserializes_with_reasoning_field
cargo test ai_issue_deserializes_without_reasoning_field

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — `#[serde(default)]` on `reasoning` ensures old YAML without the field still parses
- [x] The CRITICAL ordering sections added to both prompts in `src/claude/prompts.rs` — these instruct the AI on the required field ordering and the self-consistency requirement between `reasoning` and `severity`
- [x] The regression-guard helper `reasoning_precedes_severity` in `src/claude/prompts.rs` — it uses first-occurrence index comparison to enforce ordering

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Design Decision — `reasoning` not surfaced to end users:**
The `reasoning` field on `AiIssue` is intentionally not displayed to end users. The concise `explanation` field is shown instead. The `reasoning` field exists purely to force the AI to work through evidence before committing to a `severity` verdict, acting as a chain-of-thought mechanism within the structured YAML output.

**Backward Compatibility:**
Existing YAML responses from the AI that lack the `reasoning` field will continue to deserialize correctly due to `#[serde(default)]`. No migration is required for previously cached or stored AI responses.