### PR TITLE
feat(atlassian): add JIRA project version management

### DIFF
--- a/src/atlassian/auth.rs
+++ b/src/atlassian/auth.rs
@@ -175,6 +175,96 @@ pub fn save_credentials(credentials: &AtlassianCredentials) -> Result<()> {
     Ok(())
 }
 
+/// Crate-internal test utilities for code that calls [`load_credentials`] /
+/// [`crate::cli::atlassian::helpers::create_client`]. Lives here because it
+/// needs the credential constants and shares process-wide env state with
+/// auth.rs's own tests — every consumer must serialise on
+/// [`AUTH_ENV_MUTEX`] to avoid racing.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+pub(crate) mod test_util {
+    use super::{ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL};
+
+    /// Mutex shared by every test that mutates `HOME` and the Atlassian
+    /// credential env vars. Serialises those tests against each other so
+    /// parallel execution doesn't race on process-wide env state.
+    pub(crate) static AUTH_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard: snapshots `HOME` + every Atlassian credential env var on
+    /// construction and restores them on drop. Concentrating the save/restore
+    /// branches into one place (here) instead of inlining them in each test
+    /// keeps coverage high — every test exercises the same guard drop path.
+    pub(crate) struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        snapshot: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        pub(crate) fn take() -> Self {
+            let lock = AUTH_ENV_MUTEX
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let keys = [
+                "HOME",
+                ATLASSIAN_INSTANCE_URL,
+                ATLASSIAN_EMAIL,
+                ATLASSIAN_API_TOKEN,
+            ];
+            let snapshot = keys
+                .into_iter()
+                .map(|k| (k, std::env::var(k).ok()))
+                .collect();
+            Self {
+                _lock: lock,
+                snapshot,
+            }
+        }
+
+        /// Clears the three Atlassian credential env vars and points `HOME`
+        /// at a fresh empty tempdir so `load_credentials()` returns
+        /// `CredentialsNotFound`. Useful for testing the Err propagation
+        /// path of code that calls `create_client()`.
+        pub(crate) fn clear_credentials(&self) -> tempfile::TempDir {
+            let dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            std::env::set_var("HOME", dir.path());
+            std::env::remove_var(ATLASSIAN_INSTANCE_URL);
+            std::env::remove_var(ATLASSIAN_EMAIL);
+            std::env::remove_var(ATLASSIAN_API_TOKEN);
+            dir
+        }
+
+        /// Sets the three Atlassian credential env vars to point at a wiremock
+        /// (or any HTTP) endpoint. The matching `HOME` is replaced with a
+        /// fresh tempdir so any `~/.omni-dev/settings.json` on the developer's
+        /// machine does not bleed in.
+        pub(crate) fn set_credentials(&self, instance_url: &str) -> tempfile::TempDir {
+            let dir = {
+                std::fs::create_dir_all("tmp").ok();
+                tempfile::TempDir::new_in("tmp").unwrap()
+            };
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var(ATLASSIAN_INSTANCE_URL, instance_url);
+            std::env::set_var(ATLASSIAN_EMAIL, "test@example.com");
+            std::env::set_var(ATLASSIAN_API_TOKEN, "test-token");
+            dir
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.snapshot {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -245,52 +335,7 @@ mod tests {
         assert!(debug.contains("AtlassianCredentials"));
     }
 
-    /// Mutex shared by every test that mutates `HOME` and the Atlassian
-    /// credential env vars. Serialises those tests against each other so
-    /// parallel execution doesn't race on process-wide env state.
-    static AUTH_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// RAII guard: snapshots `HOME` + every Atlassian credential env var on
-    /// construction and restores them on drop. Concentrating the save/restore
-    /// branches into one place (here) instead of inlining them in each test
-    /// keeps coverage high — every test exercises the same guard drop path.
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        snapshot: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn take() -> Self {
-            let lock = AUTH_ENV_MUTEX
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let keys = [
-                "HOME",
-                ATLASSIAN_INSTANCE_URL,
-                ATLASSIAN_EMAIL,
-                ATLASSIAN_API_TOKEN,
-            ];
-            let snapshot = keys
-                .into_iter()
-                .map(|k| (k, std::env::var(k).ok()))
-                .collect();
-            Self {
-                _lock: lock,
-                snapshot,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.snapshot {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-    }
+    use super::test_util::EnvGuard;
 
     fn with_empty_home(_guard: &EnvGuard) -> tempfile::TempDir {
         let dir = {

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -405,6 +405,36 @@ pub struct AgileSprintList {
     pub total: u32,
 }
 
+/// A JIRA project version (release version).
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraProjectVersion {
+    /// Version ID.
+    pub id: String,
+    /// Version name (e.g., "1.0.0").
+    pub name: String,
+    /// Version description.
+    pub description: Option<String>,
+    /// Owning project key.
+    pub project_key: String,
+    /// Whether the version is released.
+    pub released: bool,
+    /// Whether the version is archived.
+    pub archived: bool,
+    /// Release date (ISO 8601, `YYYY-MM-DD`).
+    pub release_date: Option<String>,
+    /// Start date (ISO 8601, `YYYY-MM-DD`).
+    pub start_date: Option<String>,
+}
+
+/// Result from listing JIRA project versions.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraProjectVersionList {
+    /// Versions returned.
+    pub versions: Vec<JiraProjectVersion>,
+    /// Total number of versions.
+    pub total: u32,
+}
+
 /// A JIRA issue changelog entry.
 #[derive(Debug, Clone, Serialize)]
 pub struct JiraChangelogEntry {
@@ -724,6 +754,17 @@ fn extract_display_name(value: Option<serde_json::Value>) -> Option<String> {
         .and_then(|n| n.as_str().map(str::to_string))
 }
 
+/// Validates that a date string is `YYYY-MM-DD`.
+///
+/// Surfaces a clear error before the request is sent, so callers don't
+/// have to interpret JIRA's opaque 400s on malformed dates.
+fn validate_iso_date(date: Option<&str>, field: &str) -> Result<()> {
+    let Some(d) = date else { return Ok(()) };
+    chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+        .with_context(|| format!("{field} must be YYYY-MM-DD, got {d:?}"))?;
+    Ok(())
+}
+
 #[derive(Deserialize)]
 struct JiraEditMetaResponse {
     #[serde(default)]
@@ -1003,6 +1044,22 @@ struct AgileSprintEntry {
     #[serde(rename = "endDate")]
     end_date: Option<String>,
     goal: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JiraProjectVersionEntry {
+    id: String,
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    released: bool,
+    #[serde(default)]
+    archived: bool,
+    #[serde(rename = "releaseDate", default)]
+    release_date: Option<String>,
+    #[serde(rename = "startDate", default)]
+    start_date: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -4102,6 +4159,337 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn get_project_versions_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {
+                        "id": "10000",
+                        "name": "1.0.0",
+                        "description": "First release",
+                        "released": true,
+                        "archived": false,
+                        "releaseDate": "2026-04-01",
+                        "startDate": "2026-03-01",
+                    },
+                    {
+                        "id": "10001",
+                        "name": "1.1.0",
+                        "released": false,
+                        "archived": false,
+                    }
+                ])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client
+            .get_project_versions("PROJ", None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.total, 2);
+        assert_eq!(result.versions[0].id, "10000");
+        assert_eq!(result.versions[0].name, "1.0.0");
+        assert_eq!(result.versions[0].project_key, "PROJ");
+        assert!(result.versions[0].released);
+        assert_eq!(
+            result.versions[0].release_date.as_deref(),
+            Some("2026-04-01")
+        );
+        assert_eq!(result.versions[1].name, "1.1.0");
+        assert!(!result.versions[1].released);
+    }
+
+    #[tokio::test]
+    async fn get_project_versions_filters_released() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": true, "archived": false},
+                    {"id": "2", "name": "2.0", "released": false, "archived": false},
+                    {"id": "3", "name": "0.9", "released": true, "archived": true},
+                ])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let result = client
+            .get_project_versions("PROJ", Some(true), Some(false))
+            .await
+            .unwrap();
+
+        assert_eq!(result.total, 1);
+        assert_eq!(result.versions[0].name, "1.0");
+    }
+
+    #[tokio::test]
+    async fn get_project_versions_api_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/NONE/versions",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .get_project_versions("NONE", None, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn create_project_version_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": "10010",
+                    "name": "1.2.0",
+                    "description": "Bugfix release",
+                    "released": false,
+                    "archived": false,
+                    "releaseDate": "2026-06-01",
+                    "startDate": "2026-05-01",
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let version = client
+            .create_project_version(
+                "PROJ",
+                "1.2.0",
+                Some("Bugfix release"),
+                Some("2026-06-01"),
+                Some("2026-05-01"),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(version.id, "10010");
+        assert_eq!(version.name, "1.2.0");
+        assert_eq!(version.project_key, "PROJ");
+        assert_eq!(version.description.as_deref(), Some("Bugfix release"));
+        assert_eq!(version.release_date.as_deref(), Some("2026-06-01"));
+    }
+
+    #[tokio::test]
+    async fn create_project_version_minimal() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(201).set_body_json(
+                serde_json::json!({"id": "10011", "name": "2.0.0", "released": false, "archived": false}),
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let version = client
+            .create_project_version("PROJ", "2.0.0", None, None, None, false, false)
+            .await
+            .unwrap();
+
+        assert_eq!(version.id, "10011");
+        assert!(version.release_date.is_none());
+    }
+
+    #[tokio::test]
+    async fn create_project_version_forbidden() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403)
+                    .set_body_string("You do not have permission to administer this project."),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .create_project_version("PROJ", "1.0", None, None, None, false, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn create_project_version_invalid_date_short_circuits() {
+        // Server should never be hit because validation fails client-side.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .create_project_version("PROJ", "1.0", None, Some("06-01-2026"), None, false, false)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("release_date"));
+        assert!(msg.contains("YYYY-MM-DD"));
+    }
+
+    #[tokio::test]
+    async fn create_project_version_invalid_start_date_short_circuits() {
+        // start_date validation runs after release_date; this test drives that
+        // second branch by passing a valid release_date with a malformed
+        // start_date.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .create_project_version(
+                "PROJ",
+                "1.0",
+                None,
+                Some("2026-06-01"),
+                Some("not-a-date"),
+                false,
+                false,
+            )
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("start_date"));
+        assert!(msg.contains("YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn validate_iso_date_accepts_valid() {
+        assert!(validate_iso_date(Some("2026-05-10"), "release_date").is_ok());
+        assert!(validate_iso_date(None, "release_date").is_ok());
+    }
+
+    #[test]
+    fn validate_iso_date_rejects_bad_shape() {
+        let err = validate_iso_date(Some("2026/05/10"), "release_date").unwrap_err();
+        assert!(err.to_string().contains("release_date"));
+    }
+
+    #[test]
+    fn validate_iso_date_rejects_impossible() {
+        let err = validate_iso_date(Some("2026-13-40"), "start_date").unwrap_err();
+        assert!(err.to_string().contains("start_date"));
+    }
+
+    /// Exercises the `?` Err propagation on the `get_json` call in
+    /// `get_project_versions` by pointing the client at an unreachable port.
+    #[tokio::test]
+    async fn get_project_versions_transport_error() {
+        // Port 1 is reserved for `tcpmux` and almost never has a listener,
+        // so connection attempts fail before any response.
+        let client = AtlassianClient::new("http://127.0.0.1:1", "user@test.com", "token").unwrap();
+        let err = client
+            .get_project_versions("PROJ", None, None)
+            .await
+            .unwrap_err();
+        // Transport failures bubble up via anyhow `Context` from `get_json`.
+        assert!(err.to_string().contains("Failed to send GET request"));
+    }
+
+    /// Exercises the `?` Err propagation on the `.json().context(...)?`
+    /// call in `get_project_versions` by returning a 200 with a body that
+    /// can't be parsed as the expected JSON shape.
+    #[tokio::test]
+    async fn get_project_versions_invalid_json() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("not-json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .get_project_versions("PROJ", None, None)
+            .await
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Failed to parse project versions response"));
+    }
+
+    /// Exercises the `?` Err propagation on the `post_json` call in
+    /// `create_project_version`.
+    #[tokio::test]
+    async fn create_project_version_transport_error() {
+        let client = AtlassianClient::new("http://127.0.0.1:1", "user@test.com", "token").unwrap();
+        let err = client
+            .create_project_version("PROJ", "1.0", None, None, None, false, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Failed to send POST request"));
+    }
+
+    /// Exercises the `?` Err propagation on the `.json().context(...)?`
+    /// call in `create_project_version`.
+    #[tokio::test]
+    async fn create_project_version_invalid_json() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(201).set_body_string("not-json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client
+            .create_project_version("PROJ", "1.0", None, None, None, false, false)
+            .await
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Failed to parse version create response"));
     }
 
     #[tokio::test]
@@ -7378,6 +7766,117 @@ impl AtlassianClient {
         }
 
         Ok(())
+    }
+
+    /// Lists versions for a JIRA project.
+    ///
+    /// Uses the lightweight `GET /rest/api/3/project/{key}/versions` endpoint,
+    /// which returns all versions in a single response without pagination.
+    /// `released` and `archived` filters are applied client-side.
+    pub async fn get_project_versions(
+        &self,
+        project_key: &str,
+        released: Option<bool>,
+        archived: Option<bool>,
+    ) -> Result<JiraProjectVersionList> {
+        let url = format!(
+            "{}/rest/api/3/project/{}/versions",
+            self.instance_url, project_key
+        );
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let entries: Vec<JiraProjectVersionEntry> = response
+            .json()
+            .await
+            .context("Failed to parse project versions response")?;
+
+        let versions: Vec<JiraProjectVersion> = entries
+            .into_iter()
+            .filter(|e| released.map_or(true, |r| e.released == r))
+            .filter(|e| archived.map_or(true, |a| e.archived == a))
+            .map(|e| JiraProjectVersion {
+                id: e.id,
+                name: e.name,
+                description: e.description,
+                project_key: project_key.to_string(),
+                released: e.released,
+                archived: e.archived,
+                release_date: e.release_date,
+                start_date: e.start_date,
+            })
+            .collect();
+
+        let total = versions.len() as u32;
+        Ok(JiraProjectVersionList { versions, total })
+    }
+
+    /// Creates a new version in a JIRA project.
+    ///
+    /// Validates `release_date` and `start_date` as `YYYY-MM-DD` client-side
+    /// to surface clear errors before JIRA rejects the request with an
+    /// opaque 400.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_project_version(
+        &self,
+        project_key: &str,
+        name: &str,
+        description: Option<&str>,
+        release_date: Option<&str>,
+        start_date: Option<&str>,
+        released: bool,
+        archived: bool,
+    ) -> Result<JiraProjectVersion> {
+        validate_iso_date(release_date, "release_date")?;
+        validate_iso_date(start_date, "start_date")?;
+
+        let url = format!("{}/rest/api/3/version", self.instance_url);
+
+        let mut body = serde_json::json!({
+            "project": project_key,
+            "name": name,
+            "released": released,
+            "archived": archived,
+        });
+        if let Some(d) = description {
+            body["description"] = serde_json::Value::String(d.to_string());
+        }
+        if let Some(rd) = release_date {
+            body["releaseDate"] = serde_json::Value::String(rd.to_string());
+        }
+        if let Some(sd) = start_date {
+            body["startDate"] = serde_json::Value::String(sd.to_string());
+        }
+
+        let response = self.post_json(&url, &body).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let entry: JiraProjectVersionEntry = response
+            .json()
+            .await
+            .context("Failed to parse version create response")?;
+
+        Ok(JiraProjectVersion {
+            id: entry.id,
+            name: entry.name,
+            description: entry.description,
+            project_key: project_key.to_string(),
+            released: entry.released,
+            archived: entry.archived,
+            release_date: entry.release_date,
+            start_date: entry.start_date,
+        })
     }
 
     /// Lists links on a JIRA issue.

--- a/src/cli/atlassian/confluence/download.rs
+++ b/src/cli/atlassian/confluence/download.rs
@@ -1117,9 +1117,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn execute_runs_with_env_credentials() {
-        use std::sync::Mutex;
-        static ENV_MUTEX: Mutex<()> = Mutex::new(());
-        let _lock = ENV_MUTEX
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -311,7 +311,14 @@ mod tests {
     /// downstream call is reached. The subsequent API call is allowed to
     /// fail — we only care that the dispatch line runs.
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn confluence_command_execute_children_dispatch() {
+        // Routes through the crate-wide `AUTH_ENV_MUTEX` so the env-var
+        // mutation doesn't race against other Atlassian-touching tests.
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         std::env::set_var("ATLASSIAN_INSTANCE_URL", "http://127.0.0.1:1");
         std::env::set_var("ATLASSIAN_EMAIL", "test@example.com");
         std::env::set_var("ATLASSIAN_API_TOKEN", "fake-token");

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 
 use crate::atlassian::client::{
     AgileBoardList, AgileSprintList, ConfluenceSearchResults, ConfluenceUserSearchResults,
-    JiraDevStatus, JiraDevStatusSummary, JiraProjectList, JiraSearchResult, JiraUserSearchResults,
-    JiraWatcherList, JiraWorklogList,
+    JiraDevStatus, JiraDevStatusSummary, JiraProjectList, JiraProjectVersionList, JiraSearchResult,
+    JiraUserSearchResults, JiraWatcherList, JiraWorklogList,
 };
 use crate::atlassian::confluence_api::ConfluenceAttachmentPage;
 
@@ -96,6 +96,12 @@ impl JsonlSerialize for JiraSearchResult {
 impl JsonlSerialize for JiraProjectList {
     fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
         write_items_jsonl(self.projects.iter(), out)
+    }
+}
+
+impl JsonlSerialize for JiraProjectVersionList {
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
+        write_items_jsonl(self.versions.iter(), out)
     }
 }
 
@@ -214,7 +220,7 @@ mod tests {
     use super::*;
     use crate::atlassian::client::{
         AgileBoard, AgileSprint, ConfluenceSearchResult, ConfluenceUserSearchResult, JiraComment,
-        JiraDevStatusCount, JiraIssue, JiraProject, JiraUser, JiraWorklog,
+        JiraDevStatusCount, JiraIssue, JiraProject, JiraProjectVersion, JiraUser, JiraWorklog,
     };
 
     // ── ContentFormat ──────────────────────────────────────────────
@@ -434,6 +440,19 @@ mod tests {
         }
     }
 
+    fn sample_project_version(id: &str, name: &str) -> JiraProjectVersion {
+        JiraProjectVersion {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            project_key: "PROJ".to_string(),
+            released: false,
+            archived: false,
+            release_date: None,
+            start_date: None,
+        }
+    }
+
     fn sample_user(name: &str) -> JiraUser {
         JiraUser {
             account_id: name.to_string(),
@@ -540,6 +559,21 @@ mod tests {
         let out = jsonl_string(&list);
         assert_eq!(out.lines().count(), 1);
         assert!(out.contains("\"key\":\"P\""));
+    }
+
+    #[test]
+    fn jira_project_version_list_jsonl() {
+        let list = JiraProjectVersionList {
+            versions: vec![
+                sample_project_version("10", "1.0.0"),
+                sample_project_version("11", "1.1.0"),
+            ],
+            total: 2,
+        };
+        let out = jsonl_string(&list);
+        assert_eq!(out.lines().count(), 2);
+        assert!(out.contains("\"id\":\"10\""));
+        assert!(out.contains("\"id\":\"11\""));
     }
 
     #[test]

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod search;
 pub(crate) mod sprint;
 pub(crate) mod transition;
 pub(crate) mod user;
+pub(crate) mod version;
 pub(crate) mod watcher;
 pub(crate) mod worklog;
 pub(crate) mod write;
@@ -72,6 +73,8 @@ pub enum JiraSubcommands {
     Worklog(worklog::WorklogCommand),
     /// JIRA user operations (search by name or email).
     User(user::UserCommand),
+    /// Manages JIRA project versions (release versions).
+    Version(version::VersionCommand),
 }
 
 impl JiraCommand {
@@ -97,6 +100,7 @@ impl JiraCommand {
             JiraSubcommands::Watcher(cmd) => cmd.execute().await,
             JiraSubcommands::Worklog(cmd) => cmd.execute().await,
             JiraSubcommands::User(cmd) => cmd.execute().await,
+            JiraSubcommands::Version(cmd) => cmd.execute().await,
         }
     }
 }
@@ -365,5 +369,60 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, JiraSubcommands::User(_)));
+    }
+
+    #[test]
+    fn jira_subcommands_version_variant() {
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Version(version::VersionCommand {
+                command: version::VersionSubcommands::List(version::ListCommand {
+                    project: "PROJ".to_string(),
+                    released: false,
+                    unreleased: false,
+                    archived: false,
+                    unarchived: false,
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, JiraSubcommands::Version(_)));
+    }
+
+    /// Drives `JiraCommand::execute` end-to-end through the new `Version`
+    /// arm so the dispatch line in the match block is exercised. Other
+    /// arms remain pre-existing convention gaps.
+    #[tokio::test]
+    async fn jira_command_execute_version_arm() {
+        use crate::atlassian::auth::test_util::EnvGuard;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": false, "archived": false}
+                ])),
+            )
+            .mount(&server)
+            .await;
+
+        let guard = EnvGuard::take();
+        let _home = guard.set_credentials(&server.uri());
+
+        let cmd = JiraCommand {
+            command: JiraSubcommands::Version(version::VersionCommand {
+                command: version::VersionSubcommands::List(version::ListCommand {
+                    project: "PROJ".to_string(),
+                    released: false,
+                    unreleased: false,
+                    archived: false,
+                    unarchived: false,
+                    output: OutputFormat::Yaml,
+                }),
+            }),
+        };
+        assert!(cmd.execute().await.is_ok());
     }
 }

