### PR TITLE
feat(atlassian): add confluence move page command

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -41,6 +41,13 @@ struct ConfluencePageResponse {
     body: Option<ConfluenceBody>,
     #[serde(rename = "parentId")]
     parent_id: Option<String>,
+    #[serde(default)]
+    ancestors: Vec<ConfluenceAncestorEntry>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceAncestorEntry {
+    id: String,
 }
 
 #[derive(Deserialize)]
@@ -383,6 +390,45 @@ struct ConfluenceUpdateVersion {
     message: Option<String>,
 }
 
+// ── Move types ─────────────────────────────────────────────────────
+
+/// Position for [`ConfluenceApi::move_page`]. Same-space only —
+/// cross-space moves are not supported by the v2 API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MovePosition {
+    /// Place the page as the last child of the target (target becomes the new parent).
+    Append,
+    /// Place the page as a sibling immediately before the target.
+    Before,
+    /// Place the page as a sibling immediately after the target.
+    After,
+}
+
+impl MovePosition {
+    /// Returns the URL-path segment used by the Confluence move endpoint.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Append => "append",
+            Self::Before => "before",
+            Self::After => "after",
+        }
+    }
+}
+
+/// Updated page metadata returned by [`ConfluenceApi::move_page`].
+#[derive(Debug, Clone, Serialize)]
+pub struct MovedPage {
+    /// Page ID.
+    pub id: String,
+    /// Page title.
+    pub title: String,
+    /// New parent page ID, if the page now has a parent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    /// Ancestor page IDs from root toward the immediate parent.
+    pub ancestors: Vec<String>,
+}
+
 impl AtlassianApi for ConfluenceApi {
     fn get_content<'a>(
         &'a self,
@@ -608,6 +654,85 @@ impl ConfluenceApi {
             .context("Failed to parse Confluence create response")?;
 
         Ok(resp.id)
+    }
+
+    /// Moves or reparents a Confluence page within its current space.
+    ///
+    /// Same-space only — cross-space moves are not supported by the v2 API.
+    /// Uses the v1 move endpoint (`PUT /wiki/rest/api/content/{id}/move/{position}/{target}`),
+    /// then re-fetches the page with `?include-ancestors=true` to populate
+    /// the returned [`MovedPage`].
+    pub async fn move_page(
+        &self,
+        page_id: &str,
+        target_id: &str,
+        position: MovePosition,
+    ) -> Result<MovedPage> {
+        let url = format!(
+            "{}/wiki/rest/api/content/{}/move/{}/{}",
+            self.client.instance_url(),
+            page_id,
+            position.as_str(),
+            target_id
+        );
+
+        let response = self
+            .client
+            .put_json(&url, &serde_json::json!({}))
+            .await
+            .context("Failed to send Confluence move request")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            if status == 403 {
+                anyhow::bail!(
+                    "Move failed: insufficient permissions to move page {page_id} \
+                     relative to target {target_id}. Confluence response: {body}"
+                );
+            }
+            if status == 404 {
+                anyhow::bail!(
+                    "Move failed: page {page_id} or target {target_id} not found, \
+                     or insufficient permissions. Confluence response: {body}"
+                );
+            }
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let page = self.fetch_page_with_ancestors(page_id).await?;
+        Ok(MovedPage {
+            id: page.id,
+            title: page.title,
+            parent_id: page.parent_id,
+            ancestors: page.ancestors.into_iter().map(|a| a.id).collect(),
+        })
+    }
+
+    /// Fetches a Confluence page with its ancestors populated.
+    async fn fetch_page_with_ancestors(&self, id: &str) -> Result<ConfluencePageResponse> {
+        let url = format!(
+            "{}/wiki/api/v2/pages/{}?include-ancestors=true",
+            self.client.instance_url(),
+            id
+        );
+
+        let response = self
+            .client
+            .get_json(&url)
+            .await
+            .context("Failed to fetch Confluence page with ancestors")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        response
+            .json()
+            .await
+            .context("Failed to parse Confluence page response")
     }
 
     /// Deletes a Confluence page.
@@ -1570,6 +1695,224 @@ mod tests {
         let api = ConfluenceApi::new(client);
         let err = api.delete_page("12345", false).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── move_page ──────────────────────────────────────────────────
+
+    #[test]
+    fn move_position_as_str() {
+        assert_eq!(MovePosition::Append.as_str(), "append");
+        assert_eq!(MovePosition::Before.as_str(), "before");
+        assert_eq!(MovePosition::After.as_str(), "after");
+    }
+
+    /// Mounts the post-move ancestor fetch (`GET /wiki/api/v2/pages/{id}?include-ancestors=true`).
+    async fn mount_ancestor_fetch(server: &wiremock::MockServer, id: &str, parent_id: &str) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!("/wiki/api/v2/pages/{id}")))
+            .and(wiremock::matchers::query_param("include-ancestors", "true"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": id,
+                    "title": "Moved Page",
+                    "status": "current",
+                    "spaceId": "98765",
+                    "parentId": parent_id,
+                    "ancestors": [
+                        {"id": "10"},
+                        {"id": parent_id}
+                    ]
+                })),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn move_page_append_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        mount_ancestor_fetch(&server, "12345", "456").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let moved = api
+            .move_page("12345", "456", MovePosition::Append)
+            .await
+            .unwrap();
+        assert_eq!(moved.id, "12345");
+        assert_eq!(moved.title, "Moved Page");
+        assert_eq!(moved.parent_id.as_deref(), Some("456"));
+        assert_eq!(moved.ancestors, vec!["10".to_string(), "456".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn move_page_before_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/before/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        mount_ancestor_fetch(&server, "12345", "789").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let moved = api
+            .move_page("12345", "456", MovePosition::Before)
+            .await
+            .unwrap();
+        assert_eq!(moved.parent_id.as_deref(), Some("789"));
+    }
+
+    #[tokio::test]
+    async fn move_page_after_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/after/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        mount_ancestor_fetch(&server, "12345", "789").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let moved = api
+            .move_page("12345", "456", MovePosition::After)
+            .await
+            .unwrap();
+        assert_eq!(moved.id, "12345");
+    }
+
+    #[tokio::test]
+    async fn move_page_forbidden_surfaces_reason() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                    "errors": [{"detail": "User cannot move page"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .move_page("12345", "456", MovePosition::Append)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("insufficient permissions"));
+        assert!(msg.contains("User cannot move page"));
+    }
+
+    #[tokio::test]
+    async fn move_page_not_found() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/99999/move/append/456",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Page not found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .move_page("99999", "456", MovePosition::Append)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found"));
+        assert!(msg.contains("Page not found"));
+    }
+
+    #[tokio::test]
+    async fn move_page_other_error_falls_through_to_generic() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string("boom"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .move_page("12345", "456", MovePosition::Append)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn move_page_ancestor_fetch_failure_is_propagated() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::query_param("include-ancestors", "true"))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string("ancestor boom"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .move_page("12345", "456", MovePosition::Append)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("500"));
     }
 
     #[tokio::test]

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod download;
 pub(crate) mod edit;
 pub(crate) mod history;
 pub(crate) mod label;
