### PR TITLE
feat(claude, cli): probe local server context length at startup

### DIFF
--- a/src/claude/ai/openai.rs
+++ b/src/claude/ai/openai.rs
@@ -2,6 +2,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use anyhow::Result;
 use reqwest::Client;
@@ -10,6 +11,33 @@ use tracing::{debug, info};
 
 use super::{AiClient, AiClientMetadata};
 use crate::claude::{error::ClaudeError, model_config::get_model_registry};
+
+/// Per-request timeout used when probing a local server's loaded context
+/// length at startup. Kept short so a stalled server can't delay the real
+/// request behind a long handshake.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Identifier for the probe endpoint that supplied the cached context
+/// length. Surfaces in the startup log line and in the metadata so users
+/// can tell which server reported the value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProbeSource {
+    /// LM Studio's `/api/v0/models` endpoint.
+    LmStudio,
+    /// Ollama's native `/api/show` endpoint.
+    Ollama,
+}
+
+impl ProbeSource {
+    /// Stable string used in logs (`source=lmstudio` etc.).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LmStudio => "lmstudio",
+            Self::Ollama => "ollama",
+        }
+    }
+}
 
 /// OpenAI API request message.
 #[derive(Serialize, Debug)]
@@ -81,6 +109,25 @@ pub struct OpenAiAiClient {
     temperature: Option<f32>,
     /// Active beta header (key, value) if enabled.
     active_beta: Option<(String, String)>,
+    /// Cached context length discovered by probing a local server. When
+    /// `Some`, this overrides the registry/default value in
+    /// [`Self::get_metadata`]. When `None`, metadata falls back to the
+    /// registry as before.
+    loaded_context_length: Option<usize>,
+}
+
+/// LM Studio `/api/v0/models` response envelope.
+#[derive(Deserialize, Debug)]
+struct LmStudioModelsResponse {
+    data: Vec<LmStudioModel>,
+}
+
+/// One entry from LM Studio's loaded-model list.
+#[derive(Deserialize, Debug)]
+struct LmStudioModel {
+    id: String,
+    state: Option<String>,
+    loaded_context_length: Option<usize>,
 }
 
 impl OpenAiAiClient {
@@ -103,6 +150,7 @@ impl OpenAiAiClient {
             max_tokens,
             temperature,
             active_beta,
+            loaded_context_length: None,
         })
     }
 
