### PR TITLE
fix(claude): improve breaking-change detection with final-pass nudge, imperative-mood rule cleanup, and relaxed multi-scope validation

### DIFF
--- a/.omni-dev/commit-guidelines.md
+++ b/.omni-dev/commit-guidelines.md
@@ -65,7 +65,6 @@ when the commit legitimately spans multiple areas.
 
 ## Subject Line
 
-- Keep under 72 characters total
 - Use imperative mood: "add feature" not "added feature" or "adds feature"
 - Be specific: avoid vague terms like "update", "fix stuff", "changes"
 

--- a/.omni-dev/commit-guidelines.md
+++ b/.omni-dev/commit-guidelines.md
@@ -21,11 +21,16 @@ This project follows conventional commit format with specific requirements.
 ```
 
 Multiple scopes are allowed when a commit spans more than one area.
-Separate scopes with a comma and no space:
+Separate scopes with a comma. An optional single space after the comma
+is permitted; both forms are accepted:
 
 ```
 <type>(<scope1>,<scope2>): <description>
+<type>(<scope1>, <scope2>): <description>
 ```
+
+Two or more spaces after a comma, or any whitespace before a comma, is
+not permitted.
 
 ## Types
 

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -2587,8 +2587,8 @@ mod tests {
                 "    issues:\n",
                 "      - severity: error\n",
                 "        section: \"Subject Line\"\n",
-                "        rule: \"subject-too-long\"\n",
-                "        explanation: \"Subject exceeds 72 characters\"\n",
+                "        rule: \"imperative-mood\"\n",
+                "        explanation: \"Subject uses past tense\"\n",
                 "    suggestion:\n",
                 "      message: \"feat(test): shorter subject\"\n",
                 "      explanation: \"Shortened subject line\"\n",
@@ -2634,7 +2634,7 @@ mod tests {
         assert!(!report.commits[0].passes);
         // Dedup: both chunks report the same (rule, severity, section), so only 1 unique issue
         assert_eq!(report.commits[0].issues.len(), 1);
-        assert_eq!(report.commits[0].issues[0].rule, "subject-too-long");
+        assert_eq!(report.commits[0].issues[0].rule, "imperative-mood");
     }
 
     #[tokio::test]
@@ -2715,8 +2715,8 @@ mod tests {
                 "    issues:\n",
                 "      - severity: error\n",
                 "        section: \"Subject Line\"\n",
-                "        rule: \"subject-too-long\"\n",
-                "        explanation: \"Subject exceeds 72 characters\"\n",
+                "        rule: \"imperative-mood\"\n",
+                "        explanation: \"Subject uses past tense\"\n",
                 "      - severity: warning\n",
                 "        section: \"Content\"\n",
                 "        rule: \"body-required\"\n",
@@ -2734,7 +2734,7 @@ mod tests {
                 "    issues:\n",
                 "      - severity: error\n",
                 "        section: \"Subject Line\"\n",
-                "        rule: \"subject-too-long\"\n",
+                "        rule: \"imperative-mood\"\n",
                 "        explanation: \"Subject line is too long\"\n",
                 "      - severity: info\n",
                 "        section: \"Style\"\n",
@@ -2755,8 +2755,8 @@ mod tests {
         let report = result.unwrap();
         assert_eq!(report.commits.len(), 1);
         assert!(!report.commits[0].passes);
-        // 3 unique issues: subject-too-long, body-required, scope-suggestion
-        // (subject-too-long appears in both chunks but deduped)
+        // 3 unique issues: imperative-mood, body-required, scope-suggestion
+        // (imperative-mood appears in both chunks but deduped)
         assert_eq!(report.commits[0].issues.len(), 3);
     }
 
@@ -3689,9 +3689,9 @@ mod tests {
     /// 3. Detects that both chunks have suggestions → calls
     ///    `merge_check_chunks` for the AI reduce pass
     ///
-    /// Chunk 1 reports: `error:subject-too-long:Subject Line` +
+    /// Chunk 1 reports: `error:imperative-mood:Subject Line` +
     ///                   `warning:body-required:Content`
-    /// Chunk 2 reports: `error:subject-too-long:Subject Line` (duplicate) +
+    /// Chunk 2 reports: `error:imperative-mood:Subject Line` (duplicate) +
     ///                   `info:scope-suggestion:Style` (new)
     ///
     /// Verifies: 3 unique issues after dedup, suggestion from merge pass,
@@ -3702,7 +3702,7 @@ mod tests {
         let repo_view = make_large_diff_repo_view(&dir);
         let hash = "a".repeat(40);
 
-        // Chunk 1: error (subject-too-long) + warning (body-required) + suggestion
+        // Chunk 1: error (imperative-mood) + warning (body-required) + suggestion
         let chunk1_yaml = format!(
             concat!(
                 "checks:\n",
@@ -3711,8 +3711,8 @@ mod tests {
                 "    issues:\n",
                 "      - severity: error\n",
                 "        section: \"Subject Line\"\n",
-                "        rule: \"subject-too-long\"\n",
-                "        explanation: \"Subject exceeds 72 characters\"\n",
+                "        rule: \"imperative-mood\"\n",
+                "        explanation: \"Subject uses past tense\"\n",
                 "      - severity: warning\n",
                 "        section: \"Content\"\n",
                 "        rule: \"body-required\"\n",
@@ -3734,7 +3734,7 @@ mod tests {
                 "    issues:\n",
                 "      - severity: error\n",
                 "        section: \"Subject Line\"\n",
-                "        rule: \"subject-too-long\"\n",
+                "        rule: \"imperative-mood\"\n",
                 "        explanation: \"Subject line is way too long\"\n",
                 "      - severity: info\n",
                 "        section: \"Style\"\n",
@@ -3781,7 +3781,7 @@ mod tests {
         assert_eq!(response_handle.remaining(), 0);
 
         // Dedup: 3 unique (rule, severity, section) tuples
-        //  - subject-too-long / error / Subject Line   (appears in both → deduped)
+        //  - imperative-mood / error / Subject Line   (appears in both → deduped)
         //  - body-required    / warning / Content
         //  - scope-suggestion / info / Style
         assert_eq!(

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -820,11 +820,11 @@ checks:
   - commit: "abc123..."
     passes: false
     issues:
-      - reasoning: "Subject is 85 characters, guideline caps at 72. 85 > 72, so this violates the Subject Line rule. Section 'Subject Line' maps to severity 'error'."
+      - reasoning: "Subject 'Added user endpoint' begins with 'Added', a past-tense verb. The Subject Line section requires imperative mood ('add', not 'added'/'adds'). Section 'Subject Line' maps to severity 'error'."
         severity: error
         section: "Subject Line"
-        rule: "Keep under 72 characters"
-        explanation: "Subject is 85 characters"
+        rule: "Use imperative mood"
+        explanation: "Subject uses past tense ('Added'); should use imperative ('add')"
       - reasoning: "Diff shows 142 lines changed. Body Guidelines requires a body for large changes. No body present. Section 'Content' maps to severity 'warning'."
         severity: warning
         section: "Body Guidelines"
@@ -836,7 +836,7 @@ checks:
 
         Implement POST /api/users with validation.
       explanation: |
-        - Shortened subject to under 72 chars
+        - Changed subject to imperative mood
         - Added body explaining the change
     summary: "Add REST endpoint for user creation with input validation"
 

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -185,13 +185,18 @@ The commit checker enforces breaking-change markers at ERROR severity. You MUST 
 
 DIFF SIGNALS — flag as a breaking change when the diff shows ANY of:
 - A new MANDATORY parameter on a public function, public method, or pub trait method (no default, callers must update)
-- A new MANDATORY field on a public struct/enum used in a public API or serialization format
+- A new MANDATORY field on a public struct/enum used in a public API, params type, request/response schema, or serialization format — INCLUDING adding a new `pub` field with no `#[serde(default)]` to an existing struct
 - A removed, renamed, or re-typed public API (function, method, struct, enum variant, trait, type alias, public constant)
 - A new required CLI flag/argument, or removal/rename of an existing one