+pub(crate) mod move_page;
 pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod user;
@@ -41,6 +42,8 @@ pub enum ConfluenceSubcommands {
     Create(create::CreateCommand),
     /// Deletes a Confluence page.
     Delete(delete::DeleteCommand),
+    /// Moves or reparents a Confluence page (same-space only).
+    Move(move_page::MoveCommand),
     /// Manages labels on Confluence pages.
     Label(label::LabelCommand),
     /// Recursively downloads a Confluence page tree.
@@ -65,6 +68,7 @@ impl ConfluenceCommand {
             ConfluenceSubcommands::Create(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Label(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Delete(cmd) => cmd.execute().await,
+            ConfluenceSubcommands::Move(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Download(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Children(cmd) => cmd.execute().await,
             ConfluenceSubcommands::History(cmd) => cmd.execute().await,
@@ -180,6 +184,41 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Delete(_)));
+    }
+
+    #[test]
+    fn confluence_subcommands_move_variant() {
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Move(move_page::MoveCommand {
+                id: "12345".to_string(),
+                target: "456".to_string(),
+                position: move_page::MovePosition::Append,
+            }),
+        };
+        assert!(matches!(cmd.command, ConfluenceSubcommands::Move(_)));
+    }
+
+    /// Exercises the `Move` dispatch arm in `ConfluenceCommand::execute` with
+    /// injected fake credentials so `create_client()` succeeds; the API call
+    /// is allowed to fail.
+    #[tokio::test]
+    async fn confluence_command_execute_move_dispatch() {
+        std::env::set_var("ATLASSIAN_INSTANCE_URL", "http://127.0.0.1:1");
+        std::env::set_var("ATLASSIAN_EMAIL", "test@example.com");
+        std::env::set_var("ATLASSIAN_API_TOKEN", "fake-token");
+
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Move(move_page::MoveCommand {
+                id: "12345".to_string(),
+                target: "456".to_string(),
+                position: move_page::MovePosition::Append,
+            }),
+        };
+        let _ = cmd.execute().await;
+
+        std::env::remove_var("ATLASSIAN_INSTANCE_URL");
+        std::env::remove_var("ATLASSIAN_EMAIL");
+        std::env::remove_var("ATLASSIAN_API_TOKEN");
     }
 
     #[test]

--- a/src/cli/atlassian/confluence/move_page.rs
+++ b/src/cli/atlassian/confluence/move_page.rs
@@ -1,0 +1,233 @@
+//! CLI command for moving/reparenting Confluence pages.
+//!
+//! Same-space only — cross-space moves are not supported by the v2 API.
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+
+use crate::atlassian::confluence_api::{ConfluenceApi, MovePosition as ApiMovePosition, MovedPage};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Position for a Confluence page move.
+#[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, Eq)]
+pub enum MovePosition {
+    /// Place the page as the last child of the target (target becomes the new parent).
+    #[default]
+    Append,
+    /// Place the page as a sibling immediately before the target.
+    Before,
+    /// Place the page as a sibling immediately after the target.
+    After,
+}
+
+impl From<MovePosition> for ApiMovePosition {
+    fn from(value: MovePosition) -> Self {
+        match value {
+            MovePosition::Append => Self::Append,
+            MovePosition::Before => Self::Before,
+            MovePosition::After => Self::After,
+        }
+    }
+}
+
+/// Moves or reparents a Confluence page within its current space.
+///
+/// Same-space only — cross-space moves are not supported by the v2 API.
+#[derive(Parser)]
+pub struct MoveCommand {
+    /// Confluence page ID to move.
+    pub id: String,
+
+    /// Target page ID — new parent for `append`, or sibling reference for `before`/`after`.
+    #[arg(long)]
+    pub target: String,
+
+    /// Position relative to the target.
+    #[arg(long, value_enum, default_value_t = MovePosition::Append)]
+    pub position: MovePosition,
+}
+
+impl MoveCommand {
+    /// Executes the move command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        run_move(&api, &self.id, &self.target, self.position.into()).await
+    }
+}
+
+/// Performs the move and prints the resulting [`MovedPage`] as YAML.
+async fn run_move(
+    api: &ConfluenceApi,
+    page_id: &str,
+    target_id: &str,
+    position: ApiMovePosition,
+) -> Result<()> {
+    let moved = api.move_page(page_id, target_id, position).await?;
+    print_moved_page(&moved)
+}
+
+fn print_moved_page(moved: &MovedPage) -> Result<()> {
+    let yaml = serde_yaml::to_string(moved).context("Failed to serialize moved page as YAML")?;
+    print!("{yaml}");
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::atlassian::client::AtlassianClient;
+
+    // ── MoveCommand struct ─────────────────────────────────────────
+
+    #[test]
+    fn move_command_struct_fields() {
+        let cmd = MoveCommand {
+            id: "12345".to_string(),
+            target: "456".to_string(),
+            position: MovePosition::Append,
+        };
+        assert_eq!(cmd.id, "12345");
+        assert_eq!(cmd.target, "456");
+        assert_eq!(cmd.position, MovePosition::Append);
+    }
+
+    #[test]
+    fn move_position_default_is_append() {
+        assert_eq!(MovePosition::default(), MovePosition::Append);
+    }
+
+    #[test]
+    fn move_position_from_cli_to_api() {
+        assert_eq!(
+            ApiMovePosition::from(MovePosition::Append),
+            ApiMovePosition::Append
+        );
+        assert_eq!(
+            ApiMovePosition::from(MovePosition::Before),
+            ApiMovePosition::Before
+        );
+        assert_eq!(
+            ApiMovePosition::from(MovePosition::After),
+            ApiMovePosition::After
+        );
+    }
+
+    // ── print_moved_page ───────────────────────────────────────────
+
+    #[test]
+    fn print_moved_page_emits_valid_yaml() {
+        let moved = MovedPage {
+            id: "12345".to_string(),
+            title: "Moved".to_string(),
+            parent_id: Some("456".to_string()),
+            ancestors: vec!["10".to_string(), "456".to_string()],
+        };
+        // Only checks that no error is returned; output goes to stdout.
+        assert!(print_moved_page(&moved).is_ok());
+    }
+
+    // ── run_move ───────────────────────────────────────────────────
+
+    async fn mock_move_endpoints(server: &wiremock::MockServer, position: &str) {
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(format!(
+                "/wiki/rest/api/content/12345/move/{position}/456"
+            )))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .mount(server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::query_param("include-ancestors", "true"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12345",
+                    "title": "Moved",
+                    "status": "current",
+                    "spaceId": "98765",
+                    "parentId": "456",
+                    "ancestors": [{"id": "10"}, {"id": "456"}]
+                })),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn run_move_append_success() {
+        let server = wiremock::MockServer::start().await;
+        mock_move_endpoints(&server, "append").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = run_move(&api, "12345", "456", ApiMovePosition::Append).await;
+        assert!(result.is_ok(), "got: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn run_move_before_success() {
+        let server = wiremock::MockServer::start().await;
+        mock_move_endpoints(&server, "before").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = run_move(&api, "12345", "456", ApiMovePosition::Before).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_move_after_success() {
+        let server = wiremock::MockServer::start().await;
+        mock_move_endpoints(&server, "after").await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let result = run_move(&api, "12345", "456", ApiMovePosition::After).await;
+        assert!(result.is_ok());
+    }
+
+    /// Drives `MoveCommand::execute` past `create_client()` with injected
+    /// fake credentials so the dispatch line runs. The downstream API call
+    /// fails (no mock server) and we only care that the entrypoint executes.
+    #[tokio::test]
+    async fn move_command_execute_dispatch() {
+        std::env::set_var("ATLASSIAN_INSTANCE_URL", "http://127.0.0.1:1");
+        std::env::set_var("ATLASSIAN_EMAIL", "test@example.com");
+        std::env::set_var("ATLASSIAN_API_TOKEN", "fake-token");
+
+        let cmd = MoveCommand {
+            id: "12345".to_string(),
+            target: "456".to_string(),
+            position: MovePosition::Append,
+        };
+        let _ = cmd.execute().await;
+
+        std::env::remove_var("ATLASSIAN_INSTANCE_URL");
+        std::env::remove_var("ATLASSIAN_EMAIL");
+        std::env::remove_var("ATLASSIAN_API_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn run_move_propagates_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = run_move(&api, "12345", "456", ApiMovePosition::Append)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("insufficient permissions"));
+    }
+}

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::api::{AtlassianApi, ContentItem};
 use crate::atlassian::client::AtlassianClient;
-use crate::atlassian::confluence_api::{ChildPage, ConfluenceApi};
+use crate::atlassian::confluence_api::{ChildPage, ConfluenceApi, MovePosition};
 use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::document::{content_item_to_document, JfmDocument, JfmFrontmatter};
 use crate::cli::atlassian::confluence::download::{
@@ -113,6 +113,21 @@ pub struct ConfluenceDeleteParams {
     /// Requires space admin permission.
     #[serde(default)]
     pub purge: Option<bool>,
+}
+
+/// Parameters for the `confluence_move` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceMoveParams {
+    /// ID of the Confluence page to move.
+    pub page_id: String,
+    /// Target page ID — new parent for `position: "append"`, or sibling
+    /// reference for `"before"`/`"after"`.
+    pub target_id: String,
+    /// Position relative to the target. Defaults to `"append"`.
+    /// Accepted values: `"append"` (target becomes new parent), `"before"`,
+    /// `"after"`. Same-space only — cross-space moves are not supported.
+    #[serde(default)]
+    pub position: Option<String>,
 }
 
 /// Parameters for the `confluence_download` tool.
@@ -693,6 +708,23 @@ impl OmniDevServer {
         ))]))
     }
 
