### PR TITLE
feat(atlassian): diagnose ADF schema violations on Confluence HTTP 500

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -14,9 +14,61 @@ use tokio_util::io::ReaderStream;
 use tracing::debug;
 
 use crate::atlassian::adf::AdfDocument;
+use crate::atlassian::adf_schema;
 use crate::atlassian::api::{AtlassianApi, ContentItem, ContentMetadata};
 use crate::atlassian::client::AtlassianClient;
 use crate::atlassian::error::AtlassianError;
+
+/// Returns a human-readable hint for resolving a known ADF nesting violation.
+///
+/// Used by [`confluence_write_error`] to enrich the diagnosis surfaced when
+/// Confluence returns HTTP 500. Returning `None` means no specific hint is
+/// known for the `(parent, child)` pair — the diagnosis line still names the
+/// violation, but no `Hint:` line is emitted.
+fn hint_for(parent: &str, child: &str) -> Option<&'static str> {
+    match (parent, child) {
+        ("panel", "expand" | "nestedExpand") => {
+            Some("invert the nesting (panel inside expand) or make them siblings")
+        }
+        ("expand", "expand" | "nestedExpand") => {
+            Some("expand cannot contain another expand; make them siblings instead")
+        }
+        ("nestedExpand", "expand" | "nestedExpand") => {
+            Some("nestedExpand cannot contain another expand; make them siblings instead")
+        }
+        ("tableCell" | "tableHeader", "expand") => {
+            Some("table cells permit nestedExpand only — replace the expand with nestedExpand")
+        }
+        ("blockquote", "expand" | "nestedExpand" | "panel" | "table") => {
+            Some("blockquote does not allow this child; move it outside the blockquote")
+        }
+        _ => None,
+    }
+}
+
+/// Builds an `anyhow::Error` for a non-success Confluence write/update/create
+/// response.
+///
+/// On HTTP 500, runs [`adf_schema::validate_document`] against the submitted
+/// ADF payload and, if a violation is found, returns
+/// [`AtlassianError::ApiRequestFailedWithDiagnosis`] with the first violation
+/// and a matching hint from [`hint_for`]. All other status codes (and 500
+/// responses with no detected violation) fall back to the existing
+/// [`AtlassianError::ApiRequestFailed`] format.
+fn confluence_write_error(status: u16, body: String, body_adf: &AdfDocument) -> anyhow::Error {
+    if status == 500 {
+        if let Some(violation) = adf_schema::validate_document(body_adf).into_iter().next() {
+            let hint = hint_for(&violation.parent_type, &violation.child_type).map(str::to_string);
+            return AtlassianError::ApiRequestFailedWithDiagnosis {
+                body,
+                diagnosis: violation,
+                hint,
+            }
+            .into();
+        }
+    }
+    AtlassianError::ApiRequestFailed { status, body }.into()
+}
 
 /// Confluence Cloud REST API v2 backend.
 pub struct ConfluenceApi {
@@ -655,7 +707,8 @@ impl AtlassianApi for ConfluenceApi {
             if !response.status().is_success() {
                 let status = response.status().as_u16();
                 let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+                debug!(status, body = %body, "Confluence update_content non-success");
+                return Err(confluence_write_error(status, body, body_adf));
             }
 
             Ok(())
@@ -742,7 +795,8 @@ impl ConfluenceApi {
         if !response.status().is_success() {
             let status = response.status().as_u16();
             let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+            debug!(status, body = %body, "Confluence create_page non-success");
+            return Err(confluence_write_error(status, body, body_adf));
         }
 
         let resp: ConfluenceCreateResponse = response
@@ -1042,7 +1096,8 @@ impl ConfluenceApi {
         if !response.status().is_success() {
             let status = response.status().as_u16();
             let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+            debug!(status, body = %body, "Confluence add_page_comment non-success");
+            return Err(confluence_write_error(status, body, body_adf));
         }
 
         Ok(())
@@ -1673,6 +1728,65 @@ mod tests {
     }
 
     #[test]
+    fn hint_for_panel_children() {
+        assert!(hint_for("panel", "expand")
+            .unwrap()
+            .contains("invert the nesting"));
+        assert!(hint_for("panel", "nestedExpand")
+            .unwrap()
+            .contains("invert the nesting"));
+    }
+
+    #[test]
+    fn hint_for_expand_self_nesting() {
+        assert!(hint_for("expand", "expand")
+            .unwrap()
+            .contains("expand cannot contain another expand"));
+        assert!(hint_for("expand", "nestedExpand")
+            .unwrap()
+            .contains("expand cannot contain another expand"));
+    }
+
+    #[test]
+    fn hint_for_nested_expand_self_nesting() {
+        assert!(hint_for("nestedExpand", "expand")
+            .unwrap()
+            .contains("nestedExpand cannot contain another expand"));
+        assert!(hint_for("nestedExpand", "nestedExpand")
+            .unwrap()
+            .contains("nestedExpand cannot contain another expand"));
+    }
+
+    #[test]
+    fn hint_for_table_cells() {
+        assert!(hint_for("tableCell", "expand")
+            .unwrap()
+            .contains("nestedExpand"));
+        assert!(hint_for("tableHeader", "expand")
+            .unwrap()
+            .contains("nestedExpand"));
+    }
+
+    #[test]
+    fn hint_for_blockquote_children() {
+        for child in &["expand", "nestedExpand", "panel", "table"] {
+            assert!(
+                hint_for("blockquote", child)
+                    .unwrap()
+                    .contains("blockquote does not allow this child"),
+                "missing hint for blockquote/{child}"
+            );
+        }
+    }
+
+    #[test]
+    fn hint_for_unknown_pair_returns_none() {
+        assert!(hint_for("paragraph", "text").is_none());
+        assert!(hint_for("doc", "panel").is_none());
+        assert!(hint_for("madeUp", "alsoMadeUp").is_none());
+    }
+
+    #[test]
     fn confluence_page_response_deserialization() {
         let json = r#"{
             "id": "12345",
@@ -1765,6 +1879,35 @@ mod tests {
         let json = r#"{"key": "ENG"}"#;
         let space: ConfluenceSpaceResponse = serde_json::from_str(json).unwrap();
         assert_eq!(space.key, "ENG");
+    }
+
+    /// Builds a small ADF document containing `expand` nested inside `panel`,
+    /// which violates Confluence's content model and should trigger the
+    /// HTTP-500 diagnosis path. The validator emits a single violation at
+    /// path `/0/0` (`expand` is the first child of the first top-level node).
+    fn adf_with_panel_expand() -> AdfDocument {
+        use crate::atlassian::adf::AdfNode;
+        AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: vec![AdfNode {
+                node_type: "panel".to_string(),
+                attrs: None,
+                content: Some(vec![AdfNode {
+                    node_type: "expand".to_string(),
+                    attrs: None,
+                    content: None,
+                    text: None,
+                    marks: None,
+                    local_id: None,
+                    parameters: None,
+                }]),
+                text: None,
+                marks: None,
+                local_id: None,
+                parameters: None,
+            }],
+        }
     }
 
     /// Helper to set up a wiremock server with the Confluence page and space endpoints.
@@ -1916,6 +2059,69 @@ mod tests {
         let adf = AdfDocument::new();
         let err = api.update_content("12345", &adf, None).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn update_content_500_with_panel_expand_diagnoses() {
+        use crate::atlassian::api::AtlassianApi;
+
+        let (server, api) = setup_confluence_mock().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string(
+                "{\"errors\":[{\"status\":500,\"code\":\"INTERNAL_SERVER_ERROR\"}]}",
+            ))
+            .mount(&server)
+            .await;
+
+        let adf = adf_with_panel_expand();
+        let err = api.update_content("12345", &adf, None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Confluence API returned HTTP 500 (Internal Server Error)"),
+            "missing 500 header in: {msg}"
+        );
+        assert!(
+            msg.contains("Diagnosis:"),
+            "missing Diagnosis line in: {msg}"
+        );
+        assert!(msg.contains("`expand`"), "missing child name in: {msg}");
+        assert!(msg.contains("`panel`"), "missing parent name in: {msg}");
+        assert!(msg.contains("Hint:"), "missing Hint line in: {msg}");
+        assert!(
+            !msg.contains("INTERNAL_SERVER_ERROR"),
+            "raw response body should not be in user-facing message: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_content_500_without_violation_falls_back() {
+        use crate::atlassian::api::AtlassianApi;
+
+        let (server, api) = setup_confluence_mock().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(500).set_body_string("Internal Server Error"),
+            )
+            .mount(&server)
+            .await;
+
+        // Empty (well-formed) document — no schema violations to surface.
+        let adf = AdfDocument::new();
+        let err = api.update_content("12345", &adf, None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("HTTP 500"), "missing status in: {msg}");
+        assert!(
+            msg.contains("Internal Server Error"),
+            "fallback should include raw body: {msg}"
+        );
+        assert!(
+            !msg.contains("Diagnosis:"),
+            "fallback should not include diagnosis: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -2088,6 +2294,42 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn create_page_500_with_panel_expand_diagnoses() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"results": [{"id": "98765"}]})),
+            )
+            .mount(&server)
+            .await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(500).set_body_string("Internal Server Error"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let adf = adf_with_panel_expand();
+        let err = api.create_page("ENG", "Bad", &adf, None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("HTTP 500"), "missing status in: {msg}");
+        assert!(
+            msg.contains("Diagnosis:"),
+            "missing Diagnosis line in: {msg}"
+        );
+        assert!(msg.contains("`expand`"), "missing child name in: {msg}");
+        assert!(msg.contains("`panel`"), "missing parent name in: {msg}");
+        assert!(msg.contains("Hint:"), "missing Hint line in: {msg}");
     }
 
     #[tokio::test]
@@ -2914,6 +3156,34 @@ mod tests {
         let adf = AdfDocument::new();
         let err = api.add_page_comment("12345", &adf).await.unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    #[tokio::test]
+    async fn add_page_comment_500_with_panel_expand_diagnoses() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/wiki/api/v2/footer-comments"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(500).set_body_string("Internal Server Error"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let api = ConfluenceApi::new(client);
+        let adf = adf_with_panel_expand();
+        let err = api.add_page_comment("12345", &adf).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("HTTP 500"), "missing status in: {msg}");
+        assert!(
+            msg.contains("Diagnosis:"),
+            "missing Diagnosis line in: {msg}"
+        );
+        assert!(msg.contains("`expand`"), "missing child name in: {msg}");
+        assert!(msg.contains("`panel`"), "missing parent name in: {msg}");
+        assert!(msg.contains("Hint:"), "missing Hint line in: {msg}");
     }
 
     // ── get_labels ────────────────────────────────────────────────

--- a/src/atlassian/error.rs
+++ b/src/atlassian/error.rs
@@ -2,6 +2,8 @@
 
 use thiserror::Error;
 
+use crate::atlassian::adf_schema::AdfSchemaViolation;
+
 /// Errors that can occur during Atlassian operations.
 #[derive(Error, Debug)]
 pub enum AtlassianError {
@@ -18,6 +20,23 @@ pub enum AtlassianError {
         body: String,
     },
 
+    /// A Confluence write/update/create returned HTTP 500 and the submitted ADF
+    /// payload contains a known schema violation that is the likely cause.
+    ///
+    /// Multi-line `Display` matches the format requested in issue #715: a header
+    /// line, a `Diagnosis:` line naming the offending nesting, and an optional
+    /// `Hint:` line. The raw response body is intentionally omitted from the
+    /// user-facing message — it is already logged at `debug!` by the call site.
+    #[error("{}", format_diagnosis(diagnosis, hint.as_deref()))]
+    ApiRequestFailedWithDiagnosis {
+        /// Raw response body (kept for callers that want to log it).
+        body: String,
+        /// The first ADF schema violation found in the submitted document.
+        diagnosis: AdfSchemaViolation,
+        /// Optional human-readable suggestion for resolving the violation.
+        hint: Option<String>,
+    },
+
     /// The JFM document is invalid or malformed.
     #[error("Invalid JFM document: {0}")]
     InvalidDocument(String),
@@ -25,6 +44,21 @@ pub enum AtlassianError {
     /// An error occurred during ADF conversion.
     #[error("ADF conversion error: {0}")]
     ConversionError(String),
+}
+
+fn format_diagnosis(diagnosis: &AdfSchemaViolation, hint: Option<&str>) -> String {
+    let mut out = format!(
+        "Confluence API returned HTTP 500 (Internal Server Error)\n\
+         Diagnosis: the submitted ADF contains `{child}` nested inside `{parent}` \
+         (not allowed by Confluence's content model).",
+        child = diagnosis.child_type,
+        parent = diagnosis.parent_type,
+    );
+    if let Some(hint) = hint {
+        out.push_str("\nHint: ");
+        out.push_str(hint);
+    }
+    out
 }
 
 #[cfg(test)]
@@ -58,5 +92,43 @@ mod tests {
     fn conversion_error_display() {
         let err = AtlassianError::ConversionError("oops".to_string());
         assert!(err.to_string().contains("oops"));
+    }
+
+    #[test]
+    fn api_request_failed_with_diagnosis_display_with_hint() {
+        let err = AtlassianError::ApiRequestFailedWithDiagnosis {
+            body: "{}".to_string(),
+            diagnosis: AdfSchemaViolation {
+                child_type: "expand".to_string(),
+                parent_type: "panel".to_string(),
+                path: vec![0, 0],
+            },
+            hint: Some(
+                "invert the nesting (panel inside expand) or make them siblings".to_string(),
+            ),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Confluence API returned HTTP 500 (Internal Server Error)"));
+        assert!(msg.contains("Diagnosis:"));
+        assert!(msg.contains("`expand`"));
+        assert!(msg.contains("`panel`"));
+        assert!(msg.contains("Hint: invert the nesting"));
+    }
+
+    #[test]
+    fn api_request_failed_with_diagnosis_display_without_hint() {
+        let err = AtlassianError::ApiRequestFailedWithDiagnosis {
+            body: String::new(),
+            diagnosis: AdfSchemaViolation {
+                child_type: "table".to_string(),
+                parent_type: "nestedExpand".to_string(),
+                path: vec![1],
+            },
+            hint: None,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("`table`"));
+        assert!(msg.contains("`nestedExpand`"));
+        assert!(!msg.contains("Hint:"));
     }
 }


### PR DESCRIPTION
## Description

When Confluence write operations (`update_content`, `create_page`, `add_page_comment`) return HTTP 500, users previously received an opaque "Internal Server Error" with no indication of the root cause. This PR adds structured ADF schema validation on 500 responses, surfacing the specific nesting violation in the user-facing error message along with an actionable hint on how to fix it.

For example, if a document contains `expand` nested inside `panel` — a combination that Confluence's content model forbids — the error now reads:

```
Confluence API returned HTTP 500 (Internal Server Error)
Diagnosis: the submitted ADF contains `expand` nested inside `panel` (not allowed by Confluence's content model).
Hint: invert the nesting (panel inside expand) or make them siblings
```

If no ADF violation is detected, the error falls back to the existing `ApiRequestFailed` format (including the raw response body) so no diagnostic information is lost.

Closes #715

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Fixes #715

## Changes Made

**Core Changes (`src/atlassian/confluence_api.rs`):**
- Added `confluence_write_error(status, body, body_adf)` helper that runs `adf_schema::validate_document` on the submitted ADF when a 500 is received, returning `AtlassianError::ApiRequestFailedWithDiagnosis` with the first violation found, or falling back to `AtlassianError::ApiRequestFailed` if no violation is detected
- Added `hint_for(parent, child)` that maps known problematic ADF nesting pairs (e.g. `expand`/`nestedExpand` inside `panel`, `expand` inside `expand`, `expand` inside table cells, block-level nodes inside `blockquote`) to human-readable fix suggestions
- Wired `confluence_write_error` into `update_content`, `create_page`, and `add_page_comment`, replacing bare `ApiRequestFailed` returns
- Added `debug!` logging of non-success response bodies at the call sites (the raw body is intentionally omitted from the user-facing error message)

**Error Variant (`src/atlassian/error.rs`):**
- Added `AtlassianError::ApiRequestFailedWithDiagnosis` variant carrying `status`, `body`, `diagnosis: AdfSchemaViolation`, and `hint: Option<String>`
- Added `format_diagnosis(status, diagnosis, hint)` formatter that produces the multi-line user-facing message with `Diagnosis:` and optional `Hint:` lines

**Testing:**
- Added `adf_with_panel_expand()` helper in the test module to build a minimal invalid ADF document
- Added `update_content_500_with_panel_expand_diagnoses` — verifies diagnosis path for `update_content`
- Added `update_content_500_without_violation_falls_back` — verifies fallback to raw body when no ADF violation is detected
- Added `create_page_500_with_panel_expand_diagnoses` — verifies diagnosis path for `create_page`
- Added `add_page_comment_500_with_panel_expand_diagnoses` — verifies diagnosis path for `add_page_comment`
- Added `api_request_failed_with_diagnosis_display_with_hint` and `api_request_failed_with_diagnosis_display_without_hint` unit tests in `error.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (6 new tests across `confluence_api.rs` and `error.rs`)
- [x] Integration tests for all three write operations (`update_content`, `create_page`, `add_page_comment`)

**Manual Testing:**
- [x] Tested happy path scenarios (non-500 errors remain unaffected)
- [x] Tested error/edge cases (500 with ADF violation, 500 without ADF violation)
- [x] Backward compatibility verified (fallback to `ApiRequestFailed` preserved)

### Test Commands
```bash
# Core test suite
cargo test

# Run only Atlassian/Confluence tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the `confluence_write_error` dispatch logic and the fallback path
- [x] User experience — the multi-line error format in `format_diagnosis` and the hint messages in `hint_for`
- [x] Backward compatibility — 500 responses with no ADF violation and all non-500 error codes still produce the original `ApiRequestFailed` format

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] Potential performance impact (describe below)

ADF schema validation via `adf_schema::validate_document` is only invoked on HTTP 500 responses. Normal successful operations are entirely unaffected. The overhead is proportional to document size and occurs only in failure paths.

## Security Considerations

- [x] No security implications

The raw HTTP 500 response body is logged at `debug!` level but is intentionally excluded from the user-facing error message, preventing accidental exposure of internal Confluence error details in higher-level log outputs.

## Breaking Changes

None. The new `ApiRequestFailedWithDiagnosis` variant is additive. All existing `ApiRequestFailed` error paths remain in place for non-500 responses and 500 responses with no detected ADF violation.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `hint_for` table can be extended as additional known-bad nesting patterns are discovered in the field
- Additional ADF schema violations beyond nesting errors (e.g. required attributes, invalid mark combinations) could be surfaced as further `AtlassianError` variants

**Known Limitations:**
- Only the first ADF schema violation is reported; documents with multiple violations require iterative fixes
- ADF validation is only triggered on HTTP 500; other error codes (400, 403, etc.) are not currently diagnosed