### PR TITLE
feat(cli): add transcript subcommand with youtube fetch, info, and list-langs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod datadog;
 pub mod git;
 pub mod help;
+pub mod transcript;
 
 /// AI backend selector.
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -100,6 +101,8 @@ pub enum Commands {
     Atlassian(atlassian::AtlassianCommand),
     /// Datadog: read-only API operations.
     Datadog(datadog::DatadogCommand),
+    /// Transcript and caption fetching from media platforms.
+    Transcript(transcript::TranscriptCommand),
     /// Displays comprehensive help for all commands.
     #[command(name = "help-all")]
     HelpAll(help::HelpCommand),
@@ -145,6 +148,7 @@ impl Cli {
             Commands::Commands(commands_cmd) => commands_cmd.execute(),
             Commands::Atlassian(cmd) => cmd.execute().await,
             Commands::Datadog(cmd) => cmd.execute().await,
+            Commands::Transcript(cmd) => cmd.execute().await,
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::HelpAll(help_cmd) => help_cmd.execute(),
         }

--- a/src/cli/transcript/format.rs
+++ b/src/cli/transcript/format.rs
@@ -1,0 +1,48 @@
+//! `clap::ValueEnum` mirror of [`crate::transcript::format::Format`].
+//!
+//! The library [`Format`](crate::transcript::format::Format) intentionally
+//! has no `clap` dependency — that's a hard architectural rule so the
+//! `transcript` library remains reusable by non-CLI consumers. This thin
+//! enum bridges clap's argument parsing to the library type.
+
+use clap::ValueEnum;
+
+use crate::transcript::format::Format;
+
+/// CLI-visible transcript output format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum CliFormat {
+    /// SubRip (`.srt`).
+    Srt,
+    /// WebVTT (`.vtt`).
+    Vtt,
+    /// Plain text — cue text only, one cue per line.
+    Txt,
+    /// JSON — the full transcript struct.
+    Json,
+}
+
+impl From<CliFormat> for Format {
+    fn from(value: CliFormat) -> Self {
+        match value {
+            CliFormat::Srt => Self::Srt,
+            CliFormat::Vtt => Self::Vtt,
+            CliFormat::Txt => Self::Txt,
+            CliFormat::Json => Self::Json,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_variant_maps_to_library_format() {
+        assert_eq!(Format::from(CliFormat::Srt), Format::Srt);
+        assert_eq!(Format::from(CliFormat::Vtt), Format::Vtt);
+        assert_eq!(Format::from(CliFormat::Txt), Format::Txt);
+        assert_eq!(Format::from(CliFormat::Json), Format::Json);
+    }
+}

--- a/src/cli/transcript/mod.rs
+++ b/src/cli/transcript/mod.rs
@@ -1,0 +1,53 @@
+//! Transcript and caption fetching from media platforms.
+//!
+//! Provider-namespaced: each source (YouTube today; Vimeo, podcast feeds, …
+//! later) lives under its own subcommand so per-source argument shapes and
+//! help text stay clean.
+
+pub mod format;
+pub mod youtube;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Transcript and caption fetching from media platforms.
+#[derive(Parser)]
+pub struct TranscriptCommand {
+    /// The transcript subcommand to execute.
+    #[command(subcommand)]
+    pub command: TranscriptSubcommands,
+}
+
+/// Transcript subcommands, one per media platform.
+#[derive(Subcommand)]
+pub enum TranscriptSubcommands {
+    /// YouTube: fetch captions, list available languages, and inspect video metadata.
+    Youtube(youtube::YoutubeCommand),
+}
+
+impl TranscriptCommand {
+    /// Dispatches to the selected provider.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            TranscriptSubcommands::Youtube(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_subcommands_youtube_variant() {
+        let cmd = TranscriptCommand {
+            command: TranscriptSubcommands::Youtube(youtube::YoutubeCommand {
+                command: youtube::YoutubeSubcommands::Info(youtube::info::InfoCommand {
+                    url: "https://youtu.be/dQw4w9WgXcQ".to_string(),
+                    output: youtube::info::InfoOutput::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, TranscriptSubcommands::Youtube(_)));
+    }
+}

--- a/src/cli/transcript/youtube/fetch.rs
+++ b/src/cli/transcript/youtube/fetch.rs
@@ -1,0 +1,156 @@
+//! `omni-dev transcript youtube fetch` — download a transcript and render it
+//! in the requested format.
+
+use std::fs;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::cli::transcript::format::CliFormat;
+use crate::transcript::format::Format;
+use crate::transcript::source::{FetchOpts, TranscriptSource};
+use crate::transcript::sources::youtube::Youtube;
+
+/// Fetches the transcript for a YouTube video.
+#[derive(Parser)]
+pub struct FetchCommand {
+    /// YouTube video URL or bare 11-character video ID.
+    pub url: String,
+
+    /// Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is
+    /// applied — `en` matches `en-US`.
+    #[arg(long, default_value = "en")]
+    pub lang: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = CliFormat::Srt)]
+    pub format: CliFormat,
+
+    /// Allow falling through to auto-generated (ASR) captions when no manual
+    /// track matches.
+    #[arg(long)]
+    pub auto: bool,
+
+    /// Synthesise a translated track in this target language when no native
+    /// track matches.
+    #[arg(long, value_name = "LANG")]
+    pub translate: Option<String>,
+
+    /// Output file (writes to stdout if omitted).
+    #[arg(short, long)]
+    pub output: Option<String>,
+}
+
+impl FetchCommand {
+    /// Fetches the transcript and writes it to stdout or `--output`.
+    pub async fn execute(self) -> Result<()> {
+        let yt = Youtube::new()?;
+        let opts = FetchOpts {
+            language: self.lang,
+            allow_auto: self.auto,
+            translate_to: self.translate,
+        };
+        let transcript = yt.fetch(&self.url, &opts).await?;
+        let rendered = Format::from(self.format).render(&transcript)?;
+        write_output(&rendered, self.output.as_deref())
+    }
+}
+
+fn write_output(text: &str, file: Option<&str>) -> Result<()> {
+    if let Some(path) = file {
+        fs::write(path, text).with_context(|| format!("Failed to write to {path}"))
+    } else {
+        print!("{text}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    /// Build a parser for `FetchCommand` rooted at `fetch` so we can drive
+    /// it with realistic argv vectors.
+    fn parse(args: &[&str]) -> FetchCommand {
+        let cmd = FetchCommand::command().no_binary_name(true);
+        let matches = cmd.try_get_matches_from(args).unwrap();
+        FetchCommand::from_arg_matches(&matches).unwrap()
+    }
+
+    use clap::FromArgMatches;
+
+    #[test]
+    fn fetch_command_defaults() {
+        let cmd = parse(&["https://youtu.be/dQw4w9WgXcQ"]);
+        assert_eq!(cmd.url, "https://youtu.be/dQw4w9WgXcQ");
+        assert_eq!(cmd.lang, "en");
+        assert_eq!(cmd.format, CliFormat::Srt);
+        assert!(!cmd.auto);
+        assert_eq!(cmd.translate, None);
+        assert_eq!(cmd.output, None);
+    }
+
+    #[test]
+    fn fetch_command_all_flags() {
+        let cmd = parse(&[
+            "abc",
+            "--lang",
+            "fr",
+            "--format",
+            "vtt",
+            "--auto",
+            "--translate",
+            "en",
+            "--output",
+            "out.vtt",
+        ]);
+        assert_eq!(cmd.url, "abc");
+        assert_eq!(cmd.lang, "fr");
+        assert_eq!(cmd.format, CliFormat::Vtt);
+        assert!(cmd.auto);
+        assert_eq!(cmd.translate.as_deref(), Some("en"));
+        assert_eq!(cmd.output.as_deref(), Some("out.vtt"));
+    }
+
+    #[test]
+    fn fetch_command_short_output_flag() {
+        let cmd = parse(&["abc", "-o", "out.srt"]);
+        assert_eq!(cmd.output.as_deref(), Some("out.srt"));
+    }
+
+    #[test]
+    fn fetch_command_format_accepts_each_variant() {
+        for (arg, want) in [
+            ("srt", CliFormat::Srt),
+            ("vtt", CliFormat::Vtt),
+            ("txt", CliFormat::Txt),
+            ("json", CliFormat::Json),
+        ] {
+            let cmd = parse(&["abc", "--format", arg]);
+            assert_eq!(cmd.format, want);
+        }
+    }
+
+    #[test]
+    fn write_output_to_file_writes_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+        write_output("hello\n", Some(path.to_str().unwrap())).unwrap();
+        let read = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(read, "hello\n");
+    }
+
+    #[test]
+    fn write_output_to_stdout_returns_ok() {
+        // Cannot easily capture stdout here; just exercise the branch.
+        write_output("noop", None).unwrap();
+    }
+
+    #[test]
+    fn write_output_invalid_path_errors() {
+        let err = write_output("x", Some("/nonexistent_dir_for_test/out.txt")).unwrap_err();
+        assert!(err.to_string().contains("Failed to write"));
+    }
+}

--- a/src/cli/transcript/youtube/info.rs
+++ b/src/cli/transcript/youtube/info.rs
@@ -1,0 +1,171 @@
+//! `omni-dev transcript youtube info` — show top-level metadata about a video.
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+
+use crate::transcript::source::{MediaInfo, TrackKind, TranscriptSource};
+use crate::transcript::sources::youtube::Youtube;
+
+/// Shows top-level metadata (title, channel, duration, languages) for a YouTube video.
+#[derive(Parser)]
+pub struct InfoCommand {
+    /// YouTube video URL or bare 11-character video ID.
+    pub url: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = InfoOutput::Table)]
+    pub output: InfoOutput,
+}
+
+/// Output format for `info`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum InfoOutput {
+    /// Human-readable key/value listing.
+    Table,
+    /// Pretty-printed JSON of `MediaInfo`.
+    Json,
+}
+
+impl InfoCommand {
+    /// Fetches the metadata and prints it.
+    pub async fn execute(self) -> Result<()> {
+        let yt = Youtube::new()?;
+        let info = yt.info(&self.url).await?;
+        match self.output {
+            InfoOutput::Table => print_table(&info),
+            InfoOutput::Json => print_json(&info)?,
+        }
+        Ok(())
+    }
+}
+
+fn print_table(info: &MediaInfo) {
+    println!("Source:    {}", info.source);
+    println!("ID:        {}", info.locator_id);
+    println!("Title:     {}", info.title);
+    if let Some(author) = &info.author {
+        println!("Channel:   {author}");
+    }
+    if let Some(duration_ms) = info.duration_ms {
+        println!("Duration:  {}", format_duration(duration_ms));
+    }
+    if info.languages.is_empty() {
+        println!("Languages: (none)");
+    } else {
+        println!("Languages:");
+        for lang in &info.languages {
+            println!("  - {} [{}] {}", lang.code, kind_str(lang.kind), lang.name);
+        }
+    }
+}
+
+fn print_json(info: &MediaInfo) -> Result<()> {
+    let json =
+        serde_json::to_string_pretty(info).context("Failed to serialize MediaInfo as JSON")?;
+    println!("{json}");
+    Ok(())
+}
+
+fn kind_str(kind: TrackKind) -> &'static str {
+    match kind {
+        TrackKind::Manual => "manual",
+        TrackKind::Auto => "auto",
+        TrackKind::Translated => "translated",
+    }
+}
+
+fn format_duration(ms: u64) -> String {
+    let total_secs = ms / 1_000;
+    let hours = total_secs / 3_600;
+    let minutes = (total_secs % 3_600) / 60;
+    let seconds = total_secs % 60;
+    if hours > 0 {
+        format!("{hours:02}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transcript::source::LanguageInfo;
+    use clap::{CommandFactory, FromArgMatches};
+
+    fn parse(args: &[&str]) -> InfoCommand {
+        let cmd = InfoCommand::command().no_binary_name(true);
+        let matches = cmd.try_get_matches_from(args).unwrap();
+        InfoCommand::from_arg_matches(&matches).unwrap()
+    }
+
+    #[test]
+    fn info_command_defaults() {
+        let cmd = parse(&["abc"]);
+        assert_eq!(cmd.url, "abc");
+        assert_eq!(cmd.output, InfoOutput::Table);
+    }
+
+    #[test]
+    fn info_command_json_output() {
+        let cmd = parse(&["abc", "--output", "json"]);
+        assert_eq!(cmd.output, InfoOutput::Json);
+    }
+
+    #[test]
+    fn format_duration_under_an_hour() {
+        assert_eq!(format_duration(0), "00:00");
+        assert_eq!(format_duration(59_000), "00:59");
+        assert_eq!(format_duration(212_000), "03:32");
+    }
+
+    #[test]
+    fn format_duration_over_an_hour() {
+        assert_eq!(format_duration(3_600_000), "01:00:00");
+        assert_eq!(format_duration(3_661_000), "01:01:01");
+    }
+
+    #[test]
+    fn print_table_handles_full_info() {
+        let info = MediaInfo {
+            source: "youtube".into(),
+            locator_id: "abc".into(),
+            title: "Title".into(),
+            author: Some("Channel".into()),
+            duration_ms: Some(60_000),
+            languages: vec![LanguageInfo {
+                code: "en".into(),
+                name: "English".into(),
+                kind: TrackKind::Manual,
+            }],
+        };
+        print_table(&info);
+    }
+
+    #[test]
+    fn print_table_handles_minimal_info() {
+        let info = MediaInfo {
+            source: "youtube".into(),
+            locator_id: "abc".into(),
+            title: "Title".into(),
+            author: None,
+            duration_ms: None,
+            languages: vec![],
+        };
+        print_table(&info);
+    }
+
+    #[test]
+    fn print_json_round_trips() {
+        let info = MediaInfo {
+            source: "youtube".into(),
+            locator_id: "abc".into(),
+            title: "Title".into(),
+            author: None,
+            duration_ms: None,
+            languages: vec![],
+        };
+        print_json(&info).unwrap();
+    }
+}

--- a/src/cli/transcript/youtube/list_langs.rs
+++ b/src/cli/transcript/youtube/list_langs.rs
@@ -1,0 +1,169 @@
+//! `omni-dev transcript youtube list-langs` — show all caption tracks on a
+//! video.
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+
+use crate::transcript::source::{LanguageInfo, TrackKind, TranscriptSource};
+use crate::transcript::sources::youtube::Youtube;
+
+/// Lists the caption tracks available on a YouTube video.
+#[derive(Parser)]
+pub struct ListLangsCommand {
+    /// YouTube video URL or bare 11-character video ID.
+    pub url: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = ListLangsOutput::Table)]
+    pub output: ListLangsOutput,
+}
+
+/// Output format for `list-langs`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum ListLangsOutput {
+    /// Human-readable table with `code`, `kind`, `name` columns.
+    Table,
+    /// Pretty-printed JSON array of `LanguageInfo`.
+    Json,
+}
+
+impl ListLangsCommand {
+    /// Fetches the caption-track list and prints it.
+    pub async fn execute(self) -> Result<()> {
+        let yt = Youtube::new()?;
+        let langs = yt.list_languages(&self.url).await?;
+        match self.output {
+            ListLangsOutput::Table => print_table(&langs),
+            ListLangsOutput::Json => print_json(&langs)?,
+        }
+        Ok(())
+    }
+}
+
+fn print_table(langs: &[LanguageInfo]) {
+    if langs.is_empty() {
+        println!("(no caption tracks available)");
+        return;
+    }
+
+    let code_width = "code"
+        .len()
+        .max(langs.iter().map(|l| l.code.len()).max().unwrap_or(0));
+    let kind_width = "kind".len().max(
+        langs
+            .iter()
+            .map(|l| kind_str(l.kind).len())
+            .max()
+            .unwrap_or(0),
+    );
+
+    println!(
+        "{:<code_w$}  {:<kind_w$}  name",
+        "code",
+        "kind",
+        code_w = code_width,
+        kind_w = kind_width,
+    );
+    println!(
+        "{:-<code_w$}  {:-<kind_w$}  {:-<name_w$}",
+        "",
+        "",
+        "",
+        code_w = code_width,
+        kind_w = kind_width,
+        name_w = "name".len(),
+    );
+    for lang in langs {
+        println!(
+            "{:<code_w$}  {:<kind_w$}  {}",
+            lang.code,
+            kind_str(lang.kind),
+            lang.name,
+            code_w = code_width,
+            kind_w = kind_width,
+        );
+    }
+}
+
+fn print_json(langs: &[LanguageInfo]) -> Result<()> {
+    let json =
+        serde_json::to_string_pretty(langs).context("Failed to serialize languages as JSON")?;
+    println!("{json}");
+    Ok(())
+}
+
+fn kind_str(kind: TrackKind) -> &'static str {
+    match kind {
+        TrackKind::Manual => "manual",
+        TrackKind::Auto => "auto",
+        TrackKind::Translated => "translated",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, FromArgMatches};
+
+    fn parse(args: &[&str]) -> ListLangsCommand {
+        let cmd = ListLangsCommand::command().no_binary_name(true);
+        let matches = cmd.try_get_matches_from(args).unwrap();
+        ListLangsCommand::from_arg_matches(&matches).unwrap()
+    }
+
+    #[test]
+    fn list_langs_command_defaults() {
+        let cmd = parse(&["abc"]);
+        assert_eq!(cmd.url, "abc");
+        assert_eq!(cmd.output, ListLangsOutput::Table);
+    }
+
+    #[test]
+    fn list_langs_command_json_output() {
+        let cmd = parse(&["abc", "--output", "json"]);
+        assert_eq!(cmd.output, ListLangsOutput::Json);
+    }
+
+    #[test]
+    fn kind_str_lowercase() {
+        assert_eq!(kind_str(TrackKind::Manual), "manual");
+        assert_eq!(kind_str(TrackKind::Auto), "auto");
+        assert_eq!(kind_str(TrackKind::Translated), "translated");
+    }
+
+    #[test]
+    fn print_json_round_trips() {
+        // Sanity check that LanguageInfo serializes to JSON without error.
+        let langs = vec![LanguageInfo {
+            code: "en".into(),
+            name: "English".into(),
+            kind: TrackKind::Manual,
+        }];
+        print_json(&langs).unwrap();
+    }
+
+    #[test]
+    fn print_table_handles_empty_input() {
+        // No panic on an empty language list.
+        print_table(&[]);
+    }
+
+    #[test]
+    fn print_table_handles_populated_input() {
+        let langs = vec![
+            LanguageInfo {
+                code: "en".into(),
+                name: "English".into(),
+                kind: TrackKind::Manual,
+            },
+            LanguageInfo {
+                code: "es-419".into(),
+                name: "Spanish (Latin America)".into(),
+                kind: TrackKind::Auto,
+            },
+        ];
+        print_table(&langs);
+    }
+}