+    /// Tool: move/reparent a Confluence page within its current space.
+    #[tool(
+        description = "Move or reparent a Confluence page within its current space. \
+                       `position` is `\"append\"` (default — target becomes new parent), \
+                       `\"before\"`, or `\"after\"` (sibling reorder relative to target). \
+                       Same-space only — cross-space moves are not supported. \
+                       Returns the moved page's metadata as YAML (id, title, parent_id, ancestors). \
+                       Mirrors `omni-dev atlassian confluence move`."
+    )]
+    pub async fn confluence_move(
+        &self,
+        Parameters(params): Parameters<ConfluenceMoveParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let yaml = run_confluence_move(&params).await.map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
     /// Tool: recursively download a Confluence page tree.
     #[tool(
         description = "Recursively download a Confluence page or an entire space into a directory. \
@@ -937,6 +969,28 @@ async fn run_confluence_delete(params: &ConfluenceDeleteParams) -> Result<()> {
     let api = ConfluenceApi::new(client);
     api.delete_page(&params.id, params.purge.unwrap_or(false))
         .await
+}
+
+/// Parses a `position` param (`"append"`/`"before"`/`"after"`, case-insensitive).
+fn parse_move_position(raw: Option<&str>) -> Result<MovePosition> {
+    match raw.map(str::to_ascii_lowercase).as_deref() {
+        None | Some("append") => Ok(MovePosition::Append),
+        Some("before") => Ok(MovePosition::Before),
+        Some("after") => Ok(MovePosition::After),
+        Some(other) => anyhow::bail!(
+            "Invalid position \"{other}\": must be \"append\", \"before\", or \"after\""
+        ),
+    }
+}
+
+async fn run_confluence_move(params: &ConfluenceMoveParams) -> Result<String> {
+    let position = parse_move_position(params.position.as_deref())?;
+    let (client, _instance_url) = create_client()?;
+    let api = ConfluenceApi::new(client);
+    let moved = api
+        .move_page(&params.page_id, &params.target_id, position)
+        .await?;
+    to_yaml(&moved)
 }
 
 async fn run_confluence_download(params: ConfluenceDownloadParams) -> Result<String> {
@@ -1997,6 +2051,112 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // ── parse_move_position ────────────────────────────────────────
+
+    #[test]
+    fn parse_move_position_default_is_append() {
+        assert!(matches!(
+            parse_move_position(None).unwrap(),
+            MovePosition::Append
+        ));
+    }
+
+    #[test]
+    fn parse_move_position_case_insensitive() {
+        assert!(matches!(
+            parse_move_position(Some("APPEND")).unwrap(),
+            MovePosition::Append
+        ));
+        assert!(matches!(
+            parse_move_position(Some("Before")).unwrap(),
+            MovePosition::Before
+        ));
+        assert!(matches!(
+            parse_move_position(Some("after")).unwrap(),
+            MovePosition::After
+        ));
+    }
+
+    #[test]
+    fn parse_move_position_invalid_errors() {
+        let err = parse_move_position(Some("sideways")).unwrap_err();
+        assert!(err.to_string().contains("Invalid position"));
+    }
+
+    // ── confluence_move handler ────────────────────────────────────
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_move_handler_invalid_position_returns_tool_error() {
+        let server = make_server();
+        let result = server
+            .confluence_move(Parameters(ConfluenceMoveParams {
+                page_id: "12345".to_string(),
+                target_id: "456".to_string(),
+                position: Some("sideways".to_string()),
+            }))
+            .await;
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid position"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_move_handler_success_via_mock() {
+        let _lock = env_lock();
+        let srv = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path(
+                "/wiki/rest/api/content/12345/move/append/456",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"pageId": "12345"})),
+            )
+            .mount(&srv)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::query_param("include-ancestors", "true"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12345",
+                    "title": "Moved Page",
+                    "status": "current",
+                    "spaceId": "98765",
+                    "parentId": "456",
+                    "ancestors": [{"id": "456"}]
+                })),
+            )
+            .mount(&srv)
+            .await;
+        let _env = EnvGuard::set(&srv.uri());
+
+        let server = make_server();
+        let result = server
+            .confluence_move(Parameters(ConfluenceMoveParams {
+                page_id: "12345".to_string(),
+                target_id: "456".to_string(),
+                position: None,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_move_handler_error_path_without_credentials() {
+        let _lock = env_lock();
+        clear_env();
+        let server = make_server();
+        let result = server
+            .confluence_move(Parameters(ConfluenceMoveParams {
+                page_id: "12345".to_string(),
+                target_id: "456".to_string(),
+                position: Some("append".to_string()),
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn confluence_download_handler_missing_id_and_space_returns_tool_error() {
         let server = make_server();
@@ -2079,6 +2239,7 @@ mod tests {
             "confluence_create",
             "confluence_write",
             "confluence_delete",
+            "confluence_move",
             "confluence_download",
             "confluence_children",
             "confluence_history",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -219,6 +219,7 @@ mod tests {
             "confluence_create",
             "confluence_write",
             "confluence_delete",
+            "confluence_move",
             "confluence_download",
             "atlassian_convert",
         ] {

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -317,6 +317,7 @@ Commands:
   search    Searches Confluence pages using CQL
   create    Creates a new Confluence page
   delete    Deletes a Confluence page
+  move      Moves or reparents a Confluence page (same-space only)
   label     Manages labels on Confluence pages
   download  Recursively downloads a Confluence page tree
   children  Lists child pages of a Confluence page or top-level pages in a space
@@ -555,6 +556,23 @@ Arguments:
 Options:
       --labels <LABELS>  Comma-separated list of labels to remove
   -h, --help             Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence move - Moves or reparents a Confluence page (same-space only)
+
+Moves or reparents a Confluence page (same-space only)
+
+Usage: move [OPTIONS] --target <TARGET> <ID>
+
+Arguments:
+  <ID>  Confluence page ID to move
+
+Options:
+      --target <TARGET>      Target page ID — new parent for `append`, or sibling reference for `before`/`after`
+      --position <POSITION>  Position relative to the target [default: append] [possible values: append, before, after]
+  -h, --help                 Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements a new `move` subcommand for reparenting Confluence pages within their current space. Users can now move a page to become the last child of a target page (`append`), or reorder it as a sibling immediately before or after a target (`before`/`after`). The operation uses the Confluence v1 move endpoint (`PUT /wiki/rest/api/content/{id}/move/{position}/{target}`) and re-fetches the updated page metadata including its full ancestor chain.

The feature is exposed both as a CLI subcommand (`omni-dev atlassian confluence move`) and as an MCP tool (`confluence_move`), following the same dual-surface pattern used by other Confluence commands in this project.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #707

## Changes Made

**API Layer (`src/atlassian/confluence_api.rs`):**
- Added `MovePosition` enum (`Append`, `Before`, `After`) with `as_str()` method mapping to URL path segments
- Added `MovedPage` result type (`id`, `title`, `parent_id`, `ancestors`) serializable as YAML
- Added `ConfluenceAncestorEntry` deserialization type and `ancestors` field to `ConfluencePageResponse`
- Implemented `ConfluenceApi::move_page` calling the v1 move endpoint with proper 403/404 error messaging
- Added `fetch_page_with_ancestors` helper that fetches a page with `?include-ancestors=true` to populate the returned ancestor list

**CLI (`src/cli/atlassian/confluence/`):**
- Added `src/cli/atlassian/confluence/move_page.rs` with `MoveCommand` (clap `Parser`) and CLI `MovePosition` `ValueEnum` defaulting to `Append`
- Added `From<MovePosition>` conversion from CLI enum to API enum
- Added `print_moved_page` helper serializing `MovedPage` to YAML on stdout
- Registered `ConfluenceSubcommands::Move` variant in `mod.rs` and wired it to the subcommand router

**MCP (`src/mcp/confluence_tools.rs`, `src/mcp/server.rs`):**
- Added `ConfluenceMoveParams` with `page_id`, `target_id`, and optional case-insensitive `position` string field
- Added `parse_move_position` helper accepting `"append"`, `"before"`, `"after"` case-insensitively and returning a clear error for invalid values
- Implemented `OmniDevServer::confluence_move` MCP tool handler
- Registered `confluence_move` in the MCP server tool list

**Snapshots & Tests:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include the new `move` subcommand entry and its full help output

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage — new tests added:**

In `confluence_api.rs`:
- `move_position_as_str` — verifies all three positions map to correct URL segments
- `move_page_append_success` — full append flow including ancestor fetch
- `move_page_before_success` — before-sibling flow
- `move_page_after_success` — after-sibling flow
- `move_page_forbidden_surfaces_reason` — 403 response includes "insufficient permissions" and API body
- `move_page_not_found` — 404 response includes "not found" and API body

In `move_page.rs` (CLI):
- `move_command_struct_fields` — field accessors
- `move_position_default_is_append` — default enum value
- `move_position_from_cli_to_api` — all three conversions
- `print_moved_page_emits_valid_yaml` — serialization smoke test
- `run_move_append_success`, `run_move_before_success`, `run_move_after_success` — full round-trips via wiremock
- `run_move_propagates_api_error` — 403 bubbles up correctly

In `confluence_tools.rs` (MCP):
- `parse_move_position_default_is_append`, `parse_move_position_case_insensitive`, `parse_move_position_invalid_errors`
- `confluence_move_handler_invalid_position_returns_tool_error`
- `confluence_move_handler_success_via_mock`
- `confluence_move_handler_error_path_without_credentials`

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run only move-related tests
cargo test move
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — 403 and 404 responses from the v1 move endpoint have distinct, human-readable messages
- [x] Architecture changes — the v1 REST endpoint is used for the move itself while the v2 API is used for the subsequent ancestor fetch; reviewers should confirm this mixed-version approach is acceptable
- [ ] Security implications
- [ ] Performance impact
- [ ] User experience
- [x] Backward compatibility

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The move operation requires two HTTP calls (PUT move + GET ancestor fetch). This is a necessary trade-off because the v1 move endpoint does not return ancestor information in its response.

## Security Considerations
- [x] No security implications

Credentials are handled via the existing `create_client()` helper consistent with all other Confluence commands. No new credential handling is introduced.

## Breaking Changes

None. This is a purely additive feature. No existing CLI subcommands, MCP tools, or API types were changed.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- Same-space moves only. Cross-space page moves are not supported by the Confluence v2 API and are therefore not implemented here. The CLI help text and tool descriptions both document this constraint explicitly.

**Alternatives Considered:**
- Using the v2 API exclusively: The v2 Confluence API does not expose a move/reparent endpoint, so the v1 endpoint is required for the move operation itself. The v2 API is still used for the subsequent ancestor fetch since it returns structured `ancestors` data more conveniently.