@@ -174,6 +222,113 @@ impl OpenAiAiClient {
     fn is_gpt5_series(&self) -> bool {
         self.model.starts_with("gpt-5") || self.model.starts_with("o1")
     }
+
+    /// Returns the cached probed context length, if any.
+    #[must_use]
+    pub fn loaded_context_length(&self) -> Option<usize> {
+        self.loaded_context_length
+    }
+
+    /// Stamps a probed context length onto the client. Used by callers
+    /// that probe externally (or reconstruct a client whose probe value
+    /// was discovered earlier).
+    pub fn set_loaded_context_length(&mut self, value: usize) {
+        self.loaded_context_length = Some(value);
+    }
+
+    /// Probes a local OpenAI-compatible server for the loaded model's
+    /// actual context length and caches the result on the client.
+    ///
+    /// Tries LM Studio's `/api/v0/models` endpoint first, then falls
+    /// back to Ollama's native `/api/show`. Returns the source on
+    /// success so callers can log which endpoint supplied the value.
+    /// Returns `None` if neither responds with a usable answer; in that
+    /// case the client is left unchanged and [`Self::get_metadata`]
+    /// will keep using the registry/default.
+    ///
+    /// Probe failures intentionally never bubble up as errors — the
+    /// goal is to *refine* metadata when the server is reachable, not
+    /// to abort startup.
+    pub async fn probe_loaded_context_length(&mut self) -> Option<ProbeSource> {
+        let host = host_root(&self.base_url);
+
+        if let Some(value) = probe_lm_studio(&self.client, &host, &self.model).await {
+            self.loaded_context_length = Some(value);
+            return Some(ProbeSource::LmStudio);
+        }
+
+        if let Some(value) = probe_ollama_native(&self.client, &host, &self.model).await {
+            self.loaded_context_length = Some(value);
+            return Some(ProbeSource::Ollama);
+        }
+
+        None
+    }
+}
+
+/// Strips a trailing `/v1` segment (and any trailing slash) so a probe
+/// URL can be built relative to the server root. LM Studio and Ollama
+/// expose probe endpoints at the host root, but `OLLAMA_BASE_URL` is
+/// commonly configured as the OpenAI-compatible path (e.g.
+/// `http://localhost:1234/v1`).
+fn host_root(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    trimmed
+        .strip_suffix("/v1")
+        .unwrap_or(trimmed)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Probes LM Studio's `/api/v0/models` endpoint for the loaded context
+/// length of a specific model id. Returns `None` if the server doesn't
+/// respond, doesn't return JSON in the expected shape, doesn't list the
+/// requested model, or the model isn't currently loaded.
+async fn probe_lm_studio(client: &Client, host: &str, model: &str) -> Option<usize> {
+    let url = format!("{host}/api/v0/models");
+    debug!(url = %url, model = %model, "Probing LM Studio for loaded context length");
+
+    let response = client.get(&url).timeout(PROBE_TIMEOUT).send().await.ok()?;
+    if !response.status().is_success() {
+        debug!(status = %response.status(), "LM Studio probe returned non-success");
+        return None;
+    }
+    let body: LmStudioModelsResponse = response.json().await.ok()?;
+    body.data
+        .into_iter()
+        .find(|entry| entry.id == model && entry.state.as_deref() == Some("loaded"))
+        .and_then(|entry| entry.loaded_context_length)
+}
+
+/// Probes Ollama's native `/api/show` endpoint for the loaded model's
+/// declared context length. The architecture prefix on the
+/// `model_info.<arch>.context_length` key varies (`llama`, `qwen2`,
+/// `gemma`, …), so we scan for any key ending in `.context_length`.
+async fn probe_ollama_native(client: &Client, host: &str, model: &str) -> Option<usize> {
+    let url = format!("{host}/api/show");
+    debug!(url = %url, model = %model, "Probing Ollama for loaded context length");
+
+    let response = client
+        .post(&url)
+        .timeout(PROBE_TIMEOUT)
+        .json(&serde_json::json!({ "name": model }))
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        debug!(status = %response.status(), "Ollama probe returned non-success");
+        return None;
+    }
+    let body: serde_json::Value = response.json().await.ok()?;
+    let model_info = body.get("model_info")?.as_object()?;
+    for (key, value) in model_info {
+        if key.ends_with(".context_length") {
+            if let Some(n) = value.as_u64() {
+                return usize::try_from(n).ok();
+            }
+        }
+    }
+    None
 }
 
 impl AiClient for OpenAiAiClient {
@@ -290,8 +445,12 @@ impl AiClient for OpenAiAiClient {
     fn get_metadata(&self) -> AiClientMetadata {
         let registry = get_model_registry();
 
-        // For unknown models, use reasonable defaults
-        let max_context_length = if registry.get_input_context(&self.model) > 0 {
+        // A successful probe overrides the registry — the server's
+        // loaded context is the authoritative limit, registry values
+        // are only an estimate.
+        let max_context_length = if let Some(probed) = self.loaded_context_length {
+            probed
+        } else if registry.get_input_context(&self.model) > 0 {
             registry.get_input_context(&self.model)
         } else {
             32768 // Reasonable default for modern models
@@ -619,5 +778,412 @@ mod tests {
     fn capabilities_default_to_no_schema_support_ollama() {
         let client = OpenAiAiClient::new_ollama("llama2".to_string(), None, None).unwrap();
         assert!(!client.capabilities().supports_response_schema);
+    }
+
+    // ── host_root ────────────────────────────────────────────────────
+
+    #[test]
+    fn host_root_strips_trailing_slash() {
+        assert_eq!(host_root("http://localhost:1234/"), "http://localhost:1234");
+    }
+
+    #[test]
+    fn host_root_strips_v1_suffix() {
+        assert_eq!(
+            host_root("http://localhost:1234/v1"),
+            "http://localhost:1234"
+        );
+    }
+
+    #[test]
+    fn host_root_strips_v1_with_trailing_slash() {
+        assert_eq!(
+            host_root("http://localhost:1234/v1/"),
+            "http://localhost:1234"
+        );
+    }
+
+    #[test]
+    fn host_root_passthrough_when_no_v1() {
+        assert_eq!(
+            host_root("http://localhost:11434"),
+            "http://localhost:11434"
+        );
+    }
+
+    // ── ProbeSource ──────────────────────────────────────────────────
+
+    #[test]
+    fn probe_source_as_str_stable() {
+        assert_eq!(ProbeSource::LmStudio.as_str(), "lmstudio");
+        assert_eq!(ProbeSource::Ollama.as_str(), "ollama");
+    }
+
+    // ── set_loaded_context_length / get_metadata interaction ─────────
+
+    #[test]
+    fn metadata_uses_probed_value_when_set() {
+        let mut client = OpenAiAiClient::new_ollama("llama2".to_string(), None, None).unwrap();
+        client.set_loaded_context_length(8192);
+        let metadata = client.get_metadata();
+        assert_eq!(metadata.max_context_length, 8192);
+    }
+
+    #[test]
+    fn metadata_falls_back_to_registry_when_probe_value_absent() {
+        // Probed value is intentionally unset → metadata mirrors the
+        // pre-probe behaviour (registry estimate). For an unknown model
+        // the registry resolves to its FALLBACK_INPUT_CONTEXT.
+        let client =
+            OpenAiAiClient::new_ollama("totally-unknown-model".to_string(), None, None).unwrap();
+        let metadata = client.get_metadata();
+        let expected = get_model_registry().get_input_context("totally-unknown-model");
+        assert_eq!(metadata.max_context_length, expected);
+    }
+
+    #[test]
+    fn loaded_context_length_starts_unset() {
+        let client = OpenAiAiClient::new_ollama("llama2".to_string(), None, None).unwrap();
+        assert!(client.loaded_context_length().is_none());
+    }
+
+    #[test]
+    fn loaded_context_length_round_trips() {
+        let mut client = OpenAiAiClient::new_ollama("llama2".to_string(), None, None).unwrap();
+        client.set_loaded_context_length(4096);
+        assert_eq!(client.loaded_context_length(), Some(4096));
+    }
+
+    // ── probe_loaded_context_length ──────────────────────────────────
+
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ollama_client_pointing_at(server_uri: &str, model: &str) -> OpenAiAiClient {
+        OpenAiAiClient::new_ollama(model.to_string(), Some(server_uri.to_string()), None).unwrap()
+    }
+
+    #[tokio::test]
+    async fn probe_returns_lm_studio_value_when_model_loaded() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "id": "llama-3.2-3b-instruct",
+                        "state": "loaded",
+                        "loaded_context_length": 4096_u64,
+                        "max_context_length": 131_072_u64,
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "llama-3.2-3b-instruct");
+        let source = client.probe_loaded_context_length().await;
+        assert_eq!(source, Some(ProbeSource::LmStudio));
+        assert_eq!(client.loaded_context_length(), Some(4096));
+        // get_metadata now reflects the probed value, not the registry.
+        assert_eq!(client.get_metadata().max_context_length, 4096);
+    }
+
+    #[tokio::test]
+    async fn probe_skips_lm_studio_entry_when_model_not_loaded() {
+        let server = MockServer::start().await;
+        // LM Studio knows the model but it isn't loaded → must fall
+        // through to the Ollama probe (which we also stub here so it
+        // succeeds, proving the fallthrough).
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    { "id": "model-a", "state": "not-loaded", "loaded_context_length": 4096_u64 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .and(body_json(serde_json::json!({ "name": "model-a" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": { "llama.context_length": 8192_u64 }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "model-a");
+        let source = client.probe_loaded_context_length().await;
+        assert_eq!(source, Some(ProbeSource::Ollama));
+        assert_eq!(client.loaded_context_length(), Some(8192));
+    }
+
+    #[tokio::test]
+    async fn probe_skips_lm_studio_when_model_id_does_not_match() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    { "id": "other-model", "state": "loaded", "loaded_context_length": 4096_u64 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "wanted-model");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+        assert!(client.loaded_context_length().is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_falls_back_to_ollama_native() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .and(body_json(serde_json::json!({ "name": "qwen2.5-coder" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": {
+                    "general.architecture": "qwen2",
+                    "qwen2.context_length": 32768_u64,
+                    "qwen2.embedding_length": 3584_u64
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "qwen2.5-coder");
+        let source = client.probe_loaded_context_length().await;
+        assert_eq!(source, Some(ProbeSource::Ollama));
+        assert_eq!(client.loaded_context_length(), Some(32768));
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_neither_endpoint_responds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+        assert!(client.loaded_context_length().is_none());
+        // Probe failure leaves metadata alone (registry/default still in effect).
+        let registry_value = get_model_registry().get_input_context("anything");
+        assert_eq!(client.get_metadata().max_context_length, registry_value);
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_ollama_payload_lacks_context_length_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": {
+                    "general.architecture": "phantom",
+                    "phantom.embedding_length": 1024_u64
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "ghost");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_handles_v1_suffix_in_base_url() {
+        // OLLAMA_BASE_URL is commonly the OpenAI-compatible path
+        // (`.../v1`). The probe must hit `/api/v0/models` at the host
+        // root, not `/v1/api/v0/models`.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    { "id": "lm", "state": "loaded", "loaded_context_length": 2048_u64 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let base_with_v1 = format!("{}/v1", server.uri());
+        let mut client = ollama_client_pointing_at(&base_with_v1, "lm");
+        let source = client.probe_loaded_context_length().await;
+        assert_eq!(source, Some(ProbeSource::LmStudio));
+        assert_eq!(client.loaded_context_length(), Some(2048));
+    }
+
+    #[tokio::test]
+    async fn probe_ignores_lm_studio_entry_with_no_loaded_context_length() {
+        let server = MockServer::start().await;
+        // Loaded but the field is null — must not panic, must skip and
+        // try the Ollama path.
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [ { "id": "x", "state": "loaded", "loaded_context_length": null } ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "x");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_lm_studio_returns_invalid_json() {
+        // Body is HTML (or anything non-JSON) — `.json::<…>().await.ok()?`
+        // returns None and the probe must fall through to Ollama.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>not json</html>"))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_ollama_returns_invalid_json() {
+        // LM Studio is unavailable (404). Ollama returns malformed JSON
+        // — `.json::<Value>()` errors, the probe must surface None.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{not json"))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_ollama_response_lacks_model_info() {
+        // 200 OK with valid JSON, but no `model_info` key at all —
+        // `body.get("model_info")?` short-circuits.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "details": { "family": "llama" }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_ollama_model_info_is_not_object() {
+        // `model_info` exists but is a string (impossible in practice,
+        // belt-and-braces against a malformed server). `.as_object()?`
+        // short-circuits.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": "not an object"
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_ollama_context_length_is_not_u64() {
+        // The arch.context_length key exists but the value is a string
+        // — `value.as_u64()` returns None, loop continues, no other
+        // matching key, probe surfaces None.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": { "llama.context_length": "8192" }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = ollama_client_pointing_at(&server.uri(), "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_none_when_server_unreachable() {
+        // Closed-port URL — both `send().await.ok()?` short-circuits
+        // fire. Pick a port we don't bind to and is unlikely to host
+        // anything; reqwest will fail fast (refused) well within the
+        // 2-second probe timeout.
+        let mut client = ollama_client_pointing_at("http://127.0.0.1:1", "anything");
+        let source = client.probe_loaded_context_length().await;
+        assert!(source.is_none());
     }
 }

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -1610,7 +1610,12 @@ fn validate_beta_header(model: &str, beta_header: &Option<(String, String)>) -> 
 }
 
 /// Creates a default Claude client using environment variables and settings.
-pub fn create_default_claude_client(
+///
+/// Async because the Ollama branch probes the local server for its
+/// loaded context length so token-budget checks reflect what the server
+/// actually loaded the model with (registry values are an estimate that
+/// can exceed the live limit). All other branches finish synchronously.
+pub async fn create_default_claude_client(
     model: Option<String>,
     beta_header: Option<(String, String)>,
 ) -> Result<ClaudeClient> {
@@ -1674,7 +1679,23 @@ pub fn create_default_claude_client(
             .unwrap_or_else(|| "llama2".to_string());
         validate_beta_header(&ollama_model, &beta_header)?;
         let base_url = get_env_var("OLLAMA_BASE_URL").ok();
-        let ai_client = OpenAiAiClient::new_ollama(ollama_model, base_url, beta_header)?;
+        let mut ai_client = OpenAiAiClient::new_ollama(ollama_model, base_url, beta_header)?;
+        match ai_client.probe_loaded_context_length().await {
+            Some(source) => {
+                info!(
+                    loaded_context_length = ai_client.loaded_context_length(),
+                    source = source.as_str(),
+                    model = %ai_client.get_metadata().model,
+                    "Probed loaded context length from local server"
+                );
+            }
+            None => {
+                debug!(
+                    "Loaded context length probe did not return a value; \
+                     falling back to registry/default for token budget"
+                );
+            }
+        }
         return Ok(ClaudeClient::new(Box::new(ai_client)));
     }
 
@@ -3975,8 +3996,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn factory_claude_cli_backend_dispatches_to_claude_cli_client() {
+    #[tokio::test]
+    async fn factory_claude_cli_backend_dispatches_to_claude_cli_client() {
         let guard = FactoryEnvGuard::new(&[
             "OMNI_DEV_AI_BACKEND",
             "USE_OPENAI",
@@ -3988,15 +4009,17 @@ mod tests {
         ]);
         guard.set("OMNI_DEV_AI_BACKEND", "claude-cli");
 
-        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
         let metadata = client.get_ai_client_metadata();
         assert_eq!(metadata.provider, "Claude CLI");
         // Default model falls through to the registry's claude default.
         assert_eq!(metadata.model, "claude-sonnet-4-6");
     }
 
-    #[test]
-    fn factory_claude_cli_backend_honours_model_precedence() {
+    #[tokio::test]
+    async fn factory_claude_cli_backend_honours_model_precedence() {
         let guard = FactoryEnvGuard::new(&[
             "OMNI_DEV_AI_BACKEND",
             "USE_OPENAI",
@@ -4011,14 +4034,16 @@ mod tests {
         // CLAUDE_MODEL has higher precedence than CLAUDE_CODE_MODEL.
         guard.set("CLAUDE_MODEL", "haiku");
 
-        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
         let metadata = client.get_ai_client_metadata();
         assert_eq!(metadata.provider, "Claude CLI");
         assert_eq!(metadata.model, "haiku");
     }
 
-    #[test]
-    fn factory_claude_cli_backend_explicit_model_wins_over_env() {
+    #[tokio::test]
+    async fn factory_claude_cli_backend_explicit_model_wins_over_env() {
         let guard = FactoryEnvGuard::new(&[
             "OMNI_DEV_AI_BACKEND",
             "USE_OPENAI",
@@ -4032,13 +4057,14 @@ mod tests {
         guard.set("CLAUDE_MODEL", "haiku");
 
         let client = create_default_claude_client(Some("opus".to_string()), None)
+            .await
             .expect("factory should succeed");
         let metadata = client.get_ai_client_metadata();
         assert_eq!(metadata.model, "opus");
     }
 
-    #[test]
-    fn factory_claude_cli_backend_accepts_underscore_alias() {
+    #[tokio::test]
+    async fn factory_claude_cli_backend_accepts_underscore_alias() {
         let guard = FactoryEnvGuard::new(&[
             "OMNI_DEV_AI_BACKEND",
             "USE_OPENAI",
@@ -4050,8 +4076,129 @@ mod tests {
         ]);
         guard.set("OMNI_DEV_AI_BACKEND", "claude_cli");
 
-        let client = create_default_claude_client(None, None).expect("factory should succeed");
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
         let metadata = client.get_ai_client_metadata();
         assert_eq!(metadata.provider, "Claude CLI");
+    }
+
+    #[tokio::test]
+    async fn factory_ollama_branch_probes_loaded_context_length() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    { "id": "lm-loaded", "state": "loaded", "loaded_context_length": 6144_u64 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "OLLAMA_BASE_URL",
+            "OLLAMA_MODEL",
+        ]);
+        guard.set("USE_OLLAMA", "true");
+        guard.set("OLLAMA_BASE_URL", &server.uri());
+        guard.set("OLLAMA_MODEL", "lm-loaded");
+
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.provider, "Ollama");
+        assert_eq!(metadata.model, "lm-loaded");
+        // The probed value (6144) overrides the registry/default.
+        assert_eq!(metadata.max_context_length, 6144);
+    }
+
+    #[tokio::test]
+    async fn factory_ollama_branch_falls_back_when_probe_fails() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "OLLAMA_BASE_URL",
+            "OLLAMA_MODEL",
+        ]);
+        guard.set("USE_OLLAMA", "true");
+        guard.set("OLLAMA_BASE_URL", &server.uri());
+        guard.set("OLLAMA_MODEL", "no-such-model");
+
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        // Probe failure → fall back to the registry estimate (which
+        // resolves to FALLBACK_INPUT_CONTEXT for unknown models).
+        let registry_value =
+            crate::claude::model_config::get_model_registry().get_input_context("no-such-model");
+        assert_eq!(metadata.max_context_length, registry_value);
+    }
+
+    /// LM Studio path is tested above. This complements it by exercising
+    /// the Ollama-native fallthrough through the factory, so the
+    /// info-log arm fires for both `ProbeSource` variants.
+    #[tokio::test]
+    async fn factory_ollama_branch_probes_via_ollama_native() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v0/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/show"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "model_info": { "llama.context_length": 12288_u64 }
+            })))
+            .mount(&server)
+            .await;
+
+        let guard = FactoryEnvGuard::new(&[
+            "OMNI_DEV_AI_BACKEND",
+            "USE_OPENAI",
+            "USE_OLLAMA",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "OLLAMA_BASE_URL",
+            "OLLAMA_MODEL",
+        ]);
+        guard.set("USE_OLLAMA", "true");
+        guard.set("OLLAMA_BASE_URL", &server.uri());
+        guard.set("OLLAMA_MODEL", "ollama-native-model");
+
+        let client = create_default_claude_client(None, None)
+            .await
+            .expect("factory should succeed");
+        let metadata = client.get_ai_client_metadata();
+        assert_eq!(metadata.max_context_length, 12288);
     }
 }

--- a/src/cli/ai/chat.rs
+++ b/src/cli/ai/chat.rs
@@ -27,7 +27,7 @@ impl ChatCommand {
         );
         eprintln!("Enter to send, Shift+Enter for newline, Ctrl+D to exit.\n");
 
-        let client = crate::claude::create_default_claude_client(self.model, None)?;
+        let client = crate::claude::create_default_claude_client(self.model, None).await?;
 
         chat_loop(&client).await
     }
@@ -49,7 +49,7 @@ pub async fn run_chat(
     system_prompt: Option<String>,
 ) -> Result<String> {
     crate::utils::preflight::check_ai_credentials(model.as_deref())?;
-    let client = crate::claude::create_default_claude_client(model, None)?;
+    let client = crate::claude::create_default_claude_client(model, None).await?;
     let system = system_prompt
         .as_deref()
         .unwrap_or("You are a helpful assistant.");

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -129,7 +129,8 @@ impl CheckCommand {
             .as_deref()
             .map(parse_beta_header)
             .transpose()?;
-        let claude_client = crate::claude::create_default_claude_client(self.model.clone(), beta)?;
+        let claude_client =
+            crate::claude::create_default_claude_client(self.model.clone(), beta).await?;
 
         if self.verbose && output_format == OutputFormat::Text {
             self.show_model_info(&claude_client)?;
@@ -910,7 +911,7 @@ pub async fn run_check(
     // Preflight: validate AI credentials.
     crate::utils::check_ai_command_prerequisites(model.as_deref())?;
 
-    let claude_client = crate::claude::create_default_claude_client(model, None)?;
+    let claude_client = crate::claude::create_default_claude_client(model, None).await?;
     run_check_with_client(range, guidelines_path, strict, &claude_client).await
 }
 

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -114,7 +114,8 @@ impl CreatePrCommand {
         self.show_guidance_files_status(&project_context)?;
 
         // 4. Show AI model configuration before generation
-        let claude_client = crate::claude::create_default_claude_client(self.model.clone(), None)?;
+        let claude_client =
+            crate::claude::create_default_claude_client(self.model.clone(), None).await?;
         self.show_model_info_from_client(&claude_client)?;
 
         // 5. Show branch analysis and commit information
@@ -1386,7 +1387,7 @@ pub async fn run_create_pr(
 
     let repo_view = cmd.generate_repository_view()?;
     let context = cmd.collect_context(&repo_view).await?;
-    let claude_client = crate::claude::create_default_claude_client(model, None)?;
+    let claude_client = crate::claude::create_default_claude_client(model, None).await?;
     run_create_pr_with_client(&cmd, &repo_view, &context, &claude_client).await
 }
 

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -166,7 +166,8 @@ impl TwiddleCommand {
             .as_deref()
             .map(parse_beta_header)
             .transpose()?;
-        let claude_client = crate::claude::create_default_claude_client(self.model.clone(), beta)?;
+        let claude_client =
+            crate::claude::create_default_claude_client(self.model.clone(), beta).await?;
 
         // Show model information
         self.show_model_info_from_client(&claude_client)?;
@@ -263,7 +264,8 @@ impl TwiddleCommand {
             .as_deref()
             .map(parse_beta_header)
             .transpose()?;
-        let claude_client = crate::claude::create_default_claude_client(self.model.clone(), beta)?;
+        let claude_client =
+            crate::claude::create_default_claude_client(self.model.clone(), beta).await?;
 
         // Show model information
         self.show_model_info_from_client(&claude_client)?;
@@ -1073,7 +1075,8 @@ impl TwiddleCommand {
             .as_deref()
             .map(parse_beta_header)
             .transpose()?;
-        let claude_client = crate::claude::create_default_claude_client(self.model.clone(), beta)?;
+        let claude_client =
+            crate::claude::create_default_claude_client(self.model.clone(), beta).await?;
 
         for attempt in 0..=MAX_CHECK_RETRIES {
             println!();
@@ -1742,7 +1745,7 @@ pub async fn run_twiddle(
         crate::utils::preflight::check_working_directory_clean()?;
     }
 
-    let claude_client = crate::claude::create_default_claude_client(model, None)?;
+    let claude_client = crate::claude::create_default_claude_client(model, None).await?;
     run_twiddle_with_client(range, dry_run, &claude_client).await
 }
 


### PR DESCRIPTION
## Description

This PR implements automatic discovery of the actual loaded context length from local LLM servers (LM Studio and Ollama) during client initialization. Previously, token budget calculations relied solely on static registry estimates, which can differ significantly from the context length a model was actually loaded with. Now, when an Ollama-compatible local server is configured, omni-dev probes the server at startup and uses the real-time context limit for all subsequent token budget decisions.

This prevents requests from exceeding the actual context limits of local models, improving the reliability of AI interactions with locally-hosted models.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Relates to #696

## Changes Made

**Core Changes (`src/claude/ai/openai.rs`):**
- Added `ProbeSource` enum (`LmStudio`, `Ollama`) to identify which endpoint supplied the probed context length
- Added `loaded_context_length: Option<usize>` field to `OpenAiAiClient` to cache the probed value
- Implemented `probe_loaded_context_length(&mut self) -> Option<ProbeSource>` async method that queries local endpoints
- Implemented `probe_lm_studio()` — queries LM Studio's `/api/v0/models` endpoint for loaded model context length
- Implemented `probe_ollama_native()` — queries Ollama's `/api/show` endpoint, scanning `model_info.<arch>.context_length` keys
- Added `host_root()` helper to strip `/v1` suffix from base URLs so probe requests target the server root correctly
- Updated `get_metadata()` to return the probed context length when available, overriding registry estimates
- Added `PROBE_TIMEOUT` constant (2 seconds) to prevent stalled servers from blocking startup

**Core Changes (`src/claude/client.rs`):**
- Changed `create_default_claude_client` from synchronous to `async` to accommodate the probing step
- Integrated `probe_loaded_context_length()` call in the Ollama branch with `info!` logging on success and `debug!` logging on fallback

**CLI Call-site Updates:**
- Updated all callers of `create_default_claude_client` to `.await` the result:
  - `src/cli/ai/chat.rs` — `ChatCommand::run` and `run_chat`
  - `src/cli/git/check.rs` — `CheckCommand` and `run_check`
  - `src/cli/git/create_pr.rs` — `CreatePrCommand` and `run_create_pr`
  - `src/cli/git/twiddle.rs` — `TwiddleCommand` (three call sites) and `run_twiddle`

**Testing:**
- Added comprehensive unit tests for `host_root` URL stripping logic
- Added unit tests for `ProbeSource::as_str` stability
- Added unit tests for `set_loaded_context_length` / `get_metadata` interaction (probed value overrides registry, fallback when unset)
- Added `wiremock`-based integration tests for `probe_loaded_context_length`:
  - Returns LM Studio value when model is in `loaded` state
  - Falls through to Ollama when LM Studio entry is not loaded
  - Falls through when model ID doesn't match
  - Falls back to Ollama native when LM Studio returns 404
  - Returns `None` when neither endpoint responds
  - Returns `None` when Ollama payload lacks a `context_length` key
  - Handles `/v1` suffix in base URL correctly
  - Handles null `loaded_context_length` in LM Studio response without panic
- Added `wiremock`-based integration tests in `client.rs`:
  - Factory Ollama branch uses probed context length when probe succeeds
  - Factory Ollama branch falls back to registry estimate when probe fails
- Updated existing factory tests from `#[test]` to `#[tokio::test]` and added `.await` to match new async signature

## Testing

**Automated Testing:**
- [x] All existing tests pass (updated to async where required)
- [x] New tests added for new functionality
- [x] Integration tests using `wiremock` for both LM Studio and Ollama probe paths

**Manual Testing:**
- [x] Tested happy path scenarios (model loaded, probe succeeds)
- [x] Tested error/edge cases (server down, model not loaded, missing fields, null values)
- [x] Backward compatibility verified (probe failure leaves client unchanged, registry fallback still works)

### Test Commands
```bash
# Core test suite
cargo test

# Run probe-specific tests
cargo test probe

# Run openai client tests
cargo test --test-module claude::ai::openai

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Performance impact — a 2-second timeout probe is added to the Ollama startup path; this is intentionally short but reviewers should confirm it is acceptable for the expected use case
- [x] Error handling — probe failures must never abort startup; verify all `None`/error paths are handled gracefully
- [x] Architecture changes — `create_default_claude_client` is now `async`; all callers required updating

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] Potential performance impact (describe below)

When the Ollama backend is configured, startup now makes up to two additional HTTP requests (LM Studio probe, then Ollama probe) before the first real AI request. Each probe has a hard 2-second timeout (`PROBE_TIMEOUT`). For most users this will complete in milliseconds against a local server; the timeout guards against stalled or slow servers. Non-Ollama backends (Claude CLI, OpenAI, Bedrock) are unaffected.

## Security Considerations
- [x] No security implications

Probe requests are made only to the already-configured local server base URL. No credentials or sensitive data are sent in probe payloads. Probe failures are silently ignored.

## Breaking Changes

`create_default_claude_client` is now an `async fn`. Any external code calling this function must be updated to `.await` the result. All internal call sites within this repository have been updated in this PR.

## Deployment Notes
- [x] No special deployment requirements

No new environment variables, configuration changes, or migrations are required. The probe uses the existing `OLLAMA_BASE_URL` configuration.

## Additional Notes

**Future Enhancements:**
- The `ProbeSource` abstraction makes it straightforward to add support for additional local server types (e.g. llama.cpp, LocalAI) by implementing a new probe function and extending the `probe_loaded_context_length` fallback chain.

**Known Limitations:**
- The LM Studio probe only matches a model entry when `state == "loaded"`; if LM Studio reports a different state string for loaded models in future versions, the probe will fall through to the Ollama path or return `None`.
- The Ollama probe scans for any `model_info` key ending in `.context_length`; if a model exposes multiple such keys, the first matching one is used.

**Alternatives Considered:**
- Making the probe synchronous by blocking on the async call — rejected because it would require a nested runtime and is an anti-pattern in async Rust.
- Caching the probe result at the registry level rather than per-client — rejected because the loaded context can differ per-model and per-server configuration; per-client caching is more accurate.