### PR TITLE
feat(atlassian): add jira comment edit command and tool

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -277,6 +277,38 @@ pub struct JiraComment {
     pub body_adf: Option<serde_json::Value>,
     /// ISO 8601 creation timestamp.
     pub created: String,
+    /// ISO 8601 last-update timestamp, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated: Option<String>,
+}
+
+/// Visibility restriction kind for a JIRA comment.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JiraVisibilityType {
+    /// Restrict to members of a JIRA group.
+    Group,
+    /// Restrict to holders of a project role.
+    Role,
+}
+
+/// Visibility restriction applied to a JIRA comment.
+#[derive(Debug, Clone)]
+pub struct JiraVisibility {
+    /// Whether the restriction targets a group or a project role.
+    pub ty: JiraVisibilityType,
+    /// Group name or project role name (sent as `identifier`).
+    pub value: String,
+}
+
+impl Serialize for JiraVisibility {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("JiraVisibility", 2)?;
+        s.serialize_field("type", &self.ty)?;
+        s.serialize_field("identifier", &self.value)?;
+        s.end()
+    }
 }
 
 /// A JIRA project.
@@ -777,6 +809,8 @@ struct JiraCommentEntry {
     author: Option<JiraCommentAuthor>,
     body: Option<serde_json::Value>,
     created: Option<String>,
+    #[serde(default)]
+    updated: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -2639,6 +2673,134 @@ mod tests {
         let adf = AdfDocument::new();
         let err = client.add_comment("PROJ-1", &adf).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn update_comment_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "author": {"displayName": "Me"},
+                    "created": "2026-04-01T10:00:00.000+0000",
+                    "updated": "2026-05-10T12:00:00.000+0000",
+                    "body": {"type": "doc", "version": 1, "content": []}
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let comment = client
+            .update_comment("PROJ-1", "100", &adf, None)
+            .await
+            .unwrap();
+        assert_eq!(comment.id, "100");
+        assert_eq!(comment.author, "Me");
+        assert_eq!(
+            comment.updated.as_deref(),
+            Some("2026-05-10T12:00:00.000+0000")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_comment_sends_visibility() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({
+                "visibility": {"type": "role", "identifier": "Administrators"}
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "author": {"displayName": "Me"},
+                    "created": "2026-04-01T10:00:00.000+0000",
+                    "updated": "2026-05-10T12:00:00.000+0000",
+                    "body": null
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let visibility = JiraVisibility {
+            ty: JiraVisibilityType::Role,
+            value: "Administrators".to_string(),
+        };
+        client
+            .update_comment("PROJ-1", "100", &adf, Some(&visibility))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_comment_forbidden_surfaces_jira_message() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                    "errorMessages": ["You do not have permission to edit this comment"],
+                    "errors": {}
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let err = client
+            .update_comment("PROJ-1", "100", &adf, None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("permission to edit"));
+    }
+
+    #[tokio::test]
+    async fn update_comment_not_found() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/9999",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "errorMessages": ["Comment not found"]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let adf = AdfDocument::new();
+        let err = client
+            .update_comment("PROJ-1", "9999", &adf, None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("404"));
+        assert!(msg.contains("Comment not found"));
     }
 
     #[tokio::test]
@@ -6182,6 +6344,7 @@ impl AtlassianClient {
                     author: c.author.and_then(|a| a.display_name).unwrap_or_default(),
                     body_adf: c.body,
                     created: c.created.unwrap_or_default(),
+                    updated: c.updated,
                 });
             }
 
@@ -6217,6 +6380,55 @@ impl AtlassianClient {
         }
 
         Ok(())
+    }
+
+    /// Updates an existing comment on a JIRA issue.
+    ///
+    /// Issues a `PUT /rest/api/3/issue/{key}/comment/{id}` with the new ADF
+    /// body and an optional visibility restriction. Returns the updated
+    /// comment as parsed from the JIRA response so callers can surface the
+    /// `updated` timestamp and any author/body changes JIRA applied.
+    pub async fn update_comment(
+        &self,
+        key: &str,
+        comment_id: &str,
+        body_adf: &AdfDocument,
+        visibility: Option<&JiraVisibility>,
+    ) -> Result<JiraComment> {
+        let url = format!(
+            "{}/rest/api/3/issue/{}/comment/{}",
+            self.instance_url, key, comment_id
+        );
+
+        let mut body = serde_json::json!({ "body": body_adf });
+        if let Some(v) = visibility {
+            body["visibility"] =
+                serde_json::to_value(v).context("Failed to serialize comment visibility")?;
+        }
+
+        let response = self.put_json(&url, &body).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let entry: JiraCommentEntry = response
+            .json()
+            .await
+            .context("Failed to parse updated comment response")?;
+
+        Ok(JiraComment {
+            id: entry.id,
+            author: entry
+                .author
+                .and_then(|a| a.display_name)
+                .unwrap_or_default(),
+            body_adf: entry.body,
+            created: entry.created.unwrap_or_default(),
+            updated: entry.updated,
+        })
     }
 
     /// Lists worklogs for a JIRA issue.

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -468,6 +468,7 @@ mod tests {
             author: "alice".to_string(),
             created: "2025-01-01T00:00:00Z".to_string(),
             body_adf: None,
+            updated: None,
         }
     }
 

