### PR TITLE
refactor(atlassian): apply clippy batch-c lint fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,5 @@ redundant_pub_crate          = "allow"  # conflicts with STYLE-0005
 missing_const_for_fn         = "allow"
 or_fun_call                  = "allow"  # false positives
 significant_drop_tightening  = "allow"  # often produces wrong suggestions
+large_stack_frames           = "allow"  # fires on test fns with large fixture literals; no usable span
+large_stack_arrays           = "allow"  # ditto — fixture arrays in tests

--- a/src/atlassian/api.rs
+++ b/src/atlassian/api.rs
@@ -83,7 +83,11 @@ pub trait AtlassianApi: Send + Sync {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::match_wildcard_for_single_variants
+)]
 mod tests {
     use super::*;
 

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -1257,7 +1257,11 @@ struct DevStatusSummaryInstance {
 // ── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::items_after_test_module
+)]
 mod tests {
     use super::*;
 

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -4845,7 +4845,13 @@ fn link_href(mark: &AdfMark) -> &str {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_update,
+    clippy::needless_collect,
+    duplicate_macro_attributes
+)]
 mod tests {
     use super::*;
 
@@ -5010,11 +5016,7 @@ mod tests {
         }"#;
         let doc: AdfDocument = serde_json::from_str(json).unwrap();
         let md = adf_to_markdown(&doc).unwrap();
-        let stripped: String = md
-            .lines()
-            .map(|l| l.trim_end())
-            .collect::<Vec<_>>()
-            .join("\n");
+        let stripped: String = md.lines().map(str::trim_end).collect::<Vec<_>>().join("\n");
         let parsed = markdown_to_adf(&stripped).unwrap();
         assert_eq!(parsed.content[0].node_type, "taskList");
         let items = parsed.content[0].content.as_ref().unwrap();
@@ -12771,7 +12773,7 @@ mod tests {
 
     #[test]
     fn media_border_size_only_defaults_color() {
-        let adf_json = r##"{"version":1,"type":"doc","content":[{"type":"mediaSingle","attrs":{"layout":"center"},"content":[{"type":"media","attrs":{"id":"abc","type":"file","collection":"col"},"marks":[{"type":"border","attrs":{"size":4}}]}]}]}"##;
+        let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"mediaSingle","attrs":{"layout":"center"},"content":[{"type":"media","attrs":{"id":"abc","type":"file","collection":"col"},"marks":[{"type":"border","attrs":{"size":4}}]}]}]}"#;
         let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
         let md = adf_to_markdown(&doc).unwrap();
         assert!(md.contains("border-size=4"), "md: {md}");
@@ -16585,7 +16587,7 @@ mod tests {
                     .as_ref()
                     .and_then(|c| c.first())
                     .and_then(|n| n.text.as_deref())
-                    .map_or(false, |t| t.contains("after"))
+                    .is_some_and(|t| t.contains("after"))
         });
         assert!(after_para.is_some(), "should have paragraph with 'after'");
     }
@@ -21264,8 +21266,7 @@ C
         for (i, child) in children.iter().enumerate() {
             assert_eq!(
                 child.node_type, "paragraph",
-                "Child {} should be a paragraph",
-                i
+                "Child {i} should be a paragraph"
             );
         }
     }

