### PR TITLE
feat(cli, mcp): implement auto-pagination for Datadog events and logs

### DIFF
--- a/src/cli/datadog/events/list.rs
+++ b/src/cli/datadog/events/list.rs
@@ -28,8 +28,9 @@ pub struct ListCommand {
     #[arg(long, default_value = "now")]
     pub to: String,
 
-    /// Maximum events to return (Datadog v2 events per-page cap is 1000;
-    /// cursor pagination across pages is a follow-up).
+    /// Maximum events to return. Pass `0` to fetch every match across
+    /// pages (capped at 10000); any non-zero value caps the total at
+    /// that count, paginating underneath as needed.
     #[arg(long, default_value_t = 100)]
     pub limit: usize,
 
@@ -91,7 +92,9 @@ async fn run_list(
     limit: usize,
     output: &OutputFormat,
 ) -> Result<()> {
-    let result: EventsResponse = EventsApi::new(client).list(filter, from, to, limit).await?;
+    let result: EventsResponse = EventsApi::new(client)
+        .list_all(filter, from, to, limit)
+        .await?;
     if output_as(&result, output)? {
         return Ok(());
     }
@@ -216,6 +219,35 @@ mod tests {
             "2026-04-22T09:00:00Z",
             "2026-04-22T10:00:00Z",
             10,
+            &OutputFormat::Json,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_list_with_zero_limit_auto_paginates_until_no_cursor() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param("page[limit]", "1000"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "data": [],
+                    "meta": { "page": {} }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        run_list(
+            &client,
+            &EventsListFilter::default(),
+            "2026-04-22T09:00:00Z",
+            "2026-04-22T10:00:00Z",
+            0,
             &OutputFormat::Json,
         )
         .await

--- a/src/cli/datadog/logs/search.rs
+++ b/src/cli/datadog/logs/search.rs
@@ -53,8 +53,9 @@ pub struct SearchCommand {
     #[arg(long, default_value = "now")]
     pub to: String,
 
-    /// Maximum events to return (Datadog v2 logs search per-page cap is
-    /// 1000; cursor pagination across pages is a Phase 2 follow-up).
+    /// Maximum events to return. Pass `0` to fetch every match across
+    /// pages (capped at 10000); any non-zero value caps the total at
+    /// that count, paginating underneath as needed.
     #[arg(long, default_value_t = 100)]
     pub limit: usize,
 
@@ -120,7 +121,7 @@ async fn run_search(
     output: &OutputFormat,
 ) -> Result<()> {
     let result: LogSearchResult = LogsApi::new(client)
-        .search(filter, from, to, limit, sort)
+        .search_all(filter, from, to, limit, sort)
         .await?;
     if output_as(&result, output)? {
         return Ok(());
@@ -147,6 +148,9 @@ mod tests {
     use crate::datadog::types::LogEventAttributes;
 
     fn search_body() -> serde_json::Value {
+        // No `meta.page.after` so the auto-paginating wrapper terminates
+        // after a single request; tests that exercise cursor follow-up
+        // live in `LogsApi::search_all` unit tests.
         serde_json::json!({
             "data": [
                 {
@@ -161,7 +165,7 @@ mod tests {
                     }
                 }
             ],
-            "meta": { "page": { "after": "next" } }
+            "meta": { "page": {} }
         })
     }
 
@@ -315,21 +319,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_search_propagates_client_side_limit_error() {
-        let client = DatadogClient::new("http://127.0.0.1:1", "api", "app").unwrap();
-        let err = run_search(
+    async fn run_search_with_zero_limit_auto_paginates_until_no_cursor() {
+        // limit == 0 means "fetch every match"; the wrapper requests
+        // pages of MAX_PAGE_LIMIT until the API stops returning a
+        // cursor.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": {
+                    "query": "*",
+                    "from": "2026-04-22T09:00:00Z",
+                    "to": "2026-04-22T10:00:00Z"
+                },
+                "page": { "limit": 1000 },
+                "sort": "-timestamp"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "data": [],
+                    "meta": { "page": {} }
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        run_search(
             &client,
             "*",
             "2026-04-22T09:00:00Z",
             "2026-04-22T10:00:00Z",
-            5000,
+            0,
             SortOrder::TimestampDesc,
-            &OutputFormat::Table,
+            &OutputFormat::Json,
         )
         .await
-        .unwrap_err();
-        assert!(err.to_string().contains("--limit"));
-        assert!(err.to_string().contains("1000"));
+        .unwrap();
     }
 
     // ── SearchCommand::execute error paths ─────────────────────────

--- a/src/datadog/events_api.rs
+++ b/src/datadog/events_api.rs
@@ -1,11 +1,15 @@
 //! Datadog Events API wrapper.
 //!
 //! Exposes a thin façade over [`DatadogClient`] for the read-only events
-//! stream (`GET /api/v2/events`) needed by the CLI.
+//! stream (`GET /api/v2/events`).
 //!
-//! Datadog v2 events use cursor pagination via `meta.page.after`; Phase 2
-//! ships single-page only and preserves the cursor on the response so a
-//! future iteration can extend without changing the wire types.
+//! Datadog v2 events use cursor pagination via `meta.page.after`.
+//! [`EventsApi::list`] issues a single request optionally seeded with an
+//! `after` cursor token; [`EventsApi::list_all`] auto-paginates up to a
+//! caller-supplied limit (or [`HARD_CAP`] when the limit is `0`),
+//! mirroring [`MonitorsApi::list`].
+//!
+//! [`MonitorsApi::list`]: crate::datadog::monitors_api::MonitorsApi::list
 
 use anyhow::{Context, Result};
 use url::Url;
@@ -15,6 +19,10 @@ use crate::datadog::types::EventsResponse;
 
 /// Per-page upper bound enforced by Datadog's v2 events API.
 pub const MAX_PAGE_LIMIT: usize = 1000;
+
+/// Per-call upper bound on the number of events returned by
+/// [`EventsApi::list_all`], even when the caller passes `limit = 0`.
+pub const HARD_CAP: usize = 10_000;
 
 /// Filters accepted by `GET /api/v2/events`.
 ///
@@ -48,21 +56,25 @@ impl<'a> EventsApi<'a> {
     /// Lists events matching `filter` between `from` and `to` (RFC 3339
     /// strings) capped at `limit` per page.
     ///
-    /// Single-page only; cursor pagination across pages is left to the
-    /// caller via the `meta.page.after` field on the response.
+    /// Single-page only. When `after` is `Some`, Datadog resumes
+    /// pagination at that cursor token (`page[cursor]` in the query
+    /// string). The next-page token is preserved on `meta.page.after`
+    /// of the response so callers (or [`EventsApi::list_all`]) can
+    /// iterate.
     pub async fn list(
         &self,
         filter: &EventsListFilter,
         from: &str,
         to: &str,
         limit: usize,
+        after: Option<&str>,
     ) -> Result<EventsResponse> {
         if limit > MAX_PAGE_LIMIT {
             return Err(anyhow::anyhow!(
-                "--limit must be <= {MAX_PAGE_LIMIT} (Datadog v2 events per-page cap; cursor pagination across pages is a follow-up)"
+                "`limit` must be <= {MAX_PAGE_LIMIT} (Datadog v2 events per-page cap; use `EventsApi::list_all` to auto-paginate across pages)"
             ));
         }
-        let url = build_list_url(self.client.base_url(), filter, from, to, limit)?;
+        let url = build_list_url(self.client.base_url(), filter, from, to, limit, after)?;
         let response = self.client.get_json(url.as_str()).await?;
         if !response.status().is_success() {
             return Err(DatadogClient::response_to_error(response).await.into());
@@ -72,15 +84,83 @@ impl<'a> EventsApi<'a> {
             .await
             .context("Failed to parse /api/v2/events response")
     }
+
+    /// Lists events, auto-paginating via cursor as needed.
+    ///
+    /// `limit == 0` means "fetch every match up to [`HARD_CAP`]". Any
+    /// non-zero `limit` is upper-bounded by [`HARD_CAP`] to keep a single
+    /// invocation from issuing more than 10k items' worth of requests.
+    /// Per-request page size is clamped to [`MAX_PAGE_LIMIT`].
+    ///
+    /// Termination follows cursor-pagination semantics: the loop stops
+    /// when the response omits `meta.page.after` (Datadog signals "no
+    /// more pages" only via the absent cursor — a short page on its own
+    /// is *not* a terminator) or when `cap` items have been collected.
+    ///
+    /// The returned envelope keeps the `meta` and `links` blocks from the
+    /// *last* successful page so the response's cursor reflects the
+    /// iterator's final position (typically `None` when the API is
+    /// exhausted).
+    pub async fn list_all(
+        &self,
+        filter: &EventsListFilter,
+        from: &str,
+        to: &str,
+        limit: usize,
+    ) -> Result<EventsResponse> {
+        let cap = effective_cap(limit);
+        let mut acc: Option<EventsResponse> = None;
+        let mut cursor: Option<String> = None;
+        loop {
+            let collected = acc.as_ref().map_or(0, |r| r.data.len());
+            let remaining = cap - collected;
+            let page_size = remaining.min(MAX_PAGE_LIMIT);
+            let page = self
+                .list(filter, from, to, page_size, cursor.as_deref())
+                .await?;
+            let next_cursor = page
+                .meta
+                .as_ref()
+                .and_then(|m| m.page.as_ref())
+                .and_then(|p| p.after.clone());
+            match acc.as_mut() {
+                Some(existing) => {
+                    existing.data.extend(page.data);
+                    existing.meta = page.meta;
+                    existing.links = page.links;
+                }
+                None => acc = Some(page),
+            }
+            let collected = acc.as_ref().map_or(0, |r| r.data.len());
+            if collected >= cap || next_cursor.is_none() {
+                break;
+            }
+            cursor = next_cursor;
+        }
+        let mut result = acc.unwrap_or_default();
+        result.data.truncate(cap);
+        Ok(result)
+    }
 }
 
-/// Builds `{base_url}/api/v2/events?filter[query]=…&filter[from]=…&filter[to]=…&page[limit]=N`.
+/// Clamps a caller-supplied limit to [`HARD_CAP`], treating `0` as
+/// "fetch as many as the cap allows".
+fn effective_cap(limit: usize) -> usize {
+    if limit == 0 {
+        HARD_CAP
+    } else {
+        limit.min(HARD_CAP)
+    }
+}
+
+/// Builds `{base_url}/api/v2/events?filter[query]=…&filter[from]=…&filter[to]=…&page[limit]=N&page[cursor]=…`.
 fn build_list_url(
     base_url: &str,
     filter: &EventsListFilter,
     from: &str,
     to: &str,
     limit: usize,
+    after: Option<&str>,
 ) -> Result<Url> {
     let mut url =
         Url::parse(&format!("{base_url}/api/v2/events")).context("Invalid Datadog base URL")?;
@@ -98,6 +178,9 @@ fn build_list_url(
         q.append_pair("filter[from]", from);
         q.append_pair("filter[to]", to);
         q.append_pair("page[limit]", &limit.to_string());
+        if let Some(cursor) = after {
+            q.append_pair("page[cursor]", cursor);
+        }
     }
     Ok(url)
 }
@@ -106,6 +189,23 @@ fn build_list_url(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // ── effective_cap ──────────────────────────────────────────────
+
+    #[test]
+    fn effective_cap_zero_means_hard_cap() {
+        assert_eq!(effective_cap(0), HARD_CAP);
+    }
+
+    #[test]
+    fn effective_cap_clamps_to_hard_cap() {
+        assert_eq!(effective_cap(HARD_CAP + 5), HARD_CAP);
+    }
+
+    #[test]
+    fn effective_cap_passes_through_small_limits() {
+        assert_eq!(effective_cap(42), 42);
+    }
 
     // ── URL builder ────────────────────────────────────────────────
 
@@ -122,6 +222,7 @@ mod tests {
             "2026-04-22T09:00:00Z",
             "2026-04-22T10:00:00Z",
             50,
+            None,
         )
         .unwrap();
         let qs = url.query().unwrap();
@@ -131,6 +232,7 @@ mod tests {
         assert!(qs.contains("page%5Blimit%5D=50"));
         assert!(!qs.contains("filter%5Bsources%5D"));
         assert!(!qs.contains("filter%5Btags%5D"));
+        assert!(!qs.contains("page%5Bcursor%5D"));
     }
 
     #[test]
@@ -146,11 +248,27 @@ mod tests {
             "2026-04-22T09:00:00Z",
             "2026-04-22T10:00:00Z",
             10,
+            None,
         )
         .unwrap();
         let qs = url.query().unwrap();
         assert!(qs.contains("filter%5Bsources%5D=aws%2Ckubernetes"));
         assert!(qs.contains("filter%5Btags%5D=env%3Aprod%2Cteam%3Asre"));
+    }
+
+    #[test]
+    fn build_list_url_appends_cursor_when_provided() {
+        let url = build_list_url(
+            "https://api.datadoghq.com",
+            &EventsListFilter::default(),
+            "2026-04-22T09:00:00Z",
+            "2026-04-22T10:00:00Z",
+            10,
+            Some("tok-2"),
+        )
+        .unwrap();
+        let qs = url.query().unwrap();
+        assert!(qs.contains("page%5Bcursor%5D=tok-2"));
     }
 
     #[test]
@@ -161,6 +279,7 @@ mod tests {
             "2026-04-22T09:00:00Z",
             "2026-04-22T10:00:00Z",
             10,
+            None,
         )
         .unwrap_err();
         assert!(err.to_string().contains("Invalid Datadog base URL"));
@@ -168,20 +287,31 @@ mod tests {
 
     // ── fixtures ───────────────────────────────────────────────────
 
+    fn event_json(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "type": "event",
+            "attributes": {
+                "timestamp": "2026-04-22T10:00:00.000Z",
+                "title": "Deploy",
+                "source": "github",
+                "tags": ["env:prod"]
+            }
+        })
+    }
+
+    fn page_body(ids: &[&str], next_cursor: Option<&str>) -> serde_json::Value {
+        let data: Vec<serde_json::Value> = ids.iter().map(|id| event_json(id)).collect();
+        let meta = match next_cursor {
+            Some(c) => serde_json::json!({ "page": { "after": c }, "status": "done" }),
+            None => serde_json::json!({ "page": {}, "status": "done" }),
+        };
+        serde_json::json!({ "data": data, "meta": meta })
+    }
+
     fn sample_body() -> serde_json::Value {
         serde_json::json!({
-            "data": [
-                {
-                    "id": "EV1",
-                    "type": "event",
-                    "attributes": {
-                        "timestamp": "2026-04-22T10:00:00.000Z",
-                        "title": "Deploy",
-                        "source": "github",
-                        "tags": ["env:prod"]
-                    }
-                }
-            ],
+            "data": [event_json("EV1")],
             "meta": {"page": {"after": "next"}, "status": "done"}
         })
     }
@@ -224,11 +354,36 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 10,
+                None,
             )
             .await
             .unwrap();
         assert_eq!(result.data.len(), 1);
         assert_eq!(result.data[0].id, "EV1");
+    }
+
+    #[tokio::test]
+    async fn list_includes_cursor_in_query_when_after_is_some() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param("page[cursor]", "tok-2"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(sample_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        EventsApi::new(&client)
+            .list(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                10,
+                Some("tok-2"),
+            )
+            .await
+            .unwrap();
     }
 
     // ── client-side / API errors ───────────────────────────────────
@@ -242,11 +397,13 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 MAX_PAGE_LIMIT + 1,
+                None,
             )
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("--limit"));
+        assert!(err.to_string().contains("limit"));
         assert!(err.to_string().contains(&MAX_PAGE_LIMIT.to_string()));
+        assert!(err.to_string().contains("list_all"));
     }
 
     #[tokio::test]
@@ -267,6 +424,7 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 10,
+                None,
             )
             .await
             .unwrap_err();
@@ -284,6 +442,7 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 10,
+                None,
             )
             .await
             .unwrap_err();
@@ -299,6 +458,7 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 10,
+                None,
             )
             .await
             .unwrap_err();
@@ -321,9 +481,200 @@ mod tests {
                 "2026-04-22T09:00:00Z",
                 "2026-04-22T10:00:00Z",
                 10,
+                None,
             )
             .await
             .unwrap_err();
         assert!(err.to_string().contains("Failed to parse"));
+    }
+
+    // ── list_all ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_all_single_page_when_response_has_no_cursor() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param("page[limit]", "100"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&["a", "b"], None)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                100,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_all_follows_cursor_until_no_more_pages() {
+        // Page 1 returns 2 events + cursor "c1"; page 2 returns 1 event +
+        // no cursor. With `limit == 0`, the loop should issue both
+        // requests and concatenate their data.
+        let server = wiremock::MockServer::start().await;
+        let limit_str = MAX_PAGE_LIMIT.to_string();
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param(
+                "page[limit]",
+                limit_str.as_str(),
+            ))
+            .and(wiremock::matchers::query_param_is_missing("page[cursor]"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(page_body(&["a", "b"], Some("c1"))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param("page[cursor]", "c1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&["c"], None)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                0,
+            )
+            .await
+            .unwrap();
+        let ids: Vec<&str> = result.data.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+        assert!(result
+            .meta
+            .as_ref()
+            .and_then(|m| m.page.as_ref())
+            .and_then(|p| p.after.as_deref())
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn list_all_stops_at_explicit_limit_within_first_page() {
+        let server = wiremock::MockServer::start().await;
+        let ids = ["a", "b", "c"];
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .and(wiremock::matchers::query_param("page[limit]", "3"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&ids, Some("c1"))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                3,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_all_truncates_to_hard_cap_when_unbounded() {
+        let server = wiremock::MockServer::start().await;
+        let full_page: Vec<serde_json::Value> = (0..MAX_PAGE_LIMIT)
+            .map(|i| event_json(&format!("e{i}")))
+            .collect();
+        let body = serde_json::json!({
+            "data": full_page,
+            "meta": { "page": { "after": "always-more" } }
+        });
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                0,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), HARD_CAP);
+    }
+
+    #[tokio::test]
+    async fn list_all_propagates_api_errors_on_first_page() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403).set_body_string(r#"{"errors":["nope"]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let err = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                0,
+            )
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("nope"));
+    }
+
+    #[tokio::test]
+    async fn list_all_caps_explicit_limit_at_hard_cap() {
+        let server = wiremock::MockServer::start().await;
+        let full_page: Vec<serde_json::Value> = (0..MAX_PAGE_LIMIT)
+            .map(|i| event_json(&format!("e{i}")))
+            .collect();
+        let body = serde_json::json!({
+            "data": full_page,
+            "meta": { "page": { "after": "always-more" } }
+        });
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/v2/events"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = EventsApi::new(&client)
+            .list_all(
+                &EventsListFilter::default(),
+                "2026-04-22T09:00:00Z",
+                "2026-04-22T10:00:00Z",
+                HARD_CAP + 50,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), HARD_CAP);
     }
 }