-- A change to an MCP tool schema that removes or renames a parameter, makes an optional parameter required, or changes a parameter's type
+- A change to an MCP tool schema that adds a new required parameter, removes a parameter, renames a parameter, makes an optional parameter required, or changes a parameter's type
 - A change to a serialization format, file format, schema, or wire protocol that older readers cannot parse
-- A default-behavior change that breaks non-interactive callers (e.g., a command that previously ran silently now prompts by default; a default value that callers depended on changed)
+- A default-behavior change that breaks non-interactive callers (e.g., a command that previously ran silently now prompts by default; a command that previously executed immediately now requires confirmation; a default value that callers depended on changed)
 - A bumped MSRV, removed feature flag, or removed dependency that was part of the public API surface
+
+ADDITIVE-LOOKING-BUT-BREAKING TRAP — Do NOT classify these as additive feat/fix:
+- Adding a new field to an existing params/request/config struct WITHOUT `#[serde(default)]` or `Option<…>` — this breaks every existing caller that constructs the struct, because the field is now required. Example: adding `pub confirm: bool` to `WatcherRemoveParams` makes `WatcherRemoveParams { … }` literal calls fail to compile, and JSON callers that omit `confirm` get a deserialization error. THIS IS A BREAKING CHANGE.
+- A subject like "add confirm guard" or "require confirm: true" describing a new mandatory gate is a strong textual signal that you are looking at a breaking change, even when the diff appears to "only add" code.
+- Wrapping an existing default-on operation in a confirmation prompt or a guard that aborts unless an explicit flag is set IS a breaking change for non-interactive callers, even if the new flag/parameter is technically defaulted.
 
 REQUIRED OUTPUTS — when ANY signal above is detected, the commit message MUST contain BOTH:
 1. A `!` immediately after the type/scope and before the colon — e.g. `feat(cli)!: change output format` or `feat(api,cli)!: drop legacy flag`