--- a/src/cli/atlassian/jira/comment.rs
+++ b/src/cli/atlassian/jira/comment.rs
@@ -1,10 +1,10 @@
 //! CLI commands for JIRA issue comments.
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::client::{AtlassianClient, JiraComment};
+use crate::atlassian::client::{AtlassianClient, JiraComment, JiraVisibility, JiraVisibilityType};
 use crate::atlassian::convert::{adf_to_markdown, markdown_to_adf};
 use crate::atlassian::document::JfmDocument;
 use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
@@ -25,6 +25,8 @@ pub enum CommentSubcommands {
     List(ListCommand),
     /// Adds a comment to a JIRA issue.
     Add(AddCommand),
+    /// Edits an existing comment on a JIRA issue.
+    Edit(EditCommand),
 }
 
 impl CommentCommand {
@@ -33,6 +35,7 @@ impl CommentCommand {
         match self.command {
             CommentSubcommands::List(cmd) => cmd.execute().await,
             CommentSubcommands::Add(cmd) => cmd.execute().await,
+            CommentSubcommands::Edit(cmd) => cmd.execute().await,
         }
     }
 }
@@ -77,30 +80,97 @@ pub struct AddCommand {
 impl AddCommand {
     /// Reads input, converts to ADF, and posts the comment.
     pub async fn execute(self) -> Result<()> {
-        let adf = self.parse_input()?;
+        let adf = parse_comment_input(self.file.as_deref(), self.format)?;
 
         let (client, _instance_url) = create_client()?;
         run_add_comment(&client, &self.key, &adf).await
     }
+}
 
-    /// Parses the input file into an ADF document.
-    fn parse_input(&self) -> Result<AdfDocument> {
-        let input = read_input(self.file.as_deref())?;
+/// Edits an existing comment on a JIRA issue.
+#[derive(Parser)]
+pub struct EditCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
 
-        match self.format {
-            ContentFormat::Jfm => {
-                // Try parsing as JFM document (with frontmatter) first,
-                // fall back to raw markdown
-                if input.starts_with("---\n") {
-                    let doc = JfmDocument::parse(&input)?;
-                    markdown_to_adf(&doc.body)
-                } else {
-                    markdown_to_adf(&input)
-                }
+    /// Comment ID to edit.
+    pub comment_id: String,
+
+    /// Input file (reads from stdin if omitted or "-").
+    pub file: Option<String>,
+
+    /// Input format.
+    #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
+    pub format: ContentFormat,
+
+    /// Visibility restriction kind. Pair with `--visibility-value`.
+    #[arg(long, value_enum, requires = "visibility_value")]
+    pub visibility_type: Option<CliVisibilityType>,
+
+    /// Visibility group or role name. Pair with `--visibility-type`.
+    #[arg(long, requires = "visibility_type")]
+    pub visibility_value: Option<String>,
+}
+
+/// Visibility restriction kind for the CLI.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum CliVisibilityType {
+    /// Restrict to a JIRA group.
+    Group,
+    /// Restrict to a project role.
+    Role,
+}
+
+impl From<CliVisibilityType> for JiraVisibilityType {
+    fn from(value: CliVisibilityType) -> Self {
+        match value {
+            CliVisibilityType::Group => Self::Group,
+            CliVisibilityType::Role => Self::Role,
+        }
+    }
+}
+
+impl EditCommand {
+    /// Reads input, converts to ADF, and updates the comment.
+    pub async fn execute(self) -> Result<()> {
+        let adf = parse_comment_input(self.file.as_deref(), self.format)?;
+        let visibility = match (self.visibility_type, self.visibility_value) {
+            (Some(ty), Some(value)) => Some(JiraVisibility {
+                ty: ty.into(),
+                value,
+            }),
+            _ => None,
+        };
+
+        let (client, _instance_url) = create_client()?;
+        run_edit_comment(
+            &client,
+            &self.key,
+            &self.comment_id,
+            &adf,
+            visibility.as_ref(),
+        )
+        .await
+    }
+}
+
+/// Parses the input file into an ADF document.
+fn parse_comment_input(file: Option<&str>, format: ContentFormat) -> Result<AdfDocument> {
+    let input = read_input(file)?;
+
+    match format {
+        ContentFormat::Jfm => {
+            // Try parsing as JFM document (with frontmatter) first,
+            // fall back to raw markdown
+            if input.starts_with("---\n") {
+                let doc = JfmDocument::parse(&input)?;
+                markdown_to_adf(&doc.body)
+            } else {
+                markdown_to_adf(&input)
             }
-            ContentFormat::Adf => {
-                serde_json::from_str(&input).context("Failed to parse ADF JSON input")
-            }
+        }
+        ContentFormat::Adf => {
+            serde_json::from_str(&input).context("Failed to parse ADF JSON input")
         }
     }
 }
@@ -124,6 +194,24 @@ async fn run_list_comments(
 async fn run_add_comment(client: &AtlassianClient, key: &str, adf: &AdfDocument) -> Result<()> {
     client.add_comment(key, adf).await?;
     println!("Comment added to {key}.");
+    Ok(())
+}
+
+/// Updates an existing comment on an issue.
+async fn run_edit_comment(
+    client: &AtlassianClient,
+    key: &str,
+    comment_id: &str,
+    adf: &AdfDocument,
+    visibility: Option<&JiraVisibility>,
+) -> Result<()> {
+    let updated = client
+        .update_comment(key, comment_id, adf, visibility)
+        .await?;
+    println!("Comment {comment_id} updated on {key}.");
+    let yaml =
+        serde_yaml::to_string(&updated).context("Failed to serialize updated comment as YAML")?;
+    print!("{yaml}");
     Ok(())
 }
 
@@ -186,6 +274,7 @@ mod tests {
             author: author.to_string(),
             body_adf,
             created: "2026-04-01T10:30:00.000+0000".to_string(),
+            updated: None,
         }
     }
 
@@ -292,7 +381,7 @@ mod tests {
         assert_eq!(format_timestamp(""), "");
     }
 
-    // ── AddCommand::parse_input ────────────────────────────────────
+    // ── parse_comment_input ────────────────────────────────────────
 
     #[test]
     fn parse_input_raw_markdown() {
@@ -300,13 +389,8 @@ mod tests {
         let file_path = temp_dir.path().join("comment.md");
         fs::write(&file_path, "Hello **world**\n").unwrap();
 
-        let cmd = AddCommand {
-            key: "PROJ-1".to_string(),
-            file: Some(file_path.to_str().unwrap().to_string()),
-            format: ContentFormat::Jfm,
-        };
-
-        let adf = cmd.parse_input().unwrap();
+        let adf =
+            parse_comment_input(Some(file_path.to_str().unwrap()), ContentFormat::Jfm).unwrap();
         assert!(!adf.content.is_empty());
     }
 
@@ -318,13 +402,8 @@ mod tests {
             "---\ntype: jira\ninstance: https://org.atlassian.net\nkey: PROJ-1\nsummary: Test\n---\n\nComment body\n";
         fs::write(&file_path, content).unwrap();
 
-        let cmd = AddCommand {
-            key: "PROJ-1".to_string(),
-            file: Some(file_path.to_str().unwrap().to_string()),
-            format: ContentFormat::Jfm,
-        };
-
-        let adf = cmd.parse_input().unwrap();
+        let adf =
+            parse_comment_input(Some(file_path.to_str().unwrap()), ContentFormat::Jfm).unwrap();
         assert!(!adf.content.is_empty());
     }
 
@@ -335,13 +414,8 @@ mod tests {
         let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello"}]}]}"#;
         fs::write(&file_path, adf_json).unwrap();
 
-        let cmd = AddCommand {
-            key: "PROJ-1".to_string(),
-            file: Some(file_path.to_str().unwrap().to_string()),
-            format: ContentFormat::Adf,
-        };
-
-        let adf = cmd.parse_input().unwrap();
+        let adf =
+            parse_comment_input(Some(file_path.to_str().unwrap()), ContentFormat::Adf).unwrap();
         assert_eq!(adf.content.len(), 1);
     }
 
@@ -351,13 +425,9 @@ mod tests {
         let file_path = temp_dir.path().join("bad.json");
         fs::write(&file_path, "not json").unwrap();
 
-        let cmd = AddCommand {
-            key: "PROJ-1".to_string(),
-            file: Some(file_path.to_str().unwrap().to_string()),
-            format: ContentFormat::Adf,
-        };
-
-        assert!(cmd.parse_input().is_err());
+        assert!(
+            parse_comment_input(Some(file_path.to_str().unwrap()), ContentFormat::Adf).is_err()
+        );
     }
 
     // ── CommentCommand dispatch ────────────────────────────────────
@@ -384,6 +454,33 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, CommentSubcommands::Add(_)));
+    }
+
+    #[test]
+    fn comment_command_edit_variant() {
+        let cmd = CommentCommand {
+            command: CommentSubcommands::Edit(EditCommand {
+                key: "PROJ-1".to_string(),
+                comment_id: "100".to_string(),
+                file: None,
+                format: ContentFormat::Jfm,
+                visibility_type: None,
+                visibility_value: None,
+            }),
+        };
+        assert!(matches!(cmd.command, CommentSubcommands::Edit(_)));
+    }
+
+    #[test]
+    fn cli_visibility_type_into_group() {
+        let mapped: JiraVisibilityType = CliVisibilityType::Group.into();
+        assert!(matches!(mapped, JiraVisibilityType::Group));
+    }
+
+    #[test]
+    fn cli_visibility_type_into_role() {
+        let mapped: JiraVisibilityType = CliVisibilityType::Role.into();
+        assert!(matches!(mapped, JiraVisibilityType::Role));
     }
 
     // ── run_list_comments / run_add_comment ────────────────────────