--- a/src/cli/transcript/youtube/mod.rs
+++ b/src/cli/transcript/youtube/mod.rs
@@ -1,0 +1,81 @@
+//! YouTube transcript subcommands.
+
+pub mod fetch;
+pub mod info;
+pub mod list_langs;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// YouTube: fetch captions, list available languages, and inspect video metadata.
+#[derive(Parser)]
+pub struct YoutubeCommand {
+    /// The YouTube subcommand to execute.
+    #[command(subcommand)]
+    pub command: YoutubeSubcommands,
+}
+
+/// YouTube subcommands.
+#[derive(Subcommand)]
+pub enum YoutubeSubcommands {
+    /// Fetches the transcript for a YouTube video.
+    Fetch(fetch::FetchCommand),
+    /// Lists the caption tracks available on a YouTube video.
+    ListLangs(list_langs::ListLangsCommand),
+    /// Shows top-level metadata (title, channel, duration, languages) for a YouTube video.
+    Info(info::InfoCommand),
+}
+
+impl YoutubeCommand {
+    /// Executes the YouTube subcommand.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            YoutubeSubcommands::Fetch(cmd) => cmd.execute().await,
+            YoutubeSubcommands::ListLangs(cmd) => cmd.execute().await,
+            YoutubeSubcommands::Info(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::transcript::format::CliFormat;
+
+    #[test]
+    fn youtube_subcommands_fetch_variant() {
+        let cmd = YoutubeCommand {
+            command: YoutubeSubcommands::Fetch(fetch::FetchCommand {
+                url: "https://youtu.be/abc".to_string(),
+                lang: "en".to_string(),
+                format: CliFormat::Srt,
+                auto: false,
+                translate: None,
+                output: None,
+            }),
+        };
+        assert!(matches!(cmd.command, YoutubeSubcommands::Fetch(_)));
+    }
+
+    #[test]
+    fn youtube_subcommands_list_langs_variant() {
+        let cmd = YoutubeCommand {
+            command: YoutubeSubcommands::ListLangs(list_langs::ListLangsCommand {
+                url: "https://youtu.be/abc".to_string(),
+                output: list_langs::ListLangsOutput::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, YoutubeSubcommands::ListLangs(_)));
+    }
+
+    #[test]
+    fn youtube_subcommands_info_variant() {
+        let cmd = YoutubeCommand {
+            command: YoutubeSubcommands::Info(info::InfoCommand {
+                url: "https://youtu.be/abc".to_string(),
+                output: info::InfoOutput::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, YoutubeSubcommands::Info(_)));
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -9,14 +9,15 @@ A comprehensive development toolkit
 Usage: omni-dev [OPTIONS] <COMMAND>
 
 Commands:
-  ai         AI operations
-  git        Git-related operations
-  commands   Command template management
-  config     Configuration and model information
-  atlassian  Atlassian: JIRA and Confluence operations
-  datadog    Datadog: read-only API operations
-  help-all   Displays comprehensive help for all commands
-  help       Print this message or the help of the given subcommand(s)
+  ai          AI operations
+  git         Git-related operations
+  commands    Command template management
+  config      Configuration and model information
+  atlassian   Atlassian: JIRA and Confluence operations
+  datadog     Datadog: read-only API operations
+  transcript  Transcript and caption fetching from media platforms
+  help-all    Displays comprehensive help for all commands
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
       --ai-backend <AI_BACKEND>
@@ -2239,3 +2240,89 @@ Usage: help-all
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev transcript - Transcript and caption fetching from media platforms
+
+Transcript and caption fetching from media platforms
+
+Usage: transcript <COMMAND>
+
+Commands:
+  youtube  YouTube: fetch captions, list available languages, and inspect video metadata
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev transcript youtube - YouTube: fetch captions, list available languages, and inspect video metadata
+
+YouTube: fetch captions, list available languages, and inspect video metadata
+
+Usage: youtube <COMMAND>
+
+Commands:
+  fetch       Fetches the transcript for a YouTube video
+  list-langs  Lists the caption tracks available on a YouTube video
+  info        Shows top-level metadata (title, channel, duration, languages) for a YouTube video
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev transcript youtube fetch - Fetches the transcript for a YouTube video
+
+Fetches the transcript for a YouTube video
+
+Usage: fetch [OPTIONS] <URL>
+
+Arguments:
+  <URL>  YouTube video URL or bare 11-character video ID
+
+Options:
+      --lang <LANG>       Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is applied — `en` matches `en-US` [default: en]
+      --format <FORMAT>   Output format [default: srt] [possible values: srt, vtt, txt, json]
+      --auto              Allow falling through to auto-generated (ASR) captions when no manual track matches
+      --translate <LANG>  Synthesise a translated track in this target language when no native track matches
+  -o, --output <OUTPUT>   Output file (writes to stdout if omitted)
+  -h, --help              Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev transcript youtube info - Shows top-level metadata (title, channel, duration, languages) for a YouTube video
+
+Shows top-level metadata (title, channel, duration, languages) for a YouTube video
+
+Usage: info [OPTIONS] <URL>
+
+Arguments:
+  <URL>  YouTube video URL or bare 11-character video ID
+
+Options:
+      --output <OUTPUT>  Output format [default: table] [possible values: table, json]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev transcript youtube list-langs - Lists the caption tracks available on a YouTube video
+
+Lists the caption tracks available on a YouTube video
+
+Usage: list-langs [OPTIONS] <URL>
+
+Arguments:
+  <URL>  YouTube video URL or bare 11-character video ID
+
+Options:
+      --output <OUTPUT>  Output format [default: table] [possible values: table, json]
+  -h, --help             Print help (see more with '--help')


### PR DESCRIPTION
## Description

This PR introduces a new `transcript` top-level command to `omni-dev`, enabling users to fetch captions and metadata from media platforms. The initial implementation targets YouTube, with a provider-namespaced subcommand structure designed to accommodate additional platforms (Vimeo, podcast feeds, etc.) in the future.

Users can now download transcripts in multiple formats, inspect video metadata, and enumerate available caption tracks directly from the CLI.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Relates to #687

## Changes Made

**Core Changes:**
- Added `TranscriptCommand` in `src/cli/transcript/mod.rs` with provider-namespaced subcommand dispatch (`TranscriptSubcommands::Youtube`)
- Added `YoutubeCommand` in `src/cli/transcript/youtube/mod.rs` with three subcommands: `fetch`, `list-langs`, and `info`
- Added `FetchCommand` (`src/cli/transcript/youtube/fetch.rs`) to download transcripts in `srt`, `vtt`, `txt`, or `json` format, with `--lang`, `--auto`, `--translate`, and `-o/--output` flags
- Added `InfoCommand` (`src/cli/transcript/youtube/info.rs`) to display video metadata (title, channel, duration, available languages) in `table` or `json` output format
- Added `ListLangsCommand` (`src/cli/transcript/youtube/list_langs.rs`) to enumerate available caption tracks in aligned `table` or `json` output format
- Added `CliFormat` enum (`src/cli/transcript/format.rs`) as a `clap::ValueEnum` mirror of the library `Format` type, keeping the transcript library free of clap dependencies
- Registered `Commands::Transcript` variant and dispatch arm in `src/cli.rs`

**Testing:**
- Added unit tests in `src/cli/transcript/format.rs` verifying all `CliFormat` → `Format` conversions
- Added unit tests in `src/cli/transcript/mod.rs` verifying `TranscriptSubcommands::Youtube` variant construction
- Added unit tests in `src/cli/transcript/youtube/fetch.rs` covering defaults, all flags, short `-o` flag, all format variants, file output, stdout output, and invalid path error handling
- Added unit tests in `src/cli/transcript/youtube/info.rs` covering defaults, JSON output flag, `format_duration` with sub-hour and over-hour durations, `print_table` with full and minimal `MediaInfo`, and JSON round-trip
- Added unit tests in `src/cli/transcript/youtube/list_langs.rs` covering defaults, JSON output flag, `kind_str` values, JSON round-trip, empty input, and populated table output
- Added unit tests in `src/cli/transcript/youtube/mod.rs` verifying all three `YoutubeSubcommands` variants

**Documentation:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include the full `transcript` command hierarchy in the help-all snapshot

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Exercise the new commands manually
omni-dev transcript youtube info https://youtu.be/dQw4w9WgXcQ
omni-dev transcript youtube list-langs https://youtu.be/dQw4w9WgXcQ
omni-dev transcript youtube fetch https://youtu.be/dQw4w9WgXcQ --lang en --format srt
omni-dev transcript youtube fetch https://youtu.be/dQw4w9WgXcQ --format vtt -o captions.vtt
omni-dev transcript youtube fetch https://youtu.be/dQw4w9WgXcQ --auto --translate fr
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the provider-namespaced subcommand structure (`transcript youtube <subcommand>`) is intentional to allow clean per-source argument shapes as more platforms are added
- [x] Error handling — `FetchCommand` and `write_output` use `anyhow::Context` for clear error messages
- [x] The `CliFormat` / library `Format` separation — the transcript library has no clap dependency by design; `CliFormat` exists solely as a CLI bridge

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive feature with no changes to existing commands or APIs.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional transcript providers (Vimeo, podcast RSS feeds, etc.) can be added as new `TranscriptSubcommands` variants following the same pattern
- The `YoutubeSubcommands` structure allows per-provider subcommands to evolve independently

**Known Limitations:**
- Only YouTube is supported as a transcript source in this iteration