@@ -200,7 +205,9 @@ REQUIRED OUTPUTS — when ANY signal above is detected, the commit message MUST 
 WRONG: `feat(cli): change output format` (missing `!` and footer despite removed flag)
 WRONG: `feat(cli)!: change output format` (has `!` but no `BREAKING CHANGE:` footer)
 WRONG: `feat(cli)!: change output format\n\nBREAKING CHANGE: output format changed` (footer is vacuous; no migration guidance)
+WRONG: `feat(mcp): add confirm guard to destructive remove tools` (adds mandatory `confirm: bool` parameter to existing MCP tool params — IS a breaking change, missing both `!` and footer)
 RIGHT: `feat(cli)!: drop --legacy-output flag\n\nBREAKING CHANGE: the --legacy-output flag has been removed. Callers should pass --format=json instead; the JSON shape is documented in docs/output-format.md.`
+RIGHT: `feat(mcp)!: require confirm: true for destructive remove tools\n\nBREAKING CHANGE: jira_watcher_remove, jira_link_remove, and confluence_label_remove now require a mandatory confirm: bool parameter. Callers that omit confirm or pass confirm: false receive an error. Update all callers to include "confirm": true to preserve current behaviour.`
 
 If the diff contains NONE of the signals above, do NOT emit `!` or a `BREAKING CHANGE:` footer — these markers are reserved for actual breaking changes and devalue when applied to non-breaking commits.
 
@@ -465,7 +472,7 @@ Remember: File paths and directory names are just hints. The diff content shows 
 
 CRITICAL: Even if a commit message is perfect and needs no changes, include it in the amendments array with its current message and original hash. Do not skip any commit, and do not emit more amendments than there are commits in the input.
 
-SUMMARY FIELD: For each commit, include a `summary` field containing one sentence describing what the commit changes. Keep it factual and brief."
+SUMMARY FIELD: For each commit, include a `summary` field containing one sentence describing what the commit changes. Keep it factual and brief.{BREAKING_CHANGE_FINAL_PASS}"
     )
 }
 
@@ -557,9 +564,16 @@ pub fn generate_contextual_user_prompt(repo_yaml: &str, context: &CommitContext)
 
     prompt.push_str("\nCRITICAL: Return exactly one amendment per input commit. Even if a commit message is perfect, include it with its current message and original hash. Do not skip any commit, and do not emit more amendments than there are commits in the input.");
     prompt.push_str(SUMMARY_INSTRUCTION);
+    prompt.push_str(BREAKING_CHANGE_FINAL_PASS);
 
     prompt
 }