@@ -513,5 +610,117 @@ mod tests {
         let adf = AdfDocument::new();
         let err = run_add_comment(&client, "PROJ-1", &adf).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── run_edit_comment ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_edit_comment_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "author": {"displayName": "Me"},
+                    "created": "2026-04-01T10:00:00.000+0000",
+                    "updated": "2026-05-10T12:00:00.000+0000",
+                    "body": null
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let adf = AdfDocument::new();
+        assert!(run_edit_comment(&client, "PROJ-1", "100", &adf, None)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_edit_comment_with_visibility_sends_payload() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({
+                "visibility": {"type": "role", "identifier": "Administrators"}
+            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "100",
+                    "author": {"displayName": "Me"},
+                    "created": "2026-04-01T10:00:00.000+0000",
+                    "updated": "2026-05-10T12:00:00.000+0000",
+                    "body": null
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let adf = AdfDocument::new();
+        let visibility = JiraVisibility {
+            ty: JiraVisibilityType::Role,
+            value: "Administrators".to_string(),
+        };
+        run_edit_comment(&client, "PROJ-1", "100", &adf, Some(&visibility))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_edit_comment_forbidden() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/100",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                    "errorMessages": ["You do not have permission to edit this comment"]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let adf = AdfDocument::new();
+        let err = run_edit_comment(&client, "PROJ-1", "100", &adf, None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("permission to edit"));
+    }
+
+    #[tokio::test]
+    async fn run_edit_comment_not_found() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/comment/9999",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "errorMessages": ["Comment not found"]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let adf = AdfDocument::new();
+        let err = run_edit_comment(&client, "PROJ-1", "9999", &adf, None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("404"));
+        assert!(msg.contains("Comment not found"));
     }
 }

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -15,7 +15,9 @@ use rmcp::{
 use serde::Deserialize;
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::client::{AtlassianClient, JiraTransition};
+use crate::atlassian::client::{
+    AtlassianClient, JiraTransition, JiraVisibility, JiraVisibilityType,
+};
 use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::custom_fields::apply_user_field_overrides;
 use crate::atlassian::document::{issue_to_jfm_document, JfmDocument};
@@ -152,6 +154,32 @@ pub struct JiraCommentParams {
     /// Maximum number of comments to return. `0` means unlimited.
     #[serde(default)]
     pub limit: Option<u32>,
+}
+
+/// Visibility restriction payload for the `jira_comment_edit` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct JiraVisibilityParam {
+    /// Restriction kind — `"group"` or `"role"`.
+    #[serde(rename = "type")]
+    pub ty: String,
+    /// Group name or project role name.
+    pub value: String,
+}
+
+/// Parameters for the `jira_comment_edit` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct JiraCommentEditParams {
+    /// JIRA issue key (e.g., `PROJ-123`).
+    pub key: String,
+    /// Comment ID to update.
+    pub comment_id: String,
+    /// New comment body (JFM markdown — see resource `omni-dev://specs/jfm`).
+    pub body: String,
+    /// Optional visibility restriction. Many JIRA configurations only allow
+    /// the comment author to change visibility — JIRA's response is surfaced
+    /// as-is when permission is denied.
+    #[serde(default)]
+    pub visibility: Option<JiraVisibilityParam>,
 }
 
 /// Parameters for the `jira_link` tool.
