### PR TITLE
feat(cli): add InnerTube client fallback chain and --client flag for YouTube transcript commands

### DIFF
--- a/src/cli/transcript/mod.rs
+++ b/src/cli/transcript/mod.rs
@@ -45,6 +45,7 @@ mod tests {
                 command: youtube::YoutubeSubcommands::Info(youtube::info::InfoCommand {
                     url: "https://youtu.be/dQw4w9WgXcQ".to_string(),
                     output: youtube::info::InfoOutput::Table,
+                    client: None,
                 }),
             }),
         };

--- a/src/cli/transcript/youtube/fetch.rs
+++ b/src/cli/transcript/youtube/fetch.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use crate::cli::transcript::format::CliFormat;
 use crate::transcript::format::Format;
 use crate::transcript::source::{FetchOpts, TranscriptSource};
-use crate::transcript::sources::youtube::Youtube;
+use crate::transcript::sources::youtube::{InnertubeClient, Youtube};
 
 /// Fetches the transcript for a YouTube video.
 #[derive(Parser)]
@@ -39,12 +39,18 @@ pub struct FetchCommand {
     /// Output file (writes to stdout if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+
+    /// Force a specific InnerTube client instead of the default fallback
+    /// chain (`web` → `android-vr` → `tv-embedded` → `ios`). Useful for
+    /// reproducing client-specific bugs and isolating regressions.
+    #[arg(long, value_enum, value_name = "CLIENT")]
+    pub client: Option<InnertubeClient>,
 }
 
 impl FetchCommand {
     /// Fetches the transcript and writes it to stdout or `--output`.
     pub async fn execute(self) -> Result<()> {
-        let yt = Youtube::new()?;
+        let yt = build_youtube(self.client)?;
         let opts = FetchOpts {
             language: self.lang,
             allow_auto: self.auto,
@@ -54,6 +60,16 @@ impl FetchCommand {
         let rendered = Format::from(self.format).render(&transcript)?;
         write_output(&rendered, self.output.as_deref())
     }
+}
+
+/// Build a [`Youtube`] source either with the default fallback chain or
+/// pinned to a single user-supplied client.
+pub(crate) fn build_youtube(client: Option<InnertubeClient>) -> Result<Youtube> {
+    let yt = Youtube::new()?;
+    Ok(match client {
+        Some(c) => yt.with_chain(vec![c]),
+        None => yt,
+    })
 }
 
 fn write_output(text: &str, file: Option<&str>) -> Result<()> {
@@ -90,6 +106,7 @@ mod tests {
         assert!(!cmd.auto);
         assert_eq!(cmd.translate, None);
         assert_eq!(cmd.output, None);
+        assert_eq!(cmd.client, None);
     }
 
     #[test]
@@ -105,6 +122,8 @@ mod tests {
             "en",
             "--output",
             "out.vtt",
+            "--client",
+            "android-vr",
         ]);
         assert_eq!(cmd.url, "abc");
         assert_eq!(cmd.lang, "fr");
@@ -112,6 +131,20 @@ mod tests {
         assert!(cmd.auto);
         assert_eq!(cmd.translate.as_deref(), Some("en"));
         assert_eq!(cmd.output.as_deref(), Some("out.vtt"));
+        assert_eq!(cmd.client, Some(InnertubeClient::AndroidVr));
+    }
+
+    #[test]
+    fn fetch_command_client_accepts_each_variant() {
+        for (arg, want) in [
+            ("web", InnertubeClient::Web),
+            ("android-vr", InnertubeClient::AndroidVr),
+            ("tv-embedded", InnertubeClient::TvEmbedded),
+            ("ios", InnertubeClient::Ios),
+        ] {
+            let cmd = parse(&["abc", "--client", arg]);
+            assert_eq!(cmd.client, Some(want));
+        }
     }
 
     #[test]

--- a/src/cli/transcript/youtube/info.rs
+++ b/src/cli/transcript/youtube/info.rs
@@ -3,8 +3,9 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 
+use crate::cli::transcript::youtube::fetch::build_youtube;
 use crate::transcript::source::{MediaInfo, TrackKind, TranscriptSource};
-use crate::transcript::sources::youtube::Youtube;
+use crate::transcript::sources::youtube::InnertubeClient;
 
 /// Shows top-level metadata (title, channel, duration, languages) for a YouTube video.
 #[derive(Parser)]
@@ -15,6 +16,11 @@ pub struct InfoCommand {
     /// Output format.
     #[arg(long, value_enum, default_value_t = InfoOutput::Table)]
     pub output: InfoOutput,
+
+    /// Force a specific InnerTube client instead of the default fallback
+    /// chain (`web` → `android-vr` → `tv-embedded` → `ios`).
+    #[arg(long, value_enum, value_name = "CLIENT")]
+    pub client: Option<InnertubeClient>,
 }
 
 /// Output format for `info`.
@@ -30,7 +36,7 @@ pub enum InfoOutput {
 impl InfoCommand {
     /// Fetches the metadata and prints it.
     pub async fn execute(self) -> Result<()> {
-        let yt = Youtube::new()?;
+        let yt = build_youtube(self.client)?;
         let info = yt.info(&self.url).await?;
         match self.output {
             InfoOutput::Table => print_table(&info),

--- a/src/cli/transcript/youtube/list_langs.rs
+++ b/src/cli/transcript/youtube/list_langs.rs
@@ -4,8 +4,9 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 
+use crate::cli::transcript::youtube::fetch::build_youtube;
 use crate::transcript::source::{LanguageInfo, TrackKind, TranscriptSource};
-use crate::transcript::sources::youtube::Youtube;
+use crate::transcript::sources::youtube::InnertubeClient;
 
 /// Lists the caption tracks available on a YouTube video.
 #[derive(Parser)]
@@ -16,6 +17,11 @@ pub struct ListLangsCommand {
     /// Output format.
     #[arg(long, value_enum, default_value_t = ListLangsOutput::Table)]
     pub output: ListLangsOutput,
+
+    /// Force a specific InnerTube client instead of the default fallback
+    /// chain (`web` → `android-vr` → `tv-embedded` → `ios`).
+    #[arg(long, value_enum, value_name = "CLIENT")]
+    pub client: Option<InnertubeClient>,
 }
 
 /// Output format for `list-langs`.
@@ -31,7 +37,7 @@ pub enum ListLangsOutput {
 impl ListLangsCommand {
     /// Fetches the caption-track list and prints it.
     pub async fn execute(self) -> Result<()> {
-        let yt = Youtube::new()?;
+        let yt = build_youtube(self.client)?;
         let langs = yt.list_languages(&self.url).await?;
         match self.output {
             ListLangsOutput::Table => print_table(&langs),

--- a/src/cli/transcript/youtube/mod.rs
+++ b/src/cli/transcript/youtube/mod.rs
@@ -52,6 +52,7 @@ mod tests {
                 auto: false,
                 translate: None,
                 output: None,
+                client: None,
             }),
         };
         assert!(matches!(cmd.command, YoutubeSubcommands::Fetch(_)));
@@ -63,6 +64,7 @@ mod tests {
             command: YoutubeSubcommands::ListLangs(list_langs::ListLangsCommand {
                 url: "https://youtu.be/abc".to_string(),
                 output: list_langs::ListLangsOutput::Table,
+                client: None,
             }),
         };
         assert!(matches!(cmd.command, YoutubeSubcommands::ListLangs(_)));
@@ -74,6 +76,7 @@ mod tests {
             command: YoutubeSubcommands::Info(info::InfoCommand {
                 url: "https://youtu.be/abc".to_string(),
                 output: info::InfoOutput::Table,
+                client: None,
             }),
         };
         assert!(matches!(cmd.command, YoutubeSubcommands::Info(_)));

--- a/src/transcript/error.rs
+++ b/src/transcript/error.rs
@@ -37,13 +37,26 @@ pub enum TranscriptError {
     /// removed, or login-required). Carries the platform's status string so
     /// callers can react to the specific reason rather than a generic HTTP
     /// failure.
-    #[error("media platform refused playback: status={status}{}", reason.as_deref().map(|r| format!(" ({r})")).unwrap_or_default())]
+    #[error(
+        "media platform refused playback: status={status}{}{}",
+        reason.as_deref().map(|r| format!(" ({r})")).unwrap_or_default(),
+        if attempted.len() > 1 {
+            format!(" [tried: {}]", attempted.join(", "))
+        } else {
+            String::new()
+        }
+    )]
     PlayabilityRefused {
         /// Platform-specific status code (e.g. YouTube `LOGIN_REQUIRED`,
         /// `AGE_VERIFICATION_REQUIRED`, `UNPLAYABLE`).
         status: String,
         /// Optional human-readable reason from the platform.
         reason: Option<String>,
+        /// Names of the source-specific clients that were tried before the
+        /// refusal was surfaced. Empty when only one client was attempted.
+        /// For YouTube these are InnerTube `clientName` values like `WEB`,
+        /// `ANDROID_VR`.
+        attempted: Vec<String>,
     },
 
     /// An I/O error occurred (e.g. writing transcript to a file).
@@ -108,6 +121,7 @@ mod tests {
         let err = TranscriptError::PlayabilityRefused {
             status: "LOGIN_REQUIRED".to_string(),
             reason: Some("Sign in to confirm your age".to_string()),
+            attempted: vec![],
         };
         let msg = err.to_string();
         assert!(msg.contains("LOGIN_REQUIRED"));
@@ -119,10 +133,36 @@ mod tests {
         let err = TranscriptError::PlayabilityRefused {
             status: "UNPLAYABLE".to_string(),
             reason: None,
+            attempted: vec![],
         };
         let msg = err.to_string();
         assert!(msg.contains("UNPLAYABLE"));
         assert!(!msg.contains("()"));
+    }
+
+    #[test]
+    fn playability_refused_with_single_attempt_omits_chain() {
+        // One-client attempt suppresses the `[tried: ...]` suffix to keep
+        // the message clean for sources that don't fan out.
+        let err = TranscriptError::PlayabilityRefused {
+            status: "UNPLAYABLE".to_string(),
+            reason: None,
+            attempted: vec!["WEB".to_string()],
+        };
+        let msg = err.to_string();
+        assert!(!msg.contains("tried"));
+    }
+
+    #[test]
+    fn playability_refused_with_multiple_attempts_shows_chain() {
+        let err = TranscriptError::PlayabilityRefused {
+            status: "UNPLAYABLE".to_string(),
+            reason: Some("Video unavailable".to_string()),
+            attempted: vec!["WEB".to_string(), "ANDROID_VR".to_string()],
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("tried: WEB, ANDROID_VR"));
+        assert!(msg.contains("Video unavailable"));
     }
 
     #[test]

--- a/src/transcript/sources/youtube.rs
+++ b/src/transcript/sources/youtube.rs
@@ -1,24 +1,27 @@
 //! YouTube [`TranscriptSource`](crate::transcript::TranscriptSource).
 //!
-//! Step 3 of [issue #687](https://github.com/rust-works/omni-dev/issues/687)
-//! wires the HTTP layer for the WEB client and binds the offline parsers
-//! ([`url`], [`player_response`], [`timedtext`]) into a concrete
-//! [`TranscriptSource`] implementation. The Android / IosEmbedded fallback
-//! chain used for age-gated content lands in step 5 and will live in a
-//! sibling `client.rs` module.
+//! Walks [`client::DEFAULT_CHAIN`] (or a caller-supplied single client) when
+//! resolving a video to a `playerResponse`: WEB first, then non-WEB clients
+//! (Android VR, TV-embedded, iOS) on retryable refusals like `UNPLAYABLE`,
+//! `LOGIN_REQUIRED`, `AGE_VERIFICATION_REQUIRED`, `CONTENT_CHECK_REQUIRED`.
+//! Healthy videos are answered by WEB on the first request and pay no
+//! extra request volume; only refused videos pay the cost of fanning out.
 
 use std::time::Duration;
 
 use async_trait::async_trait;
+use tracing::debug;
 
-use crate::transcript::error::Result;
+use crate::transcript::error::{Result, TranscriptError};
 use crate::transcript::source::{FetchOpts, LanguageInfo, MediaInfo, Transcript, TranscriptSource};
 
+pub mod client;
 pub mod innertube;
 pub mod player_response;
 pub mod timedtext;
 pub mod url;
 
+pub use client::{ClientContext, InnertubeClient, DEFAULT_CHAIN};
 pub use player_response::{
     check_playability, extract_media_info, list_languages, parse as parse_player_response,
     select_track, CaptionTrack, PlayerResponse, SelectedTrack,
@@ -34,18 +37,40 @@ const DEFAULT_BASE_URL: &str = "https://www.youtube.com";
 /// [`crate::atlassian::client::AtlassianClient`]'s 30 s timeout.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// User-Agent advertised to YouTube. A recent desktop Chrome string maximises
-/// compatibility with the WEB context InnerTube expects; YouTube tightens
-/// caption-track availability for unrecognised UAs.
-const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
-     (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
 /// Whether `input` is recognised as a YouTube locator (URL or bare ID).
 ///
 /// Used by the future `omni-dev transcript fetch <url>` auto-detection
 /// path and by [`TranscriptSource::matches`].
 pub fn matches_url(input: &str) -> bool {
     extract_video_id(input).is_ok()
+}
+
+/// Whether an error is worth retrying with a different InnerTube client.
+///
+/// Returns `true` for failures that may vary per-client:
+///
+/// * `PlayabilityRefused` (any status except `LIVE_STREAM_OFFLINE`) — WEB
+///   enforces JS-derived signatures, sign-in checks, and clientVersion
+///   staleness checks that the non-WEB clients skip. `ERROR` is included
+///   because YouTube uses it as an ambiguous catch-all — covering both
+///   genuinely-deleted videos *and* "client no longer supported" rejections
+///   triggered by stale clientVersion strings — and the disambiguation
+///   only happens once the chain has been walked.
+/// * `Http` — different clients send subtly different request shapes;
+///   IOS may receive 400 where ANDROID_VR receives a 200 with playability
+///   refusal. yt-dlp retries across clients on HTTP errors too.
+///
+/// Returns `false` for `LIVE_STREAM_OFFLINE` (no client provides captions
+/// for a stream that hasn't started), parse errors (next client will fail
+/// the same way), and locator errors (purely client-side validation).
+fn is_retryable_refusal(err: &TranscriptError) -> bool {
+    match err {
+        TranscriptError::PlayabilityRefused { status, .. } => {
+            !matches!(status.as_str(), "LIVE_STREAM_OFFLINE")
+        }
+        TranscriptError::Http(_) => true,
+        _ => false,
+    }
 }
 
 /// YouTube [`TranscriptSource`].
@@ -57,45 +82,166 @@ pub fn matches_url(input: &str) -> bool {
 pub struct Youtube {
     http: reqwest::Client,
     base_url: String,
+    chain: Vec<InnertubeClient>,
 }
 
 impl Youtube {
-    /// Construct a YouTube source with default HTTP settings (30 s timeout,
-    /// desktop Chrome User-Agent) targeting the public YouTube origin.
+    /// Construct a YouTube source with default HTTP settings (30 s timeout)
+    /// targeting the public YouTube origin and the full
+    /// [`DEFAULT_CHAIN`] fallback. The User-Agent is set per-request based
+    /// on the active client.
     pub fn new() -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
-            .user_agent(USER_AGENT)
             .build()?;
         Ok(Self {
             http,
             base_url: DEFAULT_BASE_URL.to_string(),
+            chain: DEFAULT_CHAIN.to_vec(),
         })
     }
 
     /// Construct a YouTube source pointed at an alternate origin. Used by
-    /// tests to inject a `wiremock::MockServer::uri()`. The HTTP client
-    /// retains the production timeout and User-Agent so request shape
-    /// matches the real client.
+    /// tests to inject a `wiremock::MockServer::uri()`.
     pub fn with_base_url(base_url: impl Into<String>) -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
-            .user_agent(USER_AGENT)
             .build()?;
         Ok(Self {
             http,
             base_url: base_url.into(),
+            chain: DEFAULT_CHAIN.to_vec(),
         })
     }
 
-    /// Common preamble: locator → video ID → InnerTube POST →
-    /// `playerResponse` parse → playability check.
-    async fn load_player_response(&self, locator: &str) -> Result<PlayerResponse> {
-        let video_id = extract_video_id(locator)?;
-        let raw = innertube::fetch_player_response(&self.http, &self.base_url, &video_id).await?;
+    /// Replace the InnerTube client fallback chain with `chain`.
+    ///
+    /// `chain` must be non-empty. Useful for `--client web` (single rung
+    /// for debugging) or for tests pinning a deterministic order.
+    #[must_use]
+    pub fn with_chain(mut self, chain: Vec<InnertubeClient>) -> Self {
+        debug_assert!(!chain.is_empty(), "Youtube chain must be non-empty");
+        self.chain = chain;
+        self
+    }
+
+    /// One rung of the fallback chain: POST to InnerTube as `client`,
+    /// parse the response, surface any non-`OK` `playabilityStatus` as
+    /// [`TranscriptError::PlayabilityRefused`].
+    async fn try_one_client(
+        &self,
+        video_id: &str,
+        client: &ClientContext,
+    ) -> Result<PlayerResponse> {
+        let raw =
+            innertube::fetch_player_response(&self.http, &self.base_url, video_id, client).await?;
         let response = parse_player_response(&raw)?;
         check_playability(&response)?;
         Ok(response)
+    }
+
+    /// Common preamble: locator → video ID → InnerTube POST loop →
+    /// `playerResponse` parse → playability check.
+    ///
+    /// Walks `self.chain` in order: returns the first response whose
+    /// `playabilityStatus.status == "OK"`. On a retryable refusal
+    /// ([`is_retryable_refusal`]), continues to the next client. On a
+    /// non-retryable refusal or any other error (HTTP / parse / locator),
+    /// short-circuits with that error. If every client refuses, the last
+    /// refusal is propagated with `attempted` populated so callers can see
+    /// the full chain that was tried.
+    async fn load_player_response(&self, locator: &str) -> Result<PlayerResponse> {
+        let video_id = extract_video_id(locator)?;
+        // Track two errors:
+        //   * `last_err` — the most recent failure, used as a fallback
+        //     when no other client produced anything more informative.
+        //   * `best_refusal` — the most informative refusal seen so far
+        //     (a `PlayabilityRefused`), preferred over opaque HTTP errors
+        //     from later clients when we surface to the caller.
+        let mut last_err: Option<TranscriptError> = None;
+        let mut best_refusal: Option<TranscriptError> = None;
+        let mut attempted: Vec<String> = Vec::with_capacity(self.chain.len());
+
+        for variant in &self.chain {
+            let ctx = variant.context();
+            attempted.push(ctx.name.to_string());
+
+            let attempt = self.try_one_client(&video_id, &ctx).await;
+            match attempt {
+                Ok(response) => {
+                    if attempted.len() > 1 {
+                        debug!(
+                            client = ctx.name,
+                            attempted = ?attempted,
+                            "InnerTube client recovered playback after fallback"
+                        );
+                    }
+                    return Ok(response);
+                }
+                Err(err) if is_retryable_refusal(&err) => {
+                    debug!(
+                        client = ctx.name,
+                        error = %err,
+                        "InnerTube client failed; falling through"
+                    );
+                    if matches!(err, TranscriptError::PlayabilityRefused { .. })
+                        && best_refusal.is_none()
+                    {
+                        // Capture the *first* PlayabilityRefused — typically
+                        // from the WEB client, which gives the most
+                        // contextual reason ("Video unavailable",
+                        // "Sign in to confirm…").
+                        best_refusal = Some(clone_refusal(&err));
+                    }
+                    last_err = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        // Every client failed. Prefer the first PlayabilityRefused over
+        // any HTTP error, since the refusal carries the platform's reason
+        // string. Fall back to the last error otherwise. Either way,
+        // attach the full chain so users can see what was tried.
+        let surfaced = best_refusal.or(last_err).unwrap_or_else(|| {
+            TranscriptError::ParseError("InnerTube fallback chain was empty".to_string())
+        });
+        Err(annotate_attempted(surfaced, attempted))
+    }
+}
+
+/// Replace the `attempted` field on a `PlayabilityRefused` with the supplied
+/// chain. Other variants are returned unchanged.
+fn annotate_attempted(err: TranscriptError, attempted: Vec<String>) -> TranscriptError {
+    match err {
+        TranscriptError::PlayabilityRefused { status, reason, .. } => {
+            TranscriptError::PlayabilityRefused {
+                status,
+                reason,
+                attempted,
+            }
+        }
+        other => other,
+    }
+}
+
+/// Clone-equivalent for the `PlayabilityRefused` variant. `TranscriptError`
+/// is not `Clone` because of the `reqwest::Error` variant; we only need to
+/// copy the refusal so we can keep the original around alongside it.
+fn clone_refusal(err: &TranscriptError) -> TranscriptError {
+    match err {
+        TranscriptError::PlayabilityRefused {
+            status,
+            reason,
+            attempted,
+        } => TranscriptError::PlayabilityRefused {
+            status: status.clone(),
+            reason: reason.clone(),
+            attempted: attempted.clone(),
+        },
+        // Should never be called with a non-refusal error; return a
+        // sentinel rather than panic.
+        other => TranscriptError::ParseError(format!("clone_refusal called on {other:?}")),
     }
 }
 
@@ -142,7 +288,7 @@ impl TranscriptSource for Youtube {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    //! Two layers:
+    //! Three layers:
     //!
     //! 1. Offline acceptance gate — parse a checked-in `playerResponse`,
     //!    select the requested track, parse a checked-in json3 transcript,
@@ -151,6 +297,10 @@ mod tests {
     //! 2. HTTP-driven `TranscriptSource` impl tested against a
     //!    `wiremock::MockServer` serving both the InnerTube `/player`
     //!    endpoint and the timedtext URL the player response points at.
+    //! 3. Multi-client fallback behaviour: verifies the chain advances on
+    //!    `UNPLAYABLE` / `LOGIN_REQUIRED`, short-circuits on transport or
+    //!    parse errors, and surfaces the full `attempted` list when every
+    //!    rung refuses.
     //!
     //! [`format::srt`]: crate::transcript::format::srt
 
@@ -159,12 +309,14 @@ mod tests {
     use crate::transcript::format::srt;
     use crate::transcript::source::{FetchOpts, TrackKind};
     use serde_json::Value;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     const PLAYER_RESPONSE: &str = include_str!("youtube/fixtures/player_response_basic.json");
     const PLAYER_RESPONSE_AGE_GATED: &str =
         include_str!("youtube/fixtures/player_response_age_gated.json");
+    const PLAYER_RESPONSE_UNPLAYABLE: &str =
+        include_str!("youtube/fixtures/player_response_unplayable.json");
     const TIMEDTEXT: &str = include_str!("youtube/fixtures/timedtext_basic.json");
     const EXPECTED_SRT: &str = include_str!("youtube/fixtures/expected_basic.srt");
 
@@ -266,10 +418,19 @@ mod tests {
         server
     }
 
+    /// Build a Youtube source with a single-client chain, so the test only
+    /// has to mock one POST and the mock server's expected request count
+    /// matches the call count exactly.
+    fn yt_web_only(server: &MockServer) -> Youtube {
+        Youtube::with_base_url(server.uri())
+            .unwrap()
+            .with_chain(vec![InnertubeClient::Web])
+    }
+
     #[tokio::test]
     async fn fetch_returns_transcript_assembled_from_both_endpoints() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
         let opts = FetchOpts::new("en-US");
 
         let transcript = yt
@@ -293,7 +454,7 @@ mod tests {
     #[tokio::test]
     async fn fetch_accepts_bare_video_id_as_locator() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
         let opts = FetchOpts::new("en-US");
 
         let transcript = yt.fetch(VIDEO_ID, &opts).await.unwrap();
@@ -303,7 +464,7 @@ mod tests {
     #[tokio::test]
     async fn fetch_propagates_language_not_found() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
         let opts = FetchOpts::new("zz");
 
         let err = yt.fetch(VIDEO_ID, &opts).await.unwrap_err();
@@ -311,7 +472,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_surfaces_age_gated_as_playability_refused() {
+    async fn fetch_surfaces_age_gated_when_chain_exhausted() {
+        // Every rung returns LOGIN_REQUIRED. The chain walks them all and
+        // surfaces the last refusal with the full attempted list.
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
@@ -322,8 +485,12 @@ mod tests {
         let yt = Youtube::with_base_url(server.uri()).unwrap();
         let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
         match err {
-            TranscriptError::PlayabilityRefused { status, .. } => {
+            TranscriptError::PlayabilityRefused {
+                status, attempted, ..
+            } => {
                 assert_eq!(status, "LOGIN_REQUIRED");
+                assert_eq!(attempted.len(), DEFAULT_CHAIN.len());
+                assert_eq!(attempted.first().map(String::as_str), Some("WEB"));
             }
             other => panic!("wrong variant: {other:?}"),
         }
@@ -341,11 +508,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_surfaces_innertube_500_as_http_error() {
+    async fn fetch_prefers_playability_refusal_over_later_http_errors() {
+        // First two rungs return refusals; remaining rungs return 500. The
+        // surfaced error should be the *first* refusal (most informative)
+        // with the full attempted chain, not the trailing HTTP error.
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname("WEB")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(PLAYER_RESPONSE_UNPLAYABLE))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname("ANDROID_VR")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(PLAYER_RESPONSE_AGE_GATED))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname(
+                "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+            )))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname("IOS")))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
+        match err {
+            TranscriptError::PlayabilityRefused {
+                status, attempted, ..
+            } => {
+                // First refusal was UNPLAYABLE on WEB.
+                assert_eq!(status, "UNPLAYABLE");
+                assert_eq!(attempted.len(), DEFAULT_CHAIN.len());
+                assert_eq!(attempted.first().map(String::as_str), Some("WEB"));
+            }
+            other => panic!("expected PlayabilityRefused, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_walks_chain_on_http_errors_then_surfaces_last() {
+        // Every rung gets a 500. The chain walks them all (HTTP failures
+        // can be per-client request-shape rejections), then surfaces the
+        // last HTTP error.
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
             .respond_with(ResponseTemplate::new(500))
+            .expect(DEFAULT_CHAIN.len() as u64)
             .mount(&server)
             .await;
 
@@ -357,7 +581,7 @@ mod tests {
     #[tokio::test]
     async fn list_languages_projects_caption_tracks() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
 
         let langs = yt.list_languages(VIDEO_ID).await.unwrap();
         let codes: Vec<_> = langs.iter().map(|l| l.code.as_str()).collect();
@@ -369,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn info_returns_video_metadata() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
 
         let info = yt.info(VIDEO_ID).await.unwrap();
         assert_eq!(info.source, "youtube");
@@ -393,16 +617,17 @@ mod tests {
     #[tokio::test]
     async fn name_is_lowercase_youtube() {
         let server = mock_server_with_basic_video().await;
-        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let yt = yt_web_only(&server);
         assert_eq!(yt.name(), "youtube");
     }
 
     #[test]
     fn new_constructs_default_client() {
         // Smoke test for the production constructor — exercises the
-        // reqwest::Client::builder() path with the pinned timeout / UA.
+        // reqwest::Client::builder() path with the pinned timeout.
         let yt = Youtube::new().unwrap();
         assert_eq!(yt.base_url, DEFAULT_BASE_URL);
+        assert_eq!(yt.chain, DEFAULT_CHAIN);
     }
 
     #[tokio::test]
@@ -411,12 +636,178 @@ mod tests {
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_string("{ not json"))
+            .expect(1) // parse errors short-circuit; no fallback
             .mount(&server)
             .await;
 
         let yt = Youtube::with_base_url(server.uri()).unwrap();
         let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
         assert!(matches!(err, TranscriptError::ParseError(_)));
+    }
+
+    // ── Multi-client fallback ──
+
+    #[tokio::test]
+    async fn fetch_falls_back_to_android_vr_when_web_unplayable() {
+        let server = MockServer::start().await;
+        let player_response_ok = fixture_with_rewritten_caption_urls(&server.uri());
+
+        // WEB rung: refuse with UNPLAYABLE.
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname("WEB")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(PLAYER_RESPONSE_UNPLAYABLE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // ANDROID_VR rung: succeed.
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .and(body_partial_json(json_clientname("ANDROID_VR")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(player_response_ok))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/timedtext"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(TIMEDTEXT))
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri())
+            .unwrap()
+            .with_chain(vec![InnertubeClient::Web, InnertubeClient::AndroidVr]);
+        let opts = FetchOpts::new("en-US");
+        let transcript = yt.fetch(VIDEO_ID, &opts).await.unwrap();
+
+        assert_eq!(transcript.source, "youtube");
+        assert_eq!(transcript.cues.len(), 3);
+        assert_eq!(srt::render(&transcript.cues), EXPECTED_SRT);
+    }
+
+    #[tokio::test]
+    async fn fetch_chain_exhausted_surfaces_last_refusal_with_attempted() {
+        let server = MockServer::start().await;
+        // Every POST returns UNPLAYABLE regardless of which client asked.
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string(PLAYER_RESPONSE_UNPLAYABLE))
+            .expect(DEFAULT_CHAIN.len() as u64)
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
+        match err {
+            TranscriptError::PlayabilityRefused {
+                status,
+                attempted,
+                reason,
+            } => {
+                assert_eq!(status, "UNPLAYABLE");
+                assert_eq!(reason.as_deref(), Some("Video unavailable"));
+                let want: Vec<String> = DEFAULT_CHAIN
+                    .iter()
+                    .map(|c| c.context().name.to_string())
+                    .collect();
+                assert_eq!(attempted, want);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_falls_back_on_error_status() {
+        // `ERROR` is retryable — YouTube uses it for both deleted videos
+        // *and* "client no longer supported" rejections, so the chain
+        // walks every rung before surfacing a refusal.
+        let server = MockServer::start().await;
+        let response = serde_json::json!({
+            "playabilityStatus": { "status": "ERROR", "reason": "Video unavailable" }
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response))
+            .expect(DEFAULT_CHAIN.len() as u64)
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
+        match err {
+            TranscriptError::PlayabilityRefused {
+                status, attempted, ..
+            } => {
+                assert_eq!(status, "ERROR");
+                assert_eq!(attempted.len(), DEFAULT_CHAIN.len());
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_short_circuits_on_live_stream_offline() {
+        // Live streams that haven't started will never have captions, so
+        // we don't waste requests fanning out.
+        let server = MockServer::start().await;
+        let response = serde_json::json!({
+            "playabilityStatus": {
+                "status": "LIVE_STREAM_OFFLINE",
+                "reason": "Premieres in 1 hour"
+            }
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
+        match err {
+            TranscriptError::PlayabilityRefused { status, .. } => {
+                assert_eq!(status, "LIVE_STREAM_OFFLINE");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    fn json_clientname(name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "context": { "client": { "clientName": name } }
+        })
+    }
+
+    #[test]
+    fn is_retryable_refusal_matches_expected_statuses() {
+        let mk = |s: &str| TranscriptError::PlayabilityRefused {
+            status: s.to_string(),
+            reason: None,
+            attempted: Vec::new(),
+        };
+        // All ambiguous refusals retry: any one of these may be a
+        // client-specific quirk that another rung will resolve.
+        assert!(is_retryable_refusal(&mk("UNPLAYABLE")));
+        assert!(is_retryable_refusal(&mk("LOGIN_REQUIRED")));
+        assert!(is_retryable_refusal(&mk("AGE_VERIFICATION_REQUIRED")));
+        assert!(is_retryable_refusal(&mk("CONTENT_CHECK_REQUIRED")));
+        assert!(is_retryable_refusal(&mk("ERROR")));
+        // Live streams that haven't started will never have captions on
+        // any client.
+        assert!(!is_retryable_refusal(&mk("LIVE_STREAM_OFFLINE")));
+        // Parse / locator errors short-circuit — same input yields the
+        // same parse failure on every client.
+        assert!(!is_retryable_refusal(&TranscriptError::ParseError(
+            "x".into()
+        )));
+        assert!(!is_retryable_refusal(&TranscriptError::InvalidLocator(
+            "x".into()
+        )));
     }
 
     // ── Online integration test ──

--- a/src/transcript/sources/youtube/client.rs
+++ b/src/transcript/sources/youtube/client.rs
@@ -1,0 +1,211 @@
+//! InnerTube client variants and the default fallback chain.
+//!
+//! YouTube's `/youtubei/v1/player` endpoint evaluates `playabilityStatus` per
+//! `client.clientName` / `clientVersion` pair. A video that returns
+//! `UNPLAYABLE` for the **WEB** client often returns `OK` for one of the
+//! mobile / VR / embedded clients, because each variant skips a different
+//! subset of YouTube's gating logic (JS-derived signatures, sign-in checks,
+//! music-content blocks, …). The behaviour is the same workaround `yt-dlp`
+//! uses internally — see its `youtube/_base.py` for the canonical client
+//! list. Values pinned here drift over months; refresh if `/player` starts
+//! returning empty `playerResponse` envelopes for healthy videos.
+//!
+//! The chain is walked by [`super::Youtube::load_player_response`] only when
+//! the previous client returned a *retryable* refusal (see
+//! [`super::is_retryable_refusal`]). Healthy videos answer on the first
+//! client and pay no extra request volume.
+//!
+//! Plain `ANDROID` is intentionally absent — YouTube has tightened it over
+//! the past year and yt-dlp has been moving away from it as a default.
+
+use clap::ValueEnum;
+use serde_json::{json, Value};
+
+/// One InnerTube client variant.
+///
+/// Variants are ordered to match [`DEFAULT_CHAIN`]: WEB first (cheapest,
+/// works for most public videos), then non-WEB clients that recover
+/// WEB-specific refusals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum InnertubeClient {
+    /// Desktop web. Default; fails on videos that require JS-derived
+    /// signatures or sign-in.
+    Web,
+    /// Android VR / Quest. Currently the most reliable recovery client for
+    /// `UNPLAYABLE` on WEB.
+    AndroidVr,
+    /// TV HTML5 embedded player. Often unblocks age-gated content.
+    TvEmbedded,
+    /// iOS native. Last-resort fallback when the Android-family clients are
+    /// also throttled.
+    Ios,
+}
+
+/// Per-client request-shaping data used to build the InnerTube POST.
+#[derive(Clone, Debug)]
+pub struct ClientContext {
+    /// `client.clientName` — uppercase, stable string YouTube switches on.
+    pub name: &'static str,
+    /// `client.clientVersion` — drifts over months.
+    pub version: &'static str,
+    /// Public InnerTube API key forwarded as `?key=`. Long-stable; not a
+    /// credential. The same key works for every variant we emit, but is
+    /// kept per-client so future drift is local.
+    pub api_key: &'static str,
+    /// `User-Agent` advertised on the request. YouTube's bot detection
+    /// cross-checks UA against `clientName`; mismatches trigger
+    /// `LOGIN_REQUIRED`.
+    pub user_agent: &'static str,
+    /// Extra fields merged into `context.client` (e.g. `androidSdkVersion`,
+    /// `deviceModel`). `None` when the client needs no extras.
+    pub extra_context: Option<Value>,
+}
+
+/// Public WEB-client API key. Long-stable across years, embedded in the
+/// YouTube watch page's bootstrapped config.
+pub(crate) const WEB_API_KEY: &str = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+
+/// User-Agent for the WEB client. A recent desktop Chrome string maximises
+/// compatibility with the WEB context InnerTube expects.
+const WEB_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/// User-Agent for the Android VR client.
+const ANDROID_VR_USER_AGENT: &str =
+    "com.google.android.apps.youtube.vr.oculus/1.57.29 (Linux; U; Android 12; \
+     Quest 3) gzip";
+
+/// User-Agent for the TV embedded client. Mirrors a recent Smart TV YouTube
+/// app build that YouTube's bot-detection treats as a first-class client.
+const TV_EMBEDDED_USER_AGENT: &str = "Mozilla/5.0 (PlayStation; PlayStation 4/12.00) \
+     AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15";
+
+/// User-Agent for the iOS client.
+const IOS_USER_AGENT: &str =
+    "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X;)";
+
+impl InnertubeClient {
+    /// Per-variant request-shaping data.
+    pub fn context(self) -> ClientContext {
+        match self {
+            Self::Web => ClientContext {
+                name: "WEB",
+                version: "2.20250101.00.00",
+                api_key: WEB_API_KEY,
+                user_agent: WEB_USER_AGENT,
+                extra_context: None,
+            },
+            Self::AndroidVr => ClientContext {
+                name: "ANDROID_VR",
+                version: "1.57.29",
+                api_key: WEB_API_KEY,
+                user_agent: ANDROID_VR_USER_AGENT,
+                extra_context: Some(json!({
+                    "androidSdkVersion": 32,
+                    "deviceMake": "Oculus",
+                    "deviceModel": "Quest 3",
+                    "osName": "Android",
+                    "osVersion": "12L",
+                })),
+            },
+            Self::TvEmbedded => ClientContext {
+                name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+                version: "2.0",
+                api_key: WEB_API_KEY,
+                user_agent: TV_EMBEDDED_USER_AGENT,
+                extra_context: None,
+            },
+            Self::Ios => ClientContext {
+                name: "IOS",
+                version: "19.45.4",
+                api_key: WEB_API_KEY,
+                user_agent: IOS_USER_AGENT,
+                extra_context: Some(json!({
+                    "deviceMake": "Apple",
+                    "deviceModel": "iPhone16,2",
+                    "osName": "iPhone",
+                    "osVersion": "18.1.0.22B83",
+                })),
+            },
+        }
+    }
+}
+
+/// Default fallback chain walked by [`super::Youtube::load_player_response`].
+///
+/// Order is "cheapest first, broadest unblock last": WEB answers most
+/// videos in one request; the remaining variants recover progressively
+/// stricter refusals.
+pub const DEFAULT_CHAIN: &[InnertubeClient] = &[
+    InnertubeClient::Web,
+    InnertubeClient::AndroidVr,
+    InnertubeClient::TvEmbedded,
+    InnertubeClient::Ios,
+];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_chain_starts_with_web() {
+        assert_eq!(DEFAULT_CHAIN.first(), Some(&InnertubeClient::Web));
+    }
+
+    #[test]
+    fn default_chain_has_no_duplicates() {
+        let mut seen = Vec::new();
+        for client in DEFAULT_CHAIN {
+            assert!(!seen.contains(client), "duplicate variant in chain");
+            seen.push(*client);
+        }
+    }
+
+    #[test]
+    fn every_variant_has_non_empty_strings() {
+        for client in DEFAULT_CHAIN {
+            let ctx = client.context();
+            assert!(!ctx.name.is_empty());
+            assert!(!ctx.version.is_empty());
+            assert!(!ctx.api_key.is_empty());
+            assert!(!ctx.user_agent.is_empty());
+        }
+    }
+
+    #[test]
+    fn client_names_are_unique() {
+        let mut names = Vec::new();
+        for client in DEFAULT_CHAIN {
+            let ctx = client.context();
+            assert!(
+                !names.contains(&ctx.name),
+                "duplicate clientName: {}",
+                ctx.name
+            );
+            names.push(ctx.name);
+        }
+    }
+
+    #[test]
+    fn web_client_has_no_extra_context() {
+        assert!(InnertubeClient::Web.context().extra_context.is_none());
+    }
+
+    #[test]
+    fn android_vr_client_carries_android_sdk_version() {
+        let ctx = InnertubeClient::AndroidVr.context();
+        let extra = ctx.extra_context.as_ref().expect("android_vr has extras");
+        assert_eq!(extra["androidSdkVersion"], 32);
+        assert_eq!(extra["osName"], "Android");
+    }
+
+    #[test]
+    fn ios_client_carries_ios_device_metadata() {
+        let ctx = InnertubeClient::Ios.context();
+        let extra = ctx.extra_context.as_ref().expect("ios has extras");
+        assert_eq!(extra["deviceMake"], "Apple");
+        assert_eq!(extra["osName"], "iPhone");
+    }
+}

--- a/src/transcript/sources/youtube/fixtures/player_response_unplayable.json
+++ b/src/transcript/sources/youtube/fixtures/player_response_unplayable.json
@@ -1,0 +1,6 @@
+{
+  "playabilityStatus": {
+    "status": "UNPLAYABLE",
+    "reason": "Video unavailable"
+  }
+}

--- a/src/transcript/sources/youtube/innertube.rs
+++ b/src/transcript/sources/youtube/innertube.rs
@@ -1,35 +1,27 @@
 //! HTTP wrapper around YouTube's InnerTube `/player` endpoint.
 //!
-//! Step 3 of [issue #687](https://github.com/rust-works/omni-dev/issues/687)
-//! pins the **WEB** client only. The Android / IosEmbedded fallback chain
-//! used for age-gated content lands in step 5; that work introduces a
-//! dedicated `client.rs` with an enum, at which point the constants below
-//! migrate. Until then they live next to the only HTTP call that uses them.
+//! Client identity (WEB / ANDROID_VR / TVHTML5_SIMPLY_EMBEDDED_PLAYER / IOS)
+//! is supplied by the caller via [`ClientContext`] so the same code path
+//! services every rung of [`super::client::DEFAULT_CHAIN`]. See
+//! [`super::client`] for the variant list and the rationale behind the
+//! fallback ordering.
 
-use serde_json::json;
+use serde_json::{json, Map, Value};
 
 use crate::transcript::error::Result;
+use crate::transcript::sources::youtube::client::ClientContext;
 
-/// Path appended to the `base_url` for the `/player` POST. YouTube also
-/// accepts this without the API key, but we forward the public WEB key for
-/// parity with browsers.
+/// Path appended to the `base_url` for the `/player` POST.
 pub(crate) const PLAYER_PATH: &str = "/youtubei/v1/player";
 
-/// Public WEB-client API key. Long-stable across years, embedded in the
-/// YouTube watch page's bootstrapped config — this is not a credential.
-pub(crate) const WEB_API_KEY: &str = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+/// Header carrying the InnerTube API key. Modern YouTube rejects requests
+/// that supply the key as the `?key=` URL parameter (returns 400), so we
+/// send it as a header instead — same as the real YouTube apps.
+const API_KEY_HEADER: &str = "X-Goog-Api-Key";
 
-/// `client.clientName` for the WEB context.
-pub(crate) const CLIENT_NAME: &str = "WEB";
-
-/// `client.clientVersion` for the WEB context. YouTube treats stale
-/// versions leniently, but the value drifts over months — refresh if
-/// `/player` starts returning empty `playerResponse` envelopes.
-pub(crate) const CLIENT_VERSION: &str = "2.20250101.00.00";
-
-/// POST `videoId` to the InnerTube `/player` endpoint at `base_url` and
-/// return the raw response body. Callers feed the body to
-/// [`super::player_response::parse`].
+/// POST `videoId` to the InnerTube `/player` endpoint at `base_url`,
+/// identifying as `client`, and return the raw response body. Callers feed
+/// the body to [`super::player_response::parse`].
 ///
 /// `base_url` is normally `https://www.youtube.com`; tests inject a
 /// `wiremock::MockServer::uri()` instead.
@@ -37,22 +29,27 @@ pub async fn fetch_player_response(
     http: &reqwest::Client,
     base_url: &str,
     video_id: &str,
+    client: &ClientContext,
 ) -> Result<String> {
     let url = format!(
-        "{base}{path}?key={key}",
+        "{base}{path}",
         base = base_url.trim_end_matches('/'),
         path = PLAYER_PATH,
-        key = WEB_API_KEY,
     );
+
+    let mut client_obj = Map::new();
+    client_obj.insert("clientName".into(), Value::String(client.name.into()));
+    client_obj.insert("clientVersion".into(), Value::String(client.version.into()));
+    client_obj.insert("hl".into(), Value::String("en".into()));
+    client_obj.insert("gl".into(), Value::String("US".into()));
+    if let Some(extra) = client.extra_context.as_ref().and_then(Value::as_object) {
+        for (k, v) in extra {
+            client_obj.insert(k.clone(), v.clone());
+        }
+    }
+
     let body = json!({
-        "context": {
-            "client": {
-                "clientName": CLIENT_NAME,
-                "clientVersion": CLIENT_VERSION,
-                "hl": "en",
-                "gl": "US",
-            },
-        },
+        "context": { "client": Value::Object(client_obj) },
         "videoId": video_id,
         "contentCheckOk": true,
         "racyCheckOk": true,
@@ -60,6 +57,8 @@ pub async fn fetch_player_response(
 
     let response = http
         .post(&url)
+        .header(reqwest::header::USER_AGENT, client.user_agent)
+        .header(API_KEY_HEADER, client.api_key)
         .json(&body)
         .send()
         .await?
@@ -71,8 +70,9 @@ pub async fn fetch_player_response(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::transcript::sources::youtube::client::InnertubeClient;
     use serde_json::Value;
-    use wiremock::matchers::{body_partial_json, method, path, query_param};
+    use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
     const VIDEO_ID: &str = "dQw4w9WgXcQ";
@@ -85,19 +85,20 @@ mod tests {
     #[tokio::test]
     async fn posts_to_player_endpoint_with_web_context_and_video_id() {
         let server = MockServer::start().await;
+        let web = InnertubeClient::Web.context();
         Mock::given(method("POST"))
             .and(path(PLAYER_PATH))
-            .and(query_param("key", WEB_API_KEY))
+            .and(header(API_KEY_HEADER, web.api_key))
             .and(body_partial_json(json!({
                 "videoId": VIDEO_ID,
-                "context": { "client": { "clientName": CLIENT_NAME } },
+                "context": { "client": { "clientName": web.name } },
             })))
             .respond_with(ResponseTemplate::new(200).set_body_string(FIXTURE_BASIC))
             .expect(1)
             .mount(&server)
             .await;
 
-        let body = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let body = fetch_player_response(&http(), &server.uri(), VIDEO_ID, &web)
             .await
             .unwrap();
         assert_eq!(body, FIXTURE_BASIC);
@@ -106,17 +107,18 @@ mod tests {
     #[tokio::test]
     async fn forwards_pinned_client_version() {
         let server = MockServer::start().await;
+        let web = InnertubeClient::Web.context();
         Mock::given(method("POST"))
             .and(path(PLAYER_PATH))
             .and(body_partial_json(json!({
-                "context": { "client": { "clientVersion": CLIENT_VERSION } },
+                "context": { "client": { "clientVersion": web.version } },
             })))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
             .await;
 
-        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, &web)
             .await
             .unwrap();
     }
@@ -130,9 +132,14 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
-            .await
-            .unwrap_err();
+        let err = fetch_player_response(
+            &http(),
+            &server.uri(),
+            VIDEO_ID,
+            &InnertubeClient::Web.context(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, crate::transcript::TranscriptError::Http(_)));
         assert!(err.to_string().contains("500"));
     }
@@ -153,9 +160,14 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
-            .await
-            .unwrap();
+        let _ = fetch_player_response(
+            &http(),
+            &server.uri(),
+            VIDEO_ID,
+            &InnertubeClient::Web.context(),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -169,8 +181,78 @@ mod tests {
             .await;
 
         let with_slash = format!("{}/", server.uri());
-        let _ = fetch_player_response(&http(), &with_slash, VIDEO_ID)
+        let _ = fetch_player_response(
+            &http(),
+            &with_slash,
+            VIDEO_ID,
+            &InnertubeClient::Web.context(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn user_agent_matches_client() {
+        let server = MockServer::start().await;
+        let android_vr = InnertubeClient::AndroidVr.context();
+        Mock::given(method("POST"))
+            .and(path(PLAYER_PATH))
+            .and(header("user-agent", android_vr.user_agent))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, &android_vr)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn android_vr_body_includes_extra_context() {
+        let server = MockServer::start().await;
+        let android_vr = InnertubeClient::AndroidVr.context();
+        Mock::given(method("POST"))
+            .and(path(PLAYER_PATH))
+            .and(body_partial_json(json!({
+                "context": {
+                    "client": {
+                        "clientName": "ANDROID_VR",
+                        "androidSdkVersion": 32,
+                        "deviceMake": "Oculus",
+                    }
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, &android_vr)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn each_chain_client_can_be_dispatched() {
+        // Smoke test: every variant produces a valid request the mock accepts.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+
+        for variant in [
+            InnertubeClient::Web,
+            InnertubeClient::AndroidVr,
+            InnertubeClient::TvEmbedded,
+            InnertubeClient::Ios,
+        ] {
+            let ctx = variant.context();
+            let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, &ctx)
+                .await
+                .unwrap();
+        }
     }
 }

--- a/src/transcript/sources/youtube/player_response.rs
+++ b/src/transcript/sources/youtube/player_response.rs
@@ -149,6 +149,10 @@ pub fn parse(raw: &str) -> Result<PlayerResponse> {
 }
 
 /// Surface a non-`OK` playability status as a typed error.
+///
+/// The returned [`TranscriptError::PlayabilityRefused`] has an empty
+/// `attempted` field; callers that try multiple clients (see
+/// [`super::DEFAULT_CHAIN`]) populate it before propagating.
 pub fn check_playability(response: &PlayerResponse) -> Result<()> {
     if response.playability_status.status == "OK" {
         Ok(())
@@ -156,6 +160,7 @@ pub fn check_playability(response: &PlayerResponse) -> Result<()> {
         Err(TranscriptError::PlayabilityRefused {
             status: response.playability_status.status.clone(),
             reason: response.playability_status.reason.clone(),
+            attempted: Vec::new(),
         })
     }
 }
@@ -377,9 +382,14 @@ mod tests {
         let r = parse(FIXTURE_AGE_GATED).unwrap();
         let err = check_playability(&r).unwrap_err();
         match err {
-            TranscriptError::PlayabilityRefused { status, reason } => {
+            TranscriptError::PlayabilityRefused {
+                status,
+                reason,
+                attempted,
+            } => {
                 assert_eq!(status, "LOGIN_REQUIRED");
                 assert_eq!(reason.as_deref(), Some("Sign in to confirm your age"));
+                assert!(attempted.is_empty());
             }
             other => panic!("wrong variant: {other:?}"),
         }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2293,6 +2293,7 @@ Options:
       --auto              Allow falling through to auto-generated (ASR) captions when no manual track matches
       --translate <LANG>  Synthesise a translated track in this target language when no native track matches
   -o, --output <OUTPUT>   Output file (writes to stdout if omitted)
+      --client <CLIENT>   Force a specific InnerTube client instead of the default fallback chain (`web` → `android-vr` → `tv-embedded` → `ios`). Useful for reproducing client-specific bugs and isolating regressions [possible values: web, android-vr, tv-embedded, ios]
   -h, --help              Print help (see more with '--help')
 
 
@@ -2309,6 +2310,7 @@ Arguments:
 
 Options:
       --output <OUTPUT>  Output format [default: table] [possible values: table, json]
+      --client <CLIENT>  Force a specific InnerTube client instead of the default fallback chain (`web` → `android-vr` → `tv-embedded` → `ios`) [possible values: web, android-vr, tv-embedded, ios]
   -h, --help             Print help (see more with '--help')
 
 
@@ -2325,4 +2327,5 @@ Arguments:
 
 Options:
       --output <OUTPUT>  Output format [default: table] [possible values: table, json]
+      --client <CLIENT>  Force a specific InnerTube client instead of the default fallback chain (`web` → `android-vr` → `tv-embedded` → `ios`) [possible values: web, android-vr, tv-embedded, ios]
   -h, --help             Print help (see more with '--help')


### PR DESCRIPTION
## Description

This PR implements a multi-client InnerTube fallback chain for the YouTube transcript source (step 5 of issue #687). Instead of always using the WEB client, the YouTube source now walks a configurable chain — `web → android-vr → tv-embedded → ios` — on retryable refusals such as `UNPLAYABLE`, `LOGIN_REQUIRED`, `AGE_VERIFICATION_REQUIRED`, and `CONTENT_CHECK_REQUIRED`. Healthy videos still answer on the first (WEB) request and pay no extra request volume; only refused videos fan out.

Users can pin a specific client via a new `--client` flag on the `fetch`, `info`, and `list-langs` subcommands, which is useful for reproducing client-specific bugs and isolating regressions.

The `PlayabilityRefused` error variant is extended with an `attempted` field so callers can see exactly which clients were tried before the failure was surfaced.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Relates to #687

## Changes Made

**Core InnerTube Client Abstraction (`src/transcript/sources/youtube/client.rs` — new file):**
- Added `InnertubeClient` enum with variants `Web`, `AndroidVr`, `TvEmbedded`, `Ios`, implementing `clap::ValueEnum` for CLI integration
- Added `ClientContext` struct carrying `name`, `version`, `api_key`, `user_agent`, and optional `extra_context` per client
- Defined `DEFAULT_CHAIN: &[InnertubeClient]` ordering clients cheapest-first: `[Web, AndroidVr, TvEmbedded, Ios]`
- Moved User-Agent constants out of `youtube.rs` and into per-client definitions in this module
- Added unit tests verifying chain uniqueness, non-empty strings, and client-specific metadata

**Fallback Chain Logic (`src/transcript/sources/youtube.rs`):**
- Added `chain: Vec<InnertubeClient>` field to `Youtube` struct; constructor initialises from `DEFAULT_CHAIN`
- Added `with_chain(Vec<InnertubeClient>) -> Self` builder for pinning a single client or custom order
- Added `try_one_client()` helper to issue a single InnerTube POST and check playability
- Rewrote `load_player_response()` to walk `self.chain` in order; returns first `OK` response, retries on retryable refusals, short-circuits on non-retryable errors (e.g. `LIVE_STREAM_OFFLINE`, parse errors)
- Added `is_retryable_refusal()` classifying which `TranscriptError` variants warrant a chain advance
- Added `annotate_attempted()` and `clone_refusal()` helpers to attach the full attempted-client list to the surfaced error
- Removed global User-Agent from `reqwest::Client`; it is now set per-request via `client.user_agent`

**InnerTube HTTP Layer (`src/transcript/sources/youtube/innertube.rs`):**
- `fetch_player_response()` now accepts `&ClientContext` and builds the request body and headers from it
- API key moved from `?key=` URL parameter to `X-Goog-Api-Key` header (modern YouTube rejects the query-param form with 400)
- `extra_context` fields (e.g. `androidSdkVersion`, `deviceMake`) are merged into `context.client` when present
- Removed module-level `CLIENT_NAME`, `CLIENT_VERSION`, `WEB_API_KEY` constants (migrated to `client.rs`)

**Error Reporting (`src/transcript/error.rs`):**
- Extended `PlayabilityRefused` with `attempted: Vec<String>` field
- Error message conditionally appends `[tried: WEB, ANDROID_VR, …]` when more than one client was attempted, keeping single-client messages clean

**CLI (`src/cli/transcript/youtube/fetch.rs`, `info.rs`, `list_langs.rs`):**
- Added `--client <CLIENT>` flag (enum, kebab-case values: `web`, `android-vr`, `tv-embedded`, `ios`) to `FetchCommand`, `InfoCommand`, `ListLangsCommand`
- Extracted `build_youtube(Option<InnertubeClient>) -> Result<Youtube>` helper in `fetch.rs`; reused by `info.rs` and `list_langs.rs`
- When `--client` is supplied, `with_chain(vec![client])` pins a single rung for the request

**Fixtures & Snapshots:**
- Added `src/transcript/sources/youtube/fixtures/player_response_unplayable.json` for test use
- Updated `tests/snapshots/integration_test__help_all_output.snap` to reflect the new `--client` option in help output

**Testing:**
- Added comprehensive multi-client fallback tests in `youtube.rs`: chain advance on `UNPLAYABLE`/`LOGIN_REQUIRED`, short-circuit on `LIVE_STREAM_OFFLINE` and parse errors, preference of first `PlayabilityRefused` over later HTTP errors, full `attempted` list on chain exhaustion
- Added `innertube.rs` tests: per-client User-Agent matching, Android VR extra-context body fields, smoke test dispatching every chain variant
- Added `client.rs` unit tests: chain starts with WEB, no duplicate variants, all fields non-empty, client-specific metadata correctness
- Added `error.rs` tests: single-attempt suppresses `[tried: …]`, multi-attempt includes full chain in message
- Updated existing tests to use `yt_web_only()` helper or include new `attempted`/`client` fields in struct literals

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (multi-client fallback, client context building, error annotation)
- [x] Integration tests updated/added (wiremock-based per-client mock routing via `body_partial_json` on `clientName`)

**Manual Testing:**
- [x] Tested happy path scenarios (WEB answers immediately, no extra requests)
- [x] Tested error/edge cases (chain exhausted, `LIVE_STREAM_OFFLINE` short-circuit, HTTP 500 across all rungs)
- [x] Backward compatibility verified (default behaviour unchanged; `--client` is optional)

### Test Commands
```bash
# Core test suite
cargo test

# Run only YouTube source and InnerTube tests
cargo test transcript::sources::youtube
cargo test transcript::sources::youtube::innertube
cargo test transcript::sources::youtube::client

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify CLI help output matches snapshot
cargo test integration_test__help_all_output
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the new `client.rs` module and `with_chain()` builder pattern
- [x] Error handling — `annotate_attempted` / `clone_refusal` and the preference logic (first `PlayabilityRefused` wins over later HTTP errors)
- [x] Performance impact — confirm only one InnerTube POST is issued for healthy videos
- [x] Backward compatibility — existing callers of `Youtube::new()` get the full default chain transparently

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact for healthy videos (WEB answers on the first request; no extra calls)
- [x] Potential performance impact (describe below)

Refused videos may now issue up to 4 InnerTube POSTs (one per chain rung) before surfacing an error. This is the expected trade-off: the additional requests only occur when the video would have failed anyway, and the fallback often recovers playback that would otherwise be an error.

## Security Considerations
- [x] No security implications

The API key (`WEB_API_KEY`) is a long-stable public key embedded in YouTube's watch page — it is not a credential. It was already present in the codebase and is now organised per-client in `client.rs`.

## Breaking Changes

None. The `attempted` field added to `TranscriptError::PlayabilityRefused` requires existing match arms that destructure this variant to be updated (existing internal callsites have been updated in this PR). External consumers using exhaustive pattern matching on `TranscriptError` will need to add the `attempted` field.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Design rationale:** The fallback strategy mirrors what `yt-dlp` does internally — WEB is cheapest and covers most public videos; non-WEB clients skip progressively stricter YouTube gating checks. `LIVE_STREAM_OFFLINE` intentionally does not retry because no client provides captions for a stream that hasn't started. `ERROR` is retryable because YouTube uses it ambiguously for both deleted videos and "client no longer supported" rejections.

**Client version drift:** `clientVersion` strings in `client.rs` drift over months. If `/player` starts returning empty `playerResponse` envelopes for healthy videos, refreshing the version constants is the first remediation step.

**Future Enhancements:**
- Add remaining InnerTube clients from the yt-dlp list (e.g. `MWEB`, `ANDROID_MUSIC`) as needed
- Expose chain configuration via a config file rather than only `--client` CLI flag

**Known Limitations:**
- Per-client `clientVersion` values are pinned and will drift; no auto-refresh mechanism exists yet