### PR TITLE
feat(mcp): add omni-dev://specs resource for embedded JFM reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,6 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit",
-        "if": "Edit(*.rs)|Write(*.rs)|MultiEdit(*.rs)",
         "hooks": [
           {
             "type": "command",
@@ -13,6 +12,11 @@
           }
         ]
       }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(target/debug/deps/omni_dev-a18167d0c04a86e3 --list)"
     ]
   }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -18,6 +18,7 @@ pub mod output_file;
 pub mod resources;
 pub mod runtime;
 pub mod server;
+pub mod specs;
 pub mod truncate;
 pub mod validate;
 

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -71,6 +71,11 @@ pub struct ConfluenceCreateParams {
     /// Page title.
     pub title: String,
     /// Page body. Parsed according to `format`.
+    ///
+    /// For `format = "jfm"` (the default), this is GitHub-style markdown,
+    /// NOT Confluence wiki markup. Use `##` not `h2.`, triple-backtick fences
+    /// not `{code}`, backtick inline code not `{{...}}`. Full reference:
+    /// MCP resource `omni-dev://specs/jfm`.
     pub content: String,
     /// Optional parent page ID for nesting under an existing page.
     #[serde(default)]
@@ -86,6 +91,11 @@ pub struct ConfluenceWriteParams {
     /// Confluence page ID.
     pub id: String,
     /// New page body.
+    ///
+    /// For `format = "jfm"` (the default), this is GitHub-style markdown,
+    /// NOT Confluence wiki markup. Use `##` not `h2.`, triple-backtick fences
+    /// not `{code}`, backtick inline code not `{{...}}`. Full reference:
+    /// MCP resource `omni-dev://specs/jfm`.
     pub content: String,
     /// Format of `content`: `"jfm"` (default markdown) or `"adf"` (raw ADF JSON).
     #[serde(default)]

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -64,7 +64,10 @@ pub struct JiraCreateParams {
     pub project: String,
     /// Issue summary / title.
     pub summary: String,
-    /// Optional description in JFM markdown.
+    /// Optional description in JFM markdown — see resource
+    /// `omni-dev://specs/jfm` for syntax. JFM is GitHub-style markdown,
+    /// NOT JIRA wiki markup (use `##` not `h2.`, triple-backtick fences not
+    /// `{code}`, backtick inline code not `{{...}}`).
     #[serde(default)]
     pub description: Option<String>,
     /// Issue type (defaults to `Task`).
@@ -78,6 +81,11 @@ pub struct JiraWriteParams {
     /// JIRA issue key (e.g., `PROJ-123`).
     pub key: String,
     /// New description body. Interpreted per `format`.
+    ///
+    /// For `format = "jfm"` (the default), this is GitHub-style markdown,
+    /// NOT JIRA wiki markup. Use `##` not `h2.`, triple-backtick fences not
+    /// `{code}`, backtick inline code not `{{...}}`. Full reference:
+    /// MCP resource `omni-dev://specs/jfm`.
     pub content: String,
     /// Content format — `jfm` (default) parses Markdown/JFM; `adf` accepts
     /// a raw ADF JSON document.
@@ -109,7 +117,8 @@ pub struct JiraCommentParams {
     pub key: String,
     /// `list` to fetch comments; `add` to post a new one.
     pub action: String,
-    /// Comment body (JFM markdown). Required for `action = "add"`.
+    /// Comment body (JFM markdown — see resource `omni-dev://specs/jfm`).
+    /// Required for `action = "add"`.
     #[serde(default)]
     pub body: Option<String>,
     /// Maximum number of comments to return. `0` means unlimited.
@@ -505,7 +514,8 @@ impl OmniDevServer {
 
     /// Tool: update a JIRA issue's description.
     #[tool(
-        description = "Update the description of a JIRA issue from JFM markdown (default) or raw ADF JSON."
+        description = "Update the description of a JIRA issue from JFM markdown (default) or raw ADF JSON. \
+                       JFM is GitHub-style markdown — see resource `omni-dev://specs/jfm` for syntax."
     )]
     pub async fn jira_write(
         &self,

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -20,6 +20,7 @@ use crate::atlassian::confluence_api::ConfluenceApi;
 use crate::atlassian::document::content_item_to_document;
 use crate::atlassian::jira_api::JiraApi;
 use crate::cli::atlassian::helpers::create_client;
+use crate::mcp::specs;
 
 /// Format suffix for a resource URI.
 ///
@@ -56,13 +57,20 @@ pub enum ResourceUri {
         /// Output format: JFM or ADF JSON.
         format: ResourceFormat,
     },
+    /// `omni-dev://specs/{name}` — embedded reference spec (e.g. `jfm`).
+    Specs {
+        /// Spec identifier — see [`specs::lookup`] for the registered set.
+        name: String,
+    },
 }
 
 /// Errors returned by the URI parser.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum UriParseError {
     /// The URI scheme is not one omni-dev knows about.
-    #[error("unknown URI scheme in `{0}`; expected git://, jira://, or confluence://")]
+    #[error(
+        "unknown URI scheme in `{0}`; expected git://, jira://, confluence://, or omni-dev://"
+    )]
     UnknownScheme(String),
     /// The URI authority/path shape does not match any known template.
     #[error("malformed URI `{0}`: {1}")]
@@ -108,6 +116,15 @@ impl ResourceUri {
             });
         }
 