--- a/src/datadog/logs_api.rs
+++ b/src/datadog/logs_api.rs
@@ -1,12 +1,13 @@
 //! Datadog Logs API wrapper.
 //!
-//! Exposes a thin façade over [`DatadogClient`] for the Phase 1 logs
-//! search endpoint. Datadog v2 logs search uses **cursor pagination**
-//! (`meta.page.after`), not offset; Phase 1 ships single-page only and
-//! caps `--limit` at [`MAX_PAGE_LIMIT`] per the decisions on [#619].
-//! Multi-page cursor iteration is a Phase 2 follow-up.
+//! Exposes a thin façade over [`DatadogClient`] for the v2 logs search
+//! endpoint. Datadog v2 logs search uses **cursor pagination**
+//! (`meta.page.after`), not offset. [`LogsApi::search`] issues a single
+//! request optionally seeded with an `after` cursor token;
+//! [`LogsApi::search_all`] auto-paginates up to a caller-supplied limit
+//! (or [`HARD_CAP`] when the limit is `0`), mirroring [`MonitorsApi::list`].
 //!
-//! [#619]: https://github.com/rust-works/omni-dev/issues/619
+//! [`MonitorsApi::list`]: crate::datadog::monitors_api::MonitorsApi::list
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -20,6 +21,10 @@ use crate::datadog::types::{LogSearchResult, SortOrder};
 /// clearer error than the server's HTTP 400 by validating before the
 /// request is sent.
 pub const MAX_PAGE_LIMIT: usize = 1000;