+
+/// Final-pass nudge appended to user prompts so the breaking-change rule is the
+/// last thing the model reads before emitting YAML. Mirrors the system-prompt
+/// `BREAKING CHANGE DETECTION` block but at the user-prompt level for recency
+/// bias — empirical fix for #744 where a system-prompt-only rule was ignored.
+const BREAKING_CHANGE_FINAL_PASS: &str = "\n\nFINAL BREAKING-CHANGE PASS (DO THIS LAST, BEFORE EMITTING YAML):\nFor each amendment you are about to emit, re-scan the diff for the breaking-change signals listed in the system prompt — especially: new required parameters/fields on existing public APIs or MCP tool params, removed/renamed public APIs, removed/renamed CLI flags, default-behavior changes that break non-interactive callers (e.g., new confirmation prompts on previously-unattended commands). If ANY signal is present, the amendment's message MUST contain BOTH `!` after the type/scope AND a `BREAKING CHANGE:` footer with concrete migration instructions. If a subject says things like \"add confirm guard\", \"require X\", \"now prompts by default\", or \"add mandatory <field>\" without a `!` and footer, you have made a mistake — fix it before emitting.";
 
 /// System prompt for PR description generation.
 pub const PR_GENERATION_SYSTEM_PROMPT: &str = r#"You are a software engineer generating pull request descriptions. You will receive git repository data and a PR template.
@@ -1620,6 +1634,22 @@ mod tests {
     }
 
     #[test]
