### PR TITLE
chore(atlassian): allow await_holding_lock in tests

### DIFF
--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -779,7 +779,7 @@ async fn spawn_with_etxtbsy_retry(cmd: &mut Command) -> std::io::Result<tokio::p
 pub(crate) static CLI_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use std::ffi::OsStr;

--- a/src/cli/atlassian/confluence/download.rs
+++ b/src/cli/atlassian/confluence/download.rs
@@ -792,7 +792,7 @@ fn file_extension(format: &ContentFormat) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
 mod tests {
     use super::*;
 

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -368,7 +368,7 @@ pub fn list_resource_templates_result() -> ListResourceTemplatesResult {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Description

This PR suppresses the `clippy::await_holding_lock` lint within test modules across three components. These warnings are triggered by async operations performed while holding a mutex lock within test contexts, which is an acceptable pattern in tests where strict async safety guarantees are less critical than in production code.

This is part of a batch of Clippy lint fixes (batch b) for issue #690.

## Type of Change
- [x] Refactoring (no functional changes)

## Related Issue
Relates to #690

## Changes Made

**Core Changes:**
- Added `clippy::await_holding_lock` to the `#[allow(...)]` attribute in the `tests` module of `src/claude/ai/claude_cli.rs`
- Added `clippy::await_holding_lock` to the `#[allow(...)]` attribute in the `tests` module of `src/cli/atlassian/confluence/download.rs`
- Added `clippy::await_holding_lock` to the `#[allow(...)]` attribute in the `tests` module of `src/mcp/resources.rs`

**Documentation:**
- No documentation changes required; these are test-only lint suppressions.

**Testing:**
- No new tests required; changes only affect lint configuration in existing test modules.

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility

The `clippy::await_holding_lock` allow attribute is scoped strictly to `#[cfg(test)]` modules, so production code is unaffected. The change is minimal and consistent across all three files.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Refactoring test code to avoid holding a mutex lock across `.await` points — this would be more invasive and is not necessary for test-only code where strict async safety is not a concern.