+
+/// Per-call upper bound on the number of log events returned by
+/// [`LogsApi::search_all`], even when the caller passes `limit = 0`.
+pub const HARD_CAP: usize = 10_000;
 
 /// Logs API façade.
 #[derive(Debug)]
@@ -41,9 +46,13 @@ impl<'a> LogsApi<'a> {
     /// shorthand like `now-15m` / `now`; callers are expected to convert
     /// CLI-level inputs into a form Datadog understands before calling.
     ///
-    /// Phase 1 returns a single page only — cursor pagination via
-    /// `meta.page.after` is not auto-iterated. `limit` is rejected
-    /// client-side when it exceeds [`MAX_PAGE_LIMIT`].
+    /// Returns a single page only. When `after` is `Some`, Datadog
+    /// resumes pagination at that cursor token (`page.cursor` in the
+    /// request body). The next-page token is preserved on
+    /// `meta.page.after` of the response so the caller (or
+    /// [`LogsApi::search_all`]) can iterate.
+    ///
+    /// `limit` is rejected client-side when it exceeds [`MAX_PAGE_LIMIT`].
     pub async fn search(
         &self,
         query: &str,
@@ -51,15 +60,19 @@ impl<'a> LogsApi<'a> {
         to: &str,
         limit: usize,
         sort: SortOrder,
+        after: Option<&str>,
     ) -> Result<LogSearchResult> {
         if limit > MAX_PAGE_LIMIT {
             return Err(anyhow::anyhow!(
-                "--limit must be <= {MAX_PAGE_LIMIT} (Datadog v2 logs search per-page cap; cursor pagination across pages is a Phase 2 follow-up)"
+                "`limit` must be <= {MAX_PAGE_LIMIT} (Datadog v2 logs search per-page cap; use `LogsApi::search_all` to auto-paginate across pages)"
             ));
         }
         let body = SearchRequest {
             filter: Filter { query, from, to },
-            page: Page { limit },
+            page: Page {
+                limit,
+                cursor: after,
+            },
             sort,
         };
         let url = format!("{}/api/v2/logs/events/search", self.client.base_url());
@@ -72,12 +85,78 @@ impl<'a> LogsApi<'a> {
             .await
             .context("Failed to parse /api/v2/logs/events/search response")
     }
+
+    /// Searches log events, auto-paginating via cursor as needed.
+    ///
+    /// `limit == 0` means "fetch every match up to [`HARD_CAP`]". Any
+    /// non-zero `limit` is upper-bounded by [`HARD_CAP`] to keep a single
+    /// invocation from issuing more than 10k items' worth of requests.
+    /// Per-request page size is clamped to [`MAX_PAGE_LIMIT`].
+    ///
+    /// Termination follows cursor-pagination semantics: the loop stops
+    /// when the response omits `meta.page.after` (Datadog signals "no
+    /// more pages" only via the absent cursor — a short page on its own
+    /// is *not* a terminator) or when `cap` items have been collected.
+    ///
+    /// The returned envelope keeps the `meta` block from the *last*
+    /// successful page so the response's cursor reflects the iterator's
+    /// final position (typically `None` when the API is exhausted).
+    pub async fn search_all(
+        &self,
+        query: &str,
+        from: &str,
+        to: &str,
+        limit: usize,
+        sort: SortOrder,
+    ) -> Result<LogSearchResult> {
+        let cap = effective_cap(limit);
+        let mut acc: Option<LogSearchResult> = None;
+        let mut cursor: Option<String> = None;
+        loop {
+            let collected = acc.as_ref().map_or(0, |r| r.data.len());
+            let remaining = cap - collected;
+            let page_size = remaining.min(MAX_PAGE_LIMIT);
+            let page = self
+                .search(query, from, to, page_size, sort, cursor.as_deref())
+                .await?;
+            let next_cursor = page
+                .meta
+                .as_ref()
+                .and_then(|m| m.page.as_ref())
+                .and_then(|p| p.after.clone());
+            match acc.as_mut() {
+                Some(existing) => {
+                    existing.data.extend(page.data);
+                    existing.meta = page.meta;
+                }
+                None => acc = Some(page),
+            }
+            let collected = acc.as_ref().map_or(0, |r| r.data.len());
+            if collected >= cap || next_cursor.is_none() {
+                break;
+            }
+            cursor = next_cursor;
+        }
+        let mut result = acc.unwrap_or_default();
+        result.data.truncate(cap);
+        Ok(result)
+    }
+}
+
+/// Clamps a caller-supplied limit to [`HARD_CAP`], treating `0` as
+/// "fetch as many as the cap allows".
+fn effective_cap(limit: usize) -> usize {
+    if limit == 0 {
+        HARD_CAP
+    } else {
+        limit.min(HARD_CAP)
+    }
 }
 
 #[derive(Debug, Serialize)]
 struct SearchRequest<'a> {
     filter: Filter<'a>,
-    page: Page,
+    page: Page<'a>,
     sort: SortOrder,
 }
 
@@ -89,8 +168,10 @@ struct Filter<'a> {
 }
 
 #[derive(Debug, Serialize)]
