### PR TITLE
feat(lib): switch YouTube InnerTube client to ANDROID_VR with visitorData bootstrap

### DIFF
--- a/src/transcript/error.rs
+++ b/src/transcript/error.rs
@@ -53,6 +53,17 @@ pub enum TranscriptError {
     /// An HTTP transport or non-2xx response error.
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
+
+    /// The bootstrap GET to a media platform's watch page returned a body
+    /// without the expected session-bootstrap token. The page format drifts
+    /// every few months; this variant signals the scrape needs to be
+    /// retuned and is distinct from a generic [`Self::ParseError`] so
+    /// callers can react to it specifically (e.g. a clearer CLI message).
+    #[error("watch page at {url} did not contain the expected session token")]
+    MissingVisitorData {
+        /// The URL whose response body was scraped.
+        url: String,
+    },
 }
 
 #[cfg(test)]
@@ -138,5 +149,15 @@ mod tests {
         let err = TranscriptError::InvalidLocator("x".to_string());
         let dbg = format!("{err:?}");
         assert!(dbg.contains("InvalidLocator"));
+    }
+
+    #[test]
+    fn missing_visitor_data_display() {
+        let err = TranscriptError::MissingVisitorData {
+            url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("watch page"));
+        assert!(msg.contains("https://www.youtube.com/watch?v=dQw4w9WgXcQ"));
     }
 }

--- a/src/transcript/sources/youtube.rs
+++ b/src/transcript/sources/youtube.rs
@@ -1,11 +1,11 @@
 //! YouTube [`TranscriptSource`](crate::transcript::TranscriptSource).
 //!
-//! Step 3 of [issue #687](https://github.com/rust-works/omni-dev/issues/687)
-//! wires the HTTP layer for the WEB client and binds the offline parsers
-//! ([`url`], [`player_response`], [`timedtext`]) into a concrete
-//! [`TranscriptSource`] implementation. The Android / IosEmbedded fallback
-//! chain used for age-gated content lands in step 5 and will live in a
-//! sibling `client.rs` module.
+//! Wires the offline parsers ([`url`], [`player_response`], [`timedtext`])
+//! into a concrete [`TranscriptSource`] backed by an HTTP client. The
+//! request shape is pinned to the `ANDROID_VR` InnerTube client (see
+//! [`innertube`]); a `visitorData` token is scraped from the watch page
+//! on first use ([`watch_page`]) and cached for the lifetime of the
+//! [`Youtube`] instance.
 
 use std::time::Duration;
 
@@ -18,6 +18,7 @@ pub mod innertube;
 pub mod player_response;
 pub mod timedtext;
 pub mod url;
