### PR TITLE
feat(claude, cli, data): add structured JSON Schema response enforcement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,14 @@ url = "2.5.8"
 base64 = "0.22"
 futures = "0.3"
 rmcp = { version = "1.5", features = ["server", "transport-io", "macros"], optional = true }
-schemars = { version = "1.2", optional = true }
+schemars = "1.2"
 tokio-util = { version = "0.7", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }
 
 [features]
-mcp = ["dep:rmcp", "dep:schemars", "dep:tokio-util"]
+mcp = ["dep:rmcp", "dep:tokio-util"]
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -8,13 +8,16 @@ pub(crate) mod diff_pack;
 pub mod error;
 pub mod model_config;
 pub mod prompts;
+pub mod response_schema;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod token_budget;
 
 pub use ai::bedrock::BedrockAiClient;
 pub use ai::claude::ClaudeAiClient;
-pub use ai::{AiClient, AiClientMetadata, PromptStyle};
+pub use ai::{
+    AiClient, AiClientCapabilities, AiClientMetadata, PromptStyle, RequestOptions, ResponseFormat,
+};
 pub use client::{create_default_claude_client, ClaudeClient};
 pub use context::*;
 pub use error::ClaudeError;

--- a/src/claude/ai.rs
+++ b/src/claude/ai.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
+use serde_json::Value;
 
 use crate::claude::error::ClaudeError;
 use crate::claude::model_config::get_model_registry;
@@ -145,6 +146,78 @@ pub(crate) fn log_response_success(provider: &str, result: &Result<String>) {
     }
 }
 
+/// Capabilities advertised by an [`AiClient`] implementation.
+///
+/// Used by call sites to decide whether to attach a structured-response
+/// schema (or other backend-specific request options) before dispatching.
+/// The default value is the conservative ''nothing supported'' baseline so
+/// new fields can be added without forcing existing implementations to
+/// update.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AiClientCapabilities {
+    /// Whether the backend can enforce a JSON Schema on its response.
+    ///
+    /// When `true`, the call site may set
+    /// [`RequestOptions::response_schema`]; the backend will hand the schema
+    /// to its underlying API (e.g. `claude -p --json-schema <file>`) and the
+    /// API re-prompts until the model produces a validating response.
+    pub supports_response_schema: bool,
+}
+
+/// Whether the response should be formatted as YAML (default) or JSON
+/// matching a schema.
+///
+/// Used by the prompts module to swap the format-specific portion of a
+/// structured prompt without rewriting the semantic instructions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ResponseFormat {
+    /// Plain YAML, with the prompt asking the model to emit a fenced or
+    /// bare YAML document.
+    #[default]
+    Yaml,
+    /// JSON object that matches a schema attached via
+    /// [`RequestOptions::response_schema`]. The prompt drops the YAML
+    /// structure literal and tells the model to return only the JSON
+    /// object.
+    JsonSchema,
+}
+
+impl ResponseFormat {
+    /// Returns the response format that should be used given a backend's
+    /// capabilities.
+    #[must_use]
+    pub fn from_capabilities(caps: &AiClientCapabilities) -> Self {
+        if caps.supports_response_schema {
+            Self::JsonSchema
+        } else {
+            Self::Yaml
+        }
+    }
+}
+
+/// Per-request options passed to [`AiClient::send_request_with_options`].
+///
+/// Schema and other knobs live on the request, not the client, so a shared
+/// client cannot leak settings between concurrent calls. Backends that do
+/// not support an option are expected to ignore it (and the call site is
+/// expected to consult [`AiClient::capabilities`] before setting it).
+#[derive(Clone, Debug, Default)]
+pub struct RequestOptions {
+    /// Optional JSON Schema (as a `serde_json::Value`) constraining the
+    /// model's response. Only honoured by backends whose
+    /// [`AiClientCapabilities::supports_response_schema`] is `true`.
+    pub response_schema: Option<Value>,
+}
+
+impl RequestOptions {
+    /// Returns a new [`RequestOptions`] with [`response_schema`] set.
+    #[must_use]
+    pub fn with_response_schema(mut self, schema: Value) -> Self {
+        self.response_schema = Some(schema);
+        self
+    }
+}
+
 /// Trait for AI service clients.
 pub trait AiClient: Send + Sync {
     /// Sends a request to the AI service and returns the raw response.
@@ -156,6 +229,33 @@ pub trait AiClient: Send + Sync {
 
     /// Returns metadata about the AI client implementation.
     fn get_metadata(&self) -> AiClientMetadata;
+
+    /// Returns the optional capabilities advertised by this backend.
+    ///
+    /// The default implementation returns the all-disabled baseline so
+    /// existing backends remain source-compatible. Backends that gain new
+    /// capabilities (e.g. structured-output enforcement) should override
+    /// this method.
+    fn capabilities(&self) -> AiClientCapabilities {
+        AiClientCapabilities::default()
+    }
+
+    /// Sends a request with optional per-request settings.
+    ///
+    /// The default implementation drops `options` and dispatches via
+    /// [`send_request`]. Backends that honour any field in
+    /// [`RequestOptions`] (e.g. `response_schema`) override this method.
+    /// Backends that don't honour an option must ignore it; call sites
+    /// should consult [`capabilities`](Self::capabilities) before setting
+    /// options that not all backends support.
+    fn send_request_with_options<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+        _options: RequestOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        self.send_request(system_prompt, user_prompt)
+    }
 }
 
 #[cfg(test)]
@@ -206,5 +306,49 @@ mod tests {
     fn prompt_style_case_sensitive() {
         assert_eq!(meta("openai").prompt_style(), PromptStyle::Claude);
         assert_eq!(meta("ollama").prompt_style(), PromptStyle::Claude);
+    }
+
+    #[test]
+    fn capabilities_default_is_all_disabled() {
+        let caps = AiClientCapabilities::default();
+        assert!(!caps.supports_response_schema);
+    }
+
+    #[test]
+    fn response_format_default_is_yaml() {
+        assert_eq!(ResponseFormat::default(), ResponseFormat::Yaml);
+    }
+
+    #[test]
+    fn response_format_from_capabilities_disabled_picks_yaml() {
+        let caps = AiClientCapabilities::default();
+        assert_eq!(
+            ResponseFormat::from_capabilities(&caps),
+            ResponseFormat::Yaml
+        );
+    }
+
+    #[test]
+    fn response_format_from_capabilities_enabled_picks_json_schema() {
+        let caps = AiClientCapabilities {
+            supports_response_schema: true,
+        };
+        assert_eq!(
+            ResponseFormat::from_capabilities(&caps),
+            ResponseFormat::JsonSchema
+        );
+    }
+
+    #[test]
+    fn request_options_with_response_schema_sets_field() {
+        let value = serde_json::json!({"type": "object"});
+        let opts = RequestOptions::default().with_response_schema(value.clone());
+        assert_eq!(opts.response_schema, Some(value));
+    }
+
+    #[test]
+    fn request_options_default_has_no_schema() {
+        let opts = RequestOptions::default();
+        assert!(opts.response_schema.is_none());
     }
 }

--- a/src/claude/ai/bedrock.rs
+++ b/src/claude/ai/bedrock.rs
@@ -388,4 +388,18 @@ mod tests {
         assert_eq!(client.base_url, "https://bedrock.us-east-1.amazonaws.com");
         assert!(client.active_beta.is_none());
     }
+
+    /// Bedrock backend doesn't expose JSON Schema enforcement here yet, so
+    /// capabilities must report `false`.
+    #[test]
+    fn capabilities_default_to_no_schema_support() {
+        let client = BedrockAiClient::new(
+            "claude-sonnet-4-20250514".to_string(),
+            "token".to_string(),
+            "https://example.com".to_string(),
+            None,
+        )
+        .unwrap();
+        assert!(!client.capabilities().supports_response_schema);
+    }
 }

--- a/src/claude/ai/claude.rs
+++ b/src/claude/ai/claude.rs
@@ -267,4 +267,13 @@ mod tests {
         let metadata = client.get_metadata();
         assert!(metadata.active_beta.is_some());
     }
+
+    /// Anthropic backend doesn't expose JSON Schema enforcement (only
+    /// claude-cli does today), so capabilities must report `false`.
+    #[test]
+    fn capabilities_default_to_no_schema_support() {
+        let client =
+            ClaudeAiClient::new("claude-sonnet-4-6".to_string(), "key".to_string(), None).unwrap();
+        assert!(!client.capabilities().supports_response_schema);
+    }
 }

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -28,7 +28,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use super::{AiClient, AiClientMetadata};
+use super::{AiClient, AiClientCapabilities, AiClientMetadata, RequestOptions};
 use crate::claude::error::ClaudeError;
 
 /// Default subprocess timeout.
