### PR TITLE
test(atlassian): add edge-case tests for confluence api and diff modules

### DIFF
--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -4532,4 +4532,64 @@ mod tests {
         let err = resolve_version("garbage", &v, 5).unwrap_err();
         assert!(err.to_string().contains("Could not parse"));
     }
+
+    #[test]
+    fn resolve_version_v_minus_with_non_numeric_suffix_rejected() {
+        // Exercises the `with_context` error path when v-N's suffix fails
+        // to parse as a u32.
+        let v = fixture_versions();
+        let err = resolve_version("v-abc", &v, 5).unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid relative version offset"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_version_v_minus_resolves_to_missing_version_errors() {
+        // Anchor (4) > offset (2), so the offset doesn't go negative — but
+        // version 2 isn't in the truncated history. Exercises the
+        // "Version N not found" path inside `offset_from`.
+        let versions = vec![
+            version_at(5, "2026-05-09T10:00:00Z"),
+            version_at(4, "2026-05-08T10:00:00Z"),
+            // v3 and v2 are absent (e.g., the cap dropped them).
+        ];
+        let err = resolve_version("v-2", &versions, 4).unwrap_err();
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn get_page_at_version_with_body_but_no_atlas_doc_format() {
+        // Exercises the `else { None }` arm where body is present but
+        // `atlas_doc_format` is missing.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12"))
+            .and(wiremock::matchers::query_param("version", "1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12",
+                    "title": "T",
+                    "status": "current",
+                    "spaceId": "1",
+                    "version": {"number": 1},
+                    "body": { /* atlas_doc_format absent */ }
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/1"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({"key": "S"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "u@t.com", "tok").unwrap();
+        let api = ConfluenceApi::new(client);
+        let item = api.get_page_at_version("12", 1).await.unwrap();
+        assert!(item.body_adf.is_none());
+    }
 }

--- a/src/atlassian/diff.rs
+++ b/src/atlassian/diff.rs
@@ -1542,6 +1542,47 @@ mod tests {
     }
 
     #[test]
+    fn table_rows_skips_non_row_children() {
+        // A table whose direct children include a non-tableRow node
+        // exercises the false branch of `if row.node_type == "tableRow"`
+        // inside `table_rows`.
+        let from = AdfNode::table(vec![
+            p("not-a-row"), // skipped by the row-type filter
+            AdfNode::table_row(vec![AdfNode::table_cell(vec![p("alpha")])]),
+        ]);
+        let to = AdfNode::table(vec![
+            p("not-a-row"),
+            AdfNode::table_row(vec![AdfNode::table_cell(vec![p("beta")])]),
+        ]);
+        let delta = diff_table(&from, &to, &DiffOptions::default()).unwrap();
+        // Inspect via the serialized form to avoid an unreachable
+        // destructuring branch — `delta` is structurally guaranteed to be
+        // `Table` by the call above.
+        let json = serde_json::to_value(&delta).unwrap();
+        assert_eq!(json["kind"], "table");
+        assert_eq!(json["cells"].as_array().unwrap().len(), 1);
+        assert_eq!(json["cells"][0]["from_text"], "alpha");
+        assert_eq!(json["cells"][0]["to_text"], "beta");
+    }
+
+    #[test]
+    fn table_rows_handles_table_with_no_content() {
+        // A `table` node with no children at all exercises the false branch
+        // of `if let Some(children)` inside `table_rows`.
+        let empty_table = AdfNode {
+            node_type: "table".to_string(),
+            attrs: None,
+            content: None,
+            text: None,
+            marks: None,
+            local_id: None,
+            parameters: None,
+        };
+        let result = diff_table(&empty_table, &empty_table, &DiffOptions::default());
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn table_rows_skips_non_cell_children() {
         // A `tableRow` with a non-cell child (here a paragraph) exercises
         // the false branch of the cell-type filter inside `table_rows`.


### PR DESCRIPTION
## Description

This PR adds unit tests covering previously untested edge-case code paths in the Confluence API client (`src/atlassian/confluence_api.rs`) and ADF diff logic (`src/atlassian/diff.rs`). These tests were identified as part of Confluence compare feature development (issue #706) to improve test coverage for boundary conditions and error handling branches.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #706

## Changes Made

**Core Changes:**
- No functional code changes; tests only

**Testing:**
- Added `resolve_version_v_minus_with_non_numeric_suffix_rejected` to cover the `with_context` error path when `v-N`'s suffix fails to parse as `u32` in `resolve_version`
- Added `resolve_version_v_minus_resolves_to_missing_version_errors` to cover the "Version N not found" path inside `offset_from` when versions are absent from a truncated history
- Added `get_page_at_version_with_body_but_no_atlas_doc_format` (async, using `wiremock`) to cover the `else { None }` arm in `get_page_at_version` where a body is present but `atlas_doc_format` is missing
- Added `table_rows_skips_non_row_children` to cover the false branch of `if row.node_type == "tableRow"` inside `table_rows` in the diff module
- Added `table_rows_handles_table_with_no_content` to cover the false branch of `if let Some(children)` inside `table_rows` when a table node has no content

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run atlassian-specific tests
cargo test atlassian

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [x] Error handling
- [ ] User experience
- [x] Backward compatibility

The new tests exercise previously uncovered branches in `resolve_version`, `get_page_at_version`, and `table_rows`. Reviewers should verify the test assertions accurately reflect intended behavior for each error/edge path.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional edge-case tests may be needed as the Confluence compare feature matures

**Known Limitations:**
- Test coverage percentages not measured in this PR

**Alternatives Considered:**
- Mutation testing was not applied; tests were derived from direct code path analysis