### PR TITLE
fix(claude): kill full process group on subprocess timeout (issue #633)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1403,7 @@ dependencies = [
  "git2",
  "globset",
  "insta",
+ "nix",
  "proptest",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ rmcp = { version = "1.5", features = ["server", "transport-io", "macros"], optio
 schemars = { version = "1.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }
+
 [features]
 mcp = ["dep:rmcp", "dep:schemars", "dep:tokio-util"]
 

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -238,6 +238,14 @@ impl ClaudeCliAiClient {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // Make the child its own process-group leader so we can later
+        // signal the whole group via `killpg`. Without this, `claude -p`
+        // helper Node workers spawned at runtime get reparented to PID 1
+        // when only the direct PID is killed on timeout, and accumulate
+        // as orphans. See issue #633.
+        #[cfg(unix)]
+        cmd.process_group(0);
+
         // Scrub risky env vars rather than clearing wholesale. Clearing the
         // env breaks the Node runtime inside `claude` (needs HOME, PATH,
         // possibly DYLD_* / homebrew PATH entries on macOS).
@@ -352,13 +360,11 @@ impl ClaudeCliAiClient {
         let (stdout_bytes, stderr_bytes) = match io_result {
             Ok(Ok(pair)) => pair,
             Ok(Err(e)) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
+                kill_and_reap(&mut child).await;
                 return Err(e);
             }
             Err(_) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
+                kill_and_reap(&mut child).await;
                 return Err(ClaudeError::SubprocessTimeout {
                     secs: self.timeout.as_secs(),
                 }
@@ -566,6 +572,46 @@ where
         buf.extend_from_slice(&chunk[..n]);
     }
     Ok(buf)
+}
+
+/// Kills the subprocess and reaps it.
+///
+/// On Unix, sends SIGKILL to the entire process group so any helpers
+/// the child forked (e.g. Node workers spawned by `claude -p`) die
+/// alongside the direct child. Pairs with the `process_group(0)` call
+/// in [`ClaudeCliAiClient::build_command`]. See issue #633.
+///
+/// On non-Unix, falls back to `tokio::process::Child::kill`, which
+/// already terminates the process tree on Windows via
+/// `TerminateProcess`.
+async fn kill_and_reap(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id() {
+            // Cast through i32: tokio's PID is u32; nix's Pid wraps i32
+            // (matching the kernel's pid_t). PIDs always fit in i32 in
+            // practice — Linux caps at PID_MAX_LIMIT (~2^22) and macOS
+            // at 99999.
+            let group = nix::unistd::Pid::from_raw(pid as i32);
+            if let Err(e) = nix::sys::signal::killpg(group, nix::sys::signal::Signal::SIGKILL) {
+                // ESRCH is expected when the group has already drained
+                // (everyone exited between timeout and kill). Anything
+                // else is worth logging but not fatal — we still wait
+                // below to reap whatever remains of the direct child.
+                if e != nix::errno::Errno::ESRCH {
+                    debug!(error = %e, pid, "killpg failed; falling back to direct kill");
+                    let _ = child.start_kill();
+                }
+            }
+        } else {
+            // Already reaped; nothing to signal.
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill().await;
+    }
+    let _ = child.wait().await;
 }
 
 /// `execve` returns `ETXTBSY` (errno 26 on Linux) when *any* process
@@ -1428,5 +1474,247 @@ mod tests {
         let out = client_with_shim(shim).run("sys", "user").await.unwrap();
         release.await.unwrap();
         assert_eq!(out, "late");
+    }
+
+    // ── Process-group reaping on timeout (issue #633) ──────────────
+
+    /// Polls `kill(pid, 0)` until the process is gone or the deadline
+    /// elapses. `Ok(())` indicates the process is gone (`ESRCH`); `Err`
+    /// reports the elapsed time so the assertion site can show how long
+    /// the process lingered.
+    #[cfg(unix)]
+    async fn wait_for_pid_gone(pid: i32, deadline: Duration) -> Result<(), Duration> {
+        let nix_pid = nix::unistd::Pid::from_raw(pid);
+        let start = std::time::Instant::now();
+        loop {
+            if nix::sys::signal::kill(nix_pid, None) == Err(nix::errno::Errno::ESRCH) {
+                return Ok(());
+            }
+            if start.elapsed() >= deadline {
+                return Err(start.elapsed());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Acceptance test for issue #633: when a `claude -p` invocation
+    /// times out, the entire subprocess group is reaped — including
+    /// helper processes the child forked into the background. Without
+    /// `process_group(0)` + `killpg`, the background sleeper would
+    /// be reparented to PID 1 and survive its parent.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn timeout_reaps_full_process_group() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let pid_file = tmp.path().join("sleeper.pid");
+        let shim = tmp.path().join("group-shim");
+
+        // Shim starts a long-lived background sleeper, records its PID
+        // for the parent test, then blocks long enough that the
+        // configured timeout fires. With process_group(0) + killpg the
+        // background sleeper dies alongside the shim; without them it
+        // survives until its own `sleep` elapses.
+        let script = format!(
+            "#!/bin/sh\nsleep 30 &\nprintf '%s' \"$!\" > '{}'\nsleep 30\n",
+            pid_file.display()
+        );
+        write_exec_script(&shim, &script);
+
+        let cli = ClaudeCliAiClient::new_with_config(
+            "sonnet".to_string(),
+            Duration::from_millis(500),
+            DEFAULT_STDOUT_CAP,
+            false,
+            shim,
+        );
+
+        let err = cli
+            .run("sys", "user")
+            .await
+            .expect_err("expected timeout error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("timed out"), "expected timeout: {chain}");
+
+        let pid_str = std::fs::read_to_string(&pid_file)
+            .expect("shim should have recorded sleeper PID before sleeping");
+        let sleeper_pid: i32 = pid_str.trim().parse().expect("valid pid");
+
+        wait_for_pid_gone(sleeper_pid, Duration::from_secs(3))
+            .await
+            .unwrap_or_else(|elapsed| {
+                panic!(
+                    "background sleeper {sleeper_pid} still alive {elapsed:?} after \
+                     parent timeout — process-group reap regressed (issue #633)"
+                )
+            });
+    }
+
+    /// Companion to `timeout_reaps_full_process_group`: same shim
+    /// shape, but the inner I/O fails (write task errors via a closed
+    /// pipe by exiting fast) is not what we want here — instead we
+    /// assert the helper still gets reaped on the *write-error* branch
+    /// of `run()` by invoking `kill_and_reap` directly against a
+    /// fresh subprocess. This exercises the helper without depending
+    /// on the timeout path.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn kill_and_reap_kills_full_process_group() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let pid_file = tmp.path().join("sleeper-direct.pid");
+        let shim = tmp.path().join("direct-shim");
+        let script = format!(
+            "#!/bin/sh\nsleep 30 &\nprintf '%s' \"$!\" > '{}'\nsleep 30\n",
+            pid_file.display()
+        );
+        write_exec_script(&shim, &script);
+
+        let mut cmd = tokio::process::Command::new(&shim);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = cmd.spawn().expect("spawn shim");
+
+        // Wait until the shim has written its sleeper PID — the file
+        // appears after a few ms in practice, but poll defensively.
+        let pid_path = pid_file.clone();
+        let pid_str = tokio::time::timeout(Duration::from_secs(2), async move {
+            loop {
+                if let Ok(s) = std::fs::read_to_string(&pid_path) {
+                    if !s.trim().is_empty() {
+                        return s;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shim wrote PID");
+        let sleeper_pid: i32 = pid_str.trim().parse().expect("valid pid");
+
+        kill_and_reap(&mut child).await;
+
+        wait_for_pid_gone(sleeper_pid, Duration::from_secs(3))
+            .await
+            .unwrap_or_else(|elapsed| {
+                panic!(
+                    "background sleeper {sleeper_pid} still alive {elapsed:?} after \
+                     kill_and_reap"
+                )
+            });
+    }
+
+    /// `kill_and_reap` must tolerate a child that has already exited.
+    /// In that case `child.id()` may still return Some until reaped —
+    /// the killpg call returns ESRCH, which the helper swallows.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn kill_and_reap_tolerates_already_exited_child() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let shim = tmp.path().join("fast-exit");
+        write_exec_script(&shim, "#!/bin/sh\nexit 0\n");
+
+        let mut cmd = tokio::process::Command::new(&shim);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = cmd.spawn().expect("spawn shim");
+
+        // Give the child a moment to exit before we try to reap.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Should not panic / hang, even though the group is already
+        // empty.
+        kill_and_reap(&mut child).await;
+    }
+
+    /// `kill_and_reap` must be safe to call even after the child has
+    /// been explicitly waited on, which makes `child.id()` return None.
+    /// Covers the `else` branch of the helper.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn kill_and_reap_handles_already_waited_child() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let shim = tmp.path().join("waited-shim");
+        write_exec_script(&shim, "#!/bin/sh\nexit 0\n");
+
+        let mut cmd = tokio::process::Command::new(&shim);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = cmd.spawn().expect("spawn shim");
+
+        // Reap explicitly so child.id() reports None on the next call.
+        let _ = child.wait().await.expect("wait succeeds");
+        assert!(child.id().is_none(), "post-wait id should be None");
+
+        // Should be a no-op — exercises the `else` branch where the
+        // helper has no PID to signal.
+        kill_and_reap(&mut child).await;
+    }
+
+    /// `wait_for_pid_gone` must report `Err` (with elapsed time) when
+    /// its deadline expires before the process dies. Covers the
+    /// deadline branch of the polling loop.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn wait_for_pid_gone_returns_err_on_deadline() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let shim = tmp.path().join("alive-long");
+        write_exec_script(&shim, "#!/bin/sh\nsleep 30\n");
+
+        let mut cmd = tokio::process::Command::new(&shim);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = cmd.spawn().expect("spawn shim");
+        let pid = child.id().expect("has pid") as i32;
+
+        let deadline = Duration::from_millis(80);
+        let res = wait_for_pid_gone(pid, deadline).await;
+        let elapsed = res.expect_err("should hit deadline before sleeper exits");
+        assert!(
+            elapsed >= deadline,
+            "elapsed {elapsed:?} should be at least the deadline {deadline:?}"
+        );
+
+        // Cleanup so we don't leak a 30s sleeper.
+        kill_and_reap(&mut child).await;
+    }
+
+    /// `kill_and_reap` must reap a child that's actively running, not
+    /// just one that already exited. Confirms the `wait()` half of the
+    /// helper (otherwise the child would persist as a zombie).
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn kill_and_reap_reaps_running_child() {
+        let _guard = shim_lock();
+        let tmp = TempDir::new().unwrap();
+        let shim = tmp.path().join("running-shim");
+        write_exec_script(&shim, "#!/bin/sh\nsleep 30\n");
+
+        let mut cmd = tokio::process::Command::new(&shim);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let mut child = cmd.spawn().expect("spawn shim");
+        let pid = child.id().expect("child has pid before reap");
+
+        kill_and_reap(&mut child).await;
+
+        wait_for_pid_gone(pid as i32, Duration::from_secs(3))
+            .await
+            .unwrap_or_else(|elapsed| {
+                panic!("direct child {pid} still alive {elapsed:?} after kill_and_reap")
+            });
     }
 }


### PR DESCRIPTION
## Description

When `claude -p` is invoked, the Node runtime spawns background worker processes. Previously, on timeout or I/O error, only the direct child PID was killed via `child.kill()`. Worker processes were reparented to PID 1 and accumulated as orphans, never being cleaned up. This caused resource leaks that would grow unbounded in long-running sessions.

This fix ensures the entire process group is reaped on both the timeout and write-error branches of `run()` by using `killpg` (Unix) to signal all processes in the group atomically.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Dependency update

## Related Issue

Fixes #633

## Changes Made

**Core Changes:**
- Added `cmd.process_group(0)` before spawning in `ClaudeCliAiClient::build_command` so the child becomes its own process-group leader, keeping all Node worker helpers in one killable group
- Added `kill_and_reap()` async helper in `src/claude/ai/claude_cli.rs` that sends `SIGKILL` to the entire process group via `nix::sys::signal::killpg` on Unix, falling back to `Child::kill` on Windows (which already terminates the process tree via `TerminateProcess`)
- Replaced all direct `child.kill().await` / `child.wait().await` call sites in the timeout and write-error branches of `run()` with `kill_and_reap(&mut child).await`
- The helper silently swallows `ESRCH` (process group already drained) and logs a debug warning for any other `killpg` errors before falling back to direct kill

**Dependencies:**
- Added `nix = { version = "0.31", default-features = false, features = ["signal"] }` as a Unix-only dependency in `Cargo.toml` for `killpg` and signal APIs
- Updated `Cargo.lock` with `nix` 0.31.2 and its transitive dependencies (`bitflags`, `cfg-if`, `cfg_aliases`, `libc`)

**Testing:**
- Added `timeout_reaps_full_process_group` — acceptance test asserting that a background sleeper spawned by a shell shim is gone after a timeout fires (validates the full end-to-end fix for #633)
- Added `kill_and_reap_kills_full_process_group` — exercises `kill_and_reap` directly against a live subprocess group with a background sleeper to confirm the entire group is reaped
- Added `kill_and_reap_tolerates_already_exited_child` — confirms `ESRCH` is silently swallowed when the group has already drained before `kill_and_reap` is called
- Added `kill_and_reap_reaps_running_child` — confirms the `wait()` half of the helper prevents zombie processes by verifying the direct child PID disappears after the call

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new process-group reaping tests
cargo test timeout_reaps_full_process_group
cargo test kill_and_reap

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — specifically the `ESRCH` swallowing logic and fallback to direct kill in `kill_and_reap`
- [x] Architecture changes — `process_group(0)` must be set before spawn for `killpg` to work correctly; these two call sites are tightly coupled
- [x] Backward compatibility — Windows uses the `#[cfg(not(unix))]` fallback path which preserves prior behaviour

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

The change adds one extra syscall (`setpgid` via `process_group(0)`) at process spawn time and one `killpg` call at teardown. Both are negligible compared to the subprocess execution itself.

## Security Considerations

- [x] No security implications

`SIGKILL` is sent only to the process group of the child we spawned. The `process_group(0)` call isolates the child in its own group at spawn time, so the signal cannot propagate to the parent process or any unrelated siblings.

## Breaking Changes

None. The fix is additive — `process_group(0)` is a no-op from the caller's perspective and `kill_and_reap` replaces semantically equivalent (but incomplete) kill+wait pairs.

## Deployment Notes

- [x] No special deployment requirements

The `nix` crate is a pure Rust library with no system library requirements beyond the standard POSIX interfaces already used by the platform. No environment variables or configuration changes are needed.

## Additional Notes

**Alternatives Considered:**
- Killing only the direct child PID (prior behaviour) — insufficient because Node worker processes survive as orphans reparented to PID 1
- Using `libc::killpg` directly — viable but `nix` provides a safe, typed wrapper that handles errno mapping and avoids unsafe blocks in application code
- Clearing the entire process environment to prevent workers spawning — considered earlier as a partial workaround but breaks the Node runtime which needs `HOME`, `PATH`, and platform-specific entries