### PR TITLE
refactor(claude): strengthen instructions for commit amendment cardinality

### DIFF
--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -180,7 +180,7 @@ TYPE SELECTION RULES (must match the commit checker's expectations):
    - Changing doc comments or help text in source code is `refactor` or `fix`, not `docs`
 3. Before finalizing, verify: would the commit checker accept this type given the files that changed?
 
-CRITICAL OUTPUT REQUIREMENT: You MUST include ALL commits in your response, regardless of whether they need changes or not. If a commit message is already perfect, include it unchanged. Never skip commits from the amendments array.
+CRITICAL OUTPUT REQUIREMENT: Return exactly one amendment per commit in the input `commits[]` array — no more, no fewer. Count the entries in `commits[]` and produce that many amendments. Each amendment's `commit` field must match a hash that appears in the input. DO NOT invent additional amendments, duplicate a commit hash across multiple amendments, or omit any input commit. If a commit message is already perfect, include it unchanged with its original hash.
 
 CRITICAL RESPONSE FORMAT: You MUST respond with ONLY valid YAML content. Do not include any explanatory text, markdown wrappers, or code blocks. Your entire response must be parseable YAML starting immediately with "amendments:" and containing nothing else.
 
@@ -427,7 +427,7 @@ CRITICAL ANALYSIS STEPS:
 3. **CHOOSE APPROPRIATE TYPE**: Select commit type (feat/fix/refactor/etc.) based on actual changes, not file locations
 4. **SELECT MEANINGFUL SCOPE**: Choose scope based on functionality affected, not just directory names
 
-MANDATORY: Include ALL commits in the amendments array - both those that need improvement AND those that are already well-formatted.
+MANDATORY CARDINALITY: The repository data above contains a `commits[]` array. Return exactly one amendment per entry — no more, no fewer. Each amendment's `commit` field must be a hash that appears in `commits[]`. Do not invent additional commits, do not emit two amendments with the same hash, and do not skip any input commit.
 
 For each commit, analyze whether improvements are needed:
 - Check if it follows conventional commit format
@@ -439,7 +439,7 @@ For each commit, analyze whether improvements are needed:
 
 Remember: File paths and directory names are just hints. The diff content shows the real changes.
 
-CRITICAL: Even if a commit message is perfect and needs no changes, include it in the amendments array with its current message unchanged. This allows users to review all commits and make manual adjustments if desired. DO NOT skip any commits from the amendments array.
+CRITICAL: Even if a commit message is perfect and needs no changes, include it in the amendments array with its current message and original hash. Do not skip any commit, and do not emit more amendments than there are commits in the input.
 
 SUMMARY FIELD: For each commit, include a `summary` field containing one sentence describing what the commit changes. Keep it factual and brief."
     )
@@ -473,7 +473,7 @@ pub fn generate_contextual_user_prompt(repo_yaml: &str, context: &CommitContext)
     prompt.push('\n');
 
     // Add context-specific focus areas
-    prompt.push_str("MANDATORY: Include ALL commits in the amendments array - both those needing improvement AND those already well-formatted.\n\n");
+    prompt.push_str("MANDATORY CARDINALITY: The repository data above contains a `commits[]` array. Return exactly one amendment per entry — no more, no fewer. Each amendment's `commit` field must be a hash that appears in `commits[]`. Do not invent additional commits, do not emit two amendments with the same hash, and do not skip any input commit.\n\n");
     prompt.push_str("For each commit, analyze whether improvements are needed:\n");
     prompt.push_str("- Check if it follows conventional commit format\n");
     prompt.push_str("- Verify descriptions are clear and accurate\n");
@@ -531,7 +531,7 @@ pub fn generate_contextual_user_prompt(repo_yaml: &str, context: &CommitContext)
         }
     }
 
-    prompt.push_str("\nCRITICAL: Include ALL commits in the amendments array. Even if a commit message is perfect and needs no changes, include it with its current message unchanged. This allows users to review all commits and make manual adjustments if desired. DO NOT skip any commits from the amendments array.");
+    prompt.push_str("\nCRITICAL: Return exactly one amendment per input commit. Even if a commit message is perfect, include it with its current message and original hash. Do not skip any commit, and do not emit more amendments than there are commits in the input.");
     prompt.push_str(SUMMARY_INSTRUCTION);
 
     prompt
@@ -1335,7 +1335,9 @@ mod tests {
     #[test]
     fn user_prompt_requires_all_commits() {
         let prompt = generate_user_prompt("test");
-        assert!(prompt.contains("Include ALL commits"));
+        assert!(prompt.contains("exactly one amendment per entry"));
+        assert!(prompt.contains("Do not skip any commit"));
+        assert!(prompt.contains("do not emit more amendments"));
     }
 
     // ── generate_contextual_system_prompt ──────────────────────────


### PR DESCRIPTION
## Description

This PR strengthens the system prompts used by the AI client to provide much stricter instructions about the number of amendments that must be returned per input commit. Previously, vague language like "Include ALL commits" was used, which was insufficient to prevent the model from duplicating or skipping commits. The new language introduces explicit "MANDATORY CARDINALITY" constraints that precisely define the one-to-one relationship between input commits and output amendments.

The root cause being addressed is that Gemma could misinterpret the old instructions and either invent additional amendments, emit two amendments for the same commit hash, or silently skip input commits — all of which cause incorrect behavior in the amendment workflow.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #697

## Changes Made

**Core Changes:**
- Replaced the vague "Include ALL commits" instruction in the system prompt with an explicit "MANDATORY CARDINALITY" requirement that counts input `commits[]` entries and demands exactly that many amendments returned
- Clarified that each amendment's `commit` field must match a hash present in the input, prohibiting invented hashes or duplicate hashes across amendments
- Explicitly forbids three specific failure modes: inventing additional amendments, emitting two amendments with the same hash, and omitting any input commit
- Updated three separate prompt locations in `src/claude/prompts.rs` — the system prompt critical output requirement, the mandatory preamble in the user prompt, and the critical closing instruction in the contextual user prompt

**Testing:**
- Updated the `user_prompt_requires_all_commits` test in `src/claude/prompts.rs` to assert against the new, more specific prompt language (`"exactly one amendment per entry"`, `"Do not skip any commit"`, `"do not emit more amendments"`) instead of the old generic `"Include ALL commits"` string

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The key areas to review are the three prompt mutation sites in `src/claude/prompts.rs`:
1. The `CRITICAL OUTPUT REQUIREMENT` line in the system prompt (~line 183)
2. The `MANDATORY` preamble in `generate_contextual_user_prompt` (~line 430)
3. The `CRITICAL` closing instruction appended at the end of the contextual user prompt (~line 534)

Verify that each new instruction is unambiguous and cannot be interpreted as allowing zero amendments or more amendments than there are input commits.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. Prompt text changes are internal to the Claude client and do not affect any public API or user-facing interface.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Leaving the vague "Include ALL commits" language and relying on post-processing validation to detect duplicate or missing amendments. This was rejected because it shifts error detection downstream and makes the failure mode harder to diagnose.
- Adding a runtime assertion that panics if the amendment count does not match the input commit count. This would be a stronger guarantee but was deferred in favour of first improving the prompt, since most issues originate from model misinterpretation rather than bugs in the parsing code.