+        if let Some(rest) = uri.strip_prefix("omni-dev://specs/") {
+            if rest.is_empty() {
+                return Err(UriParseError::EmptyIdentifier(uri.to_string()));
+            }
+            return Ok(Self::Specs {
+                name: rest.to_string(),
+            });
+        }
+
         // Reject `<scheme>://` URIs with a different path shape explicitly
         // rather than falling through to UnknownScheme, so the client sees
         // what's actually wrong. Placeholders are escaped for the lint.
@@ -127,6 +144,12 @@ impl ResourceUri {
             return Err(UriParseError::Malformed(
                 uri.to_string(),
                 "expected `confluence://page/<id>` or `confluence://page/<id>.adf`",
+            ));
+        }
+        if uri.starts_with("omni-dev://") {
+            return Err(UriParseError::Malformed(
+                uri.to_string(),
+                "expected `omni-dev://specs/<name>`",
             ));
         }
 
@@ -172,12 +195,21 @@ pub fn resource_templates() -> Vec<ResourceTemplate> {
             .with_description("Confluence page body as raw ADF JSON.")
             .with_mime_type("application/json");
 
+    let omni_dev_spec = RawResourceTemplate::new("omni-dev://specs/{name}", "omni_dev_spec")
+        .with_description(
+            "Reference specs maintained by omni-dev. Currently supports `jfm` \
+             (JIRA-Flavoured Markdown) — fetch before writing JIRA or Confluence \
+             content via `jira_write`, `jira_create`, or `confluence_write`.",
+        )
+        .with_mime_type("text/markdown");
+
     vec![
         annotate_template(git_commits),
         annotate_template(jira_issue_jfm),
         annotate_template(jira_issue_adf),
         annotate_template(confluence_page_jfm),
         annotate_template(confluence_page_adf),
+        annotate_template(omni_dev_spec),
     ]
 }
 
@@ -263,6 +295,19 @@ pub async fn read_resource(uri: &ResourceUri, raw_uri: &str) -> Result<ReadResou
             let (text, mime) = render_content_item(&item, &instance_url, *format)?;
             Ok(ReadResourceResult::new(vec![ResourceContents::text(
                 text, raw_uri,
+            )
+            .with_mime_type(mime)]))
+        }
+        ResourceUri::Specs { name } => {
+            let (text, mime) = specs::lookup(name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown spec `{name}`; known: {known}",
+                    known = specs::KNOWN_SPECS,
+                )
+            })?;
+            Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                text.to_string(),
+                raw_uri,
             )
             .with_mime_type(mime)]))
         }
