### PR TITLE
feat(claude): add breaking change detection instructions to system prompts

### DIFF
--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -180,6 +180,30 @@ TYPE SELECTION RULES (must match the commit checker's expectations):
    - Changing doc comments or help text in source code is `refactor` or `fix`, not `docs`
 3. Before finalizing, verify: would the commit checker accept this type given the files that changed?
 
+BREAKING CHANGE DETECTION (MANDATORY):
+The commit checker enforces breaking-change markers at ERROR severity. You MUST detect breaking changes from the diff and emit BOTH markers when any of these signals appear:
+
+DIFF SIGNALS — flag as a breaking change when the diff shows ANY of:
+- A new MANDATORY parameter on a public function, public method, or pub trait method (no default, callers must update)
+- A new MANDATORY field on a public struct/enum used in a public API or serialization format
+- A removed, renamed, or re-typed public API (function, method, struct, enum variant, trait, type alias, public constant)
+- A new required CLI flag/argument, or removal/rename of an existing one
+- A change to an MCP tool schema that removes or renames a parameter, makes an optional parameter required, or changes a parameter's type
+- A change to a serialization format, file format, schema, or wire protocol that older readers cannot parse
+- A default-behavior change that breaks non-interactive callers (e.g., a command that previously ran silently now prompts by default; a default value that callers depended on changed)
+- A bumped MSRV, removed feature flag, or removed dependency that was part of the public API surface
+
+REQUIRED OUTPUTS — when ANY signal above is detected, the commit message MUST contain BOTH:
+1. A `!` immediately after the type/scope and before the colon — e.g. `feat(cli)!: change output format` or `feat(api,cli)!: drop legacy flag`
+2. A `BREAKING CHANGE:` footer (uppercase, exactly that label, followed by a colon) at the bottom of the body, separated from preceding paragraphs by a blank line, containing CONCRETE migration instructions — what callers must do, not just that something broke
+
+WRONG: `feat(cli): change output format` (missing `!` and footer despite removed flag)
+WRONG: `feat(cli)!: change output format` (has `!` but no `BREAKING CHANGE:` footer)
+WRONG: `feat(cli)!: change output format\n\nBREAKING CHANGE: output format changed` (footer is vacuous; no migration guidance)
+RIGHT: `feat(cli)!: drop --legacy-output flag\n\nBREAKING CHANGE: the --legacy-output flag has been removed. Callers should pass --format=json instead; the JSON shape is documented in docs/output-format.md.`
+
+If the diff contains NONE of the signals above, do NOT emit `!` or a `BREAKING CHANGE:` footer — these markers are reserved for actual breaking changes and devalue when applied to non-breaking commits.
+
 CRITICAL OUTPUT REQUIREMENT: Return exactly one amendment per commit in the input `commits[]` array — no more, no fewer. Count the entries in `commits[]` and produce that many amendments. Each amendment's `commit` field must match a hash that appears in the input. DO NOT invent additional amendments, duplicate a commit hash across multiple amendments, or omit any input commit. If a commit message is already perfect, include it unchanged with its original hash.
 
 CRITICAL RESPONSE FORMAT: You MUST respond with ONLY valid YAML content. Do not include any explanatory text, markdown wrappers, or code blocks. Your entire response must be parseable YAML starting immediately with "amendments:" and containing nothing else.
@@ -1571,6 +1595,50 @@ mod tests {
     fn basic_system_prompt_not_empty() {
         assert!(BASIC_SYSTEM_PROMPT.len() > 100);
         assert!(BASIC_SYSTEM_PROMPT.contains("amendments:"));
+    }
+
+    #[test]
+    fn basic_system_prompt_mentions_breaking_changes() {
+        assert!(BASIC_SYSTEM_PROMPT.contains("BREAKING CHANGE DETECTION"));
+    }
+
+    #[test]
+    fn basic_system_prompt_lists_breaking_change_signals() {
+        for signal in [
+            "MANDATORY parameter",
+            "removed, renamed",
+            "CLI flag",
+            "MCP tool schema",
+            "serialization format",
+            "default-behavior change",
+        ] {
+            assert!(
+                BASIC_SYSTEM_PROMPT.contains(signal),
+                "BASIC_SYSTEM_PROMPT missing breaking-change signal: {signal:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn basic_system_prompt_requires_both_breaking_markers() {
+        assert!(
+            BASIC_SYSTEM_PROMPT.contains("`!` immediately after the type/scope"),
+            "BASIC_SYSTEM_PROMPT must require `!` after type/scope"
+        );
+        assert!(
+            BASIC_SYSTEM_PROMPT.contains("`BREAKING CHANGE:` footer"),
+            "BASIC_SYSTEM_PROMPT must require BREAKING CHANGE: footer"
+        );
+    }
+
+    #[test]
+    fn contextual_system_prompt_inherits_breaking_change_block() {
+        let context = make_context();
+        let prompt = generate_contextual_system_prompt(&context);
+        assert!(
+            prompt.contains("BREAKING CHANGE DETECTION"),
+            "contextual system prompt must inherit BREAKING CHANGE DETECTION block from BASIC_SYSTEM_PROMPT"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR adds a mandatory `BREAKING CHANGE DETECTION` section to the AI system prompts in `src/claude/prompts.rs`. The new instructions guide the AI to reliably identify breaking changes from diffs and emit the required conventional commit markers — both the `!` suffix on the type/scope and a `BREAKING CHANGE:` footer with concrete migration instructions.

Previously, the AI lacked explicit guidance on what diff signals constitute a breaking change, leading to inconsistent or missing breaking-change markers in generated commit messages. This change ensures the commit checker's ERROR-severity breaking-change rules are properly satisfied by the AI output.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #744

## Changes Made

**Core Changes:**
- Added `BREAKING CHANGE DETECTION (MANDATORY)` section to `BASIC_SYSTEM_PROMPT` in `src/claude/prompts.rs`
- Defined eight concrete diff signals that require breaking-change markers: new mandatory parameters on public APIs, removed/renamed public APIs, new required CLI flags or removal of existing ones, MCP tool schema changes, serialization format changes, default-behavior changes, bumped MSRV, and removed feature flags
- Specified that both `!` after type/scope and `BREAKING CHANGE:` footer with migration instructions are required when any signal is detected
- Provided correct and incorrect examples to guide the AI's output

**Testing:**
- Added `basic_system_prompt_mentions_breaking_changes` test — asserts `BASIC_SYSTEM_PROMPT` contains the `BREAKING CHANGE DETECTION` block
- Added `basic_system_prompt_lists_breaking_change_signals` test — asserts all expected signal keywords are present in the prompt
- Added `basic_system_prompt_requires_both_breaking_markers` test — asserts both the `!` after type/scope and `BREAKING CHANGE:` footer requirements are stated
- Added `contextual_system_prompt_inherits_breaking_change_block` test — asserts the contextual system prompt derived from `generate_contextual_system_prompt` also includes the detection block

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- Four new unit tests added covering the new prompt content and its inheritance by the contextual prompt

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new prompt tests
cargo test basic_system_prompt_mentions_breaking_changes
cargo test basic_system_prompt_lists_breaking_change_signals
cargo test basic_system_prompt_requires_both_breaking_markers
cargo test contextual_system_prompt_inherits_breaking_change_block

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The wording of the detection section is critical — it must be precise enough that the AI consistently applies it without over-triggering (emitting `!` on non-breaking commits) or under-triggering (missing genuine breaking changes). Please review the signal list and the examples for correctness and completeness.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider extending the signal list as new public API surface areas are identified (e.g., plugin interfaces, configuration file schema)
- The examples in the prompt could be expanded with scope-based scenarios (e.g., `fix(api)!:`) to cover more commit patterns

**Known Limitations:**
- The detection relies entirely on the AI correctly interpreting the instructions; edge cases in novel API shapes may still be missed until the prompt is further refined

**Alternatives Considered:**
- Implementing a static analysis linter to detect breaking changes in Rust source — rejected as too complex and incomplete for detecting behavioral changes
- Relying on the commit checker's post-hoc error messages to guide re-tries — rejected as it produces poor user experience and extra round-trips