-struct Page {
+struct Page<'a> {
     limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cursor: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -120,6 +201,48 @@ mod tests {
             }
         })
     }
+
+    fn log_event_json(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "type": "log",
+            "attributes": {
+                "timestamp": "2026-04-22T10:00:00.000Z",
+                "service": "api",
+                "status": "info",
+                "message": id,
+                "tags": []
+            }
+        })
+    }
+
+    fn page_body(ids: &[&str], next_cursor: Option<&str>) -> serde_json::Value {
+        let data: Vec<serde_json::Value> = ids.iter().map(|id| log_event_json(id)).collect();
+        let meta = match next_cursor {
+            Some(c) => serde_json::json!({ "page": { "after": c }, "status": "done" }),
+            None => serde_json::json!({ "page": {}, "status": "done" }),
+        };
+        serde_json::json!({ "data": data, "meta": meta })
+    }
+
+    // ── effective_cap ──────────────────────────────────────────────
+
+    #[test]
+    fn effective_cap_zero_means_hard_cap() {
+        assert_eq!(effective_cap(0), HARD_CAP);
+    }
+
+    #[test]
+    fn effective_cap_clamps_to_hard_cap() {
+        assert_eq!(effective_cap(HARD_CAP + 5), HARD_CAP);
+    }
+
+    #[test]
+    fn effective_cap_passes_through_small_limits() {
+        assert_eq!(effective_cap(42), 42);
+    }
+
+    // ── search ─────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn search_posts_exact_body_shape_and_parses_response() {
@@ -154,6 +277,7 @@ mod tests {
                 "now",
                 100,
                 SortOrder::TimestampDesc,
+                None,
             )
             .await
             .unwrap();