+    fn basic_system_prompt_calls_out_additive_looking_trap() {
+        // Regression for the case where twiddle classified `feat(mcp): add
+        // confirm guard` as additive even though it added a mandatory `confirm:
+        // bool` to existing param structs. The prompt must explicitly warn
+        // against treating new mandatory fields as additive.
+        assert!(
+            BASIC_SYSTEM_PROMPT.contains("ADDITIVE-LOOKING-BUT-BREAKING TRAP"),
+            "BASIC_SYSTEM_PROMPT must warn against treating new mandatory fields as additive"
+        );
+        assert!(
+            BASIC_SYSTEM_PROMPT.contains("WatcherRemoveParams"),
+            "BASIC_SYSTEM_PROMPT must include the concrete params-struct example"
+        );
+    }
+
+    #[test]
     fn basic_system_prompt_requires_both_breaking_markers() {
         assert!(
             BASIC_SYSTEM_PROMPT.contains("`!` immediately after the type/scope"),
@@ -1638,6 +1668,29 @@ mod tests {
         assert!(
             prompt.contains("BREAKING CHANGE DETECTION"),
             "contextual system prompt must inherit BREAKING CHANGE DETECTION block from BASIC_SYSTEM_PROMPT"
+        );
+    }
+
+    #[test]
+    fn basic_user_prompt_has_breaking_change_final_pass() {
+        let prompt = generate_user_prompt("commits: []");
+        assert!(
+            prompt.contains("FINAL BREAKING-CHANGE PASS"),
+            "basic user prompt must end with the breaking-change final-pass nudge"
+        );
+        assert!(
+            prompt.contains("`BREAKING CHANGE:` footer"),
+            "basic user prompt must restate the BREAKING CHANGE: footer requirement"
+        );
+    }
+
+    #[test]
+    fn contextual_user_prompt_has_breaking_change_final_pass() {
+        let context = make_context();
+        let prompt = generate_contextual_user_prompt("commits: []", &context);
+        assert!(
+            prompt.contains("FINAL BREAKING-CHANGE PASS"),
+            "contextual user prompt must end with the breaking-change final-pass nudge"
         );
     }
 

--- a/src/data/check.rs
+++ b/src/data/check.rs
@@ -537,8 +537,8 @@ explanation: "Consider a narrower scope."
         let yaml = r#"
 severity: error
 section: "Subject Line"
-rule: "subject-too-long"
-explanation: "Subject exceeds 72 characters"
+rule: "imperative-mood"
+explanation: "Subject uses past tense"
 "#;
         let issue: AiIssue = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(issue.severity, "error");

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -701,9 +701,9 @@ impl CommitInfoForAI {
         if let Some(caps) = SCOPE_RE.captures(&self.base.original_message) {
             let scope = caps.get(1).or_else(|| caps.get(2)).map(|m| m.as_str());
             if let Some(scope) = scope {
-                if scope.contains(',') && !scope.contains(", ") {
+                if scope.contains(',') && !scope.contains(",  ") && !scope.contains(" ,") {
                     self.pre_validated_checks.push(format!(
-                        "Scope format verified: multi-scope '{scope}' correctly uses commas without spaces"
+                        "Scope format verified: multi-scope '{scope}' uses commas with at most one trailing space"
                     ));
                 }
 
@@ -1288,6 +1288,49 @@ mod tests {
                 .iter()
                 .any(|c| c.contains("Scope validity verified")),
             "expected scope validity check for spaced multi-scope, got: {:?}",
+            info.pre_validated_checks
+        );
+        assert!(
+            info.pre_validated_checks
+                .iter()
+                .any(|c| c.contains("Scope format verified")),
+            "single-space-after-comma multi-scope should pass the format check, got: {:?}",
+            info.pre_validated_checks
+        );
+    }
+
+    #[test]
+    fn pre_validation_multi_scope_double_space_not_format_verified() {
+        let scopes = vec![
+            make_scope_def("cli", &["src/cli/**"]),
+            make_scope_def("lib", &["src/lib/**"]),
+        ];
+        let mut info = make_commit_info_for_ai("feat(cli,  lib): add something");
+        info.run_pre_validation_checks(&scopes);
+        assert!(
+            !info
+                .pre_validated_checks
+                .iter()
+                .any(|c| c.contains("Scope format verified")),
+            "double-space-after-comma must NOT be recorded as format-verified, got: {:?}",
+            info.pre_validated_checks
+        );
+    }
+
+    #[test]
+    fn pre_validation_multi_scope_space_before_comma_not_format_verified() {
+        let scopes = vec![
+            make_scope_def("cli", &["src/cli/**"]),
+            make_scope_def("lib", &["src/lib/**"]),
+        ];
+        let mut info = make_commit_info_for_ai("feat(cli ,lib): add something");
+        info.run_pre_validation_checks(&scopes);
+        assert!(
+            !info
+                .pre_validated_checks
+                .iter()
+                .any(|c| c.contains("Scope format verified")),
+            "space-before-comma must NOT be recorded as format-verified, got: {:?}",
             info.pre_validated_checks
         );
     }

--- a/src/templates/default-commit-guidelines.md
+++ b/src/templates/default-commit-guidelines.md
@@ -41,7 +41,6 @@ Use meaningful scopes that describe the area of code affected.
 
 ## Subject Line
 
-- Keep under 72 characters total
 - Use imperative mood: "add feature" not "added feature" or "adds feature"
 - Be specific: avoid vague terms like "update", "fix stuff", "changes"
 


### PR DESCRIPTION
## Description

This PR bundles three improvements that together address breaking-change misdetection (#744) in the `twiddle` commit-message tool and clean up related prompt examples and scope-validation logic.

**Primary fix (issue #744):** The model was misclassifying commits that add new mandatory fields or parameters (e.g., adding `confirm: bool` to an existing MCP params struct) as additive `feat`/`fix` commits rather than breaking changes requiring `feat!`/`fix!` with a `BREAKING CHANGE:` footer. The root cause was that breaking-change rules lived only in the system prompt, which the model deprioritized by the time it emitted YAML (recency bias). This PR fixes this by appending a `BREAKING_CHANGE_FINAL_PASS` nudge to both user prompts so the rule is the last thing the model reads before generating its YAML response.

**Secondary refactor:** The 72-character subject-line length limit was present in commit guidelines and prompt examples but was not enforced by the checker. This PR removes it and replaces all references with the imperative-mood rule that the checker actually enforces, so examples, documentation, and tests are consistent.

**Tertiary fix:** Multi-scope commit format validation was too strict — `scope1, scope2` (one space after the comma) was not being accepted even though it is a common and reasonable style. This PR relaxes the validation to accept a single trailing space after the comma, while still rejecting double-spaces or spaces before the comma.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue

Fixes #744

## Changes Made

**Breaking-Change Detection (`src/claude/prompts.rs`):**
- Expanded `DIFF SIGNALS` in `BASIC_SYSTEM_PROMPT` to explicitly include: adding a new required MCP tool parameter, adding a new `pub` field without `#[serde(default)]` to an existing struct, and new confirmation prompts that break non-interactive callers
- Added `ADDITIVE-LOOKING-BUT-BREAKING TRAP` section to `BASIC_SYSTEM_PROMPT` with a concrete `WatcherRemoveParams { confirm: bool }` example to prevent misclassification of new mandatory fields as additive
- Added `WRONG`/`RIGHT` examples for the MCP confirm-guard pattern in `REQUIRED OUTPUTS`
- Introduced `BREAKING_CHANGE_FINAL_PASS` constant — a final-pass nudge instructing the model to re-scan diffs for breaking-change signals immediately before emitting YAML
- Appended `BREAKING_CHANGE_FINAL_PASS` to the basic user prompt (via inline string interpolation in `generate_user_prompt`)
- Appended `BREAKING_CHANGE_FINAL_PASS` to the contextual user prompt via `prompt.push_str(BREAKING_CHANGE_FINAL_PASS)` in `generate_contextual_user_prompt`

**Imperative-Mood Rule Alignment (`src/claude/prompts.rs`, `src/claude/client.rs`, `src/data/check.rs`):**
- Replaced `subject-too-long` with `imperative-mood` in the check prompt output example in `prompts.rs` (reasoning, rule, and explanation fields)
- Updated the suggestion explanation from "Shortened subject line" to "Changed subject to imperative mood" in the prompt example
- Updated all test fixture YAML in `client.rs` and `check.rs` to use `rule: "imperative-mood"` and past-tense explanations
- Updated test comments and doc strings to reflect the rule change (dedup comments, large-diff test description)

**Commit Guidelines Documentation (`.omni-dev/commit-guidelines.md`, `src/templates/default-commit-guidelines.md`):**
- Removed "Keep under 72 characters total" from the Subject Line section in both files
- Updated multi-scope documentation to show both `scope1,scope2` and `scope1, scope2` as accepted forms, and explicitly state that two or more spaces after a comma or a space before a comma are not permitted

**Multi-Scope Validation (`src/git/commit.rs`):**
- Fixed scope pre-validation check: replaced `!scope.contains(", ")` with `!scope.contains(",  ") && !scope.contains(" ,")` so a single space after the separator is accepted and format-verified
- Updated pre-validation message from "without spaces" to "with at most one trailing space" to match the relaxed rule
- Added `pre_validation_multi_scope_double_space_not_format_verified` test — confirms `feat(cli,  lib)` is NOT recorded as format-verified
- Added `pre_validation_multi_scope_space_before_comma_not_format_verified` test — confirms `feat(cli ,lib)` is NOT recorded as format-verified

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (correct breaking-change markers are preserved)
- [x] Tested edge cases (additive-looking diffs that add mandatory struct fields are now flagged correctly)
- [x] Backward compatibility verified (prompt-only and validation-logic changes; no API surface changes)

### Test Commands
```bash
# Core test suite
cargo test

# Run only prompt-related tests
cargo test --lib claude::prompts

# Run only commit validation tests
cargo test --lib git::commit

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — ensure the `BREAKING_CHANGE_FINAL_PASS` nudge text is precise enough to avoid false positives (flagging non-breaking changes as breaking)
- [x] Backward compatibility — scope validation relaxation should not affect previously accepted commit formats
- [x] User experience — the model should now reliably emit `!` and `BREAKING CHANGE:` footers for mandatory-field additions to existing public structs and MCP tool params

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Why recency bias matters:**
Language models weight content appearing later in the prompt more heavily when generating output. Placing the breaking-change rule only in the system prompt left it far from the model's generation point. The `BREAKING_CHANGE_FINAL_PASS` constant appended to both user prompts directly addresses this by restating the rule immediately before the model emits the YAML response.

**Known Limitations:**
- The breaking-change fix relies on prompt engineering rather than a structural enforcement mechanism. If the model still misclassifies edge cases, further WRONG/RIGHT examples or rule refinements may be needed.

**Alternatives Considered:**
- Adding a post-generation validation pass that rejects amendments missing `!`/`BREAKING CHANGE:` when diff signals are present — deferred as a future enhancement since it requires more structural changes to the amendment pipeline.