--- a/src/cli/atlassian/jira/user.rs
+++ b/src/cli/atlassian/jira/user.rs
@@ -128,9 +128,8 @@ mod tests {
     }
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock()
+        crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 

--- a/src/cli/atlassian/jira/version.rs
+++ b/src/cli/atlassian/jira/version.rs
@@ -1,0 +1,641 @@
+//! CLI commands for JIRA project versions (release versions).
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::client::{AtlassianClient, JiraProjectVersionList};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages JIRA project versions (release versions).
+#[derive(Parser)]
+pub struct VersionCommand {
+    /// The version subcommand to execute.
+    #[command(subcommand)]
+    pub command: VersionSubcommands,
+}
+
+/// Version subcommands.
+#[derive(Subcommand)]
+pub enum VersionSubcommands {
+    /// Lists versions for a project.
+    List(ListCommand),
+    /// Creates a new project version.
+    Create(CreateCommand),
+}
+
+impl VersionCommand {
+    /// Executes the version command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            VersionSubcommands::List(cmd) => cmd.execute().await,
+            VersionSubcommands::Create(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists versions for a JIRA project.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Project key (e.g., "PROJ").
+    #[arg(long)]
+    pub project: String,
+
+    /// Show only released versions.
+    #[arg(long, conflicts_with = "unreleased")]
+    pub released: bool,
+
+    /// Show only unreleased versions.
+    #[arg(long, conflicts_with = "released")]
+    pub unreleased: bool,
+
+    /// Show only archived versions.
+    #[arg(long, conflicts_with = "unarchived")]
+    pub archived: bool,
+
+    /// Show only non-archived versions.
+    #[arg(long, conflicts_with = "archived")]
+    pub unarchived: bool,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Fetches and displays versions.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_list_versions(
+            &client,
+            &self.project,
+            tri_state(self.released, self.unreleased),
+            tri_state(self.archived, self.unarchived),
+            &self.output,
+        )
+        .await
+    }
+}
+
+/// Creates a new version on a JIRA project.
+#[derive(Parser)]
+pub struct CreateCommand {
+    /// Project key (e.g., "PROJ").
+    #[arg(long)]
+    pub project: String,
+
+    /// Version name (e.g., "1.0.0").
+    #[arg(long)]
+    pub name: String,
+
+    /// Version description.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Release date (ISO 8601, "YYYY-MM-DD").
+    #[arg(long)]
+    pub release_date: Option<String>,
+
+    /// Start date (ISO 8601, "YYYY-MM-DD").
+    #[arg(long)]
+    pub start_date: Option<String>,
+
+    /// Mark the version as released.
+    #[arg(long)]
+    pub released: bool,
+
+    /// Mark the version as archived.
+    #[arg(long)]
+    pub archived: bool,
+}
+
+impl CreateCommand {
+    /// Creates the version.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_create_version(
+            &client,
+            &self.project,
+            &self.name,
+            self.description.as_deref(),
+            self.release_date.as_deref(),
+            self.start_date.as_deref(),
+            self.released,
+            self.archived,
+        )
+        .await
+    }
+}
+
+/// Folds a pair of mutually-exclusive boolean flags into a tri-state filter:
+/// `Some(true)` for the positive flag, `Some(false)` for the negative,
+/// `None` when neither was passed.
+fn tri_state(yes: bool, no: bool) -> Option<bool> {
+    match (yes, no) {
+        (true, _) => Some(true),
+        (_, true) => Some(false),
+        _ => None,
+    }
+}
+
+async fn run_list_versions(
+    client: &AtlassianClient,
+    project: &str,
+    released: Option<bool>,
+    archived: Option<bool>,
+    output: &OutputFormat,
+) -> Result<()> {
+    let result = client
+        .get_project_versions(project, released, archived)
+        .await?;
+    if output_as(&result, output)? {
+        return Ok(());
+    }
+    print_versions(&result);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_create_version(
+    client: &AtlassianClient,
+    project: &str,
+    name: &str,
+    description: Option<&str>,
+    release_date: Option<&str>,
+    start_date: Option<&str>,
+    released: bool,
+    archived: bool,
+) -> Result<()> {
+    let version = client
+        .create_project_version(
+            project,
+            name,
+            description,
+            release_date,
+            start_date,
+            released,
+            archived,
+        )
+        .await?;
+    println!("Created version {} (id: {}).", version.name, version.id);
+    Ok(())
+}
+
+/// Prints versions as a formatted table.
+fn print_versions(result: &JiraProjectVersionList) {
+    if result.versions.is_empty() {
+        println!("No versions found.");
+        return;
+    }
+
+    let id_width = result
+        .versions
+        .iter()
+        .map(|v| v.id.len())
+        .max()
+        .unwrap_or(2)
+        .max(2);
+    let name_width = result
+        .versions
+        .iter()
+        .map(|v| v.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    println!(
+        "{:<id_width$}  {:<name_width$}  RELEASED  ARCHIVED  RELEASE     DESCRIPTION",
+        "ID", "NAME"
+    );
+    let desc_sep = "-".repeat(11);
+    println!(
+        "{:<id_width$}  {:<name_width$}  --------  --------  ----------  {desc_sep}",
+        "-".repeat(id_width),
+        "-".repeat(name_width),
+    );
+
+    for v in &result.versions {
+        let release = format_date(v.release_date.as_deref());
+        let description = v.description.as_deref().unwrap_or("-");
+        println!(
+            "{:<id_width$}  {:<name_width$}  {:<8}  {:<8}  {:<10}  {}",
+            v.id,
+            v.name,
+            yes_no(v.released),
+            yes_no(v.archived),
+            release,
+            description,
+        );
+    }
+}
+
+fn yes_no(b: bool) -> &'static str {
+    if b {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn format_date(date: Option<&str>) -> &str {
+    match date {
+        Some(d) if d.len() >= 10 => &d[..10],
+        Some(d) => d,
+        None => "-",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::JiraProjectVersion;
+
+    fn sample_version(
+        id: &str,
+        name: &str,
+        released: bool,
+        archived: bool,
+        release_date: Option<&str>,
+    ) -> JiraProjectVersion {
+        JiraProjectVersion {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            project_key: "PROJ".to_string(),
+            released,
+            archived,
+            release_date: release_date.map(String::from),
+            start_date: None,
+        }
+    }
+
+    fn mock_client(base_url: &str) -> AtlassianClient {
+        AtlassianClient::new(base_url, "user@test.com", "token").unwrap()
+    }
+
+    // ── tri_state ──────────────────────────────────────────────────
+
+    #[test]
+    fn tri_state_neither() {
+        assert_eq!(tri_state(false, false), None);
+    }
+
+    #[test]
+    fn tri_state_yes() {
+        assert_eq!(tri_state(true, false), Some(true));
+    }
+
+    #[test]
+    fn tri_state_no() {
+        assert_eq!(tri_state(false, true), Some(false));
+    }
+
+    #[test]
+    fn tri_state_yes_wins_when_both_set() {
+        // Clap normally rejects this via conflicts_with; defensive default.
+        assert_eq!(tri_state(true, true), Some(true));
+    }
+
+    // ── format helpers ─────────────────────────────────────────────
+
+    #[test]
+    fn yes_no_true() {
+        assert_eq!(yes_no(true), "yes");
+    }
+
+    #[test]
+    fn yes_no_false() {
+        assert_eq!(yes_no(false), "no");
+    }
+
+    #[test]
+    fn format_date_full_iso() {
+        assert_eq!(format_date(Some("2026-04-01T00:00:00.000Z")), "2026-04-01");
+    }
+
+    #[test]
+    fn format_date_just_date() {
+        assert_eq!(format_date(Some("2026-04-01")), "2026-04-01");
+    }
+
+    #[test]
+    fn format_date_short() {
+        assert_eq!(format_date(Some("2026")), "2026");
+    }
+
+    #[test]
+    fn format_date_none() {
+        assert_eq!(format_date(None), "-");
+    }
+
+    // ── print_versions ─────────────────────────────────────────────
+
+    #[test]
+    fn print_versions_empty() {
+        let result = JiraProjectVersionList {
+            versions: vec![],
+            total: 0,
+        };
+        print_versions(&result);
+    }
+
+    #[test]
+    fn print_versions_with_data() {
+        let result = JiraProjectVersionList {
+            versions: vec![
+                sample_version("10000", "1.0.0", true, false, Some("2026-04-01")),
+                sample_version("10001", "1.1.0", false, false, None),
+            ],
+            total: 2,
+        };
+        print_versions(&result);
+    }
+
+    // ── dispatch ───────────────────────────────────────────────────
+
+    #[test]
+    fn version_command_list_variant() {
+        let cmd = VersionCommand {
+            command: VersionSubcommands::List(ListCommand {
+                project: "PROJ".to_string(),
+                released: false,
+                unreleased: false,
+                archived: false,
+                unarchived: false,
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, VersionSubcommands::List(_)));
+    }
+
+    #[test]
+    fn version_command_create_variant() {
+        let cmd = VersionCommand {
+            command: VersionSubcommands::Create(CreateCommand {
+                project: "PROJ".to_string(),
+                name: "1.0.0".to_string(),
+                description: None,
+                release_date: None,
+                start_date: None,
+                released: false,
+                archived: false,
+            }),
+        };
+        assert!(matches!(cmd.command, VersionSubcommands::Create(_)));
+    }
+
+    // ── run_* version functions ────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_list_versions_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": true, "archived": false}
+                ])),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(
+            run_list_versions(&client, "PROJ", None, None, &OutputFormat::Table)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_list_versions_yaml_output_returns_early() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": true, "archived": false}
+                ])),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        // Yaml output path branches before print_versions, exercising the
+        // `if output_as { return Ok(()); }` early return.
+        assert!(
+            run_list_versions(&client, "PROJ", None, None, &OutputFormat::Yaml)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_list_versions_with_filter() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": true, "archived": false},
+                    {"id": "2", "name": "2.0", "released": false, "archived": false},
+                ])),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(
+            run_list_versions(&client, "PROJ", Some(true), None, &OutputFormat::Table)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_list_versions_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/NONE/versions",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_list_versions(&client, "NONE", None, None, &OutputFormat::Table)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn run_create_version_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(201).set_body_json(
+                serde_json::json!({"id": "100", "name": "1.0.0", "released": false, "archived": false}),
+            ))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(
+            run_create_version(&client, "PROJ", "1.0.0", None, None, None, false, false)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_create_version_forbidden() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_create_version(&client, "PROJ", "1.0", None, None, None, false, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn run_create_version_invalid_date() {
+        let server = wiremock::MockServer::start().await;
+        // No mock — request must short-circuit before HTTP.
+        let client = mock_client(&server.uri());
+        let err = run_create_version(
+            &client,
+            "PROJ",
+            "1.0",
+            None,
+            Some("not-a-date"),
+            None,
+            false,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("YYYY-MM-DD"));
+    }
+
+    // ── execute() integration via env-injected creds ───────────────
+    //
+    // These tests drive each `*Command::execute()` end-to-end against a
+    // wiremock server by setting `ATLASSIAN_*` env vars so `create_client()`
+    // builds a client pointed at the mock. They share a process-wide mutex
+    // (`AUTH_ENV_MUTEX`) with auth.rs tests to serialise env mutation.
+
+    use crate::atlassian::auth::test_util::EnvGuard;
+
+    #[tokio::test]
+    async fn version_command_execute_list_dispatches_through_create_client() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/project/PROJ/versions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": "1", "name": "1.0", "released": false, "archived": false}
+                ])),
+            )
+            .mount(&server)
+            .await;
+
+        let guard = EnvGuard::take();
+        let _home = guard.set_credentials(&server.uri());
+
+        let cmd = VersionCommand {
+            command: VersionSubcommands::List(ListCommand {
+                project: "PROJ".to_string(),
+                released: false,
+                unreleased: false,
+                archived: false,
+                unarchived: false,
+                output: OutputFormat::Yaml,
+            }),
+        };
+        assert!(cmd.execute().await.is_ok());
+    }
+
+    /// Exercises the `?` Err path on `create_client()` in
+    /// `ListCommand::execute` by clearing all credential env vars before
+    /// calling.
+    #[tokio::test]
+    async fn list_command_execute_propagates_create_client_error() {
+        let guard = EnvGuard::take();
+        let _home = guard.clear_credentials();
+
+        let cmd = ListCommand {
+            project: "PROJ".to_string(),
+            released: false,
+            unreleased: false,
+            archived: false,
+            unarchived: false,
+            output: OutputFormat::Yaml,
+        };
+        assert!(cmd.execute().await.is_err());
+    }
+
+    /// Exercises the `?` Err path on `create_client()` in
+    /// `CreateCommand::execute` by clearing all credential env vars before
+    /// calling.
+    #[tokio::test]
+    async fn create_command_execute_propagates_create_client_error() {
+        let guard = EnvGuard::take();
+        let _home = guard.clear_credentials();
+
+        let cmd = CreateCommand {
+            project: "PROJ".to_string(),
+            name: "1.0.0".to_string(),
+            description: None,
+            release_date: None,
+            start_date: None,
+            released: false,
+            archived: false,
+        };
+        assert!(cmd.execute().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn version_command_execute_create_dispatches_through_create_client() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/rest/api/3/version"))
+            .respond_with(wiremock::ResponseTemplate::new(201).set_body_json(
+                serde_json::json!({"id": "100", "name": "1.0.0", "released": false, "archived": false}),
+            ))
+            .mount(&server)
+            .await;
+
+        let guard = EnvGuard::take();
+        let _home = guard.set_credentials(&server.uri());
+
+        let cmd = VersionCommand {
+            command: VersionSubcommands::Create(CreateCommand {
+                project: "PROJ".to_string(),
+                name: "1.0.0".to_string(),
+                description: None,
+                release_date: None,
+                start_date: None,
+                released: false,
+                archived: false,
+            }),
+        };
+        assert!(cmd.execute().await.is_ok());
+    }
+}

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -1200,10 +1200,11 @@ mod tests {
 
     /// Serialize env-backed tests — `create_client()` reads process-wide
     /// environment variables, so concurrent tests would race without a lock.
+    /// Routes through the crate-wide `AUTH_ENV_MUTEX` so we don't race
+    /// against env-mutating tests in other Atlassian-touching modules.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock()
+        crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 

--- a/src/mcp/jira_tools.rs
+++ b/src/mcp/jira_tools.rs
@@ -369,6 +369,86 @@ pub(crate) async fn sprint_update_yaml(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Project version tools
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Parameters for the `jira_version_list` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct VersionListParams {
+    /// Project key (e.g., `PROJ`).
+    pub project: String,
+    /// Filter to only released (`true`) or only unreleased (`false`) versions.
+    /// Omit for both.
+    #[serde(default)]
+    pub released: Option<bool>,
+    /// Filter to only archived (`true`) or only non-archived (`false`)
+    /// versions. Omit for both.
+    #[serde(default)]
+    pub archived: Option<bool>,
+}
+
+/// Parameters for the `jira_version_create` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct VersionCreateParams {
+    /// Project key (e.g., `PROJ`).
+    pub project: String,
+    /// Version name (e.g., `1.0.0`).
+    pub name: String,
+    /// Version description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Release date (ISO 8601, `YYYY-MM-DD`). Validated client-side.
+    #[serde(default)]
+    pub release_date: Option<String>,
+    /// Start date (ISO 8601, `YYYY-MM-DD`). Validated client-side.
+    #[serde(default)]
+    pub start_date: Option<String>,
+    /// Whether the version is released. Defaults to `false`.
+    #[serde(default)]
+    pub released: bool,
+    /// Whether the version is archived. Defaults to `false`.
+    #[serde(default)]
+    pub archived: bool,
+}
+
+pub(crate) async fn version_list_yaml(
+    client: &AtlassianClient,
+    project: &str,
+    released: Option<bool>,
+    archived: Option<bool>,
+) -> Result<String> {
+    let result = client
+        .get_project_versions(project, released, archived)
+        .await?;
+    serde_yaml::to_string(&result).context("Failed to serialize project versions as YAML")
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn version_create_yaml(
+    client: &AtlassianClient,
+    project: &str,
+    name: &str,
+    description: Option<&str>,
+    release_date: Option<&str>,
+    start_date: Option<&str>,
+    released: bool,
+    archived: bool,
+) -> Result<String> {
+    let version = client
+        .create_project_version(
+            project,
+            name,
+            description,
+            release_date,
+            start_date,
+            released,
+            archived,
+        )
+        .await?;
+    serde_yaml::to_string(&version).context("Failed to serialize project version as YAML")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Watcher tools
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -842,6 +922,56 @@ impl OmniDevServer {
                 params.start_date.as_deref(),
                 params.end_date.as_deref(),
                 params.goal.as_deref(),
+            )
+            .await
+        })
+        .await
+        .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    // ── project versions ───────────────────────────────────────────
+
+    /// Tool: list project versions.
+    #[tool(
+        description = "List versions for a JIRA project, optionally filtered by `released` \
+                       and `archived` flags. Returns YAML. Mirrors `omni-dev atlassian jira \
+                       version list`."
+    )]
+    pub async fn jira_version_list(
+        &self,
+        Parameters(params): Parameters<VersionListParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let yaml = (async {
+            let (client, _) = create_client()?;
+            version_list_yaml(&client, &params.project, params.released, params.archived).await
+        })
+        .await
+        .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Tool: create a project version.
+    #[tool(
+        description = "Create a new version in a JIRA project. Dates must be `YYYY-MM-DD` and \
+                       are validated client-side. Returns YAML for the created version. \
+                       Mirrors `omni-dev atlassian jira version create`."
+    )]
+    pub async fn jira_version_create(
+        &self,
+        Parameters(params): Parameters<VersionCreateParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let yaml = (async {
+            let (client, _) = create_client()?;
+            version_create_yaml(
+                &client,
+                &params.project,
+                &params.name,
+                params.description.as_deref(),
+                params.release_date.as_deref(),
+                params.start_date.as_deref(),
+                params.released,
+                params.archived,
             )
             .await
         })
@@ -1522,6 +1652,133 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("404"));
+    }
+
+    // ── project versions ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn version_list_yaml_returns_yaml() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/project/PROJ/versions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": "1", "name": "1.0.0", "released": true, "archived": false}
+            ])))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let yaml = version_list_yaml(&client, "PROJ", None, None)
+            .await
+            .unwrap();
+        assert!(yaml.contains("1.0.0"));
+        assert!(yaml.contains("project_key: PROJ"));
+    }
+
+    #[tokio::test]
+    async fn version_list_yaml_filters_released() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/project/PROJ/versions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": "1", "name": "1.0.0", "released": true, "archived": false},
+                {"id": "2", "name": "2.0.0", "released": false, "archived": false},
+            ])))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let yaml = version_list_yaml(&client, "PROJ", Some(false), None)
+            .await
+            .unwrap();
+        assert!(yaml.contains("2.0.0"));
+        assert!(!yaml.contains("1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn version_list_yaml_propagates_api_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/project/NONE/versions"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let err = version_list_yaml(&client, "NONE", None, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn version_create_yaml_returns_yaml() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/version"))
+            .and(body_json(serde_json::json!({
+                "project": "PROJ",
+                "name": "1.0.0",
+                "released": false,
+                "archived": false,
+                "releaseDate": "2026-06-01"
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "100",
+                "name": "1.0.0",
+                "released": false,
+                "archived": false,
+                "releaseDate": "2026-06-01"
+            })))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let yaml = version_create_yaml(
+            &client,
+            "PROJ",
+            "1.0.0",
+            None,
+            Some("2026-06-01"),
+            None,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(yaml.contains("id: '100'"));
+        assert!(yaml.contains("1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn version_create_yaml_propagates_api_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/version"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let err = version_create_yaml(&client, "PROJ", "1.0", None, None, None, false, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn version_create_yaml_validates_dates_client_side() {
+        let server = MockServer::start().await;
+        // No mock — request must short-circuit before HTTP.
+        let client = mock_client(&server.uri());
+        let err = version_create_yaml(
+            &client,
+            "PROJ",
+            "1.0",
+            None,
+            Some("2026/06/01"),
+            None,
+            false,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("YYYY-MM-DD"));
     }
 
     // ── watchers ───────────────────────────────────────────────────

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -809,6 +809,7 @@ Commands:
   watcher     Manages watchers on a JIRA issue
   worklog     Manages worklogs (time tracking) on a JIRA issue
   user        JIRA user operations (search by name or email)
+  version     Manages JIRA project versions (release versions)
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1461,6 +1462,60 @@ Options:
       --limit <LIMIT>    Maximum number of results, 0 for unlimited (default: 25) [default: 25]
   -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira version - Manages JIRA project versions (release versions)
+
+Manages JIRA project versions (release versions)
+
+Usage: version <COMMAND>
+
+Commands:
+  list    Lists versions for a project
+  create  Creates a new project version
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira version create - Creates a new project version
+
+Creates a new project version
+
+Usage: create [OPTIONS] --project <PROJECT> --name <NAME>
+
+Options:
+      --project <PROJECT>            Project key (e.g., "PROJ")
+      --name <NAME>                  Version name (e.g., "1.0.0")
+      --description <DESCRIPTION>    Version description
+      --release-date <RELEASE_DATE>  Release date (ISO 8601, "YYYY-MM-DD")
+      --start-date <START_DATE>      Start date (ISO 8601, "YYYY-MM-DD")
+      --released                     Mark the version as released
+      --archived                     Mark the version as archived
+  -h, --help                         Print help
+
+
+================================================================================
+
+omni-dev atlassian jira version list - Lists versions for a project
+
+Lists versions for a project
+
+Usage: list [OPTIONS] --project <PROJECT>
+
+Options:
+      --project <PROJECT>  Project key (e.g., "PROJ")
+      --released           Show only released versions
+      --unreleased         Show only unreleased versions
+      --archived           Show only archived versions
+      --unarchived         Show only non-archived versions
+  -o, --output <OUTPUT>    Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help               Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements full JIRA project version (release version) management across the Atlassian client, CLI, and MCP server layers. Users can now list and create JIRA project versions directly from `omni-dev atlassian jira version`, or via the new `jira_version_list` and `jira_version_create` MCP tools.

Client-side `YYYY-MM-DD` date validation via `validate_iso_date` surfaces clear errors before requests are sent, avoiding opaque JIRA 400 responses. The `released`/`archived` filters on the list command use tri-state flag logic (`--released`/`--unreleased`, `--archived`/`--unarchived`) and are applied client-side after fetching all versions from the lightweight `GET /rest/api/3/project/{key}/versions` endpoint.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #712

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `JiraProjectVersion` and `JiraProjectVersionList` public data structures
- Added internal `JiraProjectVersionEntry` deserialization struct (maps `releaseDate`/`startDate` camelCase fields)
- Implemented `get_project_versions(project_key, released, archived)` using `GET /rest/api/3/project/{key}/versions` with client-side filtering
- Implemented `create_project_version(...)` using `POST /rest/api/3/version` with optional description, release/start dates, released, and archived flags
- Added `validate_iso_date(date, field)` helper using `chrono::NaiveDate` to provide clear errors before JIRA rejects requests with opaque 400s

**CLI (`src/cli/atlassian/jira/version.rs` — new file):**
- Added `VersionCommand` with `list` and `create` subcommands via `VersionSubcommands` enum
- `ListCommand` accepts `--project`, `--released`/`--unreleased` (mutually exclusive), `--archived`/`--unarchived` (mutually exclusive), and `-o`/`--output` flags
- `CreateCommand` accepts `--project`, `--name`, `--description`, `--release-date`, `--start-date`, `--released`, and `--archived` flags
- `tri_state(yes, no)` helper converts paired boolean flags into `Option<bool>` filter values
- `print_versions()` renders a dynamically-width-padded ASCII table with ID, name, released, archived, release date, and description columns

**CLI Integration (`src/cli/atlassian/jira/mod.rs`):**
- Registered `version` module and added `Version(version::VersionCommand)` variant to `JiraSubcommands`
- Wired `JiraSubcommands::Version(cmd) => cmd.execute().await` in the dispatch match

**Format (`src/cli/atlassian/format.rs`):**
- Implemented `JsonlSerialize` for `JiraProjectVersionList`, enabling `--output jsonl` support

**MCP Server (`src/mcp/jira_tools.rs`):**
- Added `VersionListParams` and `VersionCreateParams` parameter structs with `schemars::JsonSchema` derives
- Implemented `version_list_yaml()` and `version_create_yaml()` internal async functions
- Registered `jira_version_list` and `jira_version_create` as MCP tools on `OmniDevServer` with descriptive tool annotations

**Snapshots (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help output snapshot to include the new `version` subcommand and its `list`/`create` sub-subcommands

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Test coverage added:**
- `client.rs`: `get_project_versions_success`, `get_project_versions_filters_released`, `get_project_versions_api_error`, `create_project_version_success`, `create_project_version_minimal`, `create_project_version_forbidden`, `create_project_version_invalid_date_short_circuits`, `validate_iso_date_accepts_valid`, `validate_iso_date_rejects_bad_shape`, `validate_iso_date_rejects_impossible`
- `version.rs`: `tri_state_*` (4 cases), `yes_no_*` (2 cases), `format_date_*` (3 cases), `print_versions_empty`, `print_versions_with_data`, `version_command_list_variant`, `version_command_create_variant`, `run_list_versions_success`, `run_list_versions_with_filter`, `run_list_versions_api_error`, `run_create_version_success`, `run_create_version_forbidden`, `run_create_version_invalid_date`
- `jira_tools.rs`: `version_list_yaml_returns_yaml`, `version_list_yaml_filters_released`, `version_list_yaml_propagates_api_errors`, `version_create_yaml_returns_yaml`, `version_create_yaml_propagates_api_errors`, `version_create_yaml_validates_dates_client_side`
- `jira/mod.rs`: `jira_subcommands_version_variant`

### Test Commands
```bash
# Core test suite
cargo test

# Run only version-related tests
cargo test version

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `validate_iso_date` short-circuits before HTTP to avoid opaque JIRA 400s; HTTP error status codes are surfaced via `AtlassianError::ApiRequestFailed`
- [x] Architecture changes — client-side filter approach (fetch all, filter locally) vs. server-side query parameters; acceptable given the lightweight endpoint returns all versions in one response without pagination
- [x] Backward compatibility — purely additive; no existing commands or data structures modified

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the `GET /rest/api/3/project/{key}/versions` endpoint returns all versions in a single non-paginated response; client-side filtering adds negligible overhead

## Security Considerations

- [x] No security implications — uses existing `AtlassianClient` authentication; no new credential handling

## Breaking Changes

None. This is a purely additive feature; all existing CLI commands and MCP tools are unchanged.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Add `version update` subcommand for modifying existing versions (rename, change dates, mark released/archived)
- Add `version delete` subcommand
- Consider server-side `orderBy` query parameter support if the API exposes it

**Known Limitations:**
- `released`/`archived` filtering is applied client-side after fetching all versions; for projects with very large version lists this fetches more data than strictly necessary, but JIRA's `GET /rest/api/3/project/{key}/versions` does not support server-side filtering