@@ -465,6 +493,36 @@ async fn run_jira_comment(
     }
 }
 
+/// Edits an existing comment on an issue.
+async fn run_jira_comment_edit(
+    client: &AtlassianClient,
+    key: &str,
+    comment_id: &str,
+    body: &str,
+    visibility: Option<&JiraVisibilityParam>,
+) -> Result<String> {
+    let adf = markdown_to_adf(body)?;
+    let visibility = visibility.map(parse_visibility).transpose()?;
+    let updated = client
+        .update_comment(key, comment_id, &adf, visibility.as_ref())
+        .await?;
+    yaml_result(&updated)
+}
+
+fn parse_visibility(param: &JiraVisibilityParam) -> Result<JiraVisibility> {
+    let ty = match param.ty.to_ascii_lowercase().as_str() {
+        "group" => JiraVisibilityType::Group,
+        "role" => JiraVisibilityType::Role,
+        other => {
+            anyhow::bail!("unknown visibility type {other:?} (expected \"group\" or \"role\")")
+        }
+    };
+    Ok(JiraVisibility {
+        ty,
+        value: param.value.clone(),
+    })
+}
+
 /// Manages issue links.
 async fn run_jira_link(
     client: &AtlassianClient,
@@ -690,6 +748,32 @@ impl OmniDevServer {
             &params.action,
             params.body.as_deref(),
             limit,
+        )
+        .await
+        .map_err(tool_error)?;
+        ok_text(text)
+    }
+
+    /// Tool: edit an existing JIRA comment.
+    #[tool(
+        description = "Edit an existing JIRA comment. `body` is JFM markdown (see resource \
+                       `omni-dev://specs/jfm`) and replaces the current comment text. Optional \
+                       `visibility = {type: \"group\"|\"role\", value: <name>}` updates the \
+                       restriction. JIRA enforces stricter permissions on edit than on add (often \
+                       only the original author can edit) — when JIRA refuses, its error message \
+                       is surfaced verbatim. Returns the updated comment metadata as YAML."
+    )]
+    pub async fn jira_comment_edit(
+        &self,
+        Parameters(params): Parameters<JiraCommentEditParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _instance_url) = create_client().map_err(tool_error)?;
+        let text = run_jira_comment_edit(
+            &client,
+            &params.key,
+            &params.comment_id,
+            &params.body,
+            params.visibility.as_ref(),
         )
         .await
         .map_err(tool_error)?;