@@ -411,6 +456,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_omni_dev_spec_jfm() {
+        let uri = ResourceUri::parse("omni-dev://specs/jfm").unwrap();
+        assert_eq!(
+            uri,
+            ResourceUri::Specs {
+                name: "jfm".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_omni_dev_spec_empty_name_is_empty_identifier() {
+        let err = ResourceUri::parse("omni-dev://specs/").unwrap_err();
+        assert!(matches!(err, UriParseError::EmptyIdentifier(_)));
+    }
+
+    #[test]
+    fn parse_omni_dev_wrong_path_is_malformed() {
+        let err = ResourceUri::parse("omni-dev://other/x").unwrap_err();
+        assert!(matches!(err, UriParseError::Malformed(_, _)));
+    }
+
+    #[test]
     fn parse_unknown_scheme_is_rejected() {
         let err = ResourceUri::parse("http://example.com/resource").unwrap_err();
         assert!(matches!(err, UriParseError::UnknownScheme(_)));
@@ -481,7 +549,7 @@ mod tests {
     // ── Templates / listings ───────────────────────────────────────
 
     #[test]
-    fn templates_include_all_five_uris() {
+    fn templates_include_all_known_uris() {
         let templates = resource_templates();
         let template_uris: Vec<&str> = templates
             .iter()
@@ -492,6 +560,7 @@ mod tests {
         assert!(template_uris.contains(&"jira://issue/{key}.adf"));
         assert!(template_uris.contains(&"confluence://page/{id}"));
         assert!(template_uris.contains(&"confluence://page/{id}.adf"));
+        assert!(template_uris.contains(&"omni-dev://specs/{name}"));
     }
 
     #[test]
@@ -525,14 +594,14 @@ mod tests {
     fn list_resources_result_has_no_pagination() {
         let result = list_resources_result();
         assert!(result.next_cursor.is_none());
-        assert_eq!(result.resources.len(), 5);
+        assert_eq!(result.resources.len(), 6);
     }
 
     #[test]
     fn list_resource_templates_result_has_no_pagination() {
         let result = list_resource_templates_result();
         assert!(result.next_cursor.is_none());
-        assert_eq!(result.resource_templates.len(), 5);
+        assert_eq!(result.resource_templates.len(), 6);
     }
 
     // ── not_found ──────────────────────────────────────────────────
@@ -1059,5 +1128,47 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
         assert_ne!(a, ResourceFormat::Jfm);
+    }
+
+    // ── Specs branch of read_resource ──────────────────────────────────
+    //
+    // No credentials, no network — the spec is embedded at compile time.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_resource_specs_jfm_returns_markdown() {
+        let uri = ResourceUri::parse("omni-dev://specs/jfm").unwrap();
+        let result = read_resource(&uri, "omni-dev://specs/jfm").await.unwrap();
+        assert_eq!(result.contents.len(), 1);
+        match &result.contents[0] {
+            ResourceContents::TextResourceContents {
+                text,
+                mime_type,
+                uri: reply_uri,
+                ..
+            } => {
+                assert_eq!(mime_type.as_deref(), Some("text/markdown"));
+                assert_eq!(reply_uri, "omni-dev://specs/jfm");
+                assert!(
+                    text.contains("# JFM (JIRA-Flavored Markdown) Specification"),
+                    "spec body missing heading"
+                );
+            }
+            other @ ResourceContents::BlobResourceContents { .. } => {
+                panic!("expected text resource contents, got {other:?}")
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_resource_specs_unknown_name_errors() {
+        let uri = ResourceUri::parse("omni-dev://specs/nope").unwrap();
+        let err = read_resource(&uri, "omni-dev://specs/nope")
+            .await
+            .expect_err("unknown spec must error");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("unknown spec") && chain.contains("nope"),
+            "unexpected chain: {chain}"
+        );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -62,7 +62,10 @@ impl ServerHandler for OmniDevServer {
         .with_instructions(
             "omni-dev MCP server. Provides tools for git analysis, commit \
              improvement, and Atlassian integration. Resources expose \
-             URI-addressable content via `git://`, `jira://`, and `confluence://`.",
+             URI-addressable content via `git://`, `jira://`, `confluence://`, \
+             and `omni-dev://` (e.g. `omni-dev://specs/jfm` for the \
+             JIRA-Flavoured Markdown reference — fetch before writing JIRA or \
+             Confluence content).",
         )
     }
 

--- a/src/mcp/specs.rs
+++ b/src/mcp/specs.rs
@@ -1,0 +1,61 @@
+//! Reference specifications exposed as MCP resources at
+//! `omni-dev://specs/{name}`.
+//!
+//! The spec text is embedded into the binary at compile time so installed
+//! builds (`cargo install omni-dev`) can serve it without reading from disk.
+//! Each spec is the same file humans browse on GitHub, so the resource and
+//! the human-readable docs cannot drift.
+
+/// JFM (JIRA-Flavoured Markdown) specification, embedded from
+/// `docs/specs/jfm.md`.
+pub const SPEC_JFM: &str = include_str!("../../docs/specs/jfm.md");
+
+/// Looks up a spec by name.
+///
+/// Returns `(content, mime_type)` for known specs. Unknown names return
+/// `None`; the caller is expected to surface that as `resource_not_found`.
+pub fn lookup(name: &str) -> Option<(&'static str, &'static str)> {
+    match name {
+        "jfm" => Some((SPEC_JFM, "text/markdown")),
+        _ => None,
+    }
+}
+
+/// Comma-separated list of known spec names, for error messages.
+pub const KNOWN_SPECS: &str = "jfm";
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jfm_spec_is_embedded_and_non_empty() {
+        assert!(!SPEC_JFM.is_empty());
+        // Guard against the file moving or being emptied: the heading is
+        // load-bearing for clients that match on it.
+        assert!(
+            SPEC_JFM.contains("# JFM (JIRA-Flavored Markdown) Specification"),
+            "JFM spec missing expected heading"
+        );
+    }
+
+    #[test]
+    fn lookup_jfm_returns_markdown() {
+        let (content, mime) = lookup("jfm").expect("jfm spec must be registered");
+        assert_eq!(mime, "text/markdown");
+        assert!(content.contains("JFM"));
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(lookup("bogus").is_none());
+        assert!(lookup("").is_none());
+        assert!(lookup("JFM").is_none(), "lookup is case-sensitive");
+    }
+
+    #[test]
+    fn known_specs_lists_jfm() {
+        assert!(KNOWN_SPECS.contains("jfm"));
+    }
+}

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1516,7 +1516,7 @@ async fn git_view_commits_default_range_is_head() -> Result<()> {
 static CWD_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[tokio::test]
-async fn list_resources_returns_all_five_uri_templates() -> Result<()> {
+async fn list_resources_returns_all_uri_templates() -> Result<()> {
     let (client, server_handle) = spawn_server().await;
     let listing = client.list_resources(Option::default()).await?;
     let uris: Vec<&str> = listing.resources.iter().map(|r| r.uri.as_str()).collect();
@@ -1528,6 +1528,7 @@ async fn list_resources_returns_all_five_uri_templates() -> Result<()> {
     assert!(uris.contains(&"jira://issue/{key}.adf"));
     assert!(uris.contains(&"confluence://page/{id}"));
     assert!(uris.contains(&"confluence://page/{id}.adf"));
+    assert!(uris.contains(&"omni-dev://specs/{name}"));
     client.cancel().await?;
     let _ = server_handle.await;
     Ok(())
@@ -1537,7 +1538,7 @@ async fn list_resources_returns_all_five_uri_templates() -> Result<()> {
 async fn list_resource_templates_returns_descriptions() -> Result<()> {
     let (client, server_handle) = spawn_server().await;
     let listing = client.list_resource_templates(Option::default()).await?;
-    assert_eq!(listing.resource_templates.len(), 5);
+    assert_eq!(listing.resource_templates.len(), 6);
     for tpl in &listing.resource_templates {
         assert!(
             tpl.description.is_some(),
@@ -1633,6 +1634,53 @@ async fn read_resource_malformed_git_uri_is_resource_not_found() -> Result<()> {
     let rendered = err.to_string();
     assert!(
         rendered.contains("git://repo/bogus-path"),
+        "missing uri in err: {rendered}"
+    );
+    client.cancel().await?;
+    let _ = server_handle.await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn read_resource_omni_dev_specs_jfm_returns_markdown() -> Result<()> {
+    let (client, server_handle) = spawn_server().await;
+    let result = client
+        .read_resource(ReadResourceRequestParams::new("omni-dev://specs/jfm"))
+        .await?;
+    assert_eq!(result.contents.len(), 1);
+    match &result.contents[0] {
+        ResourceContents::TextResourceContents {
+            text,
+            mime_type,
+            uri,
+            ..
+        } => {
+            assert_eq!(mime_type.as_deref(), Some("text/markdown"));
+            assert_eq!(uri, "omni-dev://specs/jfm");
+            assert!(
+                text.contains("# JFM (JIRA-Flavored Markdown) Specification"),
+                "spec body missing heading"
+            );
+        }
+        other @ ResourceContents::BlobResourceContents { .. } => {
+            panic!("expected text resource, got {other:?}")
+        }
+    }
+    client.cancel().await?;
+    let _ = server_handle.await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn read_resource_omni_dev_specs_unknown_name_errors() -> Result<()> {
+    let (client, server_handle) = spawn_server().await;
+    let err = client
+        .read_resource(ReadResourceRequestParams::new("omni-dev://specs/bogus"))
+        .await
+        .expect_err("unknown spec should error");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("omni-dev://specs/bogus"),
         "missing uri in err: {rendered}"
     );
     client.cancel().await?;


### PR DESCRIPTION
## Description

This PR introduces a new `omni-dev://specs/{name}` MCP resource URI scheme that serves reference specifications embedded directly into the binary at compile time. The initial spec is the JFM (JIRA-Flavoured Markdown) reference, embedded from `docs/specs/jfm.md`.

The motivation is twofold: installed builds (`cargo install omni-dev`) can serve the spec without needing access to the source tree, and the resource content cannot drift from the human-readable documentation since both reference the same source file via `include_str!`.

AI clients using the MCP server are now guided — via updated tool descriptions, doc comments, and server instructions — to fetch `omni-dev://specs/jfm` before writing JIRA or Confluence content, reducing formatting errors caused by confusion between JFM and native JIRA/Confluence wiki markup.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #672

## Changes Made

**Core Changes:**
- Added `src/mcp/specs.rs` with `lookup(name)` function returning `(content, mime_type)` and `SPEC_JFM` compile-time constant embedded via `include_str!("../../docs/specs/jfm.md")`
- Added `ResourceUri::Specs { name }` variant to `src/mcp/resources.rs` with `omni-dev://specs/` parsing logic, including `EmptyIdentifier` and `Malformed` error handling
- Registered `omni-dev://specs/{name}` resource template in `resource_templates()` with description guiding AI clients to fetch before writing JIRA or Confluence content
- Implemented `ResourceUri::Specs` branch in `read_resource()` that dispatches to `specs::lookup` and returns an error mentioning known specs when the name is unrecognised
- Exposed `pub mod specs` in `src/mcp.rs`
- Updated server instructions in `src/mcp/server.rs` to mention the `omni-dev://` URI scheme and recommend fetching `omni-dev://specs/jfm` before writing content

**Documentation / API Guidance:**
- Added doc comments to `content` fields in `ConfluenceCreateParams`, `ConfluenceWriteParams`, `JiraWriteParams`, and `JiraCreateParams` (in `src/mcp/confluence_tools.rs` and `src/mcp/jira_core_tools.rs`) clarifying JFM syntax and referencing the spec resource
- Updated `body` doc comment in `JiraCommentParams` to reference `omni-dev://specs/jfm`
- Updated `jira_write` tool description to mention JFM and the spec resource

**Testing:**
- Added unit tests in `src/mcp/specs.rs`: spec is embedded and non-empty, `lookup("jfm")` returns markdown, unknown names return `None`, case-sensitivity verified
- Added unit tests in `src/mcp/resources.rs`: URI parsing for `omni-dev://specs/jfm`, empty name yields `EmptyIdentifier`, wrong path yields `Malformed`, `read_resource` dispatches correctly for both the happy path and an unknown spec name
- Updated `templates_include_all_known_uris` and `list_resources_result_has_no_pagination` / `list_resource_templates_result_has_no_pagination` unit tests to account for the new sixth resource
- Added integration tests in `tests/mcp_integration_test.rs`: `read_resource_omni_dev_specs_jfm_returns_markdown` and `read_resource_omni_dev_specs_unknown_name_errors`
- Updated `list_resources_returns_all_uri_templates` and `list_resource_templates_returns_descriptions` integration tests to assert on the new template and count

**Tooling:**
- Updated `.claude/settings.json`: removed redundant `if` condition on the Edit/Write/MultiEdit hook and added a `permissions.allow` entry for listing test binaries

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`src/mcp/specs.rs` unit tests)
- [x] Integration tests updated/added (`tests/mcp_integration_test.rs`)
- [ ] Performance tests (not applicable — spec is a compile-time constant)

**Manual Testing:**
- [x] Tested happy path: fetching `omni-dev://specs/jfm` via MCP client returns markdown with correct mime type and expected heading
- [x] Tested error/edge cases: unknown spec name returns an error containing the URI and the word "unknown spec"
- [x] Backward compatibility verified: existing git, jira, and confluence resource URIs are unaffected

### Test Commands

```bash
# Core test suite (includes all unit and integration tests)
cargo test

# Run only specs-related unit tests
cargo test --lib mcp::specs

# Run only resources unit tests covering the new Specs variant
cargo test --lib mcp::resources::tests::parse_omni_dev
cargo test --lib mcp::resources::tests::read_resource_specs

# Run integration tests for the new resource
cargo test read_resource_omni_dev_specs
cargo test list_resources_returns_all_uri_templates

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — new `ResourceUri::Specs` variant extends the URI dispatch table; reviewers should confirm the error path (`EmptyIdentifier` vs `Malformed` vs `UnknownScheme`) is consistent with existing variants
- [x] Error handling — `read_resource` for an unknown spec name should surface a useful message listing known specs; verify the `KNOWN_SPECS` constant is kept in sync as new specs are added
- [ ] Security implications — no credentials or network involved; spec content is a compile-time constant
- [ ] Performance impact — none; `include_str!` embeds content at compile time

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the JFM spec is embedded via `include_str!` at compile time; serving it requires no I/O and no heap allocation beyond converting the `&'static str` to `String` for the response payload.

## Security Considerations

- [x] No security implications — the spec content is a read-only compile-time constant with no user-controlled input influencing which bytes are returned (only which known name is selected from a fixed match arm).

## Breaking Changes

None. The new `omni-dev://specs/{name}` URI scheme is purely additive. All existing `git://`, `jira://`, and `confluence://` resource URIs continue to work unchanged. The resource count visible to clients increases from 5 to 6, which is reflected in the updated tests.

## Deployment Notes

- [x] No special deployment requirements — the spec content is embedded in the binary at compile time. No environment variables, configuration changes, or migrations are required.

## Additional Notes

**Future Enhancements:**
- Additional specs (e.g. ADF JSON schema reference, Confluence storage format guide) can be registered by adding a new `include_str!` constant and a match arm in `specs::lookup`, then updating `KNOWN_SPECS`
- The `omni-dev://specs/` namespace is intentionally generic so non-markdown specs (e.g. JSON Schema) can be served with an appropriate mime type

**Known Limitations:**
- `KNOWN_SPECS` is a manually maintained comma-separated string used only in error messages; it must be kept in sync with the `lookup` match arms by convention rather than by the compiler

**Alternatives Considered:**
- Serving the spec by reading `docs/specs/jfm.md` from disk at runtime — rejected because installed binaries (`cargo install`) do not have access to the source tree
- Generating the spec list dynamically via a registry — deferred as premature given the current single-spec case