@@ -205,7 +205,21 @@ impl ClaudeCliAiClient {
     /// Broken out so tests can inspect the argv / env / cwd via
     /// `Command::get_args`, `get_envs`, `get_current_dir` without running
     /// a subprocess.
+    #[cfg(test)]
     pub(crate) fn build_command(&self, system_prompt: &str, cwd: &Path) -> Command {
+        self.build_command_with_schema(system_prompt, cwd, None)
+    }
+
+    /// Variant of [`build_command`] that adds a `--json-schema <path>`
+    /// argument when `schema_path` is supplied. The path itself is the
+    /// caller's responsibility — typically a file written into the same
+    /// `cwd` so its lifetime tracks the temp directory.
+    pub(crate) fn build_command_with_schema(
+        &self,
+        system_prompt: &str,
+        cwd: &Path,
+        schema_path: Option<&Path>,
+    ) -> Command {
         let mut cmd = Command::new(&self.binary_path);
         cmd.arg("-p")
             .arg("--model")
@@ -231,6 +245,12 @@ impl ClaudeCliAiClient {
             // format that round-trips through its parser (no locale
             // formatting, no scientific notation).
             cmd.arg("--max-budget-usd").arg(format!("{budget}"));
+        }
+
+        if let Some(path) = schema_path {
+            // Schemas can grow large; pass via file path rather than inline
+            // argv to avoid argv-length limits and shell-escape pitfalls.
+            cmd.arg("--json-schema").arg(path);
         }
 
         cmd.current_dir(cwd);
@@ -261,12 +281,45 @@ impl ClaudeCliAiClient {
     }
 
     async fn run(&self, system_prompt: &str, user_prompt: &str) -> Result<String> {
+        self.run_with_options(system_prompt, user_prompt, &RequestOptions::default())
+            .await
+    }
+
+    /// Variant of [`run`] that materialises any options on the request.
+    ///
+    /// When `options.response_schema` is `Some`, the schema is written to
+    /// a `response_schema.json` file inside the subprocess's temp cwd and
+    /// passed via `--json-schema <path>`. The file lives only as long as
+    /// the [`tempfile::TempDir`], so it is cleaned up when this function
+    /// returns regardless of success or error.
+    async fn run_with_options(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        options: &RequestOptions,
+    ) -> Result<String> {
         let combined_system = format!("{system_prompt}{TOOL_SUPPRESSION_SUFFIX}");
 
         let temp_dir = tempfile::TempDir::new()
             .context("Failed to create temp directory for claude subprocess")?;
 
-        let mut cmd = self.build_command(&combined_system, temp_dir.path());
+        let schema_path = if let Some(schema) = &options.response_schema {
+            let path = temp_dir.path().join("response_schema.json");
+            let body = serde_json::to_vec(schema)
+                .context("Failed to serialize response schema for claude -p --json-schema")?;
+            tokio::fs::write(&path, body)
+                .await
+                .context("Failed to write response schema file for claude -p")?;
+            Some(path)
+        } else {
+            None
+        };
+
+        let mut cmd = self.build_command_with_schema(
+            &combined_system,
+            temp_dir.path(),
+            schema_path.as_deref(),
+        );
 
         if self.allow_tools {
             warn!(
@@ -485,6 +538,31 @@ impl AiClient for ClaudeCliAiClient {
                 "Preparing claude -p subprocess request"
             );
             self.run(system_prompt, user_prompt).await
+        })
+    }
+
+    fn capabilities(&self) -> AiClientCapabilities {
+        AiClientCapabilities {
+            supports_response_schema: true,
+        }
+    }
+
+    fn send_request_with_options<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+        options: RequestOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        Box::pin(async move {
+            debug!(
+                system_prompt_len = system_prompt.len(),
+                user_prompt_len = user_prompt.len(),
+                has_schema = options.response_schema.is_some(),
+                model = %self.model,
+                "Preparing claude -p subprocess request (with options)"
+            );
+            self.run_with_options(system_prompt, user_prompt, &options)
+                .await
         })
     }
 
@@ -1107,6 +1185,114 @@ mod tests {
     }
 
     #[test]
+    fn capabilities_advertise_response_schema_support() {
+        let cli = client_with_defaults("sonnet");
+        let caps = cli.capabilities();
+        assert!(
+            caps.supports_response_schema,
+            "claude-cli backend should advertise response-schema support"
+        );
+    }
+
+    #[test]
+    fn build_command_omits_json_schema_when_no_path_given() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let cmd = cli.build_command_with_schema("sys", tmp.path(), None);
+        let args = args_of(&cmd);
+        assert!(
+            !args.contains(&"--json-schema".to_string()),
+            "no schema → argv must omit --json-schema: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_command_includes_json_schema_when_path_given() {
+        let cli = client_with_defaults("sonnet");
+        let tmp = TempDir::new().unwrap();
+        let schema_path = tmp.path().join("schema.json");
+        let cmd = cli.build_command_with_schema("sys", tmp.path(), Some(&schema_path));
+        let args = args_of(&cmd);
+        let idx = args
+            .iter()
+            .position(|a| a == "--json-schema")
+            .expect("argv should contain --json-schema");
+        assert_eq!(args[idx + 1], schema_path.to_string_lossy());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn run_with_options_writes_schema_and_succeeds() {
+        let _guard = shim_lock();
+        // The shim ignores --json-schema and just emits a JSON envelope.
+        // What matters is that run_with_options serializes/writes the
+        // schema and adds the flag without erroring out.
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(&tmp, r#"{"is_error":false,"result":"ok"}"#, 0);
+        let cli = client_with_shim(shim);
+        let schema = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title"],
+            "properties": {"title": {"type": "string"}}
+        });
+        let opts = RequestOptions::default().with_response_schema(schema);
+        let out = cli
+            .run_with_options("sys", "user", &opts)
+            .await
+            .expect("run_with_options should succeed");
+        assert_eq!(out, "ok");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn send_request_with_options_default_acts_like_send_request() {
+        let _guard = shim_lock();
+        // No schema in options → behaves exactly like send_request.
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(&tmp, r#"{"is_error":false,"result":"hi"}"#, 0);
+        let cli = client_with_shim(shim);
+        let out = cli
+            .send_request_with_options("sys", "user", RequestOptions::default())
+            .await
+            .expect("send_request_with_options should succeed");
+        assert_eq!(out, "hi");
+    }
+
+    /// Initialises a tracing subscriber at debug level so the
+    /// instrumented `debug!` macro inside [`send_request_with_options`]
+    /// evaluates its arguments — without a subscriber, the macro elides
+    /// its body and the field-formatting expressions register as
+    /// uncovered. The test set is otherwise the same shape as
+    /// [`send_request_with_options_default_acts_like_send_request`].
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn send_request_with_options_records_debug_trace() {
+        let _guard = shim_lock();
+        // Ignore the result: another test may have already installed a
+        // subscriber. Either way is fine; we only need *some* subscriber
+        // to make the debug! macro's expressions execute.
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_test_writer()
+            .try_init();
+
+        let tmp = TempDir::new().unwrap();
+        let shim = make_shim(&tmp, r#"{"is_error":false,"result":"hi"}"#, 0);
+        let cli = client_with_shim(shim);
+        let schema = serde_json::json!({"type": "object", "additionalProperties": false});
+        let out = cli
+            .send_request_with_options(
+                "sys",
+                "user",
+                RequestOptions::default().with_response_schema(schema),
+            )
+            .await
+            .expect("send_request_with_options should succeed");
+        assert_eq!(out, "hi");
+    }
+
+    #[test]
     fn strip_fence_removes_yaml_wrapping() {
         let raw = "```yaml\namendments: []\n```";
         assert_eq!(strip_wrapping_code_fence(raw), "amendments: []");
@@ -1575,7 +1761,13 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut child = cmd.spawn().expect("spawn shim");
+        // Bare cmd.spawn() races with sibling test threads on Linux —
+        // the kernel returns ETXTBSY while another thread holds a
+        // writable FD on the freshly-written shim. Use the same retry
+        // helper production code uses.
+        let mut child = spawn_with_etxtbsy_retry(&mut cmd)
+            .await
+            .expect("spawn shim");
 
         // Wait until the shim has written its sleeper PID — the file
         // appears after a few ms in practice, but poll defensively.
@@ -1622,7 +1814,9 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut child = cmd.spawn().expect("spawn shim");
+        let mut child = spawn_with_etxtbsy_retry(&mut cmd)
+            .await
+            .expect("spawn shim");
 
         // Give the child a moment to exit before we try to reap.
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1648,7 +1842,9 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut child = cmd.spawn().expect("spawn shim");
+        let mut child = spawn_with_etxtbsy_retry(&mut cmd)
+            .await
+            .expect("spawn shim");
 
         // Reap explicitly so child.id() reports None on the next call.
         let _ = child.wait().await.expect("wait succeeds");
@@ -1675,7 +1871,9 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut child = cmd.spawn().expect("spawn shim");
+        let mut child = spawn_with_etxtbsy_retry(&mut cmd)
+            .await
+            .expect("spawn shim");
         let pid = child.id().expect("has pid") as i32;
 
         let deadline = Duration::from_millis(80);
@@ -1706,7 +1904,13 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0);
-        let mut child = cmd.spawn().expect("spawn shim");
+        // Use the same ETXTBSY-retry helper that production code uses;
+        // a bare cmd.spawn() races with concurrent test threads on Linux
+        // because the kernel returns ETXTBSY while another thread holds
+        // a writable FD on the shim binary.
+        let mut child = spawn_with_etxtbsy_retry(&mut cmd)
+            .await
+            .expect("spawn shim");
         let pid = child.id().expect("child has pid before reap");
 
         kill_and_reap(&mut child).await;

--- a/src/claude/ai/openai.rs
+++ b/src/claude/ai/openai.rs
@@ -605,4 +605,19 @@ mod tests {
         assert!(!json.contains("max_completion_tokens"));
         assert!(json.contains("\"temperature\""));
     }
+
+    /// OpenAI / Ollama backends don't expose JSON Schema enforcement
+    /// here yet, so capabilities must report `false` for both.
+    #[test]
+    fn capabilities_default_to_no_schema_support_openai() {
+        let client =
+            OpenAiAiClient::new_openai("gpt-4o".to_string(), "key".to_string(), None).unwrap();
+        assert!(!client.capabilities().supports_response_schema);
+    }
+
+    #[test]
+    fn capabilities_default_to_no_schema_support_ollama() {
+        let client = OpenAiAiClient::new_ollama("llama2".to_string(), None, None).unwrap();
+        assert!(!client.capabilities().supports_response_schema);
+    }
 }

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -5,7 +5,11 @@ use tracing::{debug, info, warn};
 
 use crate::claude::token_budget::TokenBudget;
 use crate::claude::{ai::bedrock::BedrockAiClient, ai::claude::ClaudeAiClient};
-use crate::claude::{ai::AiClient, error::ClaudeError, prompts};
+use crate::claude::{
+    ai::{AiClient, RequestOptions, ResponseFormat},
+    error::ClaudeError,
+    prompts, response_schema,
+};
 use crate::data::{
     amendments::{Amendment, AmendmentFile},
     context::CommitContext,
@@ -39,6 +43,69 @@ impl ClaudeClient {
     /// Returns metadata about the AI client.
     pub fn get_ai_client_metadata(&self) -> crate::claude::ai::AiClientMetadata {
         self.ai_client.get_metadata()
+    }
+
+    /// Adjusts a structured-call system prompt for the active backend's
+    /// response format.
+    ///
+    /// Backends advertising
+    /// [`AiClientCapabilities::supports_response_schema`](crate::claude::ai::AiClientCapabilities::supports_response_schema)
+    /// receive the [`prompts::JSON_SCHEMA_RESPONSE_OVERRIDE`] suffix, which
+    /// instructs the model to emit a bare JSON object matching the schema
+    /// supplied via [`RequestOptions`]. Other backends receive the prompt
+    /// unchanged. Should be called once at the top of each entry point so
+    /// the suffix is included in subsequent token-budget calculations.
+    fn adjusted_system_prompt(&self, system_prompt: String) -> String {
+        let format = ResponseFormat::from_capabilities(&self.ai_client.capabilities());
+        prompts::apply_response_format_to_system_prompt(system_prompt, format)
+    }
+
+    /// Returns the cached schema when the active backend can enforce
+    /// response schemas, or `None` when it cannot.
+    ///
+    /// Used to gate per-call schema attachment so call sites stay
+    /// readable: build the schema unconditionally, gate attachment on
+    /// capabilities.
+    fn schema_if_supported<'a>(
+        &self,
+        schema: &'a serde_json::Value,
+    ) -> Option<&'a serde_json::Value> {
+        if self.ai_client.capabilities().supports_response_schema {
+            Some(schema)
+        } else {
+            None
+        }
+    }
+
+    /// Dispatches a structured AI call with optional schema enforcement.
+    ///
+    /// When `schema` is `Some`, sends via
+    /// [`AiClient::send_request_with_options`] so the backend can enforce
+    /// the schema (e.g. `claude -p --json-schema <file>`); otherwise
+    /// falls back to plain [`AiClient::send_request`]. Backends without
+    /// schema support are expected to report
+    /// [`AiClientCapabilities::supports_response_schema`](crate::claude::ai::AiClientCapabilities::supports_response_schema)
+    /// `= false`, in which case [`schema_if_supported`](Self::schema_if_supported)
+    /// at the call site returns `None` and we take the second branch.
+    async fn send_with_optional_schema(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        schema: Option<&serde_json::Value>,
+    ) -> Result<String> {
+        match schema {
+            Some(s) => {
+                let opts = RequestOptions::default().with_response_schema(s.clone());
+                self.ai_client
+                    .send_request_with_options(system_prompt, user_prompt, opts)
+                    .await
+            }
+            None => {
+                self.ai_client
+                    .send_request(system_prompt, user_prompt)
+                    .await
+            }
+        }
     }
 
     /// Validates that the prompt fits within the model's token budget.
@@ -240,8 +307,11 @@ impl ClaudeClient {
             );
 
             let content = match self
-                .ai_client
-                .send_request(system_prompt, &user_prompt)
+                .send_with_optional_schema(
+                    system_prompt,
+                    &user_prompt,
+                    self.schema_if_supported(response_schema::amendment_file_schema()),
+                )
                 .await
             {
                 Ok(content) => content,
@@ -307,7 +377,8 @@ impl ClaudeClient {
         diff_summary: &str,
         chunk_amendments: &[Amendment],
     ) -> Result<Amendment> {
-        let system_prompt = prompts::AMENDMENT_CHUNK_MERGE_SYSTEM_PROMPT;
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::AMENDMENT_CHUNK_MERGE_SYSTEM_PROMPT.to_string());
         let user_prompt = prompts::generate_chunk_merge_user_prompt(
             commit_hash,
             original_message,
@@ -315,11 +386,14 @@ impl ClaudeClient {
             chunk_amendments,
         );
 
-        self.validate_prompt_budget(system_prompt, &user_prompt)?;
+        self.validate_prompt_budget(&system_prompt, &user_prompt)?;
 
         let content = self
-            .ai_client
-            .send_request(system_prompt, &user_prompt)
+            .send_with_optional_schema(
+                &system_prompt,
+                &user_prompt,
+                self.schema_if_supported(response_schema::amendment_file_schema()),
+            )
             .await
             .context("Merge pass failed for chunk amendments")?;
 
@@ -485,8 +559,11 @@ impl ClaudeClient {
                 self.build_prompt_fitting_budget(&partial_view, system_prompt, &build_user_prompt)?;
 
             let content = self
-                .ai_client
-                .send_request(system_prompt, &user_prompt)
+                .send_with_optional_schema(
+                    system_prompt,
+                    &user_prompt,
+                    self.schema_if_supported(response_schema::check_response_schema()),
+                )
                 .await
                 .with_context(|| {
                     format!(
@@ -587,7 +664,8 @@ impl ClaudeClient {
         let summaries: Vec<Option<&str>> =
             chunk_results.iter().map(|r| r.summary.as_deref()).collect();
 
-        let system_prompt = prompts::CHECK_CHUNK_MERGE_SYSTEM_PROMPT;
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::CHECK_CHUNK_MERGE_SYSTEM_PROMPT.to_string());
         let user_prompt = prompts::generate_check_chunk_merge_user_prompt(
             commit_hash,
             original_message,
@@ -597,11 +675,14 @@ impl ClaudeClient {
             &summaries,
         );
 
-        self.validate_prompt_budget(system_prompt, &user_prompt)?;
+        self.validate_prompt_budget(&system_prompt, &user_prompt)?;
 
         let content = self
-            .ai_client
-            .send_request(system_prompt, &user_prompt)
+            .send_with_optional_schema(
+                &system_prompt,
+                &user_prompt,
+                self.schema_if_supported(response_schema::check_response_schema()),
+            )
             .await
             .context("Merge pass failed for check chunk suggestions")?;
 
@@ -661,13 +742,13 @@ impl ClaudeClient {
             RepositoryViewForAI::from_repository_view_with_options(repo_view.clone(), fresh)
                 .context("Failed to enhance repository view with diff content")?;
 
-        let system_prompt = prompts::SYSTEM_PROMPT;
+        let system_prompt = self.adjusted_system_prompt(prompts::SYSTEM_PROMPT.to_string());
         let build_user_prompt = |yaml: &str| prompts::generate_user_prompt(yaml);
 
         // Try full view first; fall back to per-commit split dispatch
-        match self.try_full_diff_budget(&ai_repo_view, system_prompt, &build_user_prompt)? {
+        match self.try_full_diff_budget(&ai_repo_view, &system_prompt, &build_user_prompt)? {
             Ok(user_prompt) => {
-                self.send_and_parse_amendment_with_retry(system_prompt, &user_prompt)
+                self.send_and_parse_amendment_with_retry(&system_prompt, &user_prompt)
                     .await
             }
             Err(_exceeded) => {
@@ -677,7 +758,7 @@ impl ClaudeClient {
                         .generate_amendment_for_commit(
                             commit,
                             &ai_repo_view,
-                            system_prompt,
+                            &system_prompt,
                             &build_user_prompt,
                             fresh,
                         )
@@ -721,8 +802,9 @@ impl ClaudeClient {
 
         // Generate contextual prompts using intelligence
         let prompt_style = self.ai_client.get_metadata().prompt_style();
-        let system_prompt =
-            prompts::generate_contextual_system_prompt_for_provider(context, prompt_style);
+        let system_prompt = self.adjusted_system_prompt(
+            prompts::generate_contextual_system_prompt_for_provider(context, prompt_style),
+        );
 
         // Debug logging to troubleshoot custom commit type issue
         match &context.project.commit_guidelines {
@@ -812,8 +894,11 @@ impl ClaudeClient {
         let mut last_error = None;
         for attempt in 0..=AMENDMENT_PARSE_MAX_RETRIES {
             match self
-                .ai_client
-                .send_request(system_prompt, user_prompt)
+                .send_with_optional_schema(
+                    system_prompt,
+                    user_prompt,
+                    self.schema_if_supported(response_schema::amendment_file_schema()),
+                )
                 .await
             {
                 Ok(content) => match self.parse_amendment_response(&content) {
@@ -942,8 +1027,11 @@ impl ClaudeClient {
                 self.build_prompt_fitting_budget(&partial_view, system_prompt, build_user_prompt)?;
 
             let content = self
-                .ai_client
-                .send_request(system_prompt, &user_prompt)
+                .send_with_optional_schema(
+                    system_prompt,
+                    &user_prompt,
+                    self.schema_if_supported(response_schema::pr_content_schema()),
+                )
                 .await
                 .with_context(|| {
                     format!(
@@ -977,15 +1065,19 @@ impl ClaudeClient {
         partial_contents: &[crate::cli::git::PrContent],
         pr_template: &str,
     ) -> Result<crate::cli::git::PrContent> {
-        let system_prompt = prompts::PR_CONTENT_MERGE_SYSTEM_PROMPT;
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::PR_CONTENT_MERGE_SYSTEM_PROMPT.to_string());
         let user_prompt =
             prompts::generate_pr_content_merge_user_prompt(partial_contents, pr_template);
 
-        self.validate_prompt_budget(system_prompt, &user_prompt)?;
+        self.validate_prompt_budget(&system_prompt, &user_prompt)?;
 
         let content = self
-            .ai_client
-            .send_request(system_prompt, &user_prompt)
+            .send_with_optional_schema(
+                &system_prompt,
+                &user_prompt,
+                self.schema_if_supported(response_schema::pr_content_schema()),
+            )
             .await
             .context("Merge pass failed for PR content chunks")?;
 
@@ -1008,8 +1100,11 @@ impl ClaudeClient {
         match self.try_full_diff_budget(&single_view, system_prompt, build_user_prompt)? {
             Ok(user_prompt) => {
                 let content = self
-                    .ai_client
-                    .send_request(system_prompt, &user_prompt)
+                    .send_with_optional_schema(
+                        system_prompt,
+                        &user_prompt,
+                        self.schema_if_supported(response_schema::pr_content_schema()),
+                    )
                     .await?;
                 self.parse_pr_response(&content)
             }
@@ -1043,19 +1138,21 @@ impl ClaudeClient {
         let ai_repo_view = RepositoryViewForAI::from_repository_view(repo_view.clone())
             .context("Failed to enhance repository view with diff content")?;
 
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::PR_GENERATION_SYSTEM_PROMPT.to_string());
+
         let build_user_prompt =
             |yaml: &str| prompts::generate_pr_description_prompt(yaml, pr_template);
 
         // Try full view first; fall back to per-commit split dispatch
-        match self.try_full_diff_budget(
-            &ai_repo_view,
-            prompts::PR_GENERATION_SYSTEM_PROMPT,
-            &build_user_prompt,
-        )? {
+        match self.try_full_diff_budget(&ai_repo_view, &system_prompt, &build_user_prompt)? {
             Ok(user_prompt) => {
                 let content = self
-                    .ai_client
-                    .send_request(prompts::PR_GENERATION_SYSTEM_PROMPT, &user_prompt)
+                    .send_with_optional_schema(
+                        &system_prompt,
+                        &user_prompt,
+                        self.schema_if_supported(response_schema::pr_content_schema()),
+                    )
                     .await?;
                 self.parse_pr_response(&content)
             }
@@ -1066,7 +1163,7 @@ impl ClaudeClient {
                         .generate_pr_content_for_commit(
                             commit,
                             &ai_repo_view,
-                            prompts::PR_GENERATION_SYSTEM_PROMPT,
+                            &system_prompt,
                             &build_user_prompt,
                             pr_template,
                         )
@@ -1098,8 +1195,9 @@ impl ClaudeClient {
 
         // Generate contextual prompts for PR description with provider-specific handling
         let prompt_style = self.ai_client.get_metadata().prompt_style();
-        let system_prompt =
-            prompts::generate_pr_system_prompt_with_context_for_provider(context, prompt_style);
+        let system_prompt = self.adjusted_system_prompt(
+            prompts::generate_pr_system_prompt_with_context_for_provider(context, prompt_style),
+        );
 
         let build_user_prompt = |yaml: &str| {
             prompts::generate_pr_description_prompt_with_context(yaml, pr_template, context)
@@ -1109,8 +1207,11 @@ impl ClaudeClient {
         match self.try_full_diff_budget(&ai_repo_view, &system_prompt, &build_user_prompt)? {
             Ok(user_prompt) => {
                 let content = self
-                    .ai_client
-                    .send_request(&system_prompt, &user_prompt)
+                    .send_with_optional_schema(
+                        &system_prompt,
+                        &user_prompt,
+                        self.schema_if_supported(response_schema::pr_content_schema()),
+                    )
                     .await?;
 
                 debug!(
@@ -1200,8 +1301,9 @@ impl ClaudeClient {
         max_retries: u32,
     ) -> Result<crate::data::check::CheckReport> {
         // Generate system prompt with scopes
-        let system_prompt =
-            prompts::generate_check_system_prompt_with_scopes(guidelines, valid_scopes);
+        let system_prompt = self.adjusted_system_prompt(
+            prompts::generate_check_system_prompt_with_scopes(guidelines, valid_scopes),
+        );
 
         let build_user_prompt =
             |yaml: &str| prompts::generate_check_user_prompt(yaml, include_suggestions);
@@ -1219,8 +1321,11 @@ impl ClaudeClient {
                 let mut last_error = None;
                 for attempt in 0..=max_retries {
                     match self
-                        .ai_client
-                        .send_request(&system_prompt, &user_prompt)
+                        .send_with_optional_schema(
+                            &system_prompt,
+                            &user_prompt,
+                            self.schema_if_supported(response_schema::check_response_schema()),
+                        )
                         .await
                     {
                         Ok(content) => match self.parse_check_response(&content, repo_view) {
@@ -1269,8 +1374,13 @@ impl ClaudeClient {
                     )? {
                         Ok(user_prompt) => {
                             let content = self
-                                .ai_client
-                                .send_request(&system_prompt, &user_prompt)
+                                .send_with_optional_schema(
+                                    &system_prompt,
+                                    &user_prompt,
+                                    self.schema_if_supported(
+                                        response_schema::check_response_schema(),
+                                    ),
+                                )
                                 .await?;
                             let report = self.parse_check_response(&content, &single_view)?;
                             all_results.extend(report.commits);
@@ -1398,14 +1508,18 @@ impl ClaudeClient {
         &self,
         items: &[(crate::data::amendments::Amendment, String)],
     ) -> Result<AmendmentFile> {
-        let system_prompt = prompts::AMENDMENT_COHERENCE_SYSTEM_PROMPT;
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::AMENDMENT_COHERENCE_SYSTEM_PROMPT.to_string());
         let user_prompt = prompts::generate_amendment_coherence_user_prompt(items);
 
-        self.validate_prompt_budget(system_prompt, &user_prompt)?;
+        self.validate_prompt_budget(&system_prompt, &user_prompt)?;
 
         let content = self
-            .ai_client
-            .send_request(system_prompt, &user_prompt)
+            .send_with_optional_schema(
+                &system_prompt,
+                &user_prompt,
+                self.schema_if_supported(response_schema::amendment_file_schema()),
+            )
             .await?;
 
         self.parse_amendment_response(&content)
@@ -1421,14 +1535,18 @@ impl ClaudeClient {
         items: &[(crate::data::check::CommitCheckResult, String)],
         repo_view: &RepositoryView,
     ) -> Result<crate::data::check::CheckReport> {
-        let system_prompt = prompts::CHECK_COHERENCE_SYSTEM_PROMPT;
+        let system_prompt =
+            self.adjusted_system_prompt(prompts::CHECK_COHERENCE_SYSTEM_PROMPT.to_string());
         let user_prompt = prompts::generate_check_coherence_user_prompt(items);
 
-        self.validate_prompt_budget(system_prompt, &user_prompt)?;
+        self.validate_prompt_budget(&system_prompt, &user_prompt)?;
 
         let content = self
-            .ai_client
-            .send_request(system_prompt, &user_prompt)
+            .send_with_optional_schema(
+                &system_prompt,
+                &user_prompt,
+                self.schema_if_supported(response_schema::check_response_schema()),
+            )
             .await?;
 
         self.parse_check_response(&content, repo_view)
@@ -1626,9 +1744,10 @@ pub fn create_default_claude_client(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::claude::ai::{AiClient, AiClientMetadata};
+    use crate::claude::ai::{AiClient, AiClientCapabilities, AiClientMetadata};
     use std::future::Future;
     use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
 
     /// Mock AI client for testing — never makes real HTTP requests.
     struct MockAiClient;
@@ -1655,6 +1774,291 @@ mod tests {
 
     fn make_client() -> ClaudeClient {
         ClaudeClient::new(Box::new(MockAiClient))
+    }
+
+    /// Mock AI client that records both prompts and per-call options
+    /// (the schema attached, if any). Used to verify
+    /// [`ClaudeClient::send_with_optional_schema`] dispatches via the
+    /// options-aware method when a schema is provided and via the plain
+    /// method otherwise.
+    ///
+    /// Returns the configured `response` string from both `send_request`
+    /// and `send_request_with_options` so tests that need a parseable
+    /// response (e.g. the refine_* coherence paths) can plug in canned
+    /// YAML/JSON.
+    struct SchemaRecordingMockAiClient {
+        capabilities: AiClientCapabilities,
+        response: String,
+        recorded_options: Arc<Mutex<Vec<RequestOptions>>>,
+        recorded_plain: Arc<Mutex<Vec<(String, String)>>>,
+    }
+    impl SchemaRecordingMockAiClient {
+        fn new(supports_response_schema: bool) -> Self {
+            Self::with_response(supports_response_schema, String::new())
+        }
+
+        fn with_response(supports_response_schema: bool, response: String) -> Self {
+            Self {
+                capabilities: AiClientCapabilities {
+                    supports_response_schema,
+                },
+                response,
+                recorded_options: Arc::new(Mutex::new(Vec::new())),
+                recorded_plain: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl AiClient for SchemaRecordingMockAiClient {
+        fn send_request<'a>(
+            &'a self,
+            system_prompt: &'a str,
+            user_prompt: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            let plain = self.recorded_plain.clone();
+            let sys = system_prompt.to_string();
+            let usr = user_prompt.to_string();
+            let response = self.response.clone();
+            Box::pin(async move {
+                plain.lock().unwrap().push((sys, usr));
+                Ok(response)
+            })
+        }
+
+        fn capabilities(&self) -> AiClientCapabilities {
+            self.capabilities
+        }
+
+        fn send_request_with_options<'a>(
+            &'a self,
+            _system_prompt: &'a str,
+            _user_prompt: &'a str,
+            options: RequestOptions,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            let recorded = self.recorded_options.clone();
+            let response = self.response.clone();
+            Box::pin(async move {
+                recorded.lock().unwrap().push(options);
+                Ok(response)
+            })
+        }
+
+        fn get_metadata(&self) -> AiClientMetadata {
+            AiClientMetadata {
+                provider: "SchemaMock".to_string(),
+                model: "schema-mock".to_string(),
+                max_context_length: 200_000,
+                max_response_length: 8_192,
+                active_beta: None,
+            }
+        }
+    }
+
+    // ── ClaudeClient schema-routing helpers ───────────────────────────
+
+    /// Backends that don't advertise schema support take the
+    /// `send_request` branch in `send_with_optional_schema` regardless
+    /// of whether a schema was supplied at the call site.
+    #[tokio::test]
+    async fn send_with_optional_schema_without_caps_uses_plain_send() {
+        let inner = SchemaRecordingMockAiClient::new(false);
+        let plain_log = inner.recorded_plain.clone();
+        let opts_log = inner.recorded_options.clone();
+        let client = ClaudeClient::new(Box::new(inner));
+
+        let schema = serde_json::json!({"type": "object"});
+        client
+            .send_with_optional_schema(
+                "sys",
+                "usr",
+                client.schema_if_supported(&schema), // → None
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(plain_log.lock().unwrap().len(), 1);
+        assert!(opts_log.lock().unwrap().is_empty());
+    }
+
+    /// Backends that advertise schema support take the
+    /// `send_request_with_options` branch and receive the schema in the
+    /// options struct.
+    #[tokio::test]
+    async fn send_with_optional_schema_with_caps_uses_options_send() {
+        let inner = SchemaRecordingMockAiClient::new(true);
+        let plain_log = inner.recorded_plain.clone();
+        let opts_log = inner.recorded_options.clone();
+        let client = ClaudeClient::new(Box::new(inner));
+
+        let schema = serde_json::json!({"type": "object", "additionalProperties": false});
+        client
+            .send_with_optional_schema(
+                "sys",
+                "usr",
+                client.schema_if_supported(&schema), // → Some
+            )
+            .await
+            .unwrap();
+
+        let recorded = opts_log.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].response_schema.as_ref(), Some(&schema));
+        assert!(plain_log.lock().unwrap().is_empty());
+    }
+
+    /// `adjusted_system_prompt` only appends the JSON-schema override
+    /// suffix when the active backend supports schema enforcement.
+    #[test]
+    fn adjusted_system_prompt_adds_suffix_when_supported() {
+        let client = ClaudeClient::new(Box::new(SchemaRecordingMockAiClient::new(true)));
+        let result = client.adjusted_system_prompt("body".to_string());
+        assert!(result.starts_with("body"));
+        assert!(result.contains("STRUCTURED OUTPUT OVERRIDE"));
+    }
+
+    #[test]
+    fn adjusted_system_prompt_passes_through_when_not_supported() {
+        let client = ClaudeClient::new(Box::new(SchemaRecordingMockAiClient::new(false)));
+        let result = client.adjusted_system_prompt("body".to_string());
+        assert_eq!(result, "body");
+    }
+
+    #[test]
+    fn schema_if_supported_returns_some_when_supported() {
+        let client = ClaudeClient::new(Box::new(SchemaRecordingMockAiClient::new(true)));
+        let schema = serde_json::json!({"type": "object"});
+        let returned = client.schema_if_supported(&schema);
+        assert!(returned.is_some());
+        assert!(std::ptr::eq(
+            returned.unwrap() as *const _,
+            &schema as *const _
+        ));
+    }
+
+    #[test]
+    fn schema_if_supported_returns_none_when_not_supported() {
+        let client = ClaudeClient::new(Box::new(SchemaRecordingMockAiClient::new(false)));
+        let schema = serde_json::json!({"type": "object"});
+        assert!(client.schema_if_supported(&schema).is_none());
+    }
+
+    // ── refine_amendments_coherence / refine_checks_coherence ────────
+
+    /// Exercises the full body of `refine_amendments_coherence`:
+    /// adjusted_system_prompt → validate_prompt_budget → schema-aware
+    /// dispatch → parse_amendment_response. Uses a schema-supporting
+    /// mock so the schema attachment branch is taken too.
+    #[tokio::test]
+    async fn refine_amendments_coherence_round_trip() {
+        let mock = SchemaRecordingMockAiClient::with_response(
+            true, // supports_response_schema
+            "amendments: []".to_string(),
+        );
+        let recorded_opts = mock.recorded_options.clone();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let amendment = crate::data::amendments::Amendment {
+            commit: "abc123".to_string(),
+            message: "feat: do thing".to_string(),
+            summary: Some("did the thing".to_string()),
+        };
+        let items = vec![(amendment, "summary text".to_string())];
+
+        let result = client
+            .refine_amendments_coherence(&items)
+            .await
+            .expect("coherence refinement should succeed");
+        assert!(result.amendments.is_empty());
+
+        // Verify the schema-aware dispatch path was taken and that the
+        // attached schema is the AmendmentFile schema.
+        let recorded = recorded_opts.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        let attached = recorded[0]
+            .response_schema
+            .as_ref()
+            .expect("schema must be attached when capability is true");
+        assert_eq!(
+            attached,
+            response_schema::amendment_file_schema(),
+            "refine_amendments_coherence should attach the AmendmentFile schema"
+        );
+    }
+
+    /// Same coverage shape as the amendment variant, but for the check
+    /// coherence path. Uses `parse_check_response` which needs a
+    /// repository view to map commit hashes back to messages — we
+    /// supply an empty view.
+    #[tokio::test]
+    async fn refine_checks_coherence_round_trip() {
+        let mock = SchemaRecordingMockAiClient::with_response(
+            true, // supports_response_schema
+            "checks: []".to_string(),
+        );
+        let recorded_opts = mock.recorded_options.clone();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let check = crate::data::check::CommitCheckResult {
+            hash: "abc123".to_string(),
+            message: "feat: do thing".to_string(),
+            issues: Vec::new(),
+            suggestion: None,
+            passes: true,
+            summary: Some("summary".to_string()),
+        };
+        let items = vec![(check, "summary text".to_string())];
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo_view = make_test_repo_view(&dir);
+
+        let result = client
+            .refine_checks_coherence(&items, &repo_view)
+            .await
+            .expect("coherence refinement should succeed");
+        assert_eq!(result.summary.total_commits, 0);
+
+        let recorded = recorded_opts.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        let attached = recorded[0]
+            .response_schema
+            .as_ref()
+            .expect("schema must be attached when capability is true");
+        assert_eq!(
+            attached,
+            response_schema::check_response_schema(),
+            "refine_checks_coherence should attach the AiCheckResponse schema"
+        );
+    }
+
+    /// Verifies the no-schema branch of refine_amendments_coherence —
+    /// when the backend doesn't advertise schema support, dispatch
+    /// falls through to plain `send_request` and no schema is attached.
+    #[tokio::test]
+    async fn refine_amendments_coherence_without_schema_capability() {
+        let mock = SchemaRecordingMockAiClient::with_response(
+            false, // supports_response_schema
+            "amendments: []".to_string(),
+        );
+        let recorded_plain = mock.recorded_plain.clone();
+        let recorded_opts = mock.recorded_options.clone();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let amendment = crate::data::amendments::Amendment {
+            commit: "abc123".to_string(),
+            message: "feat: do thing".to_string(),
+            summary: None,
+        };
+        let items = vec![(amendment, "summary".to_string())];
+
+        client
+            .refine_amendments_coherence(&items)
+            .await
+            .expect("coherence refinement should succeed without schema support");
+
+        assert_eq!(recorded_plain.lock().unwrap().len(), 1);
+        assert!(
+            recorded_opts.lock().unwrap().is_empty(),
+            "no-schema backend must not be reached via the options path"
+        );
     }
 
     // ── extract_yaml_from_response ─────────────────────────────────

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -1,7 +1,116 @@
 //! Prompt templates and engineering for Claude API.
 
-use crate::claude::ai::PromptStyle;
+use crate::claude::ai::{PromptStyle, ResponseFormat};
 use crate::data::context::{CommitContext, VerbosityLevel, WorkPattern};
+
+/// Suffix appended to the system prompt when the response is constrained
+/// by a JSON Schema (i.e. [`ResponseFormat::JsonSchema`]).
+///
+/// Existing prompts ask the model to format the response as YAML in a
+/// fenced or bare block. When `claude -p --json-schema` is in play, the
+/// CLI re-prompts until the model produces a JSON object validating
+/// against the supplied schema. The original YAML instructions are then
+/// actively misleading: they cost a re-prompt as the model first emits
+/// YAML and the CLI rejects it.
+///
+/// This suffix overrides the format directive without rewriting the
+/// surrounding semantic content. It is intentionally placed at the end
+/// of the system prompt so its instructions are the most-recent (and
+/// thus most-attended-to) text for the model.
+pub const JSON_SCHEMA_RESPONSE_OVERRIDE: &str = "\n\n=== STRUCTURED OUTPUT OVERRIDE ===\n\
+DISREGARD any previous instructions to format your response as YAML or in a fenced \
+code block. Instead, return a single JSON object that exactly matches the JSON Schema \
+provided to the runtime via the --json-schema flag. \
+\n\nFormat rules:\
+\n- Return ONLY the JSON object — no preamble, no narration, no explanation, no fenced \
+code blocks around the response itself.\
+\n- The outer response must be a bare JSON object. Markdown values inside the JSON \
+(e.g. a `description` field) MAY contain fenced code blocks like ```rust ...``` — only \
+the outermost wrapping must be a bare object, not the string contents within it.\
+\n- All required fields must be present. Do not invent additional fields not in the schema.";
+
+/// Returns the system-prompt suffix to apply for the given response
+/// format, or `None` when no override is needed (YAML path).
+///
+/// Call sites append this to the end of their system prompt before
+/// dispatching, so the override always wins over earlier YAML
+/// formatting instructions when [`ResponseFormat::JsonSchema`] is in
+/// effect.
+#[must_use]
+pub fn response_format_system_suffix(format: ResponseFormat) -> Option<&'static str> {
+    match format {
+        ResponseFormat::Yaml => None,
+        ResponseFormat::JsonSchema => Some(JSON_SCHEMA_RESPONSE_OVERRIDE),
+    }
+}
+
+/// Appends [`response_format_system_suffix`] when needed.
+///
+/// Returns `prompt` with the suffix appended when the format is
+/// [`ResponseFormat::JsonSchema`]; otherwise returns `prompt`
+/// unchanged. Convenience for call sites that already have a system
+/// prompt string in hand.
+#[must_use]
+pub fn apply_response_format_to_system_prompt(prompt: String, format: ResponseFormat) -> String {
+    match response_format_system_suffix(format) {
+        Some(suffix) => format!("{prompt}{suffix}"),
+        None => prompt,
+    }
+}
+
+#[cfg(test)]
+mod response_format_tests {
+    use super::*;
+
+    #[test]
+    fn yaml_format_returns_no_suffix() {
+        assert!(response_format_system_suffix(ResponseFormat::Yaml).is_none());
+    }
+
+    #[test]
+    fn json_schema_format_returns_override_suffix() {
+        assert_eq!(
+            response_format_system_suffix(ResponseFormat::JsonSchema),
+            Some(JSON_SCHEMA_RESPONSE_OVERRIDE)
+        );
+    }
+
+    #[test]
+    fn apply_with_yaml_passes_prompt_through() {
+        let original = "system prompt body".to_string();
+        let result = apply_response_format_to_system_prompt(original.clone(), ResponseFormat::Yaml);
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn apply_with_json_schema_appends_override() {
+        let original = "system prompt body".to_string();
+        let result =
+            apply_response_format_to_system_prompt(original.clone(), ResponseFormat::JsonSchema);
+        assert!(result.starts_with(&original));
+        assert!(result.contains("STRUCTURED OUTPUT OVERRIDE"));
+        assert!(result.len() > original.len());
+    }
+
+    /// The override addendum must explicitly carve out the embedded-fence
+    /// case so PR descriptions containing rust/json/etc. fenced blocks
+    /// inside the response's string fields are not mangled.
+    #[test]
+    fn override_carves_out_embedded_fences() {
+        assert!(JSON_SCHEMA_RESPONSE_OVERRIDE.contains("Markdown values inside the JSON"));
+    }
+
+    /// Override must instruct the model to drop preamble/narration so a
+    /// stray "Here is the response:" line doesn't trigger a re-prompt.
+    #[test]
+    fn override_forbids_preamble() {
+        let lower = JSON_SCHEMA_RESPONSE_OVERRIDE.to_ascii_lowercase();
+        assert!(
+            lower.contains("no preamble") || lower.contains("only the json object"),
+            "override should forbid preamble: {JSON_SCHEMA_RESPONSE_OVERRIDE}"
+        );
+    }
+}
 
 /// Default commit guidelines embedded from markdown file at compile time.
 /// Used by both twiddle and check commands when no project-specific guidelines are provided.

--- a/src/claude/response_schema.rs
+++ b/src/claude/response_schema.rs
@@ -1,0 +1,186 @@
+//! Response-schema registry for structured AI calls.
+//!
+//! Schemas are derived once from Rust types via `schemars`, cached in a
+//! `OnceLock`, and handed out as `serde_json::Value` so call sites can
+//! pass them through `RequestOptions` without recomputing each call.
+//!
+//! Adding a new structured response type:
+//! 1. Derive `JsonSchema` on the response type with
+//!    `#[schemars(deny_unknown_fields)]` for strictness.
+//! 2. Add a constant identifier here and a getter that returns its
+//!    cached `serde_json::Value`.
+//! 3. The `tests::all_schemas_serialize` golden test will pick it up
+//!    automatically once it's listed in [`ALL_SCHEMAS`].
+
+use std::sync::OnceLock;
+
+use schemars::{schema_for, JsonSchema};
+use serde_json::Value;
+
+use crate::cli::git::PrContent;
+use crate::data::amendments::AmendmentFile;
+use crate::data::check::AiCheckResponse;
+
+/// Returns the cached JSON Schema for the AI response of a structured call.
+fn schema_value<T: JsonSchema>(slot: &'static OnceLock<Value>) -> &'static Value {
+    slot.get_or_init(|| {
+        // schema_for! returns a `schemars::Schema` whose `Serialize` impl
+        // produces the JSON Schema document. Routing through serde_json
+        // gives us a `Value` we can pass around without exposing schemars
+        // types in public APIs.
+        let schema = schema_for!(T);
+        serde_json::to_value(schema).unwrap_or(Value::Null)
+    })
+}
+
+/// JSON Schema for [`AmendmentFile`] responses (twiddle, check-with-suggestions).
+pub fn amendment_file_schema() -> &'static Value {
+    static SLOT: OnceLock<Value> = OnceLock::new();
+    schema_value::<AmendmentFile>(&SLOT)
+}
+
+/// JSON Schema for [`PrContent`] responses (PR title + description).
+pub fn pr_content_schema() -> &'static Value {
+    static SLOT: OnceLock<Value> = OnceLock::new();
+    schema_value::<PrContent>(&SLOT)
+}
+
+/// JSON Schema for [`AiCheckResponse`] responses (commit-check list).
+pub fn check_response_schema() -> &'static Value {
+    static SLOT: OnceLock<Value> = OnceLock::new();
+    schema_value::<AiCheckResponse>(&SLOT)
+}
+
+/// Cached-schema getter signature, used by the golden-coverage test.
+#[cfg(test)]
+type SchemaGetter = fn() -> &'static Value;
+
+/// Identifiers for golden snapshot coverage.
+#[cfg(test)]
+const ALL_SCHEMAS: &[(&str, SchemaGetter)] = &[
+    ("amendment_file", amendment_file_schema),
+    ("pr_content", pr_content_schema),
+    ("check_response", check_response_schema),
+];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Sanity-check that every schema serializes to a non-null object.
+    #[test]
+    fn all_schemas_are_non_null_objects() {
+        for (name, getter) in ALL_SCHEMAS {
+            let value = getter();
+            assert!(
+                value.is_object(),
+                "{name} schema should serialize to an object: {value}"
+            );
+        }
+    }
+
+    /// Cached getters return pointer-equal values across calls.
+    #[test]
+    fn schemas_are_cached() {
+        let amendment_first = amendment_file_schema();
+        let amendment_second = amendment_file_schema();
+        assert!(
+            std::ptr::eq(amendment_first, amendment_second),
+            "amendment_file_schema should return the same OnceLock value"
+        );
+
+        let pr_first = pr_content_schema();
+        let pr_second = pr_content_schema();
+        assert!(
+            std::ptr::eq(pr_first, pr_second),
+            "pr_content_schema should return the same OnceLock value"
+        );
+
+        let check_first = check_response_schema();
+        let check_second = check_response_schema();
+        assert!(
+            std::ptr::eq(check_first, check_second),
+            "check_response_schema should return the same OnceLock value"
+        );
+    }
+
+    /// Strict-mode invariant: every nested object enforces
+    /// `additionalProperties: false`.
+    #[test]
+    fn schemas_enforce_strict_objects() {
+        for (name, getter) in ALL_SCHEMAS {
+            let value = getter();
+            assert_strict_objects(value, name);
+        }
+    }
+
+    /// Walks the schema and asserts every object subschema either has
+    /// `additionalProperties: false` or is a wildcard reference. Object
+    /// types are detected by the presence of a `properties` map.
+    fn assert_strict_objects(value: &Value, name: &str) {
+        if let Some(map) = value.as_object() {
+            if map.contains_key("properties") {
+                let strict = map
+                    .get("additionalProperties")
+                    .and_then(Value::as_bool)
+                    .is_some_and(|b| !b);
+                assert!(
+                    strict,
+                    "{name}: object subschema missing `additionalProperties: false`: {value}"
+                );
+            }
+            for (_, child) in map {
+                assert_strict_objects(child, name);
+            }
+        } else if let Some(arr) = value.as_array() {
+            for item in arr {
+                assert_strict_objects(item, name);
+            }
+        }
+    }
+
+    /// PrContent must require both fields.
+    #[test]
+    fn pr_content_requires_title_and_description() {
+        let value = pr_content_schema();
+        let required = value
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("pr_content schema should have a `required` array");
+        let names: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
+        assert!(
+            names.contains(&"title"),
+            "missing title in required: {names:?}"
+        );
+        assert!(
+            names.contains(&"description"),
+            "missing description in required: {names:?}"
+        );
+    }
+
+    /// AmendmentFile must require `amendments`; nested `Amendment`
+    /// must require `commit` and `message` (not `summary`).
+    #[test]
+    fn amendment_file_required_fields() {
+        let value = amendment_file_schema();
+        let required = value
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("amendment_file schema should have a `required` array");
+        let names: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
+        assert_eq!(names, vec!["amendments"]);
+    }
+
+    /// CheckResponse exposes a `checks` array.
+    #[test]
+    fn check_response_required_fields() {
+        let value = check_response_schema();
+        let required = value
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("check_response schema should have a `required` array");
+        let names: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
+        assert_eq!(names, vec!["checks"]);
+    }
+}

--- a/src/claude/test_utils.rs
+++ b/src/claude/test_utils.rs
@@ -135,3 +135,42 @@ impl AiClient for ConfigurableMockAiClient {
         self.metadata.clone()
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::claude::ai::RequestOptions;
+
+    /// MockAiClient must default to ''no schema support'' so existing
+    /// tests don't have to care about the new schema plumbing.
+    #[test]
+    fn mock_client_defaults_to_no_schema_support() {
+        let client = ConfigurableMockAiClient::new(vec![]);
+        let caps = client.capabilities();
+        assert!(
+            !caps.supports_response_schema,
+            "mock client should default to no schema support so tests don't have to care"
+        );
+    }
+
+    /// `send_request_with_options` falls through to `send_request` by
+    /// default — verify the mock observes the call.
+    #[tokio::test]
+    async fn mock_client_send_with_options_falls_through_to_send_request() {
+        let client = ConfigurableMockAiClient::new(vec![Ok("hello".to_string())]);
+        let prompt_handle = client.prompt_handle();
+
+        let result = client
+            .send_request_with_options("sys", "user", RequestOptions::default())
+            .await
+            .expect("default send_request_with_options should succeed");
+        assert_eq!(result, "hello");
+
+        // The default impl forwards to send_request, so the prompt is recorded
+        // exactly once.
+        let prompts = prompt_handle.prompts();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0], ("sys".to_string(), "user".to_string()));
+    }
+}

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -51,7 +51,8 @@ enum PrAction {
 }
 
 /// AI-generated PR content with structured fields.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct PrContent {
     /// Concise PR title (ideally 50-80 characters).
     pub title: String,

--- a/src/data/amendments.rs
+++ b/src/data/amendments.rs
@@ -4,17 +4,20 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Amendment file structure.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct AmendmentFile {
     /// List of commit amendments to apply.
     pub amendments: Vec<Amendment>,
 }
 
 /// Individual commit amendment.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct Amendment {
     /// Full 40-character SHA-1 commit hash.
     pub commit: String,

--- a/src/data/check.rs
+++ b/src/data/check.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Complete check report containing all commit analysis results.
@@ -55,7 +56,7 @@ pub struct CommitSuggestion {
 }
 
 /// Severity level for issues.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum IssueSeverity {
     /// Errors block CI (exit code 1).
@@ -218,14 +219,16 @@ impl fmt::Display for OutputFormat {
 }
 
 /// AI response structure for parsing check results.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct AiCheckResponse {
     /// List of commit checks.
     pub checks: Vec<AiCommitCheck>,
 }
 
 /// Single commit check from AI response.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct AiCommitCheck {
     /// Commit hash (short or full).
     pub commit: String,
@@ -235,7 +238,7 @@ pub struct AiCommitCheck {
     #[serde(default)]
     pub issues: Vec<AiIssue>,
     /// Suggested message improvement.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<AiSuggestion>,
     /// Brief summary of what this commit changes (for cross-commit coherence).
     #[serde(default)]
@@ -243,7 +246,8 @@ pub struct AiCommitCheck {
 }
 
 /// Issue from AI response.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct AiIssue {
     /// Reasoning written before the verdict. Forces think-first ordering so
     /// `severity` is conditioned on fully-worked-through reasoning instead of
@@ -262,7 +266,8 @@ pub struct AiIssue {
 }
 
 /// Suggestion from AI response.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct AiSuggestion {
     /// Suggested message.
     pub message: String,


### PR DESCRIPTION
## Description

This PR implements capability-gated JSON Schema enforcement for AI responses in the `claude-cli` backend. When the active backend supports it, the system now passes a `--json-schema <file>` argument to the `claude -p` subprocess, which causes the CLI to re-prompt the model until it produces a structurally valid JSON response. This eliminates reliance on YAML parsing heuristics and post-hoc fenced-block stripping for backends that support structured output enforcement.

The design is backward-compatible: existing backends (Bedrock, Anthropic direct API, OpenAI/Ollama) continue to use the YAML path unchanged, while `ClaudeCliAiClient` opts in by advertising `supports_response_schema = true` via the new `capabilities()` method.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [x] Dependency update

## Related Issue
Fixes #632

## Changes Made

**AiClient Trait Extensions (`src/claude/ai.rs`):**
- Added `AiClientCapabilities` struct with `supports_response_schema: bool` field, defaulting to `false` for backward compatibility
- Added `ResponseFormat` enum (`Yaml` | `JsonSchema`) with `from_capabilities()` constructor
- Added `RequestOptions` struct with `response_schema: Option<serde_json::Value>` and builder method `with_response_schema()`
- Added `capabilities()` method to `AiClient` trait with default returning all-disabled baseline
- Added `send_request_with_options()` method to `AiClient` trait with default falling back to `send_request()`

**ClaudeCliAiClient Implementation (`src/claude/ai/claude_cli.rs`):**
- Implemented `capabilities()` returning `supports_response_schema: true`
- Implemented `send_request_with_options()` dispatching to new `run_with_options()` internal method
- Added `build_command_with_schema()` variant that appends `--json-schema <path>` to subprocess argv when a schema path is provided (passing via file rather than inline argv to avoid length limits)
- Added `run_with_options()` which serializes `options.response_schema` to `response_schema.json` inside the subprocess temp dir and calls `build_command_with_schema()`
- Refactored `build_command()` to `#[cfg(test)]` only, delegating to `build_command_with_schema(..None)`

**Response Schema Registry (`src/claude/response_schema.rs` — new file):**
- Added `schema_value<T: JsonSchema>()` generic helper that populates a `OnceLock<Value>` on first call
- Added `amendment_file_schema()`, `pr_content_schema()`, and `check_response_schema()` getters returning cached `&'static serde_json::Value`
- Schemas are derived via `schemars::schema_for!` and serialized to `serde_json::Value` once at runtime

**ClaudeClient Helpers (`src/claude/client.rs`):**
- Added `adjusted_system_prompt()`: appends `JSON_SCHEMA_RESPONSE_OVERRIDE` suffix when backend supports schema enforcement, passes prompt through unchanged otherwise
- Added `schema_if_supported()`: returns `Some(&schema)` when backend advertises schema support, `None` otherwise
- Added `send_with_optional_schema()`: dispatches via `send_request_with_options` with schema when `Some`, falls back to plain `send_request` when `None`
- Updated all AI dispatch call sites (amendment generation, amendment merging, check generation, check merging, PR generation, PR merging, coherence passes) to use `send_with_optional_schema()` and `adjusted_system_prompt()`

**Prompt Override (`src/claude/prompts.rs`):**
- Added `JSON_SCHEMA_RESPONSE_OVERRIDE` constant: a system-prompt suffix that explicitly overrides YAML formatting instructions and directs the model to emit a bare JSON object matching the schema, while carving out an exception for embedded Markdown fenced blocks within string values (e.g. PR descriptions)
- Added `response_format_system_suffix()` and `apply_response_format_to_system_prompt()` helpers

**Structured Type Annotations (`src/data/amendments.rs`, `src/data/check.rs`, `src/cli/git/create_pr.rs`):**
- Derived `JsonSchema` with `#[schemars(deny_unknown_fields)]` on: `AmendmentFile`, `Amendment`, `PrContent`, `AiCheckResponse`, `AiCommitCheck`, `AiIssue`, `AiSuggestion`, `IssueSeverity`
- Added `Serialize` to `AiCheckResponse`, `AiCommitCheck`, `AiIssue`, `AiSuggestion` (previously `Deserialize`-only)
- Added `#[serde(default)]` to `AiCommitCheck::suggestion` for schema compatibility

**Dependency (`Cargo.toml`):**
- Promoted `schemars = "1.2"` from `optional` (mcp feature) to unconditional dependency
- Removed `schemars` from the `mcp` feature gate (it is now always present)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**New unit tests added:**
- `src/claude/ai.rs`: `capabilities_default_is_all_disabled`, `response_format_default_is_yaml`, `response_format_from_capabilities_disabled_picks_yaml`, `response_format_from_capabilities_enabled_picks_json_schema`, `request_options_with_response_schema_sets_field`, `request_options_default_has_no_schema`
- `src/claude/ai/bedrock.rs`: `capabilities_default_to_no_schema_support`
- `src/claude/ai/claude.rs`: `capabilities_default_to_no_schema_support`
- `src/claude/ai/openai.rs`: `capabilities_default_to_no_schema_support_openai`, `capabilities_default_to_no_schema_support_ollama`
- `src/claude/ai/claude_cli.rs`: `capabilities_advertise_response_schema_support`, `build_command_omits_json_schema_when_no_path_given`, `build_command_includes_json_schema_when_path_given`, `run_with_options_writes_schema_and_succeeds` (async/unix), `send_request_with_options_default_acts_like_send_request` (async/unix)
- `src/claude/client.rs`: `send_with_optional_schema_without_caps_uses_plain_send`, `send_with_optional_schema_with_caps_uses_options_send`, `adjusted_system_prompt_adds_suffix_when_supported`, `adjusted_system_prompt_passes_through_when_not_supported`, `schema_if_supported_returns_some_when_supported`, `schema_if_supported_returns_none_when_not_supported`
- `src/claude/prompts.rs`: `yaml_format_returns_no_suffix`, `json_schema_format_returns_override_suffix`, `apply_with_yaml_passes_prompt_through`, `apply_with_json_schema_appends_override`, `override_carves_out_embedded_fences`, `override_forbids_preamble`
- `src/claude/response_schema.rs`: `all_schemas_are_non_null_objects`, `schemas_are_cached`, `schemas_enforce_strict_objects`, `pr_content_requires_title_and_description`, `amendment_file_required_fields`, `check_response_required_fields`
- `src/claude/test_utils.rs`: `mock_client_defaults_to_no_schema_support`, `mock_client_send_with_options_falls_through_to_send_request`

### Test Commands
```bash
# Core test suite
cargo test

# Schema-specific tests
cargo test response_schema
cargo test capabilities
cargo test send_with_optional_schema

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
cargo build
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — new capability-negotiation layer on `AiClient` trait; ensure the default impls remain source-compatible for all existing backends
- [x] Error handling — schema serialization and temp-file write in `run_with_options` use `.context()` for clean error messages; verify error propagation
- [x] Backward compatibility — all backends that don't override `capabilities()` continue to use the YAML path unchanged; `send_request_with_options` default falls through to `send_request`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Potential performance impact (describe below)

Schema values are computed once via `OnceLock` and cached for the process lifetime, so there is no per-call overhead beyond a pointer dereference after the first call. The schema JSON file written to the subprocess temp dir adds one async `fs::write` per structured AI call when using `claude-cli`; the file is cleaned up automatically when the `TempDir` drops at end of `run_with_options`.

## Security Considerations
- [x] No security implications

Schema content is derived from compiled Rust types via `schemars` and never includes user-supplied data. The schema file is written to a `tempfile::TempDir` and not exposed outside the subprocess.

## Breaking Changes

None. The `AiClient` trait gains two new methods (`capabilities` and `send_request_with_options`) with default implementations, so all existing implementors remain source-compatible without any changes. The `schemars` crate moves from optional to unconditional, which may slightly increase compile time for projects that previously only used non-mcp features.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Extend `AiClientCapabilities` and `ResponseFormat` when Bedrock or OpenAI backends gain their own structured-output enforcement APIs
- Consider adding a `strict` flag to `RequestOptions` for backends that support strict schema validation (e.g. OpenAI structured outputs)

**Known Limitations:**
- The `--json-schema` flag is specific to the `claude` CLI tool; other backends use the YAML parse path until their respective APIs are wired up
- The schema file path passed to `--json-schema` must be accessible from the subprocess working directory; this is guaranteed by writing it into the same `TempDir` used as `cwd`

**Alternatives Considered:**
- Inline schema in argv: rejected due to argv length limits and shell-escape complexity; file path approach is more robust
- Storing schemas as static JSON strings: rejected in favour of deriving from Rust types via `schemars` to keep the schema in sync with the actual response structs at compile time