### PR TITLE
docs(docs): accept adr-0021 for mcp server via second binary

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -44,4 +44,4 @@ by Michael Nygard.
 | [ADR-0018](adr-0018.md)  | ✅ Accepted | 2026-02-25 | Automatic Context Detection for Adaptive AI Prompts                                    |
 | [ADR-0019](adr-0019.md)  | ✅ Accepted | 2026-02-25 | Ecosystem-Aware Scope Auto-Detection                                                   |
 | [ADR-0020](adr-0020.md)  | ✅ Proposed | 2026-04-16 | JFM — A Markdown Dialect for Bidirectional ADF Interchange                             |
-| [ADR-0021](adr-0021.md)  | 🟡 Proposed | 2026-04-18 | MCP Server via Second Binary with `rmcp`                                                |
+| [ADR-0021](adr-0021.md)  | ✅ Accepted | 2026-04-18 | MCP Server via Second Binary with `rmcp`                                                |

--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-🟡 Proposed
+✅ Accepted
 
 ## Context
 


### PR DESCRIPTION
## Description

This PR updates the status of ADR-0021 from Proposed to Accepted. ADR-0021 describes the architectural decision to implement the MCP (Model Context Protocol) server via a second binary using the `rmcp` crate, rather than integrating it into the main binary. With this acceptance, the decision is now officially ratified and the implementation can proceed with confidence.

## Type of Change

- [x] Documentation update

## Related Issue

Implements RFC/Design: [ADR-0021 — MCP Server via Second Binary with `rmcp`](docs/adrs/adr-0021.md)

## Changes Made

**Documentation:**
- Updated `docs/adrs/README.md`: Changed ADR-0021 status from `🟡 Proposed` to `✅ Accepted` in the ADR index table
- Updated `docs/adrs/adr-0021.md`: Changed the status header from `🟡 Proposed` to `✅ Accepted`

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Verified both files reflect the correct Accepted status consistently

### Test Commands
```bash
# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes

This acceptance formalises the decision to implement the MCP server as a separate binary using `rmcp`. Reviewers should confirm they agree with this architectural direction before approving, as acceptance of the ADR signals team consensus.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a documentation-only change updating ADR status metadata.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Implementation work for the MCP server second binary can now proceed under the guidance of the accepted ADR-0021

**Known Limitations:**
- None

**Alternatives Considered:**
- Keeping the status as Proposed pending further review; rejected in favour of accepting and proceeding with implementation