### PR TITLE
feat(claude): add PostToolUse hook to auto-format Rust files after Claude edits

### DIFF
--- a/.claude/hooks/format-rust.sh
+++ b/.claude/hooks/format-rust.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-# PostToolUse hook: run `cargo fmt --all` after Claude edits a Rust source file.
+# PostToolUse hook: run rustfmt on the edited Rust source file.
 # Non-blocking: always exits 0 so a transient fmt failure does not interrupt edits.
 
 set -u
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 
-cargo fmt --all >/dev/null 2>&1 || true
+file_path="$(jq -r '.tool_input.file_path // empty')"
+
+if [ -n "$file_path" ] && [ -f "$file_path" ]; then
+  rustfmt "$file_path" >/dev/null 2>&1 || true
+fi
 
 exit 0

--- a/.claude/hooks/format-rust.sh
+++ b/.claude/hooks/format-rust.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run `cargo fmt --all` after Claude edits a Rust source file.
+# Non-blocking: always exits 0 so a transient fmt failure does not interrupt edits.
+
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+cargo fmt --all >/dev/null 2>&1 || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "if": "Edit(*.rs)|Write(*.rs)|MultiEdit(*.rs)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-rust.sh",
+            "timeout": 60,
+            "statusMessage": "cargo fmt --all"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-rust.sh",
             "timeout": 60,
-            "statusMessage": "cargo fmt --all"
+            "statusMessage": "rustfmt"
           }
         ]
       }


### PR DESCRIPTION
## Description

This PR adds a Claude Code PostToolUse hook that automatically runs `rustfmt` on any Rust source file edited by Claude, ensuring consistent code formatting without requiring manual `cargo fmt` invocations. The hook is non-blocking — it always exits 0 so a transient formatter error never prevents an edit from completing. CI's Rustfmt job remains the authoritative source of truth for persistent formatting issues.

The implementation started with a broad `cargo fmt --all` approach and was subsequently refined to use a targeted per-file `rustfmt` call on only the specific file Claude edited, avoiding unnecessary reformatting of unrelated files on each edit.

Closes #610

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD changes

## Related Issue

Fixes #610

## Changes Made

**Core Changes:**
- Added `.claude/hooks/format-rust.sh`: a bash script registered as a PostToolUse hook that reads `tool_input.file_path` from stdin via `jq`, then runs `rustfmt` on the specific file if it exists. Non-blocking — always exits 0 even on formatter failure.
- Added `.claude/settings.json`: Claude Code configuration that wires the hook to the `PostToolUse` event for `Edit`, `Write`, and `MultiEdit` tool uses on `*.rs` files, with a 60-second timeout.

**Refinements (second commit):**
- Replaced the initial broad `cargo fmt --all` invocation with a targeted `rustfmt <file>` call, parsing the edited file path from the hook's stdin JSON payload using `jq`.
- Updated the status message in `settings.json` from `"cargo fmt --all"` to `"rustfmt"` to reflect the more targeted operation.

**Documentation:**
- No documentation changes required; the hook and settings files are self-contained and self-explanatory.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (shell hook not unit-tested; validated manually)

**Manual Testing:**
- [x] Tested happy path scenarios: editing a `.rs` file triggers `rustfmt` on that file only
- [x] Tested error/edge cases: hook exits 0 when `rustfmt` fails or `file_path` is empty/missing
- [x] Backward compatibility verified: no impact on existing CI or developer workflows

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manual hook validation (simulate Claude hook invocation)
echo '{"tool_input": {"file_path": "src/main.rs"}}' | .claude/hooks/format-rust.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — hook must never block Claude edits; `|| true` and `exit 0` ensure this
- [x] Security implications — hook executes a shell script scoped to `CLAUDE_PROJECT_DIR`; no external network calls or sensitive data handling
- [x] Backward compatibility — existing developer and CI workflows are unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement — targeting only the edited file with `rustfmt` instead of reformatting all crate files with `cargo fmt --all` reduces per-edit overhead significantly in large workspaces.

## Security Considerations

- [x] No security implications — the hook script runs entirely within the project directory (`CLAUDE_PROJECT_DIR`), invokes only `jq` and `rustfmt`, and does not handle any credentials, network requests, or sensitive data.

## Breaking Changes

None. This is a purely additive change introducing new Claude Code hook configuration files. No existing functionality is affected.

## Deployment Notes

- [x] No special deployment requirements — the hook is only active within Claude Code sessions and has no effect on CI or production builds.

## Additional Notes

**Future Enhancements:**
- Consider adding hooks for other formatters (e.g., `prettier` for JSON/YAML files) following the same pattern.
- The `jq` dependency should be present on developer machines; a guard checking for `jq` availability could be added if portability becomes a concern.

**Known Limitations:**
- Requires `jq` to be installed on the developer's machine for `tool_input.file_path` parsing; the hook silently skips formatting if `jq` is unavailable or returns an empty path.
- `rustfmt` must be installed (typically via `rustup component add rustfmt`); failures are silently swallowed and do not block edits.

**Alternatives Considered:**
- Keeping `cargo fmt --all`: simpler but reformats the entire workspace on every single file edit, which is slow for large crates and produces noisy diffs.
- Using a `PreToolUse` hook: rejected because formatting before an edit would be immediately overwritten; `PostToolUse` is the correct lifecycle point.