+pub mod watch_page;
 
 pub use player_response::{
     check_playability, extract_media_info, list_languages, parse as parse_player_response,
@@ -34,11 +35,16 @@ const DEFAULT_BASE_URL: &str = "https://www.youtube.com";
 /// [`crate::atlassian::client::AtlassianClient`]'s 30 s timeout.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// User-Agent advertised to YouTube. A recent desktop Chrome string maximises
-/// compatibility with the WEB context InnerTube expects; YouTube tightens
-/// caption-track availability for unrecognised UAs.
-const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
-     (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+/// User-Agent advertised to YouTube on InnerTube `/player` calls. Must
+/// match the `clientName` / `clientVersion` constants in [`innertube`] —
+/// YouTube cross-checks UA against `clientName` as part of bot detection
+/// and a mismatch is one of the flagged signals. The trailing `gzip`
+/// token isn't decorative; that's what the real Quest YouTube app emits.
+///
+/// The watch-page bootstrap in [`watch_page`] uses a separate
+/// browser-shaped UA — it scrapes a public HTML page, not InnerTube.
+const USER_AGENT: &str = "com.google.android.apps.youtube.vr.oculus/1.62.27 \
+     (Linux; U; Android 12; Quest 3) gzip";
 
 /// Whether `input` is recognised as a YouTube locator (URL or bare ID).
 ///
@@ -50,18 +56,24 @@ pub fn matches_url(input: &str) -> bool {
 
 /// YouTube [`TranscriptSource`].
 ///
-/// Holds a single [`reqwest::Client`] reused across the InnerTube and
-/// timedtext calls. Cheap to construct; in steady state it is fine to keep
-/// one instance per process.
+/// Holds a single [`reqwest::Client`] reused across the watch-page,
+/// InnerTube, and timedtext calls. Cheap to construct; in steady state
+/// it is fine to keep one instance per process.
+///
+/// On first use, a `visitorData` token is scraped from the watch page
+/// and cached in [`tokio::sync::OnceCell`]. Concurrent first-callers
+/// serialise on a single fetch rather than double-fetching, and every
+/// subsequent InnerTube `/player` POST forwards the cached token.
 #[derive(Debug, Clone)]
 pub struct Youtube {
     http: reqwest::Client,
     base_url: String,
+    visitor_data: tokio::sync::OnceCell<String>,
 }
 
 impl Youtube {
     /// Construct a YouTube source with default HTTP settings (30 s timeout,
-    /// desktop Chrome User-Agent) targeting the public YouTube origin.
+    /// ANDROID_VR User-Agent) targeting the public YouTube origin.
     pub fn new() -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
@@ -70,6 +82,7 @@ impl Youtube {
         Ok(Self {
             http,
             base_url: DEFAULT_BASE_URL.to_string(),
+            visitor_data: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -85,14 +98,32 @@ impl Youtube {
         Ok(Self {
             http,
             base_url: base_url.into(),
+            visitor_data: tokio::sync::OnceCell::new(),
         })
     }
 
-    /// Common preamble: locator → video ID → InnerTube POST →
-    /// `playerResponse` parse → playability check.
+    /// Cached `visitorData` token. First call scrapes the watch page;
+    /// concurrent first-callers serialise on a single in-flight scrape
+    /// (`OnceCell::get_or_try_init`) rather than double-fetching.
+    async fn visitor_data(&self) -> Result<&str> {
+        self.visitor_data
+            .get_or_try_init(|| watch_page::fetch_visitor_data(&self.http, &self.base_url))
+            .await
+            .map(String::as_str)
+    }
+
+    /// Common preamble: locator → video ID → watch-page bootstrap →
+    /// InnerTube POST → `playerResponse` parse → playability check.
+    ///
+    /// `extract_video_id` runs first so an invalid locator short-circuits
+    /// before any HTTP — lazy `visitor_data` fetch only happens on a
+    /// validated locator.
     async fn load_player_response(&self, locator: &str) -> Result<PlayerResponse> {
         let video_id = extract_video_id(locator)?;
-        let raw = innertube::fetch_player_response(&self.http, &self.base_url, &video_id).await?;
+        let visitor_data = self.visitor_data().await?;
+        let raw =
+            innertube::fetch_player_response(&self.http, &self.base_url, &video_id, visitor_data)
+                .await?;
         let response = parse_player_response(&raw)?;
         check_playability(&response)?;
         Ok(response)
@@ -247,9 +278,29 @@ mod tests {
         serde_json::to_string(&value).unwrap()
     }
 
+    /// Watch-page fixture used to satisfy the `visitorData` bootstrap in
+    /// every wiremock-driven test below. The exact token value doesn't
+    /// matter for these tests — only that the bootstrap returns *some*
+    /// token so [`load_player_response`] can proceed.
+    const WATCH_PAGE: &str = include_str!("youtube/fixtures/watch_page_with_visitor_data.html");
+
+    /// Mount the watch-page bootstrap mock onto `server`. Every
+    /// [`Youtube::fetch`] / `list_languages` / `info` call in the tests
+    /// below triggers this on first use (cached thereafter via
+    /// `OnceCell`).
+    async fn mount_watch_page(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(WATCH_PAGE))
+            .mount(server)
+            .await;
+    }
+
     async fn mock_server_with_basic_video() -> MockServer {
         let server = MockServer::start().await;
         let player_response = fixture_with_rewritten_caption_urls(&server.uri());
+
+        mount_watch_page(&server).await;
 
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
@@ -313,6 +364,7 @@ mod tests {
     #[tokio::test]
     async fn fetch_surfaces_age_gated_as_playability_refused() {
         let server = MockServer::start().await;
+        mount_watch_page(&server).await;
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_string(PLAYER_RESPONSE_AGE_GATED))
@@ -343,6 +395,7 @@ mod tests {
     #[tokio::test]
     async fn fetch_surfaces_innertube_500_as_http_error() {
         let server = MockServer::start().await;
+        mount_watch_page(&server).await;
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
             .respond_with(ResponseTemplate::new(500))
@@ -406,8 +459,137 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_threads_visitor_data_into_innertube_body() {
+        // Pin the bootstrap → InnerTube wiring: the token scraped from the
+        // watch page must appear under `context.client.visitorData` on the
+        // outbound /player POST. Captures the inbound JSON and asserts on
+        // the value the fixture publishes.
+        const EXPECTED_TOKEN: &str = "CgtkUTQyOFR3aV9NSSjFoYvBBjIKCgJVUxIEGgAgPg%3D%3D";
+
+        let server = MockServer::start().await;
+        mount_watch_page(&server).await;
+        let player_response = fixture_with_rewritten_caption_urls(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(move |req: &wiremock::Request| {
+                let parsed: Value = serde_json::from_slice(&req.body).unwrap();
+                assert_eq!(
+                    parsed["context"]["client"]["visitorData"],
+                    Value::String(EXPECTED_TOKEN.to_string()),
+                );
+                ResponseTemplate::new(200).set_body_string(player_response.clone())
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/timedtext"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(TIMEDTEXT))
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let _ = yt.fetch(VIDEO_ID, &FetchOpts::new("en-US")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn visitor_data_fetched_only_once_for_repeated_calls() {
+        // Sequential calls via a single `Youtube` instance must hit the
+        // watch page exactly once — `OnceCell` caches across calls.
+        let server = MockServer::start().await;
+        let player_response = fixture_with_rewritten_caption_urls(&server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(WATCH_PAGE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string(player_response))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/timedtext"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(TIMEDTEXT))
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let _ = yt.fetch(VIDEO_ID, &FetchOpts::new("en-US")).await.unwrap();
+        let _ = yt.fetch(VIDEO_ID, &FetchOpts::new("en-US")).await.unwrap();
+        // wiremock asserts expect(1) on server drop.
+    }
+
+    #[tokio::test]
+    async fn visitor_data_fetched_only_once_under_concurrency() {
+        // Concurrent first-callers must serialise on a single in-flight
+        // scrape rather than each issuing their own watch-page GET.
+        // `tokio::sync::OnceCell::get_or_try_init` is documented to
+        // provide this guarantee; this test pins the contract.
+        let server = MockServer::start().await;
+        let player_response = fixture_with_rewritten_caption_urls(&server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(WATCH_PAGE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path(innertube::PLAYER_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string(player_response))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/timedtext"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(TIMEDTEXT))
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let opts = FetchOpts::new("en-US");
+        let (a, b, c) = tokio::join!(
+            yt.fetch(VIDEO_ID, &opts),
+            yt.fetch(VIDEO_ID, &opts),
+            yt.fetch(VIDEO_ID, &opts),
+        );
+        a.unwrap();
+        b.unwrap();
+        c.unwrap();
+        // wiremock asserts expect(1) on server drop.
+    }
+
+    #[tokio::test]
+    async fn fetch_surfaces_missing_visitor_data_as_typed_error() {
+        // Watch-page format has drifted (no visitorData token): the fetch
+        // must propagate `MissingVisitorData` rather than fall through to
+        // an unauthenticated /player call.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html><body>no token</body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        let err = yt.fetch(VIDEO_ID, &FetchOpts::new("en")).await.unwrap_err();
+        assert!(matches!(err, TranscriptError::MissingVisitorData { .. }));
+    }
+
+    #[tokio::test]
     async fn fetch_surfaces_malformed_innertube_json_as_parse_error() {
         let server = MockServer::start().await;
+        mount_watch_page(&server).await;
         Mock::given(method("POST"))
             .and(path(innertube::PLAYER_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_string("{ not json"))

--- a/src/transcript/sources/youtube/fixtures/watch_page_with_visitor_data.html
+++ b/src/transcript/sources/youtube/fixtures/watch_page_with_visitor_data.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sample Watch Page</title>
+</head>
+<body>
+<!--
+This fixture mimics the shape of a real YouTube /watch page response — only
+the bits the scraper actually inspects. Three quirks of the live page are
+intentionally preserved:
+
+  1. ytcfg.set is called once with a single JSON literal argument.
+  2. INNERTUBE_CONTEXT.client.visitorData is a long opaque base64-ish string.
+  3. There are several other "...Data" keys nearby (sessionData, fooData) so
+     the regex must anchor on "visitorData" specifically, not a suffix match.
+-->
+<script nonce="abc">
+(function() {
+window.ytcfg = window.ytcfg || {};
+window.ytcfg.set({"INNERTUBE_API_KEY":"AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w","INNERTUBE_CONTEXT":{"client":{"hl":"en","gl":"US","clientName":"WEB","clientVersion":"2.20250101.00.00","sessionData":"unrelated-session-blob","visitorData":"CgtkUTQyOFR3aV9NSSjFoYvBBjIKCgJVUxIEGgAgPg%3D%3D","extraData":"trailing-noise"}},"VISITOR_DATA":"CgtkUTQyOFR3aV9NSSjFoYvBBjIKCgJVUxIEGgAgPg%3D%3D"});
+})();
+</script>
+<div>player markup goes here in the real response</div>
+</body>
+</html>

--- a/src/transcript/sources/youtube/innertube.rs
+++ b/src/transcript/sources/youtube/innertube.rs
@@ -1,31 +1,62 @@
 //! HTTP wrapper around YouTube's InnerTube `/player` endpoint.
 //!
-//! Step 3 of [issue #687](https://github.com/rust-works/omni-dev/issues/687)
-//! pins the **WEB** client only. The Android / IosEmbedded fallback chain
-//! used for age-gated content lands in step 5; that work introduces a
-//! dedicated `client.rs` with an enum, at which point the constants below
-//! migrate. Until then they live next to the only HTTP call that uses them.
+//! Pins the `ANDROID_VR` client. YouTube's anti-bot gating cross-checks
+//! `clientName`, `clientVersion`, the per-endpoint API key, the device
+//! fingerprint fields (`deviceMake` / `deviceModel` / `osVersion`) and the
+//! request `User-Agent`; mismatches are flagged. The constants below match
+//! what the real Oculus YouTube app emits at time of writing.
+//!
+//! Sessions also carry a `visitorData` token scraped from the watch page
+//! (see [`super::watch_page`]); requests without it are treated as
+//! unauthenticated bot traffic and refused on most videos.
+//!
+//! ## Refresh signal
+//!
+//! These values drift over months as YouTube tightens per-client checks.
+//! When `/player` starts returning empty or refused responses for known-
+//! healthy videos, bump [`CLIENT_VERSION`] (and the matching `User-Agent`
+//! token in [`super::USER_AGENT`]) to the value currently shipped by the
+//! Oculus YouTube app, and refresh [`INNERTUBE_API_KEY`] if the
+//! ANDROID-family key starts being rejected.
 
 use serde_json::json;
 
 use crate::transcript::error::Result;
 
-/// Path appended to the `base_url` for the `/player` POST. YouTube also
-/// accepts this without the API key, but we forward the public WEB key for
-/// parity with browsers.
+/// Path appended to the `base_url` for the `/player` POST.
 pub(crate) const PLAYER_PATH: &str = "/youtubei/v1/player";
 
-/// Public WEB-client API key. Long-stable across years, embedded in the
-/// YouTube watch page's bootstrapped config — this is not a credential.
-pub(crate) const WEB_API_KEY: &str = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+/// Public InnerTube API key for the ANDROID-family clients (including
+/// `ANDROID_VR`). Sent as the `X-Goog-Api-Key` header — YouTube returns
+/// 400 for the legacy `?key=` query form on modern `/player` paths.
+/// Embedded in the public Oculus YouTube app binary; not a credential.
+pub(crate) const INNERTUBE_API_KEY: &str = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
 
-/// `client.clientName` for the WEB context.
-pub(crate) const CLIENT_NAME: &str = "WEB";
+/// `client.clientName`.
+pub(crate) const CLIENT_NAME: &str = "ANDROID_VR";
 
-/// `client.clientVersion` for the WEB context. YouTube treats stale
-/// versions leniently, but the value drifts over months — refresh if
-/// `/player` starts returning empty `playerResponse` envelopes.
-pub(crate) const CLIENT_VERSION: &str = "2.20250101.00.00";
+/// `client.clientVersion` — version published by the Oculus YouTube app.
+pub(crate) const CLIENT_VERSION: &str = "1.62.27";
+
+/// `client.androidSdkVersion` — API level for Android 12L.
+pub(crate) const ANDROID_SDK_VERSION: u32 = 32;
+
+/// `client.deviceMake`.
+pub(crate) const DEVICE_MAKE: &str = "Oculus";
+
+/// `client.deviceModel`.
+pub(crate) const DEVICE_MODEL: &str = "Quest 3";
+
+/// `client.osName`.
+pub(crate) const OS_NAME: &str = "Android";
+
+/// `client.osVersion`. Quest 3 specifically reports `12L` (literal), not
+/// `12` — a mismatch is one of the bot-detection signals.
+pub(crate) const OS_VERSION: &str = "12L";
+
+/// Header carrying the InnerTube API key. Replaces the legacy `?key=` query
+/// param; modern YouTube `/player` paths reject the latter with HTTP 400.
+const API_KEY_HEADER: &str = "X-Goog-Api-Key";
 
 /// POST `videoId` to the InnerTube `/player` endpoint at `base_url` and
 /// return the raw response body. Callers feed the body to
@@ -33,24 +64,34 @@ pub(crate) const CLIENT_VERSION: &str = "2.20250101.00.00";
 ///
 /// `base_url` is normally `https://www.youtube.com`; tests inject a
 /// `wiremock::MockServer::uri()` instead.
+///
+/// `visitor_data` is the opaque token scraped from the watch page by
+/// [`super::watch_page::fetch_visitor_data`]. Requests without it are
+/// treated as unauthenticated bot traffic and refused.
 pub async fn fetch_player_response(
     http: &reqwest::Client,
     base_url: &str,
     video_id: &str,
+    visitor_data: &str,
 ) -> Result<String> {
     let url = format!(
-        "{base}{path}?key={key}",
+        "{base}{path}",
         base = base_url.trim_end_matches('/'),
         path = PLAYER_PATH,
-        key = WEB_API_KEY,
     );
     let body = json!({
         "context": {
             "client": {
                 "clientName": CLIENT_NAME,
                 "clientVersion": CLIENT_VERSION,
+                "androidSdkVersion": ANDROID_SDK_VERSION,
+                "deviceMake": DEVICE_MAKE,
+                "deviceModel": DEVICE_MODEL,
+                "osName": OS_NAME,
+                "osVersion": OS_VERSION,
                 "hl": "en",
                 "gl": "US",
+                "visitorData": visitor_data,
             },
         },
         "videoId": video_id,
@@ -60,6 +101,7 @@ pub async fn fetch_player_response(
 
     let response = http
         .post(&url)
+        .header(API_KEY_HEADER, INNERTUBE_API_KEY)
         .json(&body)
         .send()
         .await?
@@ -72,10 +114,11 @@ pub async fn fetch_player_response(
 mod tests {
     use super::*;
     use serde_json::Value;
-    use wiremock::matchers::{body_partial_json, method, path, query_param};
+    use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
     const VIDEO_ID: &str = "dQw4w9WgXcQ";
+    const VISITOR_DATA: &str = "test-visitor-data";
     const FIXTURE_BASIC: &str = include_str!("fixtures/player_response_basic.json");
 
     fn http() -> reqwest::Client {
@@ -83,11 +126,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn posts_to_player_endpoint_with_web_context_and_video_id() {
+    async fn posts_to_player_endpoint_with_android_vr_context_and_video_id() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path(PLAYER_PATH))
-            .and(query_param("key", WEB_API_KEY))
+            .and(header(API_KEY_HEADER, INNERTUBE_API_KEY))
             .and(body_partial_json(json!({
                 "videoId": VIDEO_ID,
                 "context": { "client": { "clientName": CLIENT_NAME } },
@@ -97,26 +140,84 @@ mod tests {
             .mount(&server)
             .await;
 
-        let body = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let body = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap();
         assert_eq!(body, FIXTURE_BASIC);
     }
 
     #[tokio::test]
-    async fn forwards_pinned_client_version() {
+    async fn body_pins_full_quest_device_fingerprint() {
+        // Catch a regression to "12" (correct value is the literal "12L"),
+        // a bumped clientVersion that misses the device fields, etc.
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path(PLAYER_PATH))
             .and(body_partial_json(json!({
-                "context": { "client": { "clientVersion": CLIENT_VERSION } },
+                "context": {
+                    "client": {
+                        "clientName":        CLIENT_NAME,
+                        "clientVersion":     CLIENT_VERSION,
+                        "androidSdkVersion": ANDROID_SDK_VERSION,
+                        "deviceMake":        DEVICE_MAKE,
+                        "deviceModel":       DEVICE_MODEL,
+                        "osName":            OS_NAME,
+                        "osVersion":         OS_VERSION,
+                        "hl":                "en",
+                        "gl":                "US",
+                    }
+                }
             })))
             .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
             .expect(1)
             .mount(&server)
             .await;
 
-        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn body_includes_visitor_data_under_client() {
+        // Visitor data is the bot-bypass token; without it on the request
+        // YouTube refuses with bot-shaped errors. Pin its placement.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PLAYER_PATH))
+            .and(body_partial_json(json!({
+                "context": { "client": { "visitorData": VISITOR_DATA } },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn url_no_longer_carries_legacy_key_query() {
+        // Modern /player rejects ?key= with HTTP 400. Capture the inbound
+        // request and assert no query string is present.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PLAYER_PATH))
+            .respond_with(|req: &Request| {
+                assert!(
+                    req.url.query().is_none(),
+                    "request URL must not carry a query string; got {:?}",
+                    req.url.query()
+                );
+                ResponseTemplate::new(200).set_body_string("{}")
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap();
     }
@@ -130,7 +231,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let err = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap_err();
         assert!(matches!(err, crate::transcript::TranscriptError::Http(_)));
@@ -153,7 +254,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID)
+        let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap();
     }
@@ -169,7 +270,7 @@ mod tests {
             .await;
 
         let with_slash = format!("{}/", server.uri());
-        let _ = fetch_player_response(&http(), &with_slash, VIDEO_ID)
+        let _ = fetch_player_response(&http(), &with_slash, VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap();
     }

--- a/src/transcript/sources/youtube/player_response.rs
+++ b/src/transcript/sources/youtube/player_response.rs
@@ -83,7 +83,7 @@ pub struct CaptionTrack {
     pub base_url: String,
     /// Display name of the track, e.g. `English (United States)`.
     #[serde(default)]
-    pub name: Option<SimpleText>,
+    pub name: Option<LocalizedText>,
     /// IETF-style language tag, e.g. `en`, `en-US`, `pt-BR`.
     pub language_code: String,
     /// Present and equal to `"asr"` for auto-generated tracks; absent
@@ -95,13 +95,47 @@ pub struct CaptionTrack {
     pub is_translatable: Option<bool>,
 }
 
-/// YouTube's `{ "simpleText": "..." }` shape. Some fields use a richer
-/// `runs[]` form; we don't model those because we only need the human label.
+/// A localised text payload, in either of YouTube's two text shapes.
+///
+/// `{ "simpleText": "..." }` for short labels, or
+/// `{ "runs": [{ "text": "..." }, ...] }` for fields that mix runs of
+/// styled text. The shape varies by client and by field; modern
+/// `ANDROID_VR` `/player` responses typically use `runs` for caption
+/// track names. Either is accepted; [`Self::text`] returns the
+/// concatenation.
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SimpleText {
-    /// The text payload.
-    pub simple_text: String,
+#[serde(untagged)]
+pub enum LocalizedText {
+    /// `{ "simpleText": "<label>" }`.
+    Simple {
+        /// The flat text payload.
+        #[serde(rename = "simpleText")]
+        simple_text: String,
+    },
+    /// `{ "runs": [{ "text": "..." }, ...] }`.
+    Runs {
+        /// The styled text fragments.
+        runs: Vec<TextRun>,
+    },
+}
+
+/// A single styled-text fragment within a [`LocalizedText::Runs`] payload.
+#[derive(Clone, Debug, Deserialize)]
+pub struct TextRun {
+    /// The fragment's text. Only the text is consumed; YouTube also
+    /// includes styling fields (`bold`, `italics`, `navigationEndpoint`,
+    /// etc.) that are dropped by this crate.
+    pub text: String,
+}
+
+impl LocalizedText {
+    /// Resolve to a flat string, joining `runs[].text` if present.
+    pub fn text(&self) -> String {
+        match self {
+            Self::Simple { simple_text } => simple_text.clone(),
+            Self::Runs { runs } => runs.iter().map(|r| r.text.as_str()).collect(),
+        }
+    }
 }
 
 /// A target language for machine translation.
@@ -112,7 +146,7 @@ pub struct TranslationLanguage {
     pub language_code: String,
     /// Display name of the translation target.
     #[serde(default)]
-    pub language_name: Option<SimpleText>,
+    pub language_name: Option<LocalizedText>,
 }
 
 impl CaptionTrack {
@@ -255,7 +289,7 @@ fn pick_translation_base<'a>(
 fn materialise_native(track: &CaptionTrack) -> SelectedTrack<'_> {
     SelectedTrack {
         track,
-        fetch_url: append_query(&track.base_url, "fmt=json3"),
+        fetch_url: timedtext_url(&track.base_url, None),
         language: track.language_code.clone(),
         kind: if track.is_asr() {
             TrackKind::Auto
@@ -266,19 +300,55 @@ fn materialise_native(track: &CaptionTrack) -> SelectedTrack<'_> {
 }
 
 fn materialise_translation<'a>(track: &'a CaptionTrack, target: &str) -> SelectedTrack<'a> {
-    let with_format = append_query(&track.base_url, "fmt=json3");
-    let with_tlang = append_query(&with_format, &format!("tlang={target}"));
     SelectedTrack {
         track,
-        fetch_url: with_tlang,
+        fetch_url: timedtext_url(&track.base_url, Some(target)),
         language: target.to_string(),
         kind: TrackKind::Translated,
     }
 }
 
-fn append_query(url: &str, kv: &str) -> String {
-    let sep = if url.contains('?') { '&' } else { '?' };
-    format!("{url}{sep}{kv}")
+/// Build the timedtext fetch URL from a caption track's `baseUrl`.
+///
+/// YouTube embeds a default `fmt=` (typically `srv3`, the legacy XML
+/// format) in the `baseUrl` it ships in `playerResponse`. A naive
+/// `&fmt=json3` append produces a URL with two `fmt=` params; YouTube
+/// honours the *first* one and returns SRV3, which the json3 parser
+/// rejects with a 1:1 "expected value" error. Replacing rather than
+/// appending is required.
+///
+/// Same treatment for `tlang=` on the translation path.
+fn timedtext_url(base_url: &str, tlang: Option<&str>) -> String {
+    let Ok(mut url) = url::Url::parse(base_url) else {
+        // Defensive: if YouTube ever returns a non-URL baseUrl, fall
+        // back to a naive append so the caller still gets *some*
+        // reachable URL instead of a hard error here.
+        let mut s = base_url.to_string();
+        s.push(if s.contains('?') { '&' } else { '?' });
+        s.push_str("fmt=json3");
+        if let Some(t) = tlang {
+            s.push_str("&tlang=");
+            s.push_str(t);
+        }
+        return s;
+    };
+    let preserved: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(k, _)| k != "fmt" && k != "tlang")
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+    url.query_pairs_mut().clear();
+    {
+        let mut q = url.query_pairs_mut();
+        for (k, v) in &preserved {
+            q.append_pair(k, v);
+        }
+        q.append_pair("fmt", "json3");
+        if let Some(t) = tlang {
+            q.append_pair("tlang", t);
+        }
+    }
+    url.to_string()
 }
 
 /// Project a [`PlayerResponse`] to the [`LanguageInfo`] list expected by
@@ -296,7 +366,7 @@ pub fn list_languages(response: &PlayerResponse) -> Vec<LanguageInfo> {
                     name: t
                         .name
                         .as_ref()
-                        .map_or_else(|| t.language_code.clone(), |n| n.simple_text.clone()),
+                        .map_or_else(|| t.language_code.clone(), LocalizedText::text),
                     kind: if t.is_asr() {
                         TrackKind::Auto
                     } else {
@@ -570,6 +640,111 @@ mod tests {
     }
 
     #[test]
+    fn fetch_url_replaces_existing_fmt_param() {
+        // Real ANDROID_VR /player responses ship caption URLs with an
+        // embedded `fmt=srv3` (legacy XML). A naive append would leave
+        // both `fmt` params; YouTube honours the first and serves SRV3,
+        // which the json3 parser rejects. Pin the replacement contract.
+        let track = CaptionTrack {
+            base_url: "https://example.com/timedtext?lang=en&fmt=srv3&signature=ABC".to_string(),
+            name: None,
+            language_code: "en".to_string(),
+            kind: None,
+            is_translatable: Some(true),
+        };
+        let s = materialise_native(&track);
+        assert!(s.fetch_url.contains("fmt=json3"));
+        assert!(!s.fetch_url.contains("fmt=srv3"));
+        assert!(s.fetch_url.contains("signature=ABC"));
+        assert!(s.fetch_url.contains("lang=en"));
+    }
+
+    #[test]
+    fn translation_url_replaces_existing_fmt_and_tlang() {
+        let track = CaptionTrack {
+            base_url: "https://example.com/timedtext?lang=en&fmt=srv3&tlang=de&signature=X"
+                .to_string(),
+            name: None,
+            language_code: "en".to_string(),
+            kind: None,
+            is_translatable: Some(true),
+        };
+        let s = materialise_translation(&track, "fr");
+        assert!(s.fetch_url.contains("fmt=json3"));
+        assert!(!s.fetch_url.contains("fmt=srv3"));
+        assert!(s.fetch_url.contains("tlang=fr"));
+        assert!(!s.fetch_url.contains("tlang=de"));
+        assert!(s.fetch_url.contains("signature=X"));
+    }
+
+    #[test]
+    fn fetch_url_handles_non_url_base_defensively() {
+        // If YouTube ever returns a baseUrl that isn't parseable as a
+        // URL, the helper falls back to a naive append rather than
+        // panicking — the caller still gets a reachable string.
+        let track = CaptionTrack {
+            base_url: "not a url".to_string(),
+            name: None,
+            language_code: "en".to_string(),
+            kind: None,
+            is_translatable: Some(true),
+        };
+        let s = materialise_native(&track);
+        assert!(s.fetch_url.contains("fmt=json3"));
+    }
+
+    #[test]
+    fn translation_url_handles_non_url_base_defensively() {
+        // Same fallback, exercised through the translation path so the
+        // `&tlang=` branch of the non-URL fallback is covered.
+        let track = CaptionTrack {
+            base_url: "not a url".to_string(),
+            name: None,
+            language_code: "en".to_string(),
+            kind: None,
+            is_translatable: Some(true),
+        };
+        let s = materialise_translation(&track, "fr");
+        assert!(s.fetch_url.contains("fmt=json3"));
+        assert!(s.fetch_url.contains("&tlang=fr"));
+    }
+
+    #[test]
+    fn fallback_appends_with_ampersand_when_base_already_has_query() {
+        // `?` vs `&` separator branch in the non-URL fallback. The
+        // string contains `?` so the next param is joined with `&`.
+        let track = CaptionTrack {
+            base_url: "broken url with ?existing=q".to_string(),
+            name: None,
+            language_code: "en".to_string(),
+            kind: None,
+            is_translatable: Some(true),
+        };
+        let s = materialise_native(&track);
+        assert!(s.fetch_url.ends_with("&fmt=json3"));
+    }
+
+    #[test]
+    fn list_languages_falls_back_to_language_code_when_name_absent() {
+        // Track without a `name` field: `LanguageInfo.name` falls back
+        // to the language code rather than panicking. Exercises the
+        // `None` branch of `t.name.as_ref().map_or_else(...)`.
+        let mut r = parse(FIXTURE_BASIC).unwrap();
+        for t in &mut r
+            .captions
+            .as_mut()
+            .unwrap()
+            .player_captions_tracklist_renderer
+            .caption_tracks
+        {
+            t.name = None;
+        }
+        let langs = list_languages(&r);
+        assert!(langs.iter().any(|l| l.code == "en-US" && l.name == "en-US"));
+        assert!(langs.iter().any(|l| l.code == "es" && l.name == "es"));
+    }
+
+    #[test]
     fn list_languages_projects_all_tracks() {
         let r = parse(FIXTURE_BASIC).unwrap();
         let langs = list_languages(&r);
@@ -580,6 +755,65 @@ mod tests {
         assert_eq!(by_code["en"].kind, TrackKind::Auto);
         assert_eq!(by_code["es"].kind, TrackKind::Manual);
         assert_eq!(by_code["en-US"].name, "English (United States)");
+    }
+
+    #[test]
+    fn localized_text_deserialises_simple_shape() {
+        let json = r#"{ "simpleText": "English (United States)" }"#;
+        let lt: LocalizedText = serde_json::from_str(json).unwrap();
+        assert!(matches!(lt, LocalizedText::Simple { .. }));
+        assert_eq!(lt.text(), "English (United States)");
+    }
+
+    #[test]
+    fn localized_text_deserialises_runs_shape() {
+        // Real-world ANDROID_VR /player responses use this shape for
+        // caption-track names; the previous struct-only deserialiser
+        // failed with `missing field simpleText` on these payloads.
+        let json = r#"{ "runs": [{ "text": "English (auto-generated)" }] }"#;
+        let lt: LocalizedText = serde_json::from_str(json).unwrap();
+        assert!(matches!(lt, LocalizedText::Runs { .. }));
+        assert_eq!(lt.text(), "English (auto-generated)");
+    }
+
+    #[test]
+    fn localized_text_concatenates_multiple_runs() {
+        let json = r#"{ "runs": [{ "text": "English" }, { "text": " " }, { "text": "(auto)" }] }"#;
+        let lt: LocalizedText = serde_json::from_str(json).unwrap();
+        assert_eq!(lt.text(), "English (auto)");
+    }
+
+    #[test]
+    fn localized_text_handles_empty_runs() {
+        let json = r#"{ "runs": [] }"#;
+        let lt: LocalizedText = serde_json::from_str(json).unwrap();
+        assert_eq!(lt.text(), "");
+    }
+
+    #[test]
+    fn caption_track_accepts_runs_name_shape() {
+        // End-to-end: a player_response carrying `name: { runs: [...] }`
+        // must deserialise and project to LanguageInfo.name correctly.
+        let json = r#"{
+            "playabilityStatus": { "status": "OK" },
+            "captions": {
+                "playerCaptionsTracklistRenderer": {
+                    "captionTracks": [{
+                        "baseUrl": "https://www.youtube.com/api/timedtext?lang=en",
+                        "name": { "runs": [{ "text": "English (auto-generated)" }] },
+                        "languageCode": "en",
+                        "kind": "asr"
+                    }],
+                    "translationLanguages": []
+                }
+            }
+        }"#;
+        let r = parse(json).unwrap();
+        let langs = list_languages(&r);
+        assert_eq!(langs.len(), 1);
+        assert_eq!(langs[0].code, "en");
+        assert_eq!(langs[0].name, "English (auto-generated)");
+        assert_eq!(langs[0].kind, TrackKind::Auto);
     }
 
     #[test]

--- a/src/transcript/sources/youtube/watch_page.rs
+++ b/src/transcript/sources/youtube/watch_page.rs
@@ -1,0 +1,241 @@
+//! Watch-page bootstrap: scrapes `INNERTUBE_CONTEXT.client.visitorData`
+//! from a YouTube `/watch` HTML response.
+//!
+//! YouTube's anti-bot gating is keyed off whether the requesting session
+//! carries a `visitorData` token, *not* the user-facing `clientName`.
+//! Procedure: GET any `/watch?v=<stable-id>` page, regex out the
+//! `"visitorData":"..."` substring from the inline `ytcfg.set({...})`
+//! script block, and forward it on subsequent InnerTube `/player` POSTs
+//! as a sibling of `clientName` under `context.client`.
+//!
+//! Requests carrying the token are treated as continuation requests from
+//! a "real" session and bypass the bot challenge that otherwise refuses
+//! every client variant with `LOGIN_REQUIRED`, `UNPLAYABLE`, etc.
+//!
+//! The token is per-process and rotates server-side; one scrape per
+//! [`super::Youtube`] instance is sufficient (callers cache via
+//! `tokio::sync::OnceCell`).
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use crate::transcript::error::{Result, TranscriptError};
+
+/// Stable, captioned video used as the bootstrap target. The `/watch`
+/// response carries the same `ytcfg.set` block regardless of which video
+/// the URL references, so a known-stable ID is preferable to whatever the
+/// caller is actually after — it short-circuits the bootstrap if the
+/// caller's video is itself unavailable.
+const BOOTSTRAP_VIDEO_ID: &str = "dQw4w9WgXcQ";
+
+/// User-Agent advertised on the watch-page GET. The watch page is a
+/// public HTML page intended for browsers; YouTube serves a different
+/// (Polymer-shaped) body to non-browser UAs that omits the
+/// `INNERTUBE_CONTEXT` block. Browser-shaped UA is required.
+///
+/// Distinct from [`super::USER_AGENT`], which the InnerTube `/player`
+/// POSTs use — that one must match `clientName: ANDROID_VR`.
+const BROWSER_USER_AGENT: &str =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/// Lazy-compiled extractor. `visitorData` strings don't contain raw `"`,
+/// so a non-greedy character class up to the closing quote is sufficient
+/// — no need for a real JSON parser. Anchored on the exact key to avoid
+/// matching neighbouring `*Data` keys (`sessionData`, etc.).
+fn visitor_data_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    #[allow(clippy::expect_used)]
+    RE.get_or_init(|| {
+        Regex::new(r#""visitorData":"([^"]+)""#).expect("visitor_data regex must compile")
+    })
+}
+
+/// GET the YouTube watch page and extract `visitorData`.
+///
+/// `base_url` is normally `https://www.youtube.com`; tests inject a
+/// `wiremock::MockServer::uri()` instead.
+///
+/// On a parseable response that lacks the token, returns
+/// [`TranscriptError::MissingVisitorData`] — distinct from a generic
+/// parse error so callers can surface a clear "watch-page format drifted"
+/// signal rather than confusing it with a malformed `playerResponse`.
+pub async fn fetch_visitor_data(http: &reqwest::Client, base_url: &str) -> Result<String> {
+    let url = format!(
+        "{base}/watch?v={video}",
+        base = base_url.trim_end_matches('/'),
+        video = BOOTSTRAP_VIDEO_ID,
+    );
+    let body = http
+        .get(&url)
+        .header(reqwest::header::USER_AGENT, BROWSER_USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    extract_visitor_data(&body)
+        .map(str::to_string)
+        .ok_or(TranscriptError::MissingVisitorData { url })
+}
+
+/// Pure helper: pull `visitorData` out of a watch-page body. Split out so
+/// the regex contract can be exercised without spinning up a mock server.
+fn extract_visitor_data(body: &str) -> Option<&str> {
+    visitor_data_regex()
+        .captures(body)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    const FIXTURE: &str = include_str!("fixtures/watch_page_with_visitor_data.html");
+    const EXPECTED_TOKEN: &str = "CgtkUTQyOFR3aV9NSSjFoYvBBjIKCgJVUxIEGgAgPg%3D%3D";
+
+    fn http() -> reqwest::Client {
+        reqwest::Client::builder().build().unwrap()
+    }
+
+    // ── pure regex layer ──
+
+    #[test]
+    fn extracts_visitor_data_from_fixture() {
+        let token = extract_visitor_data(FIXTURE).unwrap();
+        assert_eq!(token, EXPECTED_TOKEN);
+    }
+
+    #[test]
+    fn extracts_first_match_when_multiple_present() {
+        // The fixture also contains a `VISITOR_DATA` (uppercase) key with
+        // the same value; the regex is anchored on the lowercase
+        // `visitorData` so it picks the right one regardless.
+        let body = r#"{"foo":"bar","visitorData":"first","visitorData":"second"}"#;
+        assert_eq!(extract_visitor_data(body), Some("first"));
+    }
+
+    #[test]
+    fn ignores_neighbouring_data_keys() {
+        // `sessionData`, `userData`, etc. must not match — only the exact
+        // key `visitorData` should.
+        let body = r#"{"sessionData":"S","userData":"U","fooData":"F"}"#;
+        assert_eq!(extract_visitor_data(body), None);
+    }
+
+    #[test]
+    fn returns_none_when_token_missing() {
+        let body = "<html><body>no ytcfg here</body></html>";
+        assert_eq!(extract_visitor_data(body), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_body() {
+        assert_eq!(extract_visitor_data(""), None);
+    }
+
+    // ── HTTP layer ──
+
+    fn watch_page_mock(body: &'static str) -> Mock {
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .and(query_param("v", BOOTSTRAP_VIDEO_ID))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_extracted_token() {
+        let server = MockServer::start().await;
+        watch_page_mock(FIXTURE).mount(&server).await;
+
+        let token = fetch_visitor_data(&http(), &server.uri()).await.unwrap();
+        assert_eq!(token, EXPECTED_TOKEN);
+    }
+
+    #[tokio::test]
+    async fn fetch_sends_browser_user_agent() {
+        // The watch page omits INNERTUBE_CONTEXT for non-browser UAs,
+        // so the bootstrap UA must be the desktop string — not the
+        // ANDROID_VR UA used by the InnerTube call. Capture inbound
+        // request and assert directly so a UA mismatch surfaces as a
+        // clear assertion rather than a 404 from a non-matching mock.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(|req: &Request| {
+                let ua = req
+                    .headers
+                    .get("user-agent")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                assert_eq!(ua, BROWSER_USER_AGENT);
+                ResponseTemplate::new(200).set_body_string(FIXTURE)
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _ = fetch_visitor_data(&http(), &server.uri()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_targets_bootstrap_video_id() {
+        // expect(1) on the mock proves the requested ?v= matched the
+        // bootstrap constant; if it didn't the mock wouldn't fire.
+        let server = MockServer::start().await;
+        watch_page_mock(FIXTURE).expect(1).mount(&server).await;
+
+        let _ = fetch_visitor_data(&http(), &server.uri()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_surfaces_missing_token_as_typed_error() {
+        let server = MockServer::start().await;
+        let body = "<html><body>no ytcfg here</body></html>";
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+
+        let err = fetch_visitor_data(&http(), &server.uri())
+            .await
+            .unwrap_err();
+        match err {
+            TranscriptError::MissingVisitorData { url } => {
+                assert!(url.contains("/watch?v=dQw4w9WgXcQ"));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_surfaces_non_2xx_as_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let err = fetch_visitor_data(&http(), &server.uri())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TranscriptError::Http(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_normalises_trailing_slash_in_base_url() {
+        let server = MockServer::start().await;
+        watch_page_mock(FIXTURE).expect(1).mount(&server).await;
+
+        let with_slash = format!("{}/", server.uri());
+        let _ = fetch_visitor_data(&http(), &with_slash).await.unwrap();
+    }
+}


### PR DESCRIPTION
## Description

This PR bypasses YouTube's bot-detection gating that was refusing transcript requests with `LOGIN_REQUIRED` / `UNPLAYABLE` errors when using the WEB InnerTube client without a valid session token. The fix has two parts: switching to the `ANDROID_VR` client profile (Oculus Quest 3) and adding a watch-page bootstrap step that scrapes a `visitorData` session token forwarded on every `/player` POST.

YouTube's anti-bot gating is keyed on whether the requesting session carries a `visitorData` token, not just the `clientName`. By GETting a public watch page with a browser UA, extracting the token from the inline `ytcfg.set({…})` script block, and forwarding it under `context.client.visitorData`, requests are treated as continuation requests from a real session and bypass the challenge.

This is step 5a of issue #687 (transcript subcommand).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Relates to #687

## Changes Made

**Core Changes:**
- Added `src/transcript/sources/youtube/watch_page.rs` module that GETs `/watch?v=<stable-id>` with a browser UA, extracts `visitorData` from the inline `ytcfg.set({…})` script block via regex, and returns `MissingVisitorData` when the token is absent
- Added `visitor_data: tokio::sync::OnceCell<String>` field to `Youtube` struct; concurrent first-callers serialise on a single in-flight scrape via `get_or_try_init`, subsequent calls are free
- Switched InnerTube constants in `innertube.rs` from WEB to ANDROID_VR: updated `CLIENT_NAME`, `CLIENT_VERSION`, and device fingerprint fields (`deviceMake`, `deviceModel`, `osName`, `osVersion`, `androidSdkVersion`)
- Moved API key from `?key=` query param to `X-Goog-Api-Key` request header — modern `/player` paths reject the legacy query form with HTTP 400
- Replaced `SimpleText` struct with `LocalizedText` enum in `player_response.rs` accepting both `{ "simpleText": "…" }` and `{ "runs": […] }` shapes — ANDROID_VR `/player` responses use `runs` for caption-track names, causing deserialisation failures with the old struct
- Fixed `timedtext_url()` in `player_response.rs` to replace existing `fmt=` and `tlang=` params rather than appending them; a naive append left two `fmt=` params and YouTube honoured the first (SRV3), breaking json3 parsing
- Added `MissingVisitorData { url: String }` error variant to `TranscriptError` to signal watch-page format drift distinctly from generic parse errors

**Documentation:**
- Updated module-level doc comments in `youtube.rs` and `innertube.rs` to reflect the ANDROID_VR client and visitorData bootstrap
- Added refresh signal guidance in `innertube.rs` explaining when and how to bump `CLIENT_VERSION` and `INNERTUBE_API_KEY`
- Documented the two distinct User-Agent constants (ANDROID_VR for InnerTube POSTs, browser UA for watch-page bootstrap) and why they differ

**Testing:**
- Added `src/transcript/sources/youtube/fixtures/watch_page_with_visitor_data.html` fixture mimicking real YouTube watch-page shape with `ytcfg.set` block
- Added `watch_page.rs` tests: regex extraction, ignoring neighbouring `*Data` keys, missing token, HTTP error, browser UA assertion, trailing-slash normalisation
- Added `youtube.rs` integration tests: `fetch_threads_visitor_data_into_innertube_body` (pins token under `context.client.visitorData`), `visitor_data_fetched_only_once_for_repeated_calls` (sequential OnceCell deduplication), `visitor_data_fetched_only_once_under_concurrency` (concurrent OnceCell deduplication), `fetch_surfaces_missing_visitor_data_as_typed_error`
- Added `innertube.rs` tests: `body_pins_full_quest_device_fingerprint`, `body_includes_visitor_data_under_client`, `url_no_longer_carries_legacy_key_query`
- Added `player_response.rs` tests: `LocalizedText` deserialisation for both shapes, multi-run concatenation, empty runs, end-to-end `caption_track_accepts_runs_name_shape`, `fetch_url_replaces_existing_fmt_param`, `translation_url_replaces_existing_fmt_and_tlang`, `fetch_url_handles_non_url_base_defensively`
- Updated all existing wiremock-driven tests in `youtube.rs` to mount the watch-page bootstrap mock

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run transcript-specific tests
cargo test transcript

# Run watch_page-specific tests
cargo test watch_page

# Run innertube-specific tests
cargo test innertube
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications
- [x] Architecture changes
- [x] Error handling
- [x] Backward compatibility

The `visitor_data` field on `Youtube` uses `tokio::sync::OnceCell` — reviewers should verify that `Youtube`'s `Clone` impl (derived) clones the `OnceCell` reference correctly and that the caching contract holds across cloned instances as intended.

The `timedtext_url` replacement logic (replacing rather than appending `fmt=` and `tlang=`) is a subtle correctness fix — the test `fetch_url_replaces_existing_fmt_param` pins this contract but the URL manipulation using `url::Url` query-pair manipulation deserves careful review.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] Potential performance impact (describe below)

One additional HTTP GET (watch-page scrape) is issued on the first `fetch`/`list_languages`/`info` call per `Youtube` instance. The `tokio::sync::OnceCell` ensures this happens exactly once regardless of concurrent callers — subsequent calls pay zero overhead. Tests `visitor_data_fetched_only_once_for_repeated_calls` and `visitor_data_fetched_only_once_under_concurrency` enforce this contract.

## Security Considerations
- [x] Potential security impact (describe below)

The `visitorData` token is scraped from a public YouTube watch page (no credentials involved). It is an opaque session token that YouTube issues to browser sessions — treating it as a secret is unnecessary but it is not logged. The `INNERTUBE_API_KEY` is the public ANDROID-family key embedded in the Oculus YouTube app binary and is not a credential.

## Breaking Changes

No breaking changes. The `fetch_player_response` function in `innertube.rs` gains a new `visitor_data: &str` parameter, but this is a `pub(crate)` internal function. The public `Youtube` struct API (`new()`, `with_base_url()`, `fetch()`, `list_languages()`, `info()`) is unchanged.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `BOOTSTRAP_VIDEO_ID` ("dQw4w9WgXcQ") is a stable constant — if that video becomes unavailable, any captioned video would work as a substitute
- The `CLIENT_VERSION` and `INNERTUBE_API_KEY` will drift over months as YouTube tightens per-client checks; the `innertube.rs` doc comment includes a refresh guide

**Known Limitations:**
- The `visitorData` token is per-process and not persisted across restarts; each new `Youtube` instance incurs one watch-page GET on first use
- Watch-page format drift (YouTube changing the `ytcfg.set` structure) will surface as `MissingVisitorData` errors, which is intentional — it signals clearly that the scraper needs retuning

**Alternatives Considered:**
- Using a cookie jar with a pre-authenticated session was rejected as it requires credential management
- Parsing the watch-page body with a full HTML/JSON parser was considered but the regex approach is sufficient since `visitorData` values never contain `"` characters and anchoring on the exact key avoids false matches on neighbouring `*Data` keys