### PR TITLE
feat(ci): add stop hook to enforce snapshot updates on CLI changes

### DIFF
--- a/.claude/hooks/check-snapshots.sh
+++ b/.claude/hooks/check-snapshots.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Stop hook: block stop when CLI surface changed without snapshot updates.
+#
+# CLAUDE.md mandates running the update-snapshots skill before declaring
+# work done if `src/cli/**` or `src/main.rs` changed. This hook enforces
+# that gate by exiting non-zero with a stderr message, which Claude Code
+# surfaces back to the model.
+
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+input="$(cat)"
+
+# Avoid infinite loops: if Claude Code has already fired this Stop hook
+# and is asking us again, defer.
+if [ "$(jq -r '.stop_hook_active // false' <<<"$input")" = "true" ]; then
+  exit 0
+fi
+
+src_drift="$(git diff --name-only HEAD -- src/cli src/main.rs 2>/dev/null || true)"
+if [ -z "$src_drift" ]; then
+  exit 0
+fi
+
+snap_drift="$(git diff --name-only HEAD -- tests/snapshots 2>/dev/null || true)"
+if [ -n "$snap_drift" ]; then
+  exit 0
+fi
+
+{
+  echo "CLI surface changed but no snapshot updates are staged:"
+  echo "$src_drift" | sed 's/^/  - /'
+  echo
+  echo "Run the update-snapshots skill (or 'cargo insta test --test integration_test')"
+  echo "before stopping. See .claude/skills/update-snapshots/SKILL.md."
+} >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,13 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(.claude/hooks/check-snapshots.sh)",
+      "Bash(target/debug/deps/omni_dev-*:*)",
+      "Bash(target/debug/deps/omni_dev:*)",
+      "Bash(target/release/deps/omni_dev-*:*)",
+      "Bash(target/release/deps/omni_dev:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {
@@ -12,11 +21,18 @@
           }
         ]
       }
-    ]
-  },
-  "permissions": {
-    "allow": [
-      "Bash(target/debug/deps/omni_dev-a18167d0c04a86e3 --list)"
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-snapshots.sh",
+            "timeout": 30,
+            "statusMessage": "snapshot drift check"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Description

This PR adds a Claude Code Stop hook that enforces snapshot test updates whenever CLI source files are modified. When an AI session attempts to stop after changing `src/cli/**` or `src/main.rs` without also updating `tests/snapshots`, the hook blocks completion with a descriptive error message directing the AI to run the `update-snapshots` skill first.

This addresses Issue 667 by creating an automated gate that prevents snapshot drift from accumulating silently during AI-assisted development sessions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [x] CI/CD changes
- [ ] Dependency update

## Related Issue

Fixes #667

## Changes Made

**Core Changes:**
- Added `.claude/hooks/check-snapshots.sh` — a new Stop hook script that detects drift between CLI source changes (`src/cli`, `src/main.rs`) and snapshot test updates (`tests/snapshots`); exits non-zero with a descriptive message when drift is detected
- Registered the Stop hook in `.claude/settings.json` with a 30-second timeout and `"snapshot drift check"` status message
- Broadened Claude Code permissions in `.claude/settings.json` to allow all `omni_dev` debug/release binaries using glob patterns (`omni_dev-*`) rather than a single hardcoded hash-suffixed binary name

**Safety / Loop Prevention:**
- Hook checks the `stop_hook_active` JSON flag from stdin and exits cleanly (`exit 0`) if already in a hook loop, preventing infinite recursion

**Documentation:**
- Hook script includes inline comments explaining the enforcement rationale and how it relates to `CLAUDE.md` mandates

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (no CLI changes → hook exits 0)
- [x] Tested error/edge cases (CLI changed, no snapshot update → hook exits 2 with message)
- [x] Tested loop-guard path (`stop_hook_active=true` → hook exits 0)
- [x] Backward compatibility verified (existing PostToolUse hooks unchanged)

**Test Coverage:**
- New code coverage: N/A (shell script hook, not covered by cargo test)
- Overall project coverage: unchanged

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Manually exercise the stop hook (simulate CLI drift)
git diff HEAD -- src/cli > /dev/null && \
  echo '{"stop_hook_active": false}' | .claude/hooks/check-snapshots.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — hook uses `set -u` and guards against missing tools gracefully
- [x] Architecture changes — Stop hook integration in `.claude/settings.json` structure
- [ ] Security implications
- [ ] Performance impact
- [ ] User experience
- [x] Backward compatibility — existing `PostToolUse` hooks are preserved; only additive changes made

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

The hook only runs at session Stop time and performs lightweight `git diff --name-only` queries, so there is no measurable impact on normal development workflows.

## Security Considerations

- [x] No security implications

The hook reads from stdin (Claude Code–provided JSON) and runs only read-only `git diff` commands. No external network calls or privilege escalation involved.

## Breaking Changes

None. All changes are additive. Existing `PostToolUse` hooks and permissions continue to work unchanged. The only behavioral change is that Claude Code sessions will now be blocked from stopping if CLI source files have been modified without corresponding snapshot updates.

## Deployment Notes

- [x] No special deployment requirements

Changes apply automatically to any Claude Code session opened in this repository. No environment variable changes or service restarts needed.

## Additional Notes

**Future Enhancements:**
- Consider extending the hook to cover other test artifact types (e.g., generated API docs or schema files) if drift becomes a problem in those areas

**Known Limitations:**
- The hook compares against `HEAD` via `git diff --name-only HEAD`, so uncommitted changes are what trigger it. Staged-but-not-committed snapshot updates will satisfy the check.

**Alternatives Considered:**
- A pre-commit hook was considered but rejected because it would block commits rather than AI session completion, which is the target enforcement point for this workflow