--- a/src/atlassian/document.rs
+++ b/src/atlassian/document.rs
@@ -542,7 +542,11 @@ impl JfmDocument {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::match_wildcard_for_single_variants
+)]
 mod tests {
     use super::*;
 

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -1762,7 +1762,11 @@ pub async fn create_default_claude_client(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::format_in_format_args
+)]
 mod tests {
     use super::*;
     use crate::claude::ai::{AiClient, AiClientCapabilities, AiClientMetadata};
@@ -1951,8 +1955,8 @@ mod tests {
         let returned = client.schema_if_supported(&schema);
         assert!(returned.is_some());
         assert!(std::ptr::eq(
-            returned.unwrap() as *const _,
-            &schema as *const _
+            std::ptr::from_ref(returned.unwrap()),
+            std::ptr::addr_of!(schema)
         ));
     }
 

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -1694,7 +1694,7 @@ mod tests {
     fn check_chunk_merge_user_prompt_includes_all_chunks() {
         use crate::data::check::CommitSuggestion;
 
-        let suggestions = vec![
+        let suggestions = [
             CommitSuggestion {
                 message: "feat(cli): add flag".to_string(),
                 explanation: "improved clarity".to_string(),
@@ -1726,7 +1726,7 @@ mod tests {
     fn check_chunk_merge_user_prompt_includes_context() {
         use crate::data::check::CommitSuggestion;
 
-        let suggestions = vec![CommitSuggestion {
+        let suggestions = [CommitSuggestion {
             message: "fix: correct typo".to_string(),
             explanation: "typo in subject".to_string(),
         }];
@@ -1751,7 +1751,7 @@ mod tests {
     fn check_chunk_merge_user_prompt_handles_missing_summaries() {
         use crate::data::check::CommitSuggestion;
 
-        let suggestions = vec![CommitSuggestion {
+        let suggestions = [CommitSuggestion {
             message: "feat: change".to_string(),
             explanation: "reason".to_string(),
         }];

--- a/src/cli/atlassian/confluence/download.rs
+++ b/src/cli/atlassian/confluence/download.rs
@@ -1119,7 +1119,9 @@ mod tests {
     async fn execute_runs_with_env_credentials() {
         use std::sync::Mutex;
         static ENV_MUTEX: Mutex<()> = Mutex::new(());
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn clone() {
         let format = ContentFormat::Adf;
-        let cloned = format.clone();
+        let cloned = format;
         assert!(matches!(cloned, ContentFormat::Adf));
     }
 
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn output_clone() {
         let format = OutputFormat::Jsonl;
-        let cloned = format.clone();
+        let cloned = format;
         assert!(matches!(cloned, OutputFormat::Jsonl));
     }
 

--- a/src/cli/atlassian/jira/field.rs
+++ b/src/cli/atlassian/jira/field.rs
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn print_fields_with_data() {
-        let fields = vec![
+        let fields = [
             sample_field("summary", "Summary", false, Some("string")),
             sample_field("customfield_10001", "Story Points", true, Some("number")),
         ];
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn print_fields_no_schema() {
-        let fields = vec![sample_field("labels", "Labels", false, None)];
+        let fields = [sample_field("labels", "Labels", false, None)];
         let refs: Vec<&JiraField> = fields.iter().collect();
         print_fields(&refs);
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -899,10 +899,10 @@ mod tests {
                 let diff_path = dir.path().join(format!("{i}.diff"));
                 std::fs::write(&diff_path, format!("+line from commit {i}\n")).unwrap();
                 CommitInfo {
-                    hash: format!("{:0>40}", i),
+                    hash: format!("{i:0>40}"),
                     author: "Test <test@test.com>".to_string(),
                     date: Utc::now().fixed_offset(),
-                    original_message: msg.to_string(),
+                    original_message: (*msg).to_string(),
                     in_main_branches: Vec::new(),
                     analysis: CommitAnalysis {
                         detected_type: "feat".to_string(),
@@ -947,9 +947,7 @@ mod tests {
         let view = make_human_view_with_diff_files(&dir, &["first", "second"]);
         assert_eq!(view.commits.len(), 2);
 
-        let mapped: RepositoryView<String> = view
-            .map_commits(|c| Ok(c.original_message.clone()))
-            .unwrap();
+        let mapped: RepositoryView<String> = view.map_commits(|c| Ok(c.original_message)).unwrap();
         assert_eq!(
             mapped.commits,
             vec!["first".to_string(), "second".to_string()]

--- a/src/mcp/git_tools.rs
+++ b/src/mcp/git_tools.rs
@@ -255,6 +255,38 @@ pub(crate) fn build_truncated_result(text: String) -> CallToolResult {
     }
 }
 
+/// Indents a multi-line string for inclusion as a YAML block scalar value.
+fn indent_for_yaml(body: &str) -> String {
+    body.lines()
+        .map(|line| format!("  {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Formats the payload returned by the `git_check_commits` tool.
+fn format_check_payload(outcome: &crate::cli::git::CheckOutcome) -> String {
+    format!(
+        "# git_check_commits outcome\nexit_code: {}\nstrict: {}\nhas_errors: {}\nhas_warnings: {}\ntotal_commits: {}\nreport: |\n{}",
+        outcome.exit_code,
+        outcome.strict,
+        outcome.has_errors,
+        outcome.has_warnings,
+        outcome.total_commits,
+        indent_for_yaml(&outcome.report_yaml),
+    )
+}
+
+/// Formats the payload returned by the `git_twiddle_commits` tool.
+fn format_twiddle_payload(outcome: &crate::cli::git::TwiddleOutcome, dry_run: bool) -> String {
+    format!(
+        "# git_twiddle_commits outcome\napplied: {}\ndry_run: {}\namendment_count: {}\namendments: |\n{}",
+        outcome.applied,
+        dry_run,
+        outcome.amendment_count,
+        indent_for_yaml(&outcome.amendments_yaml),
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -435,36 +467,4 @@ mod tests {
         let err = server.git_create_pr(Parameters(params)).await.unwrap_err();
         assert!(!err.message.is_empty());
     }
-}
-
-/// Indents a multi-line string for inclusion as a YAML block scalar value.
-fn indent_for_yaml(body: &str) -> String {
-    body.lines()
-        .map(|line| format!("  {line}"))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// Formats the payload returned by the `git_check_commits` tool.
-fn format_check_payload(outcome: &crate::cli::git::CheckOutcome) -> String {
-    format!(
-        "# git_check_commits outcome\nexit_code: {}\nstrict: {}\nhas_errors: {}\nhas_warnings: {}\ntotal_commits: {}\nreport: |\n{}",
-        outcome.exit_code,
-        outcome.strict,
-        outcome.has_errors,
-        outcome.has_warnings,
-        outcome.total_commits,
-        indent_for_yaml(&outcome.report_yaml),
-    )
-}
-
-/// Formats the payload returned by the `git_twiddle_commits` tool.
-fn format_twiddle_payload(outcome: &crate::cli::git::TwiddleOutcome, dry_run: bool) -> String {
-    format!(
-        "# git_twiddle_commits outcome\napplied: {}\ndry_run: {}\namendment_count: {}\namendments: |\n{}",
-        outcome.applied,
-        dry_run,
-        outcome.amendment_count,
-        indent_for_yaml(&outcome.amendments_yaml),
-    )
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -22,7 +22,9 @@ pub(crate) mod shim {
     /// intentional panics in one test don't cascade into the rest of the
     /// suite.
     pub(crate) fn shim_lock() -> MutexGuard<'static, ()> {
-        SHIM_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+        SHIM_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// Writes an executable script at `path`, flushes it to disk, and

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -5,7 +5,11 @@
 //! tool dispatch end-to-end.
 
 #![cfg(feature = "mcp")]
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::semicolon_if_nothing_returned
+)]
 
 use std::fs;
 use std::path::PathBuf;
@@ -427,7 +431,9 @@ impl AtlassianEnvGuard {
     /// env vars to the given values, suppressing any real credentials
     /// in the process for the duration of the guard.
     fn new(instance_url: &str, email: &str, token: &str) -> Result<Self> {
-        let guard = ATLASSIAN_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let guard = ATLASSIAN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = tempfile::tempdir()?;
         let prev_home = std::env::var("HOME").ok();
         let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
@@ -453,7 +459,9 @@ impl AtlassianEnvGuard {
     /// Variant that clears every Atlassian env var so `create_client()`
     /// will fail with a credentials-not-found error.
     fn empty() -> Result<Self> {
-        let guard = ATLASSIAN_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let guard = ATLASSIAN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = tempfile::tempdir()?;
         let prev_home = std::env::var("HOME").ok();
         let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
@@ -697,12 +705,12 @@ async fn jira_tool_handlers_surface_tool_error_without_credentials() -> Result<(
                 CallToolRequestParams::new(name).with_arguments(args.as_object().unwrap().clone()),
             )
             .await;
-        match outcome {
-            Ok(result) => assert!(
+        if let Ok(result) = outcome {
+            assert!(
                 result.is_error.unwrap_or(false),
                 "{name} should have returned tool_error without credentials"
-            ),
-            Err(_) => { /* protocol-level error is also acceptable */ }
+            )
+        } else { /* protocol-level error is also acceptable */
         }
     }
 
@@ -1100,7 +1108,9 @@ async fn git_branch_info_invalid_repo_returns_error() -> Result<()> {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn atlassian_auth_status_never_leaks_secrets() -> Result<()> {
-    let _lock = ATLASSIAN_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _lock = ATLASSIAN_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let original_home = std::env::var("HOME").ok();
     let original_url = std::env::var("ATLASSIAN_INSTANCE_URL").ok();
@@ -1168,7 +1178,9 @@ async fn atlassian_auth_status_never_leaks_secrets() -> Result<()> {
 async fn ai_chat_returns_tool_error_when_credentials_missing() -> Result<()> {
     // Share the Atlassian env lock so this test doesn't race with other
     // env-mutating tests in the binary.
-    let _lock = ATLASSIAN_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _lock = ATLASSIAN_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let original_home = std::env::var("HOME").ok();
     let snapshots: Vec<(&str, Option<String>)> = vec![


### PR DESCRIPTION
## Description

This PR resolves a batch of Clippy warnings (issue #690, batch C) spanning 14 files across multiple modules. The changes keep the codebase lint-clean without altering any functional behavior. All modifications are purely mechanical refactors guided by Clippy's suggestions.

## Type of Change

- [x] Refactoring (no functional changes)

## Related Issue

Relates to #690

## Changes Made

**Cargo.toml — Global lint allowances:**
- Added global `large_stack_frames = "allow"` and `large_stack_arrays = "allow"` to suppress spurious warnings on test functions that contain large fixture literals (Clippy cannot produce a usable span for these)

**Test module `#[allow(...)]` expansions:**
- `src/atlassian/api.rs`: Added `clippy::match_wildcard_for_single_variants`
- `src/atlassian/client.rs`: Added `clippy::items_after_test_module`
- `src/atlassian/convert.rs`: Added `clippy::needless_update`, `clippy::needless_collect`, `duplicate_macro_attributes`
- `src/atlassian/document.rs`: Added `clippy::match_wildcard_for_single_variants`
- `src/claude/client.rs`: Added `clippy::format_in_format_args`
- `tests/mcp_integration_test.rs`: Added `clippy::semicolon_if_nothing_returned`

**Code quality improvements:**
- `src/atlassian/convert.rs`: Replaced `map_or(false, |t| ...)` with `is_some_and(|t| ...)` for clearer intent; used inline format arg `{i}` instead of positional `{}` with trailing arg; simplified closure chain with `str::trim_end` method reference; downgraded raw string literal `r##"..."##` to `r#"..."#` where triple-hash was unnecessary
- `src/claude/client.rs`: Replaced raw pointer casts `as *const _` with `std::ptr::from_ref(...)` and `std::ptr::addr_of!(...)` in pointer equality assertion
- `src/claude/prompts.rs`: Replaced `vec![...]` with array literals `[...]` for three test fixture collections
- `src/cli/atlassian/confluence/download.rs`: Replaced `|e| e.into_inner()` closure with `std::sync::PoisonError::into_inner` method reference on mutex lock
- `src/cli/atlassian/format.rs`: Removed redundant `.clone()` calls on `Copy` types (`ContentFormat::Adf`, `OutputFormat::Jsonl`)
- `src/cli/atlassian/jira/field.rs`: Replaced `vec![...]` with array literals `[...]` for two test fixture collections
- `src/data.rs`: Used inline format args (`{i:0>40}`); removed redundant `.clone()` on a `String` already being consumed; dereferenced `&&str` for `.to_string()` call
- `src/mcp/git_tools.rs`: Moved `indent_for_yaml`, `format_check_payload`, and `format_twiddle_payload` helper functions before the `#[cfg(test)]` block to comply with `items_after_test_module` lint
- `src/test_support.rs`: Replaced `|p| p.into_inner()` closure with `std::sync::PoisonError::into_inner` method reference
- `tests/mcp_integration_test.rs`: Replaced `|p| p.into_inner()` closures with method references in four `ATLASSIAN_ENV_LOCK.lock()` call sites; converted `match` with one meaningful arm to `if let` in Jira tool handler test

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration tests updated/added (allow-list expansion in `tests/mcp_integration_test.rs`)

**Manual Testing:**
- [x] Backward compatibility verified — no functional logic was changed

### Test Commands

```bash
# Core test suite
cargo test

# Code quality checks (should produce zero new warnings)
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — all changes are non-functional; verify no logic was inadvertently altered in `src/atlassian/convert.rs` and `src/mcp/git_tools.rs` where the most lines changed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

This is batch C of a multi-batch Clippy cleanup effort tracked in issue #690. Subsequent batches will address remaining lint warnings in other parts of the codebase.