@@ -167,6 +291,35 @@ mod tests {
                 .and_then(|p| p.after.as_deref()),
             Some("next-cursor")
         );
+    }
+
+    #[tokio::test]
+    async fn search_includes_cursor_in_body_when_after_is_some() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": { "query": "*", "from": "now-1h", "to": "now" },
+                "page": { "limit": 50, "cursor": "tok-2" },
+                "sort": "-timestamp"
+            })))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(sample_search_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        LogsApi::new(&client)
+            .search(
+                "*",
+                "now-1h",
+                "now",
+                50,
+                SortOrder::TimestampDesc,
+                Some("tok-2"),
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -186,15 +339,13 @@ mod tests {
 
         let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
         LogsApi::new(&client)
-            .search("*", "now-1h", "now", 50, SortOrder::TimestampAsc)
+            .search("*", "now-1h", "now", 50, SortOrder::TimestampAsc, None)
             .await
             .unwrap();
     }
 
     #[tokio::test]
     async fn search_rejects_limit_above_max_page_limit_client_side() {
-        // No server is started — the validation must fire before any
-        // network call.
         let client = DatadogClient::new("http://127.0.0.1:1", "api", "app").unwrap();
         let err = LogsApi::new(&client)
             .search(
@@ -203,13 +354,14 @@ mod tests {
                 "now",
                 MAX_PAGE_LIMIT + 1,
                 SortOrder::TimestampDesc,
+                None,
             )
             .await
             .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("--limit"));
+        assert!(msg.contains("limit"));
         assert!(msg.contains("1000"));
-        assert!(msg.contains("Phase 2"));
+        assert!(msg.contains("search_all"));
     }
 
     #[tokio::test]
@@ -235,6 +387,7 @@ mod tests {
                 "now",
                 MAX_PAGE_LIMIT,
                 SortOrder::TimestampDesc,
+                None,
             )
             .await
             .unwrap();
@@ -253,7 +406,7 @@ mod tests {
 
         let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
         let err = LogsApi::new(&client)
-            .search("???", "now-1h", "now", 10, SortOrder::TimestampDesc)
+            .search("???", "now-1h", "now", 10, SortOrder::TimestampDesc, None)
             .await
             .unwrap_err();
         let msg = err.to_string();
@@ -265,7 +418,7 @@ mod tests {
     async fn search_propagates_network_errors() {
         let client = DatadogClient::new("http://127.0.0.1:1", "api", "app").unwrap();
         let err = LogsApi::new(&client)
-            .search("*", "now-1h", "now", 10, SortOrder::TimestampDesc)
+            .search("*", "now-1h", "now", 10, SortOrder::TimestampDesc, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("Failed to send"));
@@ -282,9 +435,193 @@ mod tests {
 
         let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
         let err = LogsApi::new(&client)
-            .search("*", "now-1h", "now", 10, SortOrder::TimestampDesc)
+            .search("*", "now-1h", "now", 10, SortOrder::TimestampDesc, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("Failed to parse"));
+    }
+
+    // ── search_all ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn search_all_single_page_when_response_has_no_cursor() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": { "query": "*", "from": "now-1h", "to": "now" },
+                "page": { "limit": 100 },
+                "sort": "-timestamp"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&["a", "b"], None)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = LogsApi::new(&client)
+            .search_all("*", "now-1h", "now", 100, SortOrder::TimestampDesc)
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn search_all_follows_cursor_until_no_more_pages() {
+        // Page 1 returns 2 items + cursor "c1", page 2 returns 1 item + no
+        // cursor. With `limit == 0`, the loop should issue both requests
+        // and concatenate their data.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": { "query": "*", "from": "now-1h", "to": "now" },
+                "page": { "limit": MAX_PAGE_LIMIT },
+                "sort": "-timestamp"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(page_body(&["a", "b"], Some("c1"))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": { "query": "*", "from": "now-1h", "to": "now" },
+                "page": { "limit": MAX_PAGE_LIMIT, "cursor": "c1" },
+                "sort": "-timestamp"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&["c"], None)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = LogsApi::new(&client)
+            .search_all("*", "now-1h", "now", 0, SortOrder::TimestampDesc)
+            .await
+            .unwrap();
+        let ids: Vec<&str> = result.data.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+        // The final response had no cursor — meta.page.after is None.
+        assert!(result
+            .meta
+            .as_ref()
+            .and_then(|m| m.page.as_ref())
+            .and_then(|p| p.after.as_deref())
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn search_all_stops_at_explicit_limit_within_first_page() {
+        // limit=5 → page_size=5; the API returns exactly 5 (a "short
+        // page" by user's request) so we stop without a second call.
+        let server = wiremock::MockServer::start().await;
+        let ids = ["a", "b", "c", "d", "e"];
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .and(wiremock::matchers::body_json(serde_json::json!({
+                "filter": { "query": "*", "from": "now-1h", "to": "now" },
+                "page": { "limit": 5 },
+                "sort": "-timestamp"
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(page_body(&ids, Some("c1"))),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = LogsApi::new(&client)
+            .search_all("*", "now-1h", "now", 5, SortOrder::TimestampDesc)
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn search_all_truncates_to_hard_cap_when_unbounded() {
+        // The mock returns a full MAX_PAGE_LIMIT page + cursor on every
+        // request, so the only stopping condition is HARD_CAP.
+        let server = wiremock::MockServer::start().await;
+        let full_page: Vec<serde_json::Value> = (0..MAX_PAGE_LIMIT)
+            .map(|i| log_event_json(&format!("e{i}")))
+            .collect();
+        let body = serde_json::json!({
+            "data": full_page,
+            "meta": { "page": { "after": "always-more" } }
+        });
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = LogsApi::new(&client)
+            .search_all("*", "now-1h", "now", 0, SortOrder::TimestampDesc)
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), HARD_CAP);
+    }
+
+    #[tokio::test]
+    async fn search_all_propagates_api_errors_on_first_page() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403).set_body_string(r#"{"errors":["nope"]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let err = LogsApi::new(&client)
+            .search_all("*", "now-1h", "now", 0, SortOrder::TimestampDesc)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("nope"));
+    }
+
+    #[tokio::test]
+    async fn search_all_caps_explicit_limit_at_hard_cap() {
+        // Caller asked for HARD_CAP + 50; per-page mock returns full pages
+        // forever. We stop at HARD_CAP without honouring the surplus.
+        let server = wiremock::MockServer::start().await;
+        let full_page: Vec<serde_json::Value> = (0..MAX_PAGE_LIMIT)
+            .map(|i| log_event_json(&format!("e{i}")))
+            .collect();
+        let body = serde_json::json!({
+            "data": full_page,
+            "meta": { "page": { "after": "always-more" } }
+        });
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/v2/logs/events/search"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let client = DatadogClient::new(&server.uri(), "api", "app").unwrap();
+        let result = LogsApi::new(&client)
+            .search_all(
+                "*",
+                "now-1h",
+                "now",
+                HARD_CAP + 50,
+                SortOrder::TimestampDesc,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), HARD_CAP);
     }
 }

--- a/src/mcp/datadog_tools.rs
+++ b/src/mcp/datadog_tools.rs
@@ -191,7 +191,9 @@ pub struct DatadogEventsListParams {
     /// Comma-separated list of `key:value` tags.
     #[serde(default)]
     pub tags: Option<String>,
-    /// Per-page cap; defaults to 100. Max 1000.
+    /// Maximum events to return. `0` means "fetch every match across
+    /// pages (capped at 10000)"; any non-zero value caps the total at
+    /// that count, paginating underneath as needed. Defaults to 100.
     #[serde(default)]
     pub limit: Option<usize>,
 }
@@ -209,9 +211,9 @@ pub struct DatadogLogsSearchParams {
     /// End of the time range. Defaults to `now` when omitted.
     #[serde(default)]
     pub to: Option<String>,
-    /// Maximum events to return (Datadog v2 logs search per-page cap is
-    /// 1000; cursor pagination across pages is a Phase 2 follow-up).
-    /// Defaults to 100 when omitted.
+    /// Maximum events to return. `0` means "fetch every match across
+    /// pages (capped at 10000)"; any non-zero value caps the total at
+    /// that count, paginating underneath as needed. Defaults to 100.
     #[serde(default)]
     pub limit: Option<usize>,
     /// Sort order: `"timestamp-asc"` (oldest first) or `"timestamp-desc"`
@@ -323,11 +325,11 @@ impl OmniDevServer {
         Ok(CallToolResult::success(vec![Content::text(yaml)]))
     }
 
-    /// Tool: search Datadog log events (single page).
+    /// Tool: search Datadog log events.
     #[tool(
-        description = "Search Datadog log events. Single page only — Datadog v2 logs \
-                       search uses cursor pagination; `limit` is the per-page cap (max 1000). \
-                       `sort` is `timestamp-asc` or `timestamp-desc` (default). \
+        description = "Search Datadog log events. `limit` of 0 (or omitted) auto-paginates \
+                       across cursor pages up to 10000; any non-zero value caps the total at \
+                       that count. `sort` is `timestamp-asc` or `timestamp-desc` (default). \
                        Mirrors `omni-dev datadog logs search`. Output is YAML."
     )]
     pub async fn datadog_logs_search(
@@ -338,11 +340,11 @@ impl OmniDevServer {
         Ok(CallToolResult::success(vec![Content::text(yaml)]))
     }
 
-    /// Tool: list Datadog events (single page).
+    /// Tool: list Datadog events.
     #[tool(
-        description = "List Datadog events. Single page only — Datadog v2 events use \
-                       cursor pagination; `limit` is the per-page cap (max 1000). \
-                       `from` / `to` accept relative shorthand (`15m`, `1h`), `now`, \
+        description = "List Datadog events. `limit` of 0 (or omitted) auto-paginates across \
+                       cursor pages up to 10000; any non-zero value caps the total at that \
+                       count. `from` / `to` accept relative shorthand (`15m`, `1h`), `now`, \
                        RFC 3339, or Unix epoch seconds. Mirrors \
                        `omni-dev datadog events list`. Output is YAML."
     )]
@@ -504,7 +506,7 @@ async fn run_logs_search(params: &DatadogLogsSearchParams) -> Result<String> {
 
     let (client, _site) = create_client()?;
     let result = LogsApi::new(&client)
-        .search(&params.filter, &from_str, &to_str, limit, sort)
+        .search_all(&params.filter, &from_str, &to_str, limit, sort)
         .await?;
     serde_yaml::to_string(&result).context("Failed to serialize logs search results")
 }
@@ -522,7 +524,7 @@ async fn run_events_list(params: &DatadogEventsListParams) -> Result<String> {
         tags: params.tags.clone(),
     };
     let result = EventsApi::new(&client)
-        .list(&filter, &from_str, &to_str, limit)
+        .list_all(&filter, &from_str, &to_str, limit)
         .await?;
     serde_yaml::to_string(&result).context("Failed to serialize events list")
 }
@@ -1042,6 +1044,9 @@ mod tests {
     // ── run_logs_search ───────────────────────────────────────────────
 
     fn logs_body() -> serde_json::Value {
+        // No `meta.page.after` so the auto-paginating wrapper terminates
+        // after a single request; cursor follow-up tests live in
+        // `LogsApi::search_all` unit tests.
         serde_json::json!({
             "data": [
                 {
@@ -1056,7 +1061,7 @@ mod tests {
                     }
                 }
             ],
-            "meta": {"page": {"after": "next"}, "status": "done"}
+            "meta": {"page": {}, "status": "done"}
         })
     }
 

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1660,7 +1660,7 @@ Options:
       --filter <FILTER>    Datadog events search filter (e.g. `service:api`)
       --from <FROM>        Start of the time range (relative shorthand like `1h`, RFC 3339, `now`, or Unix epoch seconds) [default: 1h]
       --to <TO>            End of the time range; defaults to `now` [default: now]
-      --limit <LIMIT>      Maximum events to return (Datadog v2 events per-page cap is 1000; cursor pagination across pages is a follow-up) [default: 100]
+      --limit <LIMIT>      Maximum events to return. Pass `0` to fetch every match across pages (capped at 10000); any non-zero value caps the total at that count, paginating underneath as needed [default: 100]
       --sources <SOURCES>  Comma-separated list of source names (e.g. `aws,kubernetes`)
       --tags <TAGS>        Comma-separated list of `key:value` tags applied to the event
   -o, --output <OUTPUT>    Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
@@ -1727,7 +1727,7 @@ Options:
       --filter <FILTER>  Search filter (Datadog logs query language; see Datadog docs)
       --from <FROM>      Start of the time range (relative shorthand like `15m`/`1h`, `now`, RFC 3339, or Unix epoch seconds) [default: 15m]
       --to <TO>          End of the time range; defaults to `now` [default: now]
-      --limit <LIMIT>    Maximum events to return (Datadog v2 logs search per-page cap is 1000; cursor pagination across pages is a Phase 2 follow-up) [default: 100]
+      --limit <LIMIT>    Maximum events to return. Pass `0` to fetch every match across pages (capped at 10000); any non-zero value caps the total at that count, paginating underneath as needed [default: 100]
       --sort <SORT>      Sort order for returned events [default: timestamp-desc] [possible values: timestamp-asc, timestamp-desc]
   -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
   -h, --help             Print help (see more with '--help')


### PR DESCRIPTION
## Description

This PR implements cursor-based auto-pagination for the Datadog events and logs APIs, replacing the previous single-page-only requests with `list_all` / `search_all` methods that follow `meta.page.after` cursor tokens until exhaustion or a configurable cap.

Previously, the CLI and MCP tools were limited to a single page of results (max 1000 items), with multi-page pagination noted as a "Phase 2 follow-up". Users who needed more than 1000 results had no way to retrieve them. With this change, passing `--limit 0` fetches every matching result up to 10,000 items automatically, while any non-zero limit paginates transparently underneath to satisfy the requested count.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #653

## Changes Made

**Core API Layer (`src/datadog/events_api.rs`, `src/datadog/logs_api.rs`):**
- Added `EventsApi::list_all` — auto-paginating wrapper that follows `meta.page.after` cursor tokens, accumulating results across pages up to a caller-supplied limit or `HARD_CAP`
- Added `LogsApi::search_all` — equivalent auto-paginating wrapper for the logs search endpoint
- Extended `EventsApi::list` with an optional `after: Option<&str>` parameter to support explicit cursor positioning (appended as `page[cursor]` query param)
- Extended `LogsApi::search` with an optional `after: Option<&str>` parameter (serialized as `cursor` in the JSON request body via the `Page` struct)
- Added `HARD_CAP = 10_000` constant as an absolute upper bound per call in both `events_api.rs` and `logs_api.rs`
- Added `effective_cap` helper in both modules: `limit == 0` maps to `HARD_CAP`; non-zero values are clamped to `HARD_CAP`
- Updated error messages to reference `list_all` / `search_all` instead of the obsolete "Phase 2 follow-up" text

**CLI (`src/cli/datadog/events/list.rs`, `src/cli/datadog/logs/search.rs`):**
- Wired `events list` to call `EventsApi::list_all` instead of `EventsApi::list`
- Wired `logs search` to call `LogsApi::search_all` instead of `LogsApi::search`
- Updated `--limit` help text to document `0` semantics: "Pass `0` to fetch every match across pages (capped at 10000); any non-zero value caps the total at that count, paginating underneath as needed"
- Replaced the now-obsolete `run_search_propagates_client_side_limit_error` test (which expected a hard rejection of limit > 1000 at the CLI level) with `run_search_with_zero_limit_auto_paginates_until_no_cursor`

**MCP Tools (`src/mcp/datadog_tools.rs`):**
- Updated `run_logs_search` to call `LogsApi::search_all` instead of `LogsApi::search`
- Updated `run_events_list` to call `EventsApi::list_all` instead of `EventsApi::list`
- Updated `#[tool(description = ...)]` annotations for both `datadog_logs_search` and `datadog_events_list` to document auto-pagination and `limit = 0` behaviour
- Updated `DatadogEventsListParams` and `DatadogLogsSearchParams` doc comments to reflect new `limit` semantics
- Fixed `logs_body()` test fixture to omit `meta.page.after` so the auto-paginating wrapper terminates after a single request in existing tests

**Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help output snapshots for `events list` and `logs search` to reflect new `--limit` help text

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**New unit tests added in `src/datadog/events_api.rs`:**
- `effective_cap_zero_means_hard_cap` — verifies `limit == 0` maps to `HARD_CAP`
- `effective_cap_clamps_to_hard_cap` — verifies values above `HARD_CAP` are clamped
- `effective_cap_passes_through_small_limits` — verifies small limits pass through unchanged
- `build_list_url_appends_cursor_when_provided` — verifies `page[cursor]` appears in URL when `after = Some(...)`
- `list_includes_cursor_in_query_when_after_is_some` — integration test for cursor forwarding
- `list_all_single_page_when_response_has_no_cursor` — stops after one page when no cursor returned
- `list_all_follows_cursor_until_no_more_pages` — two-page traversal with cursor "c1", verifies data concatenation and final `meta.page.after` is `None`
- `list_all_stops_at_explicit_limit_within_first_page` — honours non-zero limit without over-fetching
- `list_all_truncates_to_hard_cap_when_unbounded` — enforces `HARD_CAP` when API keeps returning cursors
- `list_all_propagates_api_errors_on_first_page` — 403 error propagated correctly
- `list_all_caps_explicit_limit_at_hard_cap` — rejects requests above `HARD_CAP`

**New unit tests added in `src/datadog/logs_api.rs`:**
- `effective_cap_zero_means_hard_cap`, `effective_cap_clamps_to_hard_cap`, `effective_cap_passes_through_small_limits`
- `search_includes_cursor_in_body_when_after_is_some` — verifies cursor appears in POST body
- `search_all_single_page_when_response_has_no_cursor`
- `search_all_follows_cursor_until_no_more_pages` — two-page traversal, verifies accumulated IDs and final cursor is `None`
- `search_all_stops_at_explicit_limit_within_first_page`
- `search_all_truncates_to_hard_cap_when_unbounded`
- `search_all_propagates_api_errors_on_first_page`
- `search_all_caps_explicit_limit_at_hard_cap`

**New CLI-level tests:**
- `run_list_with_zero_limit_auto_paginates_until_no_cursor` (events)
- `run_search_with_zero_limit_auto_paginates_until_no_cursor` (logs)

### Test Commands
```bash
# Core test suite
cargo test

# Run pagination-specific tests
cargo test list_all
cargo test search_all
cargo test effective_cap

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Performance impact — each `list_all` / `search_all` call may issue up to 10 requests (10,000 items / 1,000 per page); the caller controls this via `limit`
- [x] Error handling — errors on any page (including mid-pagination pages) are propagated immediately without partial results
- [x] Backward compatibility — existing callers of `EventsApi::list` and `LogsApi::search` now require an additional `after: Option<&str>` argument; all internal call sites have been updated

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact

- [x] Potential performance impact (describe below)

Auto-pagination can issue multiple HTTP requests per CLI invocation. With the default `--limit 100`, behaviour is unchanged (a single request capped at 100 items). With `--limit 0`, up to 10 sequential requests are issued to collect up to 10,000 items. The `HARD_CAP = 10_000` constant prevents unbounded request loops regardless of what the Datadog API returns.

## Security Considerations

- [x] No security implications

## Breaking Changes

`EventsApi::list` and `LogsApi::search` now require an additional `after: Option<&str>` argument. All internal call sites (CLI, MCP, and test code) have been updated. External consumers of these APIs will need to pass `None` for the `after` parameter to retain single-page behaviour.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Design decisions:**
- Termination is driven solely by the absence of `meta.page.after` in the response, matching Datadog's documented cursor-pagination contract. A "short page" (fewer items than requested) does not terminate the loop by itself.
- The accumulated response retains `meta` and `links` from the *last* page, so the cursor in the returned envelope reflects the iterator's final position (typically `None` when the API is exhausted).
- The `effective_cap` helper is module-private and shared between `list`/`list_all` and `search`/`search_all` within each module.