### PR TITLE
feat(atlassian): add confluence attachment management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1414,7 @@ dependencies = [
  "git2",
  "globset",
  "insta",
+ "mime_guess",
  "nix",
  "proptest",
  "regex",
@@ -1771,6 +1782,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1781,6 +1793,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1792,12 +1805,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2561,6 +2576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +2784,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ termcolor = "1.1"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.27"
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", features = ["json", "multipart", "stream"] }
 tokio = { version = "1.52", features = ["full"] }
 thiserror = "2.0"
 async-trait = "0.1"
@@ -40,13 +40,14 @@ base64 = "0.22"
 futures = "0.3"
 rmcp = { version = "1.6", features = ["server", "transport-io", "macros"], optional = true }
 schemars = "1.2"
-tokio-util = { version = "0.7", optional = true }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+mime_guess = "2"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }
 
 [features]
-mcp = ["dep:rmcp", "dep:tokio-util"]
+mcp = ["dep:rmcp"]
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -5990,6 +5990,29 @@ impl AtlassianClient {
         unreachable!()
     }
 
+    /// Sends an authenticated POST request with a multipart body and returns the raw response.
+    ///
+    /// Does not retry on 429: a streamed multipart body cannot be replayed. Callers
+    /// that need retry must rebuild the form and call again.
+    pub async fn post_multipart(
+        &self,
+        url: &str,
+        form: reqwest::multipart::Form,
+        extra_headers: &[(&str, &str)],
+    ) -> Result<reqwest::Response> {
+        let mut req = self
+            .client
+            .post(url)
+            .header("Authorization", &self.auth_header)
+            .multipart(form);
+        for (name, value) in extra_headers {
+            req = req.header(*name, *value);
+        }
+        req.send()
+            .await
+            .context("Failed to send multipart POST request to Atlassian API")
+    }
+
     /// Internal: GET with custom Accept header and 429 retry.
     async fn get_json_raw_accept(&self, url: &str, accept: &str) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {

--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -5,10 +5,12 @@
 //! number increments for optimistic locking.
 
 use std::future::Future;
+use std::path::Path;
 use std::pin::Pin;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use tokio_util::io::ReaderStream;
 use tracing::debug;
 
 use crate::atlassian::adf::AdfDocument;
@@ -347,6 +349,101 @@ pub struct PageMetadata {
     pub title: String,
     /// Current version number, if known.
     pub current_version: Option<u32>,
+}
+
+// ── Attachments ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ConfluenceAttachmentsResponse {
+    results: Vec<ConfluenceAttachmentEntry>,
+    #[serde(rename = "_links", default)]
+    links: Option<ConfluenceAttachmentLinks>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceAttachmentLinks {
+    next: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceAttachmentEntry {
+    id: String,
+    title: String,
+    #[serde(rename = "mediaType", default)]
+    media_type: Option<String>,
+    #[serde(rename = "fileSize", default)]
+    file_size: Option<u64>,
+    #[serde(rename = "downloadLink", default)]
+    download_link: Option<String>,
+    #[serde(default)]
+    version: Option<ConfluenceAttachmentVersion>,
+    #[serde(rename = "pageId", default)]
+    page_id: Option<String>,
+    #[serde(rename = "fileId", default)]
+    file_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ConfluenceAttachmentVersion {
+    number: u32,
+}
+
+/// An attachment on a Confluence page.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceAttachment {
+    /// Attachment ID (used for delete and get).
+    pub id: String,
+    /// Display title (filename).
+    pub title: String,
+    /// MIME type, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    /// File size in bytes, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_size: Option<u64>,
+    /// Download URL path or absolute URL, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub download_url: Option<String>,
+    /// Version number, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+    /// Owning page ID, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_id: Option<String>,
+    /// Underlying file ID, when reported by the API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
+}
+
+impl From<ConfluenceAttachmentEntry> for ConfluenceAttachment {
+    fn from(e: ConfluenceAttachmentEntry) -> Self {
+        Self {
+            id: e.id,
+            title: e.title,
+            media_type: e.media_type,
+            file_size: e.file_size,
+            download_url: e.download_link,
+            version: e.version.map(|v| v.number),
+            page_id: e.page_id,
+            file_id: e.file_id,
+        }
+    }
+}
+
+/// A page of attachments returned by [`ConfluenceApi::list_attachments`].
+///
+/// Pagination is *not* auto-drained: callers receive one page at a time and
+/// pass `next_cursor` back to fetch the next page. Other v2 list helpers in
+/// this module (e.g. [`ConfluenceApi::get_labels`]) auto-drain — attachments
+/// expose the cursor explicitly so MCP/CLI callers can stream very large
+/// attachment lists without buffering everything in memory.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceAttachmentPage {
+    /// Attachments on this page.
+    pub results: Vec<ConfluenceAttachment>,
+    /// Opaque cursor for the next page, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 // ── Create request ─────────────────────────────────────────────────
@@ -1193,6 +1290,218 @@ impl ConfluenceApi {
             }
         }
     }