@@ -1865,6 +1949,146 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── run_jira_comment_edit ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_jira_comment_edit_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/rest/api/3/issue/PROJ-1/comment/100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "100",
+                "author": {"displayName": "Me"},
+                "created": "2026-04-01T10:00:00.000+0000",
+                "updated": "2026-05-10T12:00:00.000+0000",
+                "body": null
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let yaml = run_jira_comment_edit(&client, "PROJ-1", "100", "hello", None)
+            .await
+            .unwrap();
+        assert!(yaml.contains("id: '100'") || yaml.contains("id: \"100\""));
+        assert!(yaml.contains("2026-05-10T12:00:00"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_comment_edit_with_visibility() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/rest/api/3/issue/PROJ-1/comment/100"))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({
+                "visibility": {"type": "group", "identifier": "jira-administrators"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "100",
+                "author": {"displayName": "Me"},
+                "created": "2026-04-01T10:00:00.000+0000",
+                "updated": "2026-05-10T12:00:00.000+0000",
+                "body": null
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let visibility = JiraVisibilityParam {
+            ty: "group".to_string(),
+            value: "jira-administrators".to_string(),
+        };
+        run_jira_comment_edit(&client, "PROJ-1", "100", "hello", Some(&visibility))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_jira_comment_edit_forbidden_surfaces_jira_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/rest/api/3/issue/PROJ-1/comment/100"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "errorMessages": ["You do not have permission to edit this comment"]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_jira_comment_edit(&client, "PROJ-1", "100", "hello", None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("403"));
+        assert!(msg.contains("permission to edit"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_comment_edit_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/rest/api/3/issue/PROJ-1/comment/9999"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "errorMessages": ["Comment not found"]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_jira_comment_edit(&client, "PROJ-1", "9999", "hello", None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("404"));
+        assert!(msg.contains("Comment not found"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_comment_edit_unknown_visibility_type() {
+        let client = mock_client("http://127.0.0.1:1");
+        let visibility = JiraVisibilityParam {
+            ty: "user".to_string(),
+            value: "alice".to_string(),
+        };
+        let err = run_jira_comment_edit(&client, "PROJ-1", "100", "hello", Some(&visibility))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown visibility type"));
+    }
+
+    #[test]
+    fn parse_visibility_group() {
+        let v = parse_visibility(&JiraVisibilityParam {
+            ty: "group".to_string(),
+            value: "jira-users".to_string(),
+        })
+        .unwrap();
+        assert!(matches!(v.ty, JiraVisibilityType::Group));
+        assert_eq!(v.value, "jira-users");
+    }
+
+    #[test]
+    fn parse_visibility_role() {
+        let v = parse_visibility(&JiraVisibilityParam {
+            ty: "role".to_string(),
+            value: "Administrators".to_string(),
+        })
+        .unwrap();
+        assert!(matches!(v.ty, JiraVisibilityType::Role));
+        assert_eq!(v.value, "Administrators");
+    }
+
+    #[test]
+    fn parse_visibility_case_insensitive() {
+        let v = parse_visibility(&JiraVisibilityParam {
+            ty: "ROLE".to_string(),
+            value: "Administrators".to_string(),
+        })
+        .unwrap();
+        assert!(matches!(v.ty, JiraVisibilityType::Role));
     }
 
     // ── run_jira_link ──────────────────────────────────────────────────────

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -283,6 +283,7 @@ mod tests {
             "jira_write",
             "jira_transition",
             "jira_comment",
+            "jira_comment_edit",
             "jira_link",
             "jira_dev",
             "jira_user_search",

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -851,6 +851,7 @@ Usage: comment <COMMAND>
 Commands:
   list  Lists comments on a JIRA issue
   add   Adds a comment to a JIRA issue
+  edit  Edits an existing comment on a JIRA issue
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -872,6 +873,30 @@ Arguments:
 Options:
       --format <FORMAT>  Input format [default: jfm] [possible values: jfm, adf]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira comment edit - Edits an existing comment on a JIRA issue
+
+Edits an existing comment on a JIRA issue
+
+Usage: edit [OPTIONS] <KEY> <COMMENT_ID> [FILE]
+
+Arguments:
+  <KEY>         JIRA issue key (e.g., PROJ-123)
+  <COMMENT_ID>  Comment ID to edit
+  [FILE]        Input file (reads from stdin if omitted or "-")
+
+Options:
+      --format <FORMAT>
+          Input format [default: jfm] [possible values: jfm, adf]
+      --visibility-type <VISIBILITY_TYPE>
+          Visibility restriction kind. Pair with `--visibility-value` [possible values: group, role]
+      --visibility-value <VISIBILITY_VALUE>
+          Visibility group or role name. Pair with `--visibility-type`
+  -h, --help
+          Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements end-to-end support for editing existing JIRA comments via both the CLI (`omni-dev atlassian jira comment edit`) and the MCP server tool interface (`jira_comment_edit`). Users can now update comment body text and optionally change visibility restrictions (group or role) on existing JIRA comments.

The implementation adds a `PUT /rest/api/3/issue/{key}/comment/{id}` path to the Atlassian client, exposes it through a new `edit` CLI subcommand, and registers it as an MCP tool on the server.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Relates to #713

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `update_comment` method to `AtlassianClient` issuing a `PUT /rest/api/3/issue/{key}/comment/{id}` with an ADF body and optional visibility restriction
- Added `JiraVisibility` and `JiraVisibilityType` structs with custom `Serialize` implementation that maps to JIRA's `{type, identifier}` wire format
- Exposed `updated` timestamp field on `JiraComment` and added it to `JiraCommentEntry` deserialization
- Propagated `updated` field when converting `JiraCommentEntry` to `JiraComment`

**CLI Changes (`src/cli/atlassian/jira/comment.rs`):**
- Added `edit` subcommand to `CommentSubcommands` dispatching to new `EditCommand`
- Implemented `EditCommand` with `key`, `comment_id`, `file`, `--format`, `--visibility-type`, and `--visibility-value` arguments (type and value flags are mutually required via clap `requires`)
- Added `CliVisibilityType` enum (`group` / `role`) implementing `From<CliVisibilityType> for JiraVisibilityType`
- Extracted shared `parse_comment_input` free function from `AddCommand::parse_input` and updated `AddCommand::execute` to use it
- Added `run_edit_comment` async helper that calls `update_comment` and prints the updated comment as YAML

**MCP Tool Changes (`src/mcp/jira_core_tools.rs`, `src/mcp/server.rs`):**
- Added `JiraVisibilityParam` and `JiraCommentEditParams` parameter structs with JSON schema support
- Added `run_jira_comment_edit` async function and `parse_visibility` helper (validates `"group"` / `"role"`, returns error for unknown types)
- Added `jira_comment_edit` tool method on `OmniDevServer` with descriptive doc string surfacing JIRA's permission semantics
- Registered `jira_comment_edit` in `src/mcp/server.rs` tool list

**Snapshot & Documentation:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include the new `edit` subcommand in `comment` help and its full option listing

**Testing:**
- Added unit tests in `client.rs`: `update_comment_success`, `update_comment_sends_visibility`, `update_comment_forbidden_surfaces_jira_message`, `update_comment_not_found`
- Added unit tests in `comment.rs`: `run_edit_comment_success`, `run_edit_comment_with_visibility_sends_payload`, `run_edit_comment_forbidden`, `run_edit_comment_not_found`, `comment_command_edit_variant`
- Added unit tests in `jira_core_tools.rs`: `run_jira_comment_edit_success`, `run_jira_comment_edit_with_visibility`, `run_jira_comment_edit_forbidden_surfaces_jira_message`, `run_jira_comment_edit_not_found`, `run_jira_comment_edit_unknown_visibility_type`
- Updated existing test helpers in `format.rs` and `comment.rs` to include the new `updated: None` field on `JiraComment`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (help snapshot)

**Manual Testing:**
- [x] Tested happy path scenarios (edit comment body via CLI)
- [x] Tested error/edge cases (403 forbidden, 404 not found, unknown visibility type)
- [x] Backward compatibility verified (existing `list` and `add` subcommands unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Exercise the new CLI command (requires configured Atlassian credentials)
echo "Updated comment text" | omni-dev atlassian jira comment edit PROJ-123 <comment-id>

# With visibility restriction
echo "Internal note" | omni-dev atlassian jira comment edit PROJ-123 <comment-id> \
  --visibility-type role --visibility-value "Administrators"
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — JIRA enforces stricter permissions on edit than on add (often only the original author can edit); errors from JIRA are surfaced verbatim via `AtlassianError::ApiRequestFailed`
- [x] Architecture changes — `parse_comment_input` is now a module-level free function shared between `AddCommand` and `EditCommand`; verify the refactor doesn't break existing `add` behaviour
- [x] Backward compatibility — `JiraComment` gains a new `updated: Option<String>` field; all existing construction sites have been updated with `updated: None`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications — the edit operation uses the same Atlassian basic-auth credentials as other client methods; visibility restrictions are passed through to JIRA which enforces its own permission model

## Breaking Changes

None. The new `updated` field on `JiraComment` is `Option<String>` and all existing construction sites have been updated. The extracted `parse_comment_input` function is private to the module and does not affect any public API.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional visibility types (e.g., JIRA project-level roles beyond `group`/`role`) can be added by extending `JiraVisibilityType` and `CliVisibilityType`
- The `jira_comment_edit` MCP tool could be extended to support partial updates (e.g., visibility-only changes without requiring a new body)

**Known Limitations:**
- JIRA Cloud enforces that only the original comment author can edit a comment in many configurations; the 403 error message from JIRA is surfaced as-is to help users understand the restriction