### PR TITLE
docs(mcp): clarify JFM markdown description in confluence tool annotations

### DIFF
--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -608,7 +608,9 @@ impl OmniDevServer {
 
     /// Tool: create a new Confluence page.
     #[tool(
-        description = "Create a new Confluence page. Returns the new page's ID. \
+        description = "Create a new Confluence page from JFM markdown (default) or raw ADF JSON. \
+                       JFM is GitHub-style markdown, NOT Confluence wiki markup — see resource \
+                       `omni-dev://specs/jfm` for syntax. Returns the new page's ID. \
                        Mirrors `omni-dev atlassian confluence create`."
     )]
     pub async fn confluence_create(
@@ -623,9 +625,12 @@ impl OmniDevServer {
     }
 
     /// Tool: update a Confluence page's body (and optionally title).
-    #[tool(description = "Overwrite a Confluence page's body. \
-                       Accepts JFM markdown (default) or ADF JSON. \
-                       Mirrors `omni-dev atlassian confluence write --force`.")]
+    #[tool(
+        description = "Overwrite a Confluence page's body from JFM markdown (default) or raw ADF JSON. \
+                       JFM is GitHub-style markdown, NOT Confluence wiki markup — see resource \
+                       `omni-dev://specs/jfm` for syntax. \
+                       Mirrors `omni-dev atlassian confluence write --force`."
+    )]
     pub async fn confluence_write(
         &self,
         Parameters(params): Parameters<ConfluenceWriteParams>,


### PR DESCRIPTION
## Description

This PR improves the MCP tool annotations for the Confluence `create` and `write` tools by adding clearer signposting about the JFM (GitHub Flavored Markdown) input format. Previously, the tool descriptions were ambiguous about what "JFM markdown" means, which could lead AI assistants or users to confuse it with Confluence wiki markup.

The updated descriptions now explicitly state that JFM is GitHub-style markdown (not Confluence wiki markup) and direct users to the `omni-dev://specs/jfm` resource for syntax reference.

## Type of Change
- [x] Documentation update

## Related Issue
Relates to the ongoing Confluence JFM signposting improvements on this branch.

## Changes Made

**Core Changes:**
- Updated `confluence_create` tool annotation in `src/mcp/confluence_tools.rs` to clarify that the page body accepts JFM markdown (default) or raw ADF JSON, and that JFM is GitHub-style markdown — not Confluence wiki markup
- Updated `confluence_write` tool annotation in `src/mcp/confluence_tools.rs` with the same JFM clarification, and reformatted the `#[tool(...)]` attribute to multi-line style for consistency

**Documentation:**
- Both tool descriptions now include a reference to `omni-dev://specs/jfm` so that AI assistants and users can look up JFM syntax directly from the MCP resource

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests required — documentation-only change to string literals

**Manual Testing:**
- [x] Verified tool annotation text is clear and unambiguous
- [x] Backward compatibility verified — no functional behaviour changes

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — ensure the updated descriptions are clear and helpful for AI assistants consuming these MCP tool annotations

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Additional Notes

**Context:**
- This is a targeted documentation improvement as part of the broader `confluence-jfm-signposting` work, ensuring that MCP tool consumers (especially AI assistants) understand that JFM markdown means GitHub-style markdown and have a clear pointer to the spec resource rather than guessing the format.

**Known Limitations:**
- None — this is a pure documentation clarification with no functional impact.