+
+    /// Uploads an attachment to a Confluence page from a local file path.
+    ///
+    /// Streams the file body — the file is never fully buffered in memory.
+    /// Sends `X-Atlassian-Token: no-check` (Atlassian convention for
+    /// state-changing multipart endpoints).
+    ///
+    /// Does not retry on 429: see [`AtlassianClient::post_multipart`].
+    pub async fn upload_attachment(
+        &self,
+        page_id: &str,
+        file_path: &Path,
+        filename: Option<&str>,
+        comment: Option<&str>,
+        minor_edit: bool,
+    ) -> Result<ConfluenceAttachment> {
+        let metadata = tokio::fs::metadata(file_path)
+            .await
+            .with_context(|| format!("Failed to read file metadata for {}", file_path.display()))?;
+        let size = metadata.len();
+        let file = tokio::fs::File::open(file_path)
+            .await
+            .with_context(|| format!("Failed to open {}", file_path.display()))?;
+
+        let resolved_name = filename
+            .map(str::to_string)
+            .or_else(|| {
+                file_path
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+            })
+            .ok_or_else(|| anyhow::anyhow!("File path has no filename component"))?;
+
+        let mime = mime_guess::from_path(file_path).first_or_octet_stream();
+
+        let stream = ReaderStream::new(file);
+        let body = reqwest::Body::wrap_stream(stream);
+
+        let part = reqwest::multipart::Part::stream_with_length(body, size)
+            .file_name(resolved_name.clone())
+            .mime_str(mime.essence_str())
+            .with_context(|| format!("Invalid MIME type for {}", file_path.display()))?;
+
+        let mut form = reqwest::multipart::Form::new().part("file", part);
+        if let Some(c) = comment {
+            form = form.text("comment", c.to_string());
+        }
+        form = form.text("minorEdit", if minor_edit { "true" } else { "false" });
+
+        let url = format!(
+            "{}/wiki/api/v2/pages/{}/attachments",
+            self.client.instance_url(),
+            page_id
+        );
+
+        let response = self
+            .client
+            .post_multipart(&url, form, &[("X-Atlassian-Token", "no-check")])
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: ConfluenceAttachmentsResponse = response
+            .json()
+            .await
+            .context("Failed to parse upload attachment response")?;
+
+        let entry = resp
+            .results
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Upload response contained no attachment"))?;
+        Ok(entry.into())
+    }
+
+    /// Lists attachments on a Confluence page (one page at a time).
+    ///
+    /// Unlike other v2 list helpers in this module, this does *not*
+    /// auto-drain pagination: pass [`ConfluenceAttachmentPage::next_cursor`]
+    /// back as `cursor` to fetch the next page.
+    pub async fn list_attachments(
+        &self,
+        page_id: &str,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> Result<ConfluenceAttachmentPage> {
+        let mut url = format!(
+            "{}/wiki/api/v2/pages/{}/attachments?limit={}",
+            self.client.instance_url(),
+            page_id,
+            limit,
+        );
+        if let Some(c) = cursor {
+            url.push_str("&cursor=");
+            url.push_str(&urlencoding(c));
+        }
+
+        let response = self
+            .client
+            .get_json(&url)
+            .await
+            .context("Failed to fetch page attachments")?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let resp: ConfluenceAttachmentsResponse = response
+            .json()
+            .await
+            .context("Failed to parse attachments response")?;
+
+        let next_cursor = resp
+            .links
+            .and_then(|l| l.next)
+            .and_then(|next_path| extract_cursor_from_next(&next_path));
+
+        let results = resp.results.into_iter().map(Into::into).collect();
+
+        Ok(ConfluenceAttachmentPage {
+            results,
+            next_cursor,
+        })
+    }
+
+    /// Deletes an attachment by ID.
+    ///
+    /// When `purge` is true, permanently purges (requires space admin);
+    /// otherwise the attachment is moved to trash.
+    pub async fn delete_attachment(&self, attachment_id: &str, purge: bool) -> Result<()> {
+        let mut url = format!(
+            "{}/wiki/api/v2/attachments/{}",
+            self.client.instance_url(),
+            attachment_id
+        );
+        if purge {
+            url.push_str("?purge=true");
+        }
+
+        let response = self.client.delete(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        Ok(())
+    }
+}
+
+/// Minimal application/x-www-form-urlencoded encoder for query-param values.
+///
+/// Only escapes the small set of characters that would otherwise corrupt the
+/// query string (`& = + % # space`). Cursor values returned by Confluence are
+/// opaque base64-ish blobs so this is sufficient.
+fn urlencoding(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("%26"),
+            '=' => out.push_str("%3D"),
+            '+' => out.push_str("%2B"),
+            '%' => out.push_str("%25"),
+            '#' => out.push_str("%23"),
+            ' ' => out.push_str("%20"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Extracts the `cursor` query parameter value from a `_links.next` URL or path.
+fn extract_cursor_from_next(next: &str) -> Option<String> {
+    let query_start = next.find('?')?;
+    let query = &next[query_start + 1..];
+    for pair in query.split('&') {
+        let mut it = pair.splitn(2, '=');
+        let key = it.next()?;
+        let value = it.next().unwrap_or("");
+        if key == "cursor" {
+            return Some(percent_decode(value));
+        }
+    }
+    None
+}
+
+/// Decodes a single `%xx`-style percent-encoded string back to UTF-8.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push(((hi << 4) | lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]
@@ -2696,6 +3005,22 @@ mod tests {
         );
     }
 
+    // ── attachments ───────────────────────────────────────────────
+
+    #[test]
+    fn extract_cursor_extracts_value() {
+        let next = "/wiki/api/v2/pages/12345/attachments?cursor=abc123&limit=25";
+        assert_eq!(extract_cursor_from_next(next), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn extract_cursor_returns_none_when_absent() {
+        assert_eq!(
+            extract_cursor_from_next("/wiki/api/v2/pages/12345/attachments?limit=25"),
+            None
+        );
+    }
+
     #[test]
     fn since_filter_parse_iso_date_no_time() {
         let f = SinceFilter::parse("2026-01-01").unwrap();
@@ -2707,6 +3032,14 @@ mod tests {
         assert_eq!(
             SinceFilter::parse("  7  ").unwrap(),
             SinceFilter::Version(7)
+        );
+    }
+
+    #[test]
+    fn extract_cursor_decodes_percent_encoded() {
+        assert_eq!(
+            extract_cursor_from_next("/wiki/api/v2/pages/1/attachments?cursor=foo%3Dbar"),
+            Some("foo=bar".to_string())
         );
     }
 
@@ -3187,5 +3520,353 @@ mod tests {
         let api = ConfluenceApi::new(client);
         let (versions, _) = api.list_page_versions("12", None, 5).await.unwrap();
         assert_eq!(versions.len(), 1);
+    }
+
+    #[test]
+    fn urlencoding_escapes_reserved_chars() {
+        assert_eq!(urlencoding("a=b&c+d %e#"), "a%3Db%26c%2Bd%20%25e%23");
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_success() {
+        use tempfile::NamedTempFile;
+        use tokio::io::AsyncWriteExt;
+
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .and(wiremock::matchers::header("X-Atlassian-Token", "no-check"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{
+                        "id": "att-1",
+                        "title": "hello.txt",
+                        "mediaType": "text/plain",
+                        "fileSize": 13,
+                        "downloadLink": "/download/att-1",
+                        "version": {"number": 1},
+                        "pageId": "12345",
+                        "fileId": "f-1"
+                    }]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut tmp = tokio::fs::File::from_std(NamedTempFile::new().unwrap().into_file());
+        tmp.write_all(b"hello, world!").await.unwrap();
+        tmp.flush().await.unwrap();
+
+        // Re-create a path-backed temp file (NamedTempFile after into_file would be unlinked).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let attachment = api
+            .upload_attachment("12345", &path, None, Some("v1"), false)
+            .await
+            .unwrap();
+
+        assert_eq!(attachment.id, "att-1");
+        assert_eq!(attachment.title, "hello.txt");
+        assert_eq!(attachment.media_type.as_deref(), Some("text/plain"));
+        assert_eq!(attachment.file_size, Some(13));
+        assert_eq!(attachment.version, Some(1));
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_page_not_found() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/99999/attachments",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.bin");
+        tokio::fs::write(&path, b"x").await.unwrap();
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .upload_attachment("99999", &path, None, None, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_too_large() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(413).set_body_string("Request entity too large"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.bin");
+        tokio::fs::write(&path, b"x").await.unwrap();
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api
+            .upload_attachment("12345", &path, None, None, false)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("413"));
+        assert!(msg.contains("Request entity too large"));
+    }
+
+    #[tokio::test]
+    async fn upload_attachment_overrides_filename() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{"id": "a", "title": "renamed.png"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("source.bin");
+        tokio::fs::write(&path, b"data").await.unwrap();
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let attachment = api
+            .upload_attachment("12345", &path, Some("renamed.png"), None, true)
+            .await
+            .unwrap();
+        assert_eq!(attachment.title, "renamed.png");
+    }
+
+    #[tokio::test]
+    async fn list_attachments_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .and(wiremock::matchers::query_param("limit", "25"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "a1", "title": "one.png", "mediaType": "image/png", "fileSize": 100, "version": {"number": 1}},
+                        {"id": "a2", "title": "two.pdf", "mediaType": "application/pdf"}
+                    ],
+                    "_links": {"next": "/wiki/api/v2/pages/12345/attachments?cursor=NEXT&limit=25"}
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let page = api.list_attachments("12345", None, 25).await.unwrap();
+        assert_eq!(page.results.len(), 2);
+        assert_eq!(page.results[0].id, "a1");
+        assert_eq!(page.results[0].file_size, Some(100));
+        assert_eq!(page.next_cursor.as_deref(), Some("NEXT"));
+    }
+
+    #[tokio::test]
+    async fn list_attachments_no_more_pages() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": []
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let page = api.list_attachments("12345", None, 25).await.unwrap();
+        assert!(page.results.is_empty());
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_attachments_page_not_found() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/99999/attachments",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.list_attachments("99999", None, 25).await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn list_attachments_pagination_round_trip() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .and(wiremock::matchers::query_param("cursor", "PAGE2"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{"id": "a3", "title": "three.bin"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let page = api
+            .list_attachments("12345", Some("PAGE2"), 25)
+            .await
+            .unwrap();
+        assert_eq!(page.results.len(), 1);
+        assert_eq!(page.results[0].id, "a3");
+    }
+
+    #[tokio::test]
+    async fn delete_attachment_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/attachments/att-1"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(api.delete_attachment("att-1", false).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_attachment_with_purge() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/attachments/att-1"))
+            .and(wiremock::matchers::query_param("purge", "true"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(api.delete_attachment("att-1", true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn delete_attachment_not_found() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/attachments/missing"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let err = api.delete_attachment("missing", false).await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[test]
+    fn confluence_attachment_serialize_skips_none_fields() {
+        let attachment = ConfluenceAttachment {
+            id: "att-1".to_string(),
+            title: "x.txt".to_string(),
+            media_type: None,
+            file_size: None,
+            download_url: None,
+            version: None,
+            page_id: None,
+            file_id: None,
+        };
+        let json = serde_json::to_value(&attachment).unwrap();
+        assert_eq!(json["id"], "att-1");
+        assert_eq!(json["title"], "x.txt");
+        // Optional fields should be entirely absent (skip_serializing_if).
+        assert!(json.get("media_type").is_none());
+        assert!(json.get("file_size").is_none());
+        assert!(json.get("download_url").is_none());
+        assert!(json.get("version").is_none());
+        assert!(json.get("page_id").is_none());
+        assert!(json.get("file_id").is_none());
+    }
+
+    #[test]
+    fn confluence_attachment_serialize_includes_some_fields() {
+        let attachment = ConfluenceAttachment {
+            id: "att-1".to_string(),
+            title: "x.txt".to_string(),
+            media_type: Some("text/plain".to_string()),
+            file_size: Some(42),
+            download_url: Some("/dl".to_string()),
+            version: Some(3),
+            page_id: Some("12345".to_string()),
+            file_id: Some("f-1".to_string()),
+        };
+        let json = serde_json::to_value(&attachment).unwrap();
+        assert_eq!(json["media_type"], "text/plain");
+        assert_eq!(json["file_size"], 42);
+        assert_eq!(json["version"], 3);
+    }
+
+    #[test]
+    fn confluence_attachment_page_serialize_skips_none_cursor() {
+        let page = ConfluenceAttachmentPage {
+            results: vec![],
+            next_cursor: None,
+        };
+        let json = serde_json::to_value(&page).unwrap();
+        assert!(json.get("next_cursor").is_none());
     }
 }

--- a/src/cli/atlassian/confluence/attachment.rs
+++ b/src/cli/atlassian/confluence/attachment.rs
@@ -1,0 +1,697 @@
+//! CLI commands for managing Confluence page attachments.
+
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use crate::atlassian::confluence_api::{
+    ConfluenceApi, ConfluenceAttachment, ConfluenceAttachmentPage,
+};
+use crate::cli::atlassian::format::{output_as, OutputFormat};
+use crate::cli::atlassian::helpers::create_client;
+
+/// Manages attachments on Confluence pages.
+#[derive(Parser)]
+pub struct AttachmentCommand {
+    /// The attachment subcommand to execute.
+    #[command(subcommand)]
+    pub command: AttachmentSubcommands,
+}
+
+/// Attachment subcommands.
+#[derive(Subcommand)]
+pub enum AttachmentSubcommands {
+    /// Uploads a file as an attachment to a Confluence page.
+    Upload(UploadCommand),
+    /// Lists attachments on a Confluence page.
+    List(ListCommand),
+    /// Deletes an attachment by ID.
+    Delete(DeleteCommand),
+}
+
+impl AttachmentCommand {
+    /// Executes the attachment command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            AttachmentSubcommands::Upload(cmd) => cmd.execute().await,
+            AttachmentSubcommands::List(cmd) => cmd.execute().await,
+            AttachmentSubcommands::Delete(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Uploads a file as an attachment to a Confluence page.
+#[derive(Parser)]
+pub struct UploadCommand {
+    /// Confluence page ID (e.g., 12345678).
+    pub page_id: String,
+
+    /// Path to the local file to upload.
+    pub file: PathBuf,
+
+    /// Override the filename used in Confluence (defaults to the local basename).
+    #[arg(long)]
+    pub filename: Option<String>,
+
+    /// Optional version comment recorded with the upload.
+    #[arg(long)]
+    pub comment: Option<String>,
+
+    /// Marks the upload as a minor edit.
+    #[arg(long)]
+    pub minor_edit: bool,
+}
+
+impl UploadCommand {
+    /// Executes the upload command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        run_upload(
+            &api,
+            &self.page_id,
+            &self.file,
+            self.filename.as_deref(),
+            self.comment.as_deref(),
+            self.minor_edit,
+        )
+        .await
+    }
+}
+
+/// Uploads a file to a page and prints the resulting attachment.
+async fn run_upload(
+    api: &ConfluenceApi,
+    page_id: &str,
+    file: &std::path::Path,
+    filename: Option<&str>,
+    comment: Option<&str>,
+    minor_edit: bool,
+) -> Result<()> {
+    let attachment = api
+        .upload_attachment(page_id, file, filename, comment, minor_edit)
+        .await?;
+    print_upload_confirmation(&attachment, page_id);
+    Ok(())
+}
+
+/// Prints confirmation after a successful upload.
+fn print_upload_confirmation(attachment: &ConfluenceAttachment, page_id: &str) {
+    println!(
+        "Uploaded {} (id={}) to page {}.",
+        attachment.title, attachment.id, page_id,
+    );
+}
+
+/// Lists attachments on a Confluence page.
+#[derive(Parser)]
+pub struct ListCommand {
+    /// Confluence page ID (e.g., 12345678).
+    pub page_id: String,
+
+    /// Pagination cursor (returned as `next_cursor` from a previous call).
+    #[arg(long)]
+    pub cursor: Option<String>,
+
+    /// Maximum number of attachments to return per page.
+    #[arg(long, default_value_t = 25)]
+    pub limit: u32,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListCommand {
+    /// Executes the list command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        run_list(
+            &api,
+            &self.page_id,
+            self.cursor.as_deref(),
+            self.limit,
+            &self.output,
+        )
+        .await
+    }
+}
+
+/// Fetches and displays a page of attachments.
+async fn run_list(
+    api: &ConfluenceApi,
+    page_id: &str,
+    cursor: Option<&str>,
+    limit: u32,
+    output: &OutputFormat,
+) -> Result<()> {
+    let page = api.list_attachments(page_id, cursor, limit).await?;
+    display_attachments(&page, output)
+}
+
+/// Formats and displays attachments in the requested output format.
+fn display_attachments(page: &ConfluenceAttachmentPage, output: &OutputFormat) -> Result<()> {
+    if output_as(page, output)? {
+        return Ok(());
+    }
+    print_attachments(page);
+    Ok(())
+}
+
+/// Prints attachments as a formatted table.
+fn print_attachments(page: &ConfluenceAttachmentPage) {
+    if page.results.is_empty() {
+        println!("No attachments found.");
+        return;
+    }
+
+    let id_width = page
+        .results
+        .iter()
+        .map(|a| a.id.len())
+        .max()
+        .unwrap_or(2)
+        .max(2);
+    let title_width = page
+        .results
+        .iter()
+        .map(|a| a.title.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let media_width = page
+        .results
+        .iter()
+        .map(|a| a.media_type.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+
+    println!(
+        "{:<id_width$}  {:<title_width$}  {:<media_width$}  {:>10}",
+        "ID", "TITLE", "MEDIA-TYPE", "SIZE"
+    );
+    println!(
+        "{:<id_width$}  {:<title_width$}  {:<media_width$}  {:>10}",
+        "-".repeat(id_width),
+        "-".repeat(title_width),
+        "-".repeat(media_width),
+        "-".repeat(10),
+    );
+
+    for a in &page.results {
+        let media = a.media_type.as_deref().unwrap_or("-");
+        let size = a
+            .file_size
+            .map_or_else(|| "-".to_string(), |s| s.to_string());
+        println!(
+            "{:<id_width$}  {:<title_width$}  {:<media_width$}  {:>10}",
+            a.id, a.title, media, size,
+        );
+    }
+
+    if let Some(cursor) = &page.next_cursor {
+        println!();
+        println!("Next page: --cursor {cursor}");
+    }
+}
+
+/// Deletes an attachment by ID.
+#[derive(Parser)]
+pub struct DeleteCommand {
+    /// Attachment ID.
+    pub attachment_id: String,
+
+    /// Skips the confirmation prompt.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Permanently purges the attachment instead of moving to trash (requires space admin).
+    #[arg(long)]
+    pub purge: bool,
+}
+
+impl DeleteCommand {
+    /// Executes the delete command using stdin for confirmation.
+    pub async fn execute(self) -> Result<()> {
+        let confirmed = self.force || self.prompt(&mut io::stdin().lock())?;
+        self.run_delete(confirmed).await
+    }
+
+    /// Reads the confirmation answer from `reader`. Synchronous so the
+    /// borrow ends before any `.await` in the async caller.
+    fn prompt(&self, reader: &mut dyn BufRead) -> Result<bool> {
+        let prompt = format_delete_prompt(&self.attachment_id, self.purge);
+        confirm_with_reader(&prompt, reader)
+    }
+
+    /// Performs the delete after the user has (or hasn't) confirmed.
+    async fn run_delete(self, confirmed: bool) -> Result<()> {
+        if !confirmed {
+            println!("Cancelled.");
+            return Ok(());
+        }
+
+        let (client, instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        api.delete_attachment(&self.attachment_id, self.purge)
+            .await?;
+        println!(
+            "Deleted attachment {} from {}.",
+            self.attachment_id, instance_url
+        );
+
+        Ok(())
+    }
+}
+
+/// Formats the deletion confirmation prompt.
+fn format_delete_prompt(attachment_id: &str, purge: bool) -> String {
+    if purge {
+        format!("Permanently purge attachment {attachment_id}? [y/N] ")
+    } else {
+        format!("Delete attachment {attachment_id}? [y/N] ")
+    }
+}
+
+/// Prompts the user for confirmation using the given reader for input.
+fn confirm_with_reader(prompt: &str, reader: &mut dyn BufRead) -> Result<bool> {
+    print!("{prompt}");
+    io::stdout().flush()?;
+
+    let mut answer = String::new();
+    reader.read_line(&mut answer)?;
+    Ok(answer.trim().eq_ignore_ascii_case("y"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn sample_attachment(id: &str, title: &str) -> ConfluenceAttachment {
+        ConfluenceAttachment {
+            id: id.to_string(),
+            title: title.to_string(),
+            media_type: Some("text/plain".to_string()),
+            file_size: Some(42),
+            download_url: Some("/dl".to_string()),
+            version: Some(1),
+            page_id: Some("12345".to_string()),
+            file_id: Some("f-1".to_string()),
+        }
+    }
+
+    fn sample_page(
+        items: Vec<ConfluenceAttachment>,
+        cursor: Option<&str>,
+    ) -> ConfluenceAttachmentPage {
+        ConfluenceAttachmentPage {
+            results: items,
+            next_cursor: cursor.map(str::to_string),
+        }
+    }
+
+    // ── AttachmentCommand variants ────────────────────────────────
+
+    #[test]
+    fn attachment_subcommands_upload_variant() {
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Upload(UploadCommand {
+                page_id: "12345".to_string(),
+                file: PathBuf::from("/tmp/x"),
+                filename: None,
+                comment: None,
+                minor_edit: false,
+            }),
+        };
+        assert!(matches!(cmd.command, AttachmentSubcommands::Upload(_)));
+    }
+
+    #[test]
+    fn attachment_subcommands_list_variant() {
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::List(ListCommand {
+                page_id: "12345".to_string(),
+                cursor: None,
+                limit: 25,
+                output: OutputFormat::Table,
+            }),
+        };
+        assert!(matches!(cmd.command, AttachmentSubcommands::List(_)));
+    }
+
+    #[test]
+    fn attachment_subcommands_delete_variant() {
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Delete(DeleteCommand {
+                attachment_id: "att-1".to_string(),
+                force: true,
+                purge: false,
+            }),
+        };
+        assert!(matches!(cmd.command, AttachmentSubcommands::Delete(_)));
+    }
+
+    // ── display_attachments ────────────────────────────────────────
+
+    #[test]
+    fn display_attachments_table() {
+        let page = sample_page(vec![sample_attachment("a", "x.txt")], None);
+        assert!(display_attachments(&page, &OutputFormat::Table).is_ok());
+    }
+
+    #[test]
+    fn display_attachments_json() {
+        let page = sample_page(vec![sample_attachment("a", "x.txt")], None);
+        assert!(display_attachments(&page, &OutputFormat::Json).is_ok());
+    }
+
+    #[test]
+    fn display_attachments_yaml() {
+        let page = sample_page(vec![sample_attachment("a", "x.txt")], None);
+        assert!(display_attachments(&page, &OutputFormat::Yaml).is_ok());
+    }
+
+    #[test]
+    fn display_attachments_empty_table() {
+        let page = sample_page(vec![], None);
+        assert!(display_attachments(&page, &OutputFormat::Table).is_ok());
+    }
+
+    #[test]
+    fn print_attachments_with_cursor() {
+        let page = sample_page(vec![sample_attachment("a", "x.txt")], Some("NEXT"));
+        print_attachments(&page);
+    }
+
+    // ── format_delete_prompt ───────────────────────────────────────
+
+    #[test]
+    fn format_delete_prompt_default() {
+        assert_eq!(
+            format_delete_prompt("att-1", false),
+            "Delete attachment att-1? [y/N] "
+        );
+    }
+
+    #[test]
+    fn format_delete_prompt_purge() {
+        assert_eq!(
+            format_delete_prompt("att-1", true),
+            "Permanently purge attachment att-1? [y/N] "
+        );
+    }
+
+    // ── confirm_with_reader ────────────────────────────────────────
+
+    #[test]
+    fn confirm_yes_lowercase() {
+        let mut input = Cursor::new(b"y\n");
+        assert!(confirm_with_reader("Delete? ", &mut input).unwrap());
+    }
+
+    #[test]
+    fn confirm_no() {
+        let mut input = Cursor::new(b"n\n");
+        assert!(!confirm_with_reader("Delete? ", &mut input).unwrap());
+    }
+
+    #[test]
+    fn confirm_empty_is_no() {
+        let mut input = Cursor::new(b"\n");
+        assert!(!confirm_with_reader("Delete? ", &mut input).unwrap());
+    }
+
+    // ── run_upload (wiremock) ─────────────────────────────────
+
+    #[tokio::test]
+    async fn run_upload_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{"id": "att-1", "title": "hello.txt"}]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        tokio::fs::write(&path, b"hi").await.unwrap();
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(run_upload(&api, "12345", &path, None, None, false)
+            .await
+            .is_ok());
+    }
+
+    // ── run_list (wiremock) ───────────────────────────────────
+
+    #[tokio::test]
+    async fn run_list_table_output() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "a", "title": "x.txt", "mediaType": "text/plain", "fileSize": 1}
+                    ]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client =
+            crate::atlassian::client::AtlassianClient::new(&server.uri(), "u@t.com", "tok")
+                .unwrap();
+        let api = ConfluenceApi::new(client);
+        assert!(run_list(&api, "12345", None, 25, &OutputFormat::Table)
+            .await
+            .is_ok());
+    }
+
+    // ── *Command::execute (env-mutex serialised) ──────────────────
+
+    fn set_atlassian_env(uri: &str) {
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_INSTANCE_URL, uri);
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_EMAIL, "user@test.com");
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_API_TOKEN, "t");
+    }
+
+    fn clear_atlassian_env() {
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_INSTANCE_URL);
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_EMAIL);
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_API_TOKEN);
+    }
+
+    use std::sync::Mutex;
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn upload_command_execute_runs_through_dispatch() {
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{"id": "att-1", "title": "x.txt"}]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.txt");
+        tokio::fs::write(&path, b"hi").await.unwrap();
+
+        set_atlassian_env(&server.uri());
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Upload(UploadCommand {
+                page_id: "12345".to_string(),
+                file: path,
+                filename: None,
+                comment: Some("v1".to_string()),
+                minor_edit: true,
+            }),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_command_execute_runs_through_dispatch() {
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/attachments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": []
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::List(ListCommand {
+                page_id: "12345".to_string(),
+                cursor: Some("opaque".to_string()),
+                limit: 5,
+                output: OutputFormat::Json,
+            }),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delete_command_execute_force_runs_through_dispatch() {
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/attachments/att-1"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = AttachmentCommand {
+            command: AttachmentSubcommands::Delete(DeleteCommand {
+                attachment_id: "att-1".to_string(),
+                force: true,
+                purge: true,
+            }),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[test]
+    fn delete_command_prompt_yes_returns_true() {
+        let cmd = DeleteCommand {
+            attachment_id: "att-1".to_string(),
+            force: false,
+            purge: false,
+        };
+        let mut input = Cursor::new(b"y\n");
+        assert!(cmd.prompt(&mut input).unwrap());
+    }
+
+    #[test]
+    fn delete_command_prompt_no_returns_false() {
+        let cmd = DeleteCommand {
+            attachment_id: "att-1".to_string(),
+            force: false,
+            purge: true,
+        };
+        let mut input = Cursor::new(b"n\n");
+        assert!(!cmd.prompt(&mut input).unwrap());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delete_command_run_delete_unconfirmed_skips_api() {
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // No DELETE mock — confirms the API is *not* called when not confirmed.
+        let server = wiremock::MockServer::start().await;
+        set_atlassian_env(&server.uri());
+        let cmd = DeleteCommand {
+            attachment_id: "att-1".to_string(),
+            force: false,
+            purge: false,
+        };
+        let result = cmd.run_delete(false).await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delete_command_execute_propagates_api_error() {
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/wiki/api/v2/attachments/missing"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .mount(&server)
+            .await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = DeleteCommand {
+            attachment_id: "missing".to_string(),
+            force: true,
+            purge: false,
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    // ── extra coverage for confirm_with_reader & print_upload ─────
+
+    #[test]
+    fn confirm_yes_uppercase() {
+        let mut input = Cursor::new(b"Y\n");
+        assert!(confirm_with_reader("Delete? ", &mut input).unwrap());
+    }
+
+    #[test]
+    fn confirm_random_text_is_no() {
+        let mut input = Cursor::new(b"maybe\n");
+        assert!(!confirm_with_reader("Delete? ", &mut input).unwrap());
+    }
+
+    #[test]
+    fn print_upload_confirmation_prints() {
+        let attachment = sample_attachment("att-1", "x.txt");
+        print_upload_confirmation(&attachment, "12345");
+    }
+
+    #[test]
+    fn print_attachments_without_cursor() {
+        let page = sample_page(vec![sample_attachment("a", "x.txt")], None);
+        print_attachments(&page);
+    }
+}

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -1,5 +1,6 @@
 //! Confluence CLI subcommands.
 
+pub(crate) mod attachment;
 pub(crate) mod children;
 pub(crate) mod comment;
 pub(crate) mod create;
@@ -46,6 +47,8 @@ pub enum ConfluenceSubcommands {
     Move(move_page::MoveCommand),
     /// Manages labels on Confluence pages.
     Label(label::LabelCommand),
+    /// Manages attachments on Confluence pages.
+    Attachment(attachment::AttachmentCommand),
     /// Recursively downloads a Confluence page tree.
     Download(download::DownloadCommand),
     /// Lists child pages of a Confluence page or top-level pages in a space.
@@ -67,6 +70,7 @@ impl ConfluenceCommand {
             ConfluenceSubcommands::Search(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Create(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Label(cmd) => cmd.execute().await,
+            ConfluenceSubcommands::Attachment(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Delete(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Move(cmd) => cmd.execute().await,
             ConfluenceSubcommands::Download(cmd) => cmd.execute().await,
@@ -172,6 +176,21 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Label(_)));
+    }
+
+    #[test]
+    fn confluence_subcommands_attachment_variant() {
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Attachment(attachment::AttachmentCommand {
+                command: attachment::AttachmentSubcommands::List(attachment::ListCommand {
+                    page_id: "12345".to_string(),
+                    cursor: None,
+                    limit: 25,
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, ConfluenceSubcommands::Attachment(_)));
     }
 
     #[test]
@@ -304,6 +323,30 @@ mod tests {
                 recursive: false,
                 max_depth: 0,
                 output: OutputFormat::Table,
+            }),
+        };
+        let _ = cmd.execute().await;
+
+        std::env::remove_var("ATLASSIAN_INSTANCE_URL");
+        std::env::remove_var("ATLASSIAN_EMAIL");
+        std::env::remove_var("ATLASSIAN_API_TOKEN");
+    }
+
+    /// Exercises the `Attachment` dispatch arm in `ConfluenceCommand::execute`.
+    #[tokio::test]
+    async fn confluence_command_execute_attachment_dispatch() {
+        std::env::set_var("ATLASSIAN_INSTANCE_URL", "http://127.0.0.1:1");
+        std::env::set_var("ATLASSIAN_EMAIL", "test@example.com");
+        std::env::set_var("ATLASSIAN_API_TOKEN", "fake-token");
+
+        let cmd = ConfluenceCommand {
+            command: ConfluenceSubcommands::Attachment(attachment::AttachmentCommand {
+                command: attachment::AttachmentSubcommands::List(attachment::ListCommand {
+                    page_id: "12345".to_string(),
+                    cursor: None,
+                    limit: 25,
+                    output: OutputFormat::Table,
+                }),
             }),
         };
         let _ = cmd.execute().await;

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -11,6 +11,7 @@ use crate::atlassian::client::{
     JiraDevStatus, JiraDevStatusSummary, JiraProjectList, JiraSearchResult, JiraUserSearchResults,
     JiraWatcherList, JiraWorklogList,
 };
+use crate::atlassian::confluence_api::ConfluenceAttachmentPage;
 
 /// Output/input format for Atlassian content (read/write/create commands).
 #[derive(Clone, Debug, Default, ValueEnum)]
@@ -119,6 +120,12 @@ impl JsonlSerialize for ConfluenceSearchResults {
 impl JsonlSerialize for ConfluenceUserSearchResults {
     fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
         write_items_jsonl(self.users.iter(), out)
+    }
+}
+
+impl JsonlSerialize for ConfluenceAttachmentPage {
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
+        write_items_jsonl(self.results.iter(), out)
     }
 }
 
@@ -576,6 +583,50 @@ mod tests {
         let out = jsonl_string(&list);
         assert_eq!(out.lines().count(), 1);
         assert!(out.contains("\"accountId\":\"u1\"") || out.contains("\"account_id\":\"u1\""));
+    }
+
+    #[test]
+    fn confluence_attachment_page_jsonl() {
+        use crate::atlassian::confluence_api::{ConfluenceAttachment, ConfluenceAttachmentPage};
+        let page = ConfluenceAttachmentPage {
+            results: vec![
+                ConfluenceAttachment {
+                    id: "a1".to_string(),
+                    title: "one.png".to_string(),
+                    media_type: Some("image/png".to_string()),
+                    file_size: Some(100),
+                    download_url: None,
+                    version: None,
+                    page_id: None,
+                    file_id: None,
+                },
+                ConfluenceAttachment {
+                    id: "a2".to_string(),
+                    title: "two.pdf".to_string(),
+                    media_type: None,
+                    file_size: None,
+                    download_url: None,
+                    version: None,
+                    page_id: None,
+                    file_id: None,
+                },
+            ],
+            next_cursor: Some("NEXT".to_string()),
+        };
+        let out = jsonl_string(&page);
+        assert_eq!(out.lines().count(), 2);
+        assert!(out.contains("\"id\":\"a1\""));
+        assert!(out.contains("\"id\":\"a2\""));
+    }
+
+    #[test]
+    fn confluence_attachment_page_jsonl_empty() {
+        use crate::atlassian::confluence_api::ConfluenceAttachmentPage;
+        let page = ConfluenceAttachmentPage {
+            results: vec![],
+            next_cursor: None,
+        };
+        assert_eq!(jsonl_string(&page), "");
     }
 
     #[test]

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -20,7 +20,9 @@ use serde::{Deserialize, Serialize};
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::api::{AtlassianApi, ContentItem};
 use crate::atlassian::client::AtlassianClient;
-use crate::atlassian::confluence_api::{ChildPage, ConfluenceApi, MovePosition};
+use crate::atlassian::confluence_api::{
+    ChildPage, ConfluenceApi, ConfluenceAttachmentPage, MovePosition,
+};
 use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::document::{content_item_to_document, JfmDocument, JfmFrontmatter};
 use crate::cli::atlassian::confluence::download::{
@@ -245,6 +247,50 @@ pub struct ConfluenceUserSearchParams {
     /// Maximum number of results (0 = unlimited). Defaults to 25.
     #[serde(default)]
     pub limit: Option<u32>,
+}
+
+/// Parameters for the `confluence_attachment_upload` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceAttachmentUploadParams {
+    /// Confluence page ID to attach the file to.
+    pub page_id: String,
+    /// Local filesystem path to the file to upload. Streamed from disk
+    /// (never fully buffered in memory).
+    pub file_path: String,
+    /// Override the filename used in Confluence (defaults to the local
+    /// basename).
+    #[serde(default)]
+    pub filename: Option<String>,
+    /// Optional version comment recorded with the upload.
+    #[serde(default)]
+    pub comment: Option<String>,
+    /// Marks the upload as a minor edit. Defaults to false.
+    #[serde(default)]
+    pub minor_edit: Option<bool>,
+}
+
+/// Parameters for the `confluence_attachment_list` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceAttachmentListParams {
+    /// Confluence page ID.
+    pub page_id: String,
+    /// Pagination cursor (use `next_cursor` from a previous call).
+    #[serde(default)]
+    pub cursor: Option<String>,
+    /// Maximum number of attachments per page. Defaults to 25.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// Parameters for the `confluence_attachment_delete` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceAttachmentDeleteParams {
+    /// Attachment ID.
+    pub attachment_id: String,
+    /// Permanently purge the attachment instead of moving it to trash
+    /// (requires space admin). Defaults to false.
+    #[serde(default)]
+    pub purge: Option<bool>,
 }
 
 // ── Output summaries ────────────────────────────────────────────────
@@ -614,6 +660,52 @@ pub async fn search_users_yaml(
     to_yaml(&results)
 }
 
+/// Uploads a file as an attachment and returns YAML for the resulting attachment.
+pub async fn upload_attachment_result(
+    api: &ConfluenceApi,
+    page_id: &str,
+    file_path: &str,
+    filename: Option<&str>,
+    comment: Option<&str>,
+    minor_edit: bool,
+) -> Result<String> {
+    let path = std::path::Path::new(file_path);
+    let attachment = api
+        .upload_attachment(page_id, path, filename, comment, minor_edit)
+        .await?;
+    to_yaml(&attachment)
+}
+
+/// Builds the YAML output for the `confluence_attachment_list` tool.
+pub async fn list_attachments_yaml(
+    api: &ConfluenceApi,
+    page_id: &str,
+    cursor: Option<&str>,
+    limit: u32,
+) -> Result<String> {
+    let page: ConfluenceAttachmentPage = api.list_attachments(page_id, cursor, limit).await?;
+    to_yaml(&page)
+}
+
+/// Deletes an attachment and returns a YAML confirmation.
+pub async fn delete_attachment_result(
+    api: &ConfluenceApi,
+    attachment_id: &str,
+    purge: bool,
+) -> Result<String> {
+    api.delete_attachment(attachment_id, purge).await?;
+    let result = MutationResult {
+        ok: true,
+        message: format!(
+            "Deleted attachment {attachment_id}{}.",
+            if purge { " (purged)" } else { "" }
+        ),
+        id: attachment_id,
+        labels: &[],
+    };
+    to_yaml(&result)
+}
+
 // ── Tool handlers ────────────────────────────────────────────────────
 
 #[allow(missing_docs)] // #[tool_router] generates a pub `confluence_tool_router` fn.
@@ -891,6 +983,78 @@ impl OmniDevServer {
         let yaml = search_users_yaml(&client, &params.query, params.limit.unwrap_or(25))
             .await
             .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Uploads a file as an attachment to a Confluence page.
+    #[tool(
+        description = "Upload a local file as an attachment to a Confluence page. \
+                       `file_path` is a path on the MCP server's filesystem (the file is \
+                       streamed from disk, never fully buffered). Optional `filename` \
+                       overrides the stored name; `comment` is recorded as a version note; \
+                       `minor_edit` (default false) marks the upload as minor. \
+                       Returns YAML describing the new attachment. Mirrors \
+                       `omni-dev atlassian confluence attachment upload`."
+    )]
+    pub async fn confluence_attachment_upload(
+        &self,
+        Parameters(params): Parameters<ConfluenceAttachmentUploadParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let api = ConfluenceApi::new(client);
+        let yaml = upload_attachment_result(
+            &api,
+            &params.page_id,
+            &params.file_path,
+            params.filename.as_deref(),
+            params.comment.as_deref(),
+            params.minor_edit.unwrap_or(false),
+        )
+        .await
+        .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Lists attachments on a Confluence page (paginated).
+    #[tool(
+        description = "List attachments on a Confluence page (one page per call). \
+                       Pass the returned `next_cursor` back as `cursor` to fetch the next \
+                       page. `limit` defaults to 25. Mirrors \
+                       `omni-dev atlassian confluence attachment list`."
+    )]
+    pub async fn confluence_attachment_list(
+        &self,
+        Parameters(params): Parameters<ConfluenceAttachmentListParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let api = ConfluenceApi::new(client);
+        let yaml = list_attachments_yaml(
+            &api,
+            &params.page_id,
+            params.cursor.as_deref(),
+            params.limit.unwrap_or(25),
+        )
+        .await
+        .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Deletes an attachment by ID.
+    #[tool(
+        description = "Delete a Confluence attachment by ID. Set `purge: true` to \
+                       permanently purge instead of moving to trash (requires space admin). \
+                       Mirrors `omni-dev atlassian confluence attachment delete --force`."
+    )]
+    pub async fn confluence_attachment_delete(
+        &self,
+        Parameters(params): Parameters<ConfluenceAttachmentDeleteParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let api = ConfluenceApi::new(client);
+        let yaml =
+            delete_attachment_result(&api, &params.attachment_id, params.purge.unwrap_or(false))
+                .await
+                .map_err(tool_error)?;
         Ok(CallToolResult::success(vec![Content::text(yaml)]))
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -144,6 +144,9 @@ mod tests {
             "confluence_label_add",
             "confluence_label_remove",
             "confluence_user_search",
+            "confluence_attachment_upload",
+            "confluence_attachment_list",
+            "confluence_attachment_delete",
         ] {
             assert!(
                 server.tool_router.has_route(name),

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1725,6 +1725,9 @@ async fn list_tools_includes_confluence_extensions() -> Result<()> {
         "confluence_label_add",
         "confluence_label_remove",
         "confluence_user_search",
+        "confluence_attachment_upload",
+        "confluence_attachment_list",
+        "confluence_attachment_delete",
     ] {
         assert!(names.contains(&expected), "missing {expected}: {names:?}");
     }
@@ -1812,6 +1815,34 @@ async fn confluence_tools_success_paths_via_wiremock() -> Result<()> {
                 {"user": {"accountId": "abc", "displayName": "Alice", "email": "a@x.com"}}
             ]
         })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/wiki/api/v2/pages/12345/attachments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{
+                "id": "att-1",
+                "title": "hello.txt",
+                "mediaType": "text/plain",
+                "fileSize": 13,
+                "version": {"number": 1}
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/wiki/api/v2/pages/12345/attachments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{"id": "att-1", "title": "hello.txt"}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/wiki/api/v2/attachments/att-1"))
+        .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
 
@@ -1904,6 +1935,65 @@ async fn confluence_tools_success_paths_via_wiremock() -> Result<()> {
         .await?;
     assert!(!users.is_error.unwrap_or(false));
     assert!(confluence_tool_text(&users).contains("Alice"));
+
+    let attach_dir = tempfile::tempdir()?;
+    let attach_path = attach_dir.path().join("hello.txt");
+    tokio::fs::write(&attach_path, b"hello, world!").await?;
+    let attach_path_str = attach_path.to_string_lossy().to_string();
+
+    // Upload — exercises the `Some` branch of all optional params
+    // (filename, comment, minor_edit) so coverage hits both arms of the
+    // `Option::unwrap_or(...)` calls in the tool handler.
+    let attachment_upload = client
+        .call_tool(
+            CallToolRequestParams::new("confluence_attachment_upload").with_arguments(
+                serde_json::json!({
+                    "page_id": "12345",
+                    "file_path": attach_path_str,
+                    "filename": "hello.txt",
+                    "comment": "v1",
+                    "minor_edit": true,
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+    assert!(!attachment_upload.is_error.unwrap_or(false));
+    assert!(confluence_tool_text(&attachment_upload).contains("att-1"));
+
+    // List — exercises the `Some` branch of `cursor` and `limit`.
+    let attachment_list = client
+        .call_tool(
+            CallToolRequestParams::new("confluence_attachment_list").with_arguments(
+                serde_json::json!({
+                    "page_id": "12345",
+                    "cursor": "PAGE2",
+                    "limit": 50,
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+    assert!(!attachment_list.is_error.unwrap_or(false));
+    assert!(confluence_tool_text(&attachment_list).contains("hello.txt"));
+
+    // Delete — exercises the `Some` branch of `purge`.
+    let attachment_delete = client
+        .call_tool(
+            CallToolRequestParams::new("confluence_attachment_delete").with_arguments(
+                serde_json::json!({"attachment_id": "att-1", "purge": false})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await?;
+    assert!(!attachment_delete.is_error.unwrap_or(false));
+    assert!(confluence_tool_text(&attachment_delete).contains("Deleted attachment att-1"));
 
     client.cancel().await?;
     let _ = server_handle.await;

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -310,23 +310,96 @@ Confluence page management, search, and more
 Usage: confluence <COMMAND>
 
 Commands:
-  comment   Manages comments on a Confluence page
-  read      Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
-  write     Pushes content to a Confluence page
-  edit      Interactive fetch-edit-push cycle for a Confluence page
-  search    Searches Confluence pages using CQL
-  create    Creates a new Confluence page
-  delete    Deletes a Confluence page
-  move      Moves or reparents a Confluence page (same-space only)
-  label     Manages labels on Confluence pages
-  download  Recursively downloads a Confluence page tree
-  children  Lists child pages of a Confluence page or top-level pages in a space
-  history   Lists version history (metadata) for a Confluence page
-  user      Confluence user operations
-  help      Print this message or the help of the given subcommand(s)
+  comment     Manages comments on a Confluence page
+  read        Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
+  write       Pushes content to a Confluence page
+  edit        Interactive fetch-edit-push cycle for a Confluence page
+  search      Searches Confluence pages using CQL
+  create      Creates a new Confluence page
+  delete      Deletes a Confluence page
+  move        Moves or reparents a Confluence page (same-space only)
+  label       Manages labels on Confluence pages
+  attachment  Manages attachments on Confluence pages
+  download    Recursively downloads a Confluence page tree
+  children    Lists child pages of a Confluence page or top-level pages in a space
+  history     Lists version history (metadata) for a Confluence page
+  user        Confluence user operations
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence attachment - Manages attachments on Confluence pages
+
+Manages attachments on Confluence pages
+
+Usage: attachment <COMMAND>
+
+Commands:
+  upload  Uploads a file as an attachment to a Confluence page
+  list    Lists attachments on a Confluence page
+  delete  Deletes an attachment by ID
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence attachment delete - Deletes an attachment by ID
+
+Deletes an attachment by ID
+
+Usage: delete [OPTIONS] <ATTACHMENT_ID>
+
+Arguments:
+  <ATTACHMENT_ID>  Attachment ID
+
+Options:
+      --force  Skips the confirmation prompt
+      --purge  Permanently purges the attachment instead of moving to trash (requires space admin)
+  -h, --help   Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence attachment list - Lists attachments on a Confluence page
+
+Lists attachments on a Confluence page
+
+Usage: list [OPTIONS] <PAGE_ID>
+
+Arguments:
+  <PAGE_ID>  Confluence page ID (e.g., 12345678)
+
+Options:
+      --cursor <CURSOR>  Pagination cursor (returned as `next_cursor` from a previous call)
+      --limit <LIMIT>    Maximum number of attachments to return per page [default: 25]
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian confluence attachment upload - Uploads a file as an attachment to a Confluence page
+
+Uploads a file as an attachment to a Confluence page
+
+Usage: upload [OPTIONS] <PAGE_ID> <FILE>
+
+Arguments:
+  <PAGE_ID>  Confluence page ID (e.g., 12345678)
+  <FILE>     Path to the local file to upload
+
+Options:
+      --filename <FILENAME>  Override the filename used in Confluence (defaults to the local basename)
+      --comment <COMMENT>    Optional version comment recorded with the upload
+      --minor-edit           Marks the upload as a minor edit
+  -h, --help                 Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements full attachment management for Confluence pages, exposing upload, list, and delete operations across the API layer, CLI, and MCP server. Users can now upload files to Confluence pages via streaming (no full in-memory buffering), paginate through large attachment lists one page at a time, and delete attachments with an optional permanent purge.

File uploads use multipart POST with `X-Atlassian-Token: no-check` (Atlassian's required convention for state-changing multipart endpoints). Because streamed bodies cannot be replayed, the upload path intentionally skips the automatic 429 retry logic used elsewhere in the client.

Attachment list pagination is deliberately caller-controlled (explicit cursor passing), unlike other v2 list helpers that auto-drain. This lets CLI and MCP callers stream very large attachment sets without buffering everything in memory.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [x] Dependency update

## Related Issue

Fixes #709

## Changes Made

**API Layer (`src/atlassian/`):**
- Added `ConfluenceAttachment` and `ConfluenceAttachmentPage` public types with full serialisation support in `src/atlassian/confluence_api.rs`
- Implemented `ConfluenceApi::upload_attachment` — streams file from disk via `ReaderStream`/`reqwest::Body::wrap_stream`, resolves MIME type with `mime_guess`, sends `X-Atlassian-Token: no-check`
- Implemented `ConfluenceApi::list_attachments` with explicit cursor-based pagination; extracts and decodes the `cursor` query parameter from `_links.next`
- Implemented `ConfluenceApi::delete_attachment` with optional `?purge=true` flag
- Added `AtlassianClient::post_multipart` in `src/atlassian/client.rs` for authenticated multipart requests; no 429 retry since streamed bodies cannot be replayed
- Added internal helpers `urlencoding` and `extract_cursor_from_next`/`percent_decode` for safe cursor round-trips

**CLI (`src/cli/atlassian/confluence/`):**
- Added `src/cli/atlassian/confluence/attachment.rs` with `upload`, `list`, and `delete` subcommands
- `upload` supports `--filename` override, `--comment`, and `--minor-edit` flags; prints confirmation on success
- `list` supports `--cursor`, `--limit`, and `-o/--output` (table/json/yaml/yamls/jsonl); renders a formatted column table with next-page cursor hint
- `delete` shows a confirmation prompt by default; `--force` skips it, `--purge` permanently purges (requires space admin)
- Registered `attachment` subcommand under `ConfluenceSubcommands` in `src/cli/atlassian/confluence/mod.rs`
- Added `JsonlSerialize` impl for `ConfluenceAttachmentPage` in `src/cli/atlassian/format.rs`

**MCP Server (`src/mcp/`):**
- Exposed `confluence_attachment_upload`, `confluence_attachment_list`, and `confluence_attachment_delete` MCP tools in `src/mcp/confluence_tools.rs`
- Added parameter structs `ConfluenceAttachmentUploadParams`, `ConfluenceAttachmentListParams`, `ConfluenceAttachmentDeleteParams`
- Registered the three new tools in `src/mcp/server.rs`

**Dependencies (`Cargo.toml` / `Cargo.lock`):**
- Added `mime_guess = "2"` dependency
- Enabled `multipart` and `stream` features on `reqwest`
- Made `tokio-util` unconditional with `codec`/`io` features (was previously optional/MCP-only)
- Removed `tokio-util` from the `mcp` feature gate (now always present)

**Testing:**
- Unit tests in `src/atlassian/confluence_api.rs`: cursor extraction, percent-decode, urlencoding, upload success/404/413/filename-override, list success/no-more-pages/404/pagination-round-trip, delete success/purge/not-found
- Unit tests in `src/cli/atlassian/confluence/attachment.rs`: subcommand variant construction, `display_attachments` for table/json/yaml/empty, cursor display, `format_delete_prompt`, `confirm_with_reader` (y/n/empty), `run_upload` and `run_list` via wiremock
- Integration tests in `tests/mcp_integration_test.rs`: upload/list/delete success paths via wiremock added to `confluence_tools_success_paths_via_wiremock`; tool registration verified in `list_tools_includes_confluence_extensions`
- Updated help snapshot `tests/snapshots/integration_test__help_all_output.snap` to reflect the new `attachment` subcommand

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (unit tests for API, CLI, and MCP layers)
- [x] Integration tests updated/added (MCP wiremock integration tests)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (404, 413, missing filename, confirmation prompt behaviour)
- [ ] Cross-platform testing
- [x] Backward compatibility verified (purely additive, no existing APIs changed)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Run attachment-specific tests
cargo test attachment
cargo test confluence_attachment
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Performance impact — streaming upload path (`ReaderStream`) ensures large files are never fully buffered; verify no accidental `.collect()` or `.bytes()` call in the upload chain
- [x] Error handling — 429 retry is intentionally absent from `post_multipart`; see doc comment on `AtlassianClient::post_multipart`
- [x] Architecture changes — attachment list pagination is caller-controlled (not auto-drained); this is a deliberate design choice documented in `ConfluenceAttachmentPage`
- [x] Security implications — `X-Atlassian-Token: no-check` header is required by Atlassian for multipart endpoints; this is expected and correct

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [ ] No performance impact
- [x] Performance improvement (describe below)

File uploads are fully streamed from disk via `tokio::fs::File` + `ReaderStream` + `reqwest::Body::wrap_stream`, so memory usage is bounded by the multipart frame size regardless of file size. Attachment list pagination is explicit so callers are never forced to buffer an entire attachment list.

## Security Considerations
- [ ] No security implications
- [x] Potential security impact (describe below)

The `X-Atlassian-Token: no-check` header disables Atlassian's CSRF check for multipart form endpoints — this is the documented Atlassian requirement for attachment upload APIs and is not a vulnerability. Authenticated requests use the existing `Authorization` header from `AtlassianClient`. No credentials are logged or exposed in error messages.

## Breaking Changes

None. All changes are purely additive. No existing CLI commands, API surface, or MCP tools were modified.

## Deployment Notes
- [x] No special deployment requirements

The new `mime_guess` crate and updated `reqwest` features are compile-time only. No environment variables, configuration changes, or database migrations are required.

## Additional Notes

**Future Enhancements:**
- Add `--all-pages` flag to `attachment list` to auto-drain pagination for scripting convenience
- Support updating existing attachment versions (PUT `/wiki/api/v2/attachments/{id}/data`)
- Add download command to fetch attachment content to a local file

**Known Limitations:**
- Upload does not retry on HTTP 429. Callers that need retry must rebuild the multipart form and call again (streamed bodies cannot be replayed).
- `--purge` on delete requires Confluence space admin privileges; the CLI surfaces the error returned by the API if the caller lacks permission.