### PR TITLE
chore(claude): add omni-dev binary and git diff permissions to settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,13 @@
   "permissions": {
     "allow": [
       "Bash(.claude/hooks/check-snapshots.sh)",
+      "Bash(target/debug/omni-dev:*)",
+      "Bash(target/release/omni-dev:*)",
       "Bash(target/debug/deps/omni_dev-*:*)",
       "Bash(target/debug/deps/omni_dev:*)",
       "Bash(target/release/deps/omni_dev-*:*)",
-      "Bash(target/release/deps/omni_dev:*)"
+      "Bash(target/release/deps/omni_dev:*)",
+      "Bash(git diff *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Description

This PR updates the Claude settings file to grant execution permissions for the compiled `omni-dev` binary (both debug and release builds) and allow `git diff` commands. Previously, only the test binary paths under `target/*/deps/` were permitted, meaning the main binary itself could not be invoked by Claude during development sessions. The addition of `git diff` permission enables Claude to inspect code changes directly.

## Type of Change
- [x] Refactoring (no functional changes)
- [x] CI/CD changes

## Related Issue
No related issue.

## Changes Made

**Core Changes:**
- Added `Bash(target/debug/omni-dev:*)` permission to `.claude/settings.json` to allow Claude to execute the debug build of the `omni-dev` binary
- Added `Bash(target/release/omni-dev:*)` permission to `.claude/settings.json` to allow Claude to execute the release build of the `omni-dev` binary
- Added `Bash(git diff *)` permission to `.claude/settings.json` to allow Claude to run `git diff` commands for inspecting changes

**Documentation:**
- No documentation changes required; this is a tooling configuration update

**Testing:**
- No tests required; this is a configuration-only change

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable)
- [ ] Integration tests updated/added (not applicable)

**Manual Testing:**
- [x] Verified permissions are correctly formatted in `.claude/settings.json`
- [x] Backward compatibility verified (existing permissions preserved)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications — granting `git diff *` and binary execution permissions to Claude; ensure the scope is appropriate for this project's threat model
- [ ] Backward compatibility

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [ ] No security implications
- [x] Potential security impact — this change broadens the set of commands Claude is permitted to execute. The added permissions allow Claude to run the `omni-dev` binary directly and inspect git diffs. Reviewers should confirm these are intentional and appropriately scoped for the development workflow.

## Breaking Changes
None. Existing permissions are preserved; only additive changes were made.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping permissions limited to only the `deps/` test binary paths, which would require workarounds for Claude to use the main binary directly during development sessions.