### PR TITLE
ci(workflows): add --all-targets flag to clippy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
     - name: Run clippy
       run: |
         if [ -z "${{ matrix.features }}" ]; then
-          cargo clippy -- -D warnings
+          cargo clippy --all-targets -- -D warnings
         else
-          cargo clippy --features "${{ matrix.features }}" -- -D warnings
+          cargo clippy --all-targets --features "${{ matrix.features }}" -- -D warnings
         fi
 
   docs:


### PR DESCRIPTION
## Description

This PR adds the `--all-targets` flag to the `cargo clippy` invocations in the CI workflow. Previously, clippy only checked the default targets (lib and bins), potentially missing lint warnings in tests, examples, benchmarks, and other targets. With `--all-targets`, all compilation targets are now linted, ensuring more comprehensive code quality coverage across the entire codebase.

## Type of Change

- [x] CI/CD changes

## Related Issue

Relates to #690

## Changes Made

**CI/CD Changes:**
- Updated `.github/workflows/ci.yml` to add `--all-targets` flag to both the default clippy invocation (`cargo clippy --all-targets -- -D warnings`) and the feature-specific invocation (`cargo clippy --all-targets --features "${{ matrix.features }}" -- -D warnings`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] CI pipeline validates the clippy changes are applied to all targets

**Manual Testing:**
- [x] Verified clippy runs cleanly with `--all-targets` locally

### Test Commands
```bash
# Verify clippy passes with all targets
cargo clippy --all-targets -- -D warnings

# Verify with specific features
cargo clippy --all-targets --features "<features>" -- -D warnings
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility

The only change is adding `--all-targets` to clippy invocations, which broadens lint coverage to include tests, examples, and benchmarks. This may surface previously undetected warnings in those targets.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements