### PR TITLE
test(cli): allow unwrap and expect in test modules to suppress Clippy warnings

### DIFF
--- a/src/atlassian/attrs.rs
+++ b/src/atlassian/attrs.rs
@@ -218,6 +218,7 @@ fn parse_quoted_value(text: &str, quote: char) -> Option<(String, &str)> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/atlassian/directive.rs
+++ b/src/atlassian/directive.rs
@@ -202,6 +202,7 @@ pub fn is_container_close(line: &str, min_colons: usize) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/claude/test_utils.rs
+++ b/src/claude/test_utils.rs
@@ -1,5 +1,7 @@
 //! Shared test utilities for the `claude` module.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -1298,6 +1298,7 @@ fn format_commit_line(icon: &str, short_hash: &str, message: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::data::check::{

--- a/src/cli/git/formatting.rs
+++ b/src/cli/git/formatting.rs
@@ -89,6 +89,7 @@ pub(crate) fn parse_editor_command(editor: &str) -> (&str, Vec<&str>) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3,6 +3,8 @@
 //! These utilities are consumed by unit tests across the crate and must
 //! stay in sync between shim-writing sites — see issue #642.
 
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 #[cfg(unix)]
 pub(crate) mod shim {
     use std::path::Path;


### PR DESCRIPTION
## Description

This PR suppresses Clippy warnings for `unwrap_used` and `expect_used` in test modules and test utility files across the codebase. In test code, panicking on failure via `.unwrap()` and `.expect()` is the intended and idiomatic behavior for assertions — these are not production code paths. Adding the allow attributes reduces noise in CI linting reports and avoids unnecessary boilerplate in test code.

This is part of the Clippy batch-a cleanup effort (issue #690) to bring the codebase into compliance with stricter Clippy lints while preserving ergonomic test authoring patterns.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #690

## Changes Made

**Core Changes:**
- Added `#[allow(clippy::unwrap_used, clippy::expect_used)]` to the `mod tests` block in `src/atlassian/attrs.rs`
- Added `#[allow(clippy::unwrap_used, clippy::expect_used)]` to the `mod tests` block in `src/atlassian/directive.rs`
- Added `#[allow(clippy::unwrap_used, clippy::expect_used)]` to the `mod tests` block in `src/cli/git/check.rs`
- Added `#[allow(clippy::unwrap_used, clippy::expect_used)]` to the `mod tests` block in `src/cli/git/formatting.rs`
- Added crate-level `#![allow(clippy::unwrap_used, clippy::expect_used)]` to `src/claude/test_utils.rs`
- Added crate-level `#![allow(clippy::unwrap_used, clippy::expect_used)]` to `src/test_support.rs`

**Documentation:**
- No documentation changes required; attributes are self-explanatory

**Testing:**
- No new tests added; this change only adds lint suppression attributes to existing test code

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified `cargo clippy -- -D warnings` passes without errors related to `unwrap_used` or `expect_used` in test modules

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — this is a lint-only change with no functional impact

The allow attributes are scoped tightly: inline test modules use `#[allow(...)]` on the `mod tests` block, and utility files that are exclusively used in tests use the crate-level `#![allow(...)]` inner attribute. No production code is affected.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional Clippy lint suppressions for other test-only patterns may follow in subsequent batches as part of issue #690.

**Known Limitations:**
- None. This is a purely mechanical change with no behavioral impact.

**Alternatives Considered:**
- Disabling these lints globally at the crate level — rejected because production code should remain subject to these warnings.
- Using `#[cfg(test)]` gated allow attributes on individual call sites — rejected as overly verbose with no additional benefit over module-level suppression.