### PR TITLE
feat(atlassian): implement ADF schema drift detection with weekly CI check

### DIFF
--- a/.github/workflows/adf-schema-drift.yml
+++ b/.github/workflows/adf-schema-drift.yml
@@ -1,0 +1,62 @@
+name: ADF Schema Drift Check
+
+on:
+  schedule:
+    # Mondays at 12:00 UTC. Within issue #731's "within a week of an upstream
+    # release" acceptance window.
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check upstream @atlaskit/adf-schema for drift
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DRIFT_LABEL: adf-schema-drift
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build adf-schema-drift
+        run: cargo build --release --bin adf-schema-drift
+
+      - name: Run drift check
+        id: drift
+        run: |
+          ./target/release/adf-schema-drift \
+            --format both \
+            --output-dir .
+
+      - name: Ensure drift label exists
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          gh label create "$DRIFT_LABEL" \
+            --description "Drift between local ADF schema snapshot and upstream @atlaskit/adf-schema" \
+            --color B60205 \
+            2>/dev/null || true
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          set -euo pipefail
+          existing=$(
+            gh issue list \
+              --label "$DRIFT_LABEL" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )
+          title="ADF schema drift: upstream @atlaskit/adf-schema update detected"
+          if [ -z "$existing" ]; then
+            gh issue create \
+              --title "$title" \
+              --label "$DRIFT_LABEL" \
+              --body-file drift-report.md
+          else
+            gh issue comment "$existing" --body-file drift-report.md
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +181,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -354,6 +369,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +411,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -452,6 +495,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -609,10 +662,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -727,6 +800,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1348,6 +1431,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1503,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "flate2",
  "futures",
  "git2",
  "globset",
@@ -1424,8 +1518,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "similar",
  "ssh2-config",
+ "tar",
  "tempfile",
  "termcolor",
  "thiserror 2.0.18",
@@ -2141,6 +2237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,6 +2292,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -2298,6 +2411,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2569,6 +2693,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -3286,6 +3416,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yaml-rust-davvid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ schemars = "1.2"
 similar = "2.7"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 mime_guess = "2"
+flate2 = "1"
+tar = "0.4"
+sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }
@@ -70,6 +73,11 @@ required-features = []
 name = "omni-dev-mcp"
 path = "src/mcp_server.rs"
 required-features = ["mcp"]
+
+[[bin]]
+name = "adf-schema-drift"
+path = "src/bin/adf_schema_drift.rs"
+required-features = []
 
 [lints.rust]
 unsafe_code = "deny"

--- a/src/atlassian/adf_schema/drift.rs
+++ b/src/atlassian/adf_schema/drift.rs
@@ -1,0 +1,1463 @@
+//! Drift detection between the local [`ENTRIES`] snapshot and upstream
+//! `@atlaskit/adf-schema`.
+//!
+//! Issue [#731]: a scheduled CI job downloads the latest upstream tarball,
+//! parses `dist/json-schema/v1/full.json` into a per-parent allowed-children
+//! map, and diffs it against the locally-encoded snapshot. The output is
+//! consumed by `bin/adf-schema-drift` and the `.github/workflows/
+//! adf-schema-drift.yml` workflow.
+//!
+//! The parser is intentionally narrow: it understands only the subset of
+//! JSON-schema patterns the upstream artefact actually uses (`anyOf` of
+//! `$ref` items, with optional alias definitions whose own subtree contains
+//! more refs). Any layout change upstream surfaces as a structured error or
+//! visible drift, not as a silent empty diff.
+//!
+//! [#731]: https://github.com/rust-works/omni-dev/issues/731
+//! [`ENTRIES`]: super::ENTRIES
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::io::Read;
+
+use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{local_schema_map, SCHEMA_VERSION, UPSTREAM_TARBALL_SHA256};
+
+/// npm registry endpoint that resolves the `latest` dist-tag for the package.
+const NPM_LATEST_URL: &str = "https://registry.npmjs.org/@atlaskit/adf-schema/latest";
+
+/// Optional env-var override for [`NPM_LATEST_URL`].
+///
+/// Honoured by [`fetch_latest_drift_report`]. Used by integration tests to
+/// point the binary at a `wiremock` server, and available as an operational
+/// knob for teams running an npm mirror.
+pub const NPM_LATEST_URL_ENV: &str = "OMNI_DEV_ADF_SCHEMA_LATEST_URL";
+
+/// Per-parent drift: children that upstream now lists but the local snapshot
+/// does not (`added_children`), and children the local snapshot lists but
+/// upstream no longer does (`removed_children`).
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct ParentDrift {
+    /// Children listed by upstream that the local snapshot does not list.
+    pub added_children: BTreeSet<String>,
+    /// Children listed by the local snapshot that upstream no longer lists.
+    pub removed_children: BTreeSet<String>,
+}
+
+/// Result of a drift comparison between upstream and the locally-encoded
+/// schema.
+///
+/// `version_changed` is true if the upstream npm version differs from the
+/// version embedded in [`SCHEMA_VERSION`] (after stripping the
+/// `-YYYY-MM-DD` transcription-date suffix). `per_parent` lists only parents
+/// that have content-model drift; parents in sync are omitted to keep the
+/// rendered report tight.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DriftReport {
+    /// `version` field from the latest upstream `package.json` (npm).
+    pub upstream_version: String,
+    /// SHA-256 of the upstream tarball bytes we downloaded.
+    pub upstream_tarball_sha256: String,
+    /// Local `SCHEMA_VERSION` (npm version + transcription date).
+    pub local_version: String,
+    /// Local `UPSTREAM_TARBALL_SHA256`.
+    pub local_tarball_sha256: String,
+    /// True iff `upstream_version` differs from the npm-version prefix of
+    /// `local_version`.
+    pub version_changed: bool,
+    /// Parents present on both sides whose allowed-children sets differ.
+    /// Parents fully in sync are omitted.
+    pub per_parent: BTreeMap<String, ParentDrift>,
+    /// Parents listed by upstream that the local snapshot does not have.
+    pub added_parents: BTreeSet<String>,
+    /// Parents listed by the local snapshot that upstream no longer has.
+    pub removed_parents: BTreeSet<String>,
+}
+
+impl DriftReport {
+    /// True iff any per-parent diff or any added/removed parent was found.
+    #[must_use]
+    pub fn has_content_drift(&self) -> bool {
+        !self.per_parent.is_empty()
+            || !self.added_parents.is_empty()
+            || !self.removed_parents.is_empty()
+    }
+
+    /// True iff the upstream version differs OR any content-model drift was
+    /// found. The CI workflow uses this to decide whether to open or update
+    /// a tracking issue.
+    #[must_use]
+    pub fn has_any_drift(&self) -> bool {
+        self.version_changed || self.has_content_drift()
+    }
+
+    /// Render a markdown body suitable for `gh issue create --body-file`.
+    #[must_use]
+    pub fn render_markdown(&self) -> String {
+        let mut out = String::new();
+        out.push_str("# ADF schema drift report\n\n");
+
+        out.push_str("## Version\n\n");
+        out.push_str(&format!(
+            "- Upstream `@atlaskit/adf-schema`: `{}`\n",
+            self.upstream_version
+        ));
+        out.push_str(&format!(
+            "- Upstream tarball SHA-256: `{}`\n",
+            self.upstream_tarball_sha256
+        ));
+        out.push_str(&format!(
+            "- Local `SCHEMA_VERSION`: `{}`\n",
+            self.local_version
+        ));
+        out.push_str(&format!(
+            "- Local `UPSTREAM_TARBALL_SHA256`: `{}`\n",
+            self.local_tarball_sha256
+        ));
+        out.push_str(&format!(
+            "- Version changed: **{}**\n\n",
+            self.version_changed
+        ));
+
+        out.push_str("## Content-model drift\n\n");
+        if !self.has_content_drift() {
+            out.push_str("No content-model changes — version bump only.\n\n");
+        } else {
+            if !self.added_parents.is_empty() {
+                out.push_str("### New parents (upstream only)\n\n");
+                for p in &self.added_parents {
+                    out.push_str(&format!("- `{p}`\n"));
+                }
+                out.push('\n');
+            }
+            if !self.removed_parents.is_empty() {
+                out.push_str("### Removed parents (local only)\n\n");
+                for p in &self.removed_parents {
+                    out.push_str(&format!("- `{p}`\n"));
+                }
+                out.push('\n');
+            }
+            if !self.per_parent.is_empty() {
+                out.push_str("### Per-parent diffs\n\n");
+                for (parent, drift) in &self.per_parent {
+                    out.push_str(&format!("#### `{parent}`\n\n"));
+                    if !drift.added_children.is_empty() {
+                        out.push_str("Added children (upstream only):\n");
+                        for c in &drift.added_children {
+                            out.push_str(&format!("- `{c}`\n"));
+                        }
+                        out.push('\n');
+                    }
+                    if !drift.removed_children.is_empty() {
+                        out.push_str("Removed children (local only):\n");
+                        for c in &drift.removed_children {
+                            out.push_str(&format!("- `{c}`\n"));
+                        }
+                        out.push('\n');
+                    }
+                }
+            }
+        }
+
+        out.push_str("---\n");
+        out.push_str(
+            "_Generated by the `adf-schema-drift` job. To refresh the snapshot, \
+             update `ENTRIES`, `SCHEMA_VERSION`, and `UPSTREAM_TARBALL_SHA256` in \
+             `src/atlassian/adf_schema/mod.rs`._\n",
+        );
+        out
+    }
+
+    /// Render the same report as a JSON object, for machine-readable CI use.
+    #[must_use]
+    pub fn render_json(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+}
+
+/// Fetch the latest upstream tarball, parse its `full.json`, and compute a
+/// drift report against the locally-encoded schema.
+///
+/// Honours the [`NPM_LATEST_URL_ENV`] environment variable as an override
+/// for the registry URL — useful for integration tests and for teams behind
+/// an npm mirror.
+pub async fn fetch_latest_drift_report() -> Result<DriftReport> {
+    let url = std::env::var(NPM_LATEST_URL_ENV).unwrap_or_else(|_| NPM_LATEST_URL.to_string());
+    fetch_drift_report_from_url(&url).await
+}
+
+/// Variant of [`fetch_latest_drift_report`] that takes a configurable
+/// `latest`-dist-tag URL. Tests use this with a `wiremock` server; production
+/// always uses [`NPM_LATEST_URL`].
+async fn fetch_drift_report_from_url(latest_url: &str) -> Result<DriftReport> {
+    let client = reqwest::Client::builder()
+        .user_agent(concat!(
+            "omni-dev-adf-schema-drift/",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .context("building HTTP client")?;
+
+    let meta: Value = client
+        .get(latest_url)
+        .send()
+        .await
+        .context("fetching npm registry latest dist-tag")?
+        .error_for_status()
+        .context("npm registry returned a non-2xx status for latest dist-tag")?
+        .json()
+        .await
+        .context("parsing npm latest dist-tag JSON")?;
+
+    let upstream_version = meta
+        .get("version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("npm latest dist-tag JSON has no `version` field"))?
+        .to_string();
+    let tarball_url = meta
+        .get("dist")
+        .and_then(|d| d.get("tarball"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("npm latest dist-tag JSON has no `dist.tarball` field"))?
+        .to_string();
+
+    let tarball_bytes = client
+        .get(&tarball_url)
+        .send()
+        .await
+        .with_context(|| format!("fetching tarball {tarball_url}"))?
+        .error_for_status()
+        .with_context(|| format!("npm tarball {tarball_url} returned a non-2xx status"))?
+        .bytes()
+        .await
+        .context("reading tarball bytes")?;
+
+    let upstream_sha = format!("{:x}", Sha256::digest(&tarball_bytes));
+    let full_json = extract_full_json_from_tarball(&tarball_bytes)
+        .context("extracting dist/json-schema/v1/full.json from tarball")?;
+
+    diff_against_upstream_json_schema(&full_json, &upstream_version, &upstream_sha)
+}
+
+/// Parse the upstream `full.json` and diff against the local snapshot.
+pub fn diff_against_upstream_json_schema(
+    full: &Value,
+    upstream_version: &str,
+    upstream_sha256: &str,
+) -> Result<DriftReport> {
+    let upstream = parse_upstream_full_json(full)?;
+    let local = local_schema_map();
+
+    let local_version_npm = strip_transcription_date(SCHEMA_VERSION);
+    let version_changed = upstream_version != local_version_npm;
+
+    let upstream_parents: BTreeSet<&str> = upstream.keys().map(String::as_str).collect();
+    let local_parents: BTreeSet<&str> = local.keys().copied().collect();
+
+    let added_parents: BTreeSet<String> = upstream_parents
+        .difference(&local_parents)
+        .map(|s| (*s).to_string())
+        .collect();
+    let removed_parents: BTreeSet<String> = local_parents
+        .difference(&upstream_parents)
+        .map(|s| (*s).to_string())
+        .collect();
+
+    let mut per_parent: BTreeMap<String, ParentDrift> = BTreeMap::new();
+    for parent in upstream_parents.intersection(&local_parents).copied() {
+        let upstream_children: &BTreeSet<String> = upstream
+            .get(parent)
+            .ok_or_else(|| anyhow!("internal: parent `{parent}` missing from upstream map"))?;
+        let local_children: &BTreeSet<&'static str> = local
+            .get(parent)
+            .ok_or_else(|| anyhow!("internal: parent `{parent}` missing from local map"))?;
+        let added_children: BTreeSet<String> = upstream_children
+            .iter()
+            .filter(|c| !local_children.contains(c.as_str()))
+            .cloned()
+            .collect();
+        let removed_children: BTreeSet<String> = local_children
+            .iter()
+            .filter(|c| !upstream_children.contains(**c))
+            .map(|s| (*s).to_string())
+            .collect();
+        if !added_children.is_empty() || !removed_children.is_empty() {
+            per_parent.insert(
+                parent.to_string(),
+                ParentDrift {
+                    added_children,
+                    removed_children,
+                },
+            );
+        }
+    }
+
+    Ok(DriftReport {
+        upstream_version: upstream_version.to_string(),
+        upstream_tarball_sha256: upstream_sha256.to_string(),
+        local_version: SCHEMA_VERSION.to_string(),
+        local_tarball_sha256: UPSTREAM_TARBALL_SHA256.to_string(),
+        version_changed,
+        per_parent,
+        added_parents,
+        removed_parents,
+    })
+}
+
+// -----------------------------------------------------------------------------
+// JSON-schema parsing
+// -----------------------------------------------------------------------------
+
+/// Parse `full.json`'s `definitions` into a per-parent allowed-children map.
+///
+/// The shape we accept:
+///
+/// - A "bare-type" definition has `properties.type.const` (or `enum`)
+///   directly readable, e.g. `paragraph_node` → bare type `paragraph`.
+/// - A "marks-overlay" definition uses `allOf [base_ref, marks_extension]`
+///   to add a marks shape to an existing node (e.g.
+///   `formatted_text_inline_node` overlays marks on `text_node`). It
+///   inherits its base's bare type via a fixed-point pass.
+/// - Allowed children are the bare types reachable from any
+///   `properties.content` subtree (including ones nested under `allOf` to
+///   handle defs like `mediaSingle_caption_node`), with alias definitions
+///   flattened transitively.
+fn parse_upstream_full_json(full: &Value) -> Result<BTreeMap<String, BTreeSet<String>>> {
+    let definitions = full
+        .get("definitions")
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow!("upstream JSON has no `definitions` object"))?;
+
+    // Pass 1: direct bare types (anything with `properties.type.const|enum`
+    // readable without crossing a `$ref`).
+    let mut def_to_bare: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for (name, def) in definitions {
+        def_to_bare.insert(name.clone(), find_bare_type(def));
+    }
+
+    // Pass 2: fixed-point inheritance. `allOf [{$ref: X}, ...]` inherits
+    // X's bare type, when X has one. Repeat until no change so chains of
+    // length >1 (`A inherits from B inherits from C`) converge.
+    loop {
+        let mut changed = false;
+        for (name, def) in definitions {
+            if def_to_bare
+                .get(name)
+                .is_some_and(std::option::Option::is_some)
+            {
+                continue;
+            }
+            if let Some(inherited) = inherited_bare_type_via_allof(def, &def_to_bare) {
+                def_to_bare.insert(name.clone(), Some(inherited));
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    let mut result: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (name, def) in definitions {
+        let Some(Some(bare)) = def_to_bare.get(name) else {
+            continue;
+        };
+        let children = definition_content_children(name, def, definitions, &def_to_bare);
+        if !children.is_empty() {
+            result.entry(bare.clone()).or_default().extend(children);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Look for an inherited bare type via an `allOf` whose items include a
+/// `$ref` to a definition whose own bare type is known.
+///
+/// Only `allOf` is followed: it represents "I am all of these"
+/// (`base + extension`), so the base's identity is the natural inheritance
+/// path. `anyOf` / `oneOf` are unions of options, NOT inheritance — collapsing
+/// them to a single bare type would silently drop the other options' types.
+fn inherited_bare_type_via_allof(
+    def: &Value,
+    def_to_bare: &BTreeMap<String, Option<String>>,
+) -> Option<String> {
+    let Value::Object(obj) = def else { return None };
+    let Some(Value::Array(arr)) = obj.get("allOf") else {
+        return None;
+    };
+    for item in arr {
+        let Some(s) = item.get("$ref").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(target) = s.strip_prefix("#/definitions/") else {
+            continue;
+        };
+        if let Some(Some(bare)) = def_to_bare.get(target) {
+            return Some(bare.clone());
+        }
+    }
+    None
+}
+
+/// Find the bare node type for a definition, if it has one.
+///
+/// Looks at `properties.type.const` and `properties.type.enum[0]`, recursing
+/// through `allOf` / `anyOf` / `oneOf` arrays.
+fn find_bare_type(def: &Value) -> Option<String> {
+    fn walk(v: &Value) -> Option<String> {
+        let Value::Object(obj) = v else { return None };
+        if let Some(Value::Object(props)) = obj.get("properties") {
+            if let Some(Value::Object(t)) = props.get("type") {
+                if let Some(Value::String(s)) = t.get("const") {
+                    return Some(s.clone());
+                }
+                if let Some(Value::Array(arr)) = t.get("enum") {
+                    if let Some(Value::String(s)) = arr.first() {
+                        return Some(s.clone());
+                    }
+                }
+            }
+        }
+        for key in ["allOf", "anyOf", "oneOf"] {
+            if let Some(Value::Array(arr)) = obj.get(key) {
+                for x in arr {
+                    if let Some(s) = walk(x) {
+                        return Some(s);
+                    }
+                }
+            }
+        }
+        None
+    }
+    walk(def)
+}
+
+/// Collect bare-type children reachable from any `properties.content`
+/// subtree of `def`, including ones nested under `allOf` / `oneOf` / `anyOf`.
+fn definition_content_children(
+    def_name: &str,
+    def: &Value,
+    definitions: &Map<String, Value>,
+    def_to_bare: &BTreeMap<String, Option<String>>,
+) -> BTreeSet<String> {
+    let mut subtrees: Vec<&Value> = Vec::new();
+    find_content_subtrees(def, &mut subtrees);
+
+    let mut refs = Vec::new();
+    for subtree in subtrees {
+        collect_refs(subtree, &mut refs);
+    }
+
+    let mut out = BTreeSet::new();
+    for r in refs {
+        let mut visited = HashSet::new();
+        visited.insert(def_name.to_string());
+        resolve_ref_to_bare_types(&r, definitions, def_to_bare, &mut visited, &mut out);
+    }
+    out
+}
+
+/// Walk a definition tree gathering every `properties.content` subtree.
+///
+/// Descends through `allOf` / `oneOf` / `anyOf` siblings (so a marks-overlay
+/// def whose content lives inside an `allOf` extension is still picked up)
+/// but does NOT descend into the values of `properties.*` itself, which
+/// keeps marks/attrs subtrees out of the content-ref search.
+fn find_content_subtrees<'a>(value: &'a Value, out: &mut Vec<&'a Value>) {
+    let Value::Object(obj) = value else { return };
+    if let Some(Value::Object(props)) = obj.get("properties") {
+        if let Some(content) = props.get("content") {
+            out.push(content);
+        }
+    }
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(Value::Array(arr)) = obj.get(key) {
+            for item in arr {
+                find_content_subtrees(item, out);
+            }
+        }
+    }
+}
+
+/// Resolve a `$ref` target to its bare type(s), flattening alias chains.
+///
+/// Bare-type targets always emit their bare type, including for legitimate
+/// self-references (e.g. `taskList` listing `taskList` as an allowed child) —
+/// reaching the same bare-type def twice is not recursion, just convergence.
+/// Only alias-only chains need the `visited` set to prevent infinite loops.
+fn resolve_ref_to_bare_types(
+    target_def_name: &str,
+    definitions: &Map<String, Value>,
+    def_to_bare: &BTreeMap<String, Option<String>>,
+    visited: &mut HashSet<String>,
+    out: &mut BTreeSet<String>,
+) {
+    if let Some(Some(bare)) = def_to_bare.get(target_def_name) {
+        out.insert(bare.clone());
+        return;
+    }
+    if !visited.insert(target_def_name.to_string()) {
+        return;
+    }
+    let Some(target_def) = definitions.get(target_def_name) else {
+        return;
+    };
+    let mut refs = Vec::new();
+    collect_refs(target_def, &mut refs);
+    for r in refs {
+        resolve_ref_to_bare_types(&r, definitions, def_to_bare, visited, out);
+    }
+}
+
+/// Recursively collect every `#/definitions/<name>` reference under `node`.
+///
+/// Skips subtrees keyed `marks` or `attrs`: those describe mark/attribute
+/// schemas, not content, and their refs (e.g. to `link_mark` whose bare type
+/// would resolve to `"link"`) would otherwise leak in as false-positive
+/// content children when walking an alias definition.
+fn collect_refs(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(obj) => {
+            if let Some(Value::String(r)) = obj.get("$ref") {
+                if let Some(name) = r.strip_prefix("#/definitions/") {
+                    out.push(name.to_string());
+                }
+            }
+            for (key, v) in obj {
+                if key == "marks" || key == "attrs" {
+                    continue;
+                }
+                collect_refs(v, out);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                collect_refs(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tarball extraction
+// -----------------------------------------------------------------------------
+
+fn extract_full_json_from_tarball(bytes: &[u8]) -> Result<Value> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+    for entry in archive.entries().context("opening tarball entries")? {
+        let mut entry = entry.context("reading tarball entry header")?;
+        let path_buf = entry
+            .path()
+            .context("decoding tarball entry path")?
+            .into_owned();
+        if path_buf == std::path::Path::new("package/dist/json-schema/v1/full.json") {
+            let mut buf = String::new();
+            entry
+                .read_to_string(&mut buf)
+                .context("reading full.json")?;
+            return serde_json::from_str(&buf).context("parsing full.json");
+        }
+    }
+    Err(anyhow!(
+        "tarball does not contain package/dist/json-schema/v1/full.json"
+    ))
+}
+
+// -----------------------------------------------------------------------------
+// Version-string handling
+// -----------------------------------------------------------------------------
+
+/// Strip the trailing `-YYYY-MM-DD` transcription-date suffix from a
+/// `SCHEMA_VERSION`-style string, leaving the npm version.
+fn strip_transcription_date(s: &str) -> &str {
+    if s.len() < 11 {
+        return s;
+    }
+    let (head, tail) = s.split_at(s.len() - 11);
+    let Some(rest) = tail.strip_prefix('-') else {
+        return s;
+    };
+    let parts: Vec<&str> = rest.split('-').collect();
+    let looks_like_date = parts.len() == 3
+        && parts[0].len() == 4
+        && parts[1].len() == 2
+        && parts[2].len() == 2
+        && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    if looks_like_date {
+        head
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn synthesise_full_json_from_local() -> Value {
+        let local = local_schema_map();
+        let parents: BTreeSet<&str> = local.keys().copied().collect();
+        let mut all_types: BTreeSet<&str> = parents.clone();
+        for children in local.values() {
+            for c in children {
+                all_types.insert(*c);
+            }
+        }
+        let leaves: BTreeSet<&str> = all_types.difference(&parents).copied().collect();
+
+        let mut definitions = serde_json::Map::new();
+        for (parent, children) in &local {
+            let any_of: Vec<Value> = children
+                .iter()
+                .map(|c| json!({"$ref": format!("#/definitions/{c}_node")}))
+                .collect();
+            definitions.insert(
+                format!("{parent}_node"),
+                json!({
+                    "properties": {
+                        "type": {"const": parent},
+                        "content": {
+                            "type": "array",
+                            "items": {"anyOf": any_of}
+                        }
+                    }
+                }),
+            );
+        }
+        for leaf in &leaves {
+            definitions.insert(
+                format!("{leaf}_node"),
+                json!({
+                    "properties": {
+                        "type": {"const": leaf}
+                    }
+                }),
+            );
+        }
+        json!({"definitions": Value::Object(definitions)})
+    }
+
+    #[test]
+    fn parses_anyof_refs_into_allowed_children_set() {
+        let full = json!({
+            "definitions": {
+                "blockquote_node": {
+                    "properties": {
+                        "type": {"const": "blockquote"},
+                        "content": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {"$ref": "#/definitions/paragraph_node"},
+                                    {"$ref": "#/definitions/codeBlock_node"}
+                                ]
+                            }
+                        }
+                    }
+                },
+                "paragraph_node": {"properties": {"type": {"const": "paragraph"}}},
+                "codeBlock_node": {"properties": {"type": {"const": "codeBlock"}}}
+            }
+        });
+        let parsed = parse_upstream_full_json(&full).unwrap();
+        let bq = parsed.get("blockquote").expect("blockquote parsed");
+        let expected: BTreeSet<String> = ["codeBlock", "paragraph"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(*bq, expected);
+    }
+
+    #[test]
+    fn alias_definition_is_flattened_transitively() {
+        // tableCell-style: bare def points at an alias; alias resolves to bare types.
+        let full = json!({
+            "definitions": {
+                "tableCell_node": {
+                    "properties": {
+                        "type": {"const": "tableCell"},
+                        "content": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/table_cell_content"}
+                        }
+                    }
+                },
+                "table_cell_content": {
+                    "anyOf": [
+                        {"$ref": "#/definitions/paragraph_node"},
+                        {"$ref": "#/definitions/heading_node"}
+                    ]
+                },
+                "paragraph_node": {"properties": {"type": {"const": "paragraph"}}},
+                "heading_node": {"properties": {"type": {"const": "heading"}}}
+            }
+        });
+        let parsed = parse_upstream_full_json(&full).unwrap();
+        let cell = parsed.get("tableCell").expect("tableCell parsed");
+        let expected: BTreeSet<String> = ["heading", "paragraph"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(*cell, expected);
+    }
+
+    #[test]
+    fn report_is_empty_when_input_matches_local_entries() {
+        // Round-trip: synthesise a JSON-schema fixture from the local table,
+        // feed it through the parser, and assert no drift. This is a stronger
+        // version of the existing `blockquote_allowed_children_match_upstream_
+        // json_schema` test: it covers every parent in the table at once.
+        let full = synthesise_full_json_from_local();
+        let report = diff_against_upstream_json_schema(
+            &full,
+            strip_transcription_date(SCHEMA_VERSION),
+            "fixture",
+        )
+        .unwrap();
+        assert!(
+            !report.has_content_drift(),
+            "synthesised-from-local fixture should produce no content drift, got: {report:#?}"
+        );
+        assert!(report.added_parents.is_empty());
+        assert!(report.removed_parents.is_empty());
+        assert!(report.per_parent.is_empty());
+        assert!(!report.version_changed);
+    }
+
+    #[test]
+    fn report_flags_added_and_removed_children() {
+        let mut full = synthesise_full_json_from_local();
+        // Add a child to blockquote that the local table doesn't list.
+        let bq_items = full
+            .pointer_mut("/definitions/blockquote_node/properties/content/items/anyOf")
+            .unwrap()
+            .as_array_mut()
+            .unwrap();
+        bq_items.push(json!({"$ref": "#/definitions/madeUpBlock_node"}));
+        full.pointer_mut("/definitions")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert(
+                "madeUpBlock_node".to_string(),
+                json!({"properties": {"type": {"const": "madeUpBlock"}}}),
+            );
+        // Remove a child from panel.
+        let panel_items = full
+            .pointer_mut("/definitions/panel_node/properties/content/items/anyOf")
+            .unwrap()
+            .as_array_mut()
+            .unwrap();
+        panel_items.retain(|v| {
+            v.get("$ref").and_then(Value::as_str) != Some("#/definitions/paragraph_node")
+        });
+
+        let report =
+            diff_against_upstream_json_schema(&full, "fixture-version", "fixture").unwrap();
+        assert!(report.has_content_drift());
+
+        let bq = report
+            .per_parent
+            .get("blockquote")
+            .expect("blockquote drift present");
+        assert_eq!(
+            bq.added_children,
+            std::iter::once("madeUpBlock").map(String::from).collect()
+        );
+        assert!(bq.removed_children.is_empty());
+
+        let panel = report.per_parent.get("panel").expect("panel drift present");
+        assert!(panel.added_children.is_empty());
+        assert_eq!(
+            panel.removed_children,
+            std::iter::once("paragraph").map(String::from).collect()
+        );
+    }
+
+    #[test]
+    fn report_flags_added_and_removed_parents() {
+        let mut full = synthesise_full_json_from_local();
+        // Remove a parent definition (`expand`) from upstream entirely.
+        full.pointer_mut("/definitions")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("expand_node");
+        // Add a parent definition that the local table doesn't have.
+        full.pointer_mut("/definitions")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert(
+                "futureBlock_node".to_string(),
+                json!({
+                    "properties": {
+                        "type": {"const": "futureBlock"},
+                        "content": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {"$ref": "#/definitions/paragraph_node"}
+                                ]
+                            }
+                        }
+                    }
+                }),
+            );
+
+        let report = diff_against_upstream_json_schema(&full, "fixture", "fixture").unwrap();
+        assert!(report.added_parents.contains("futureBlock"));
+        assert!(report.removed_parents.contains("expand"));
+    }
+
+    #[test]
+    fn version_changed_distinguishes_npm_version_from_transcription_date() {
+        let full = synthesise_full_json_from_local();
+        // Same as local: not changed.
+        let r = diff_against_upstream_json_schema(
+            &full,
+            strip_transcription_date(SCHEMA_VERSION),
+            "fixture",
+        )
+        .unwrap();
+        assert!(!r.version_changed);
+
+        // Different: changed.
+        let r = diff_against_upstream_json_schema(&full, "999.0.0", "fixture").unwrap();
+        assert!(r.version_changed);
+    }
+
+    #[test]
+    fn strip_transcription_date_handles_yyyy_mm_dd_suffix() {
+        assert_eq!(strip_transcription_date("52.9.5-2026-05-10"), "52.9.5");
+        assert_eq!(strip_transcription_date("52.9.5"), "52.9.5");
+        assert_eq!(strip_transcription_date("52.9.5-rc1"), "52.9.5-rc1");
+        assert_eq!(
+            strip_transcription_date("52.9.5-rc1-2026-05-10"),
+            "52.9.5-rc1"
+        );
+        assert_eq!(strip_transcription_date(""), "");
+    }
+
+    #[test]
+    fn strip_transcription_date_returns_input_when_suffix_lacks_leading_dash() {
+        // 12+ chars but no `-` at the suffix-start position: returns input.
+        assert_eq!(strip_transcription_date("abcdefghijkl"), "abcdefghijkl");
+    }
+
+    #[test]
+    fn strip_transcription_date_returns_input_when_suffix_is_not_a_date() {
+        // 14 chars; tail = "-1234-XX-YY", parts non-numeric → returns input.
+        assert_eq!(strip_transcription_date("abc-1234-XX-YY"), "abc-1234-XX-YY");
+    }
+
+    #[test]
+    fn render_markdown_is_terse_when_no_drift() {
+        let full = synthesise_full_json_from_local();
+        let report = diff_against_upstream_json_schema(
+            &full,
+            strip_transcription_date(SCHEMA_VERSION),
+            "fixture",
+        )
+        .unwrap();
+        let md = report.render_markdown();
+        assert!(md.contains("No content-model changes"));
+        assert!(!md.contains("Per-parent diffs"));
+    }
+
+    #[test]
+    fn render_markdown_includes_per_parent_diffs() {
+        let mut full = synthesise_full_json_from_local();
+        let bq_items = full
+            .pointer_mut("/definitions/blockquote_node/properties/content/items/anyOf")
+            .unwrap()
+            .as_array_mut()
+            .unwrap();
+        bq_items.push(json!({"$ref": "#/definitions/text_node"}));
+        let report = diff_against_upstream_json_schema(&full, "fixture", "fixture").unwrap();
+        let md = report.render_markdown();
+        assert!(md.contains("Per-parent diffs"));
+        assert!(md.contains("`blockquote`"));
+        assert!(md.contains("text"));
+    }
+
+    #[test]
+    fn render_json_is_serializable() {
+        let full = synthesise_full_json_from_local();
+        let report = diff_against_upstream_json_schema(&full, "fixture", "fixture").unwrap();
+        let v = report.render_json();
+        assert!(v.is_object());
+        assert!(v.get("upstream_version").is_some());
+        assert!(v.get("per_parent").is_some());
+    }
+
+    // ---- find_bare_type variants -----------------------------------------
+
+    #[test]
+    fn find_bare_type_recognises_enum_array() {
+        // Some upstream defs use `"enum": ["nodeName"]` instead of
+        // `"const": "nodeName"` — both must resolve to the bare type.
+        let def = json!({"properties": {"type": {"enum": ["paragraph"]}}});
+        assert_eq!(find_bare_type(&def).as_deref(), Some("paragraph"));
+    }
+
+    #[test]
+    fn find_bare_type_walks_into_oneof_for_nested_const() {
+        let def = json!({
+            "oneOf": [
+                {"properties": {"type": {"const": "nestedExpand"}}},
+                {"properties": {"type": {"const": "ignoredVariant"}}}
+            ]
+        });
+        // First match wins.
+        assert_eq!(find_bare_type(&def).as_deref(), Some("nestedExpand"));
+    }
+
+    #[test]
+    fn find_bare_type_returns_none_for_nodes_with_no_type_const() {
+        let def = json!({"anyOf": [{"$ref": "#/definitions/x"}]});
+        assert_eq!(find_bare_type(&def), None);
+    }
+
+    #[test]
+    fn find_bare_type_returns_none_when_enum_is_empty_or_non_string() {
+        // Empty enum array: the `first()` Option is None.
+        let empty = json!({"properties": {"type": {"enum": []}}});
+        assert_eq!(find_bare_type(&empty), None);
+        // Enum with a non-string head element: the Value::String pattern fails.
+        let non_string = json!({"properties": {"type": {"enum": [42]}}});
+        assert_eq!(find_bare_type(&non_string), None);
+    }
+
+    #[test]
+    fn find_bare_type_returns_none_on_non_object() {
+        assert_eq!(find_bare_type(&json!(null)), None);
+        assert_eq!(find_bare_type(&json!([])), None);
+        assert_eq!(find_bare_type(&json!("string")), None);
+    }
+
+    // ---- inherited_bare_type_via_allof -----------------------------------
+
+    #[test]
+    fn inheritance_via_allof_finds_known_base() {
+        let def = json!({
+            "allOf": [
+                {"$ref": "#/definitions/paragraph_node"},
+                {"properties": {"marks": {}}}
+            ]
+        });
+        let mut def_to_bare = BTreeMap::new();
+        def_to_bare.insert("paragraph_node".to_string(), Some("paragraph".to_string()));
+        assert_eq!(
+            inherited_bare_type_via_allof(&def, &def_to_bare).as_deref(),
+            Some("paragraph")
+        );
+    }
+
+    #[test]
+    fn inheritance_via_allof_returns_none_when_no_allof() {
+        let def = json!({"anyOf": [{"$ref": "#/definitions/x_node"}]});
+        let mut def_to_bare = BTreeMap::new();
+        def_to_bare.insert("x_node".to_string(), Some("x".to_string()));
+        // anyOf is intentionally NOT followed for inheritance.
+        assert_eq!(inherited_bare_type_via_allof(&def, &def_to_bare), None);
+    }
+
+    #[test]
+    fn inheritance_via_allof_returns_none_when_target_unknown() {
+        let def = json!({"allOf": [{"$ref": "#/definitions/unknown_node"}]});
+        let def_to_bare: BTreeMap<String, Option<String>> = BTreeMap::new();
+        assert_eq!(inherited_bare_type_via_allof(&def, &def_to_bare), None);
+    }
+
+    #[test]
+    fn inheritance_via_allof_skips_items_without_ref_or_with_external_ref() {
+        // Items inside `allOf` may be plain objects (no `$ref`) — skip.
+        // Items with `$ref` not pointing into `#/definitions/` — also skip.
+        let def = json!({
+            "allOf": [
+                {"properties": {"marks": {}}},                  // no $ref
+                {"$ref": "https://example.com/external.json"},   // external ref
+                {"$ref": "#/definitions/paragraph_node"}         // valid; should be picked
+            ]
+        });
+        let mut def_to_bare = BTreeMap::new();
+        def_to_bare.insert("paragraph_node".to_string(), Some("paragraph".to_string()));
+        assert_eq!(
+            inherited_bare_type_via_allof(&def, &def_to_bare).as_deref(),
+            Some("paragraph")
+        );
+    }
+
+    #[test]
+    fn inheritance_via_allof_returns_none_when_only_non_ref_items() {
+        // No item carries a usable `$ref` — function returns None.
+        let def = json!({
+            "allOf": [
+                {"properties": {"marks": {}}},
+                {"$ref": "https://example.com/external.json"}
+            ]
+        });
+        let def_to_bare: BTreeMap<String, Option<String>> = BTreeMap::new();
+        assert_eq!(inherited_bare_type_via_allof(&def, &def_to_bare), None);
+    }
+
+    #[test]
+    fn inheritance_via_allof_returns_none_for_non_object_input() {
+        // Defensive `let Value::Object(obj) = def else { return None }`.
+        let def_to_bare: BTreeMap<String, Option<String>> = BTreeMap::new();
+        assert_eq!(
+            inherited_bare_type_via_allof(&json!(null), &def_to_bare),
+            None
+        );
+        assert_eq!(
+            inherited_bare_type_via_allof(&json!([]), &def_to_bare),
+            None
+        );
+        assert_eq!(
+            inherited_bare_type_via_allof(&json!("string"), &def_to_bare),
+            None
+        );
+    }
+
+    #[test]
+    fn inheritance_via_allof_handles_marks_overlay_pattern() {
+        // Real-world pattern: formatted_text_inline_node.
+        let full = json!({
+            "definitions": {
+                "paragraph_node": {
+                    "properties": {
+                        "type": {"const": "paragraph"},
+                        "content": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/formatted_text_inline_node"}
+                        }
+                    }
+                },
+                "text_node": {"properties": {"type": {"const": "text"}}},
+                "formatted_text_inline_node": {
+                    "allOf": [
+                        {"$ref": "#/definitions/text_node"},
+                        {
+                            "properties": {
+                                "marks": {
+                                    "type": "array",
+                                    "items": {
+                                        "anyOf": [
+                                            {"$ref": "#/definitions/link_mark"}
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                "link_mark": {"properties": {"type": {"const": "link"}}}
+            }
+        });
+        let parsed = parse_upstream_full_json(&full).unwrap();
+        // paragraph's children must be exactly {text}; the link mark must
+        // NOT leak in via the marks subtree.
+        let p = parsed.get("paragraph").expect("paragraph present");
+        let expected: BTreeSet<String> = std::iter::once("text").map(String::from).collect();
+        assert_eq!(*p, expected);
+    }
+
+    // ---- parse error paths -----------------------------------------------
+
+    #[test]
+    fn parse_returns_error_when_definitions_missing() {
+        let full = json!({"foo": "bar"});
+        let err = parse_upstream_full_json(&full).unwrap_err();
+        assert!(err.to_string().contains("definitions"));
+    }
+
+    #[test]
+    fn diff_propagates_parse_error_when_definitions_missing() {
+        let err = diff_against_upstream_json_schema(&json!({}), "1.0.0", "sha").unwrap_err();
+        assert!(err.to_string().contains("definitions"));
+    }
+
+    // ---- collect_refs / find_content_subtrees corner cases ---------------
+
+    #[test]
+    fn collect_refs_skips_marks_and_attrs_subtrees() {
+        let v = json!({
+            "properties": {
+                "content": {"$ref": "#/definitions/keep_me"},
+                "marks": {"$ref": "#/definitions/skip_me_mark"},
+                "attrs": {"$ref": "#/definitions/skip_me_attrs"}
+            }
+        });
+        let mut refs = Vec::new();
+        collect_refs(&v, &mut refs);
+        assert!(refs.contains(&"keep_me".to_string()));
+        assert!(!refs.contains(&"skip_me_mark".to_string()));
+        assert!(!refs.contains(&"skip_me_attrs".to_string()));
+    }
+
+    #[test]
+    fn collect_refs_handles_arrays_of_refs() {
+        let v = json!([
+            {"$ref": "#/definitions/a"},
+            {"$ref": "#/definitions/b"},
+            {"$ref": "https://example.com/schema"}, // non-#/definitions, ignored
+        ]);
+        let mut refs = Vec::new();
+        collect_refs(&v, &mut refs);
+        assert_eq!(refs, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn find_content_subtrees_returns_nothing_for_non_object_input() {
+        // Defensive `let Value::Object(obj) = value else { return }`.
+        let null = json!(null);
+        let array = json!([]);
+        let string = json!("string");
+        let mut subtrees = Vec::new();
+        find_content_subtrees(&null, &mut subtrees);
+        find_content_subtrees(&array, &mut subtrees);
+        find_content_subtrees(&string, &mut subtrees);
+        assert!(subtrees.is_empty());
+    }
+
+    #[test]
+    fn find_content_subtrees_picks_up_content_nested_in_allof() {
+        // mediaSingle_caption_node-style: bare type comes via $ref, content
+        // sits inside an `allOf` extension.
+        let def = json!({
+            "allOf": [
+                {"$ref": "#/definitions/mediaSingle_node"},
+                {
+                    "properties": {
+                        "content": {
+                            "type": "array",
+                            "items": [
+                                {"$ref": "#/definitions/media_node"},
+                                {"$ref": "#/definitions/caption_node"}
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        let mut subtrees = Vec::new();
+        find_content_subtrees(&def, &mut subtrees);
+        assert_eq!(subtrees.len(), 1);
+    }
+
+    // ---- resolve cycle protection ----------------------------------------
+
+    #[test]
+    fn resolve_handles_alias_cycles_without_infinite_loop() {
+        let mut definitions = serde_json::Map::new();
+        definitions.insert(
+            "alias_a".to_string(),
+            json!({"anyOf": [{"$ref": "#/definitions/alias_b"}]}),
+        );
+        definitions.insert(
+            "alias_b".to_string(),
+            json!({"anyOf": [{"$ref": "#/definitions/alias_a"}]}),
+        );
+        let mut def_to_bare = BTreeMap::new();
+        def_to_bare.insert("alias_a".to_string(), None);
+        def_to_bare.insert("alias_b".to_string(), None);
+
+        let mut visited = HashSet::new();
+        let mut out = BTreeSet::new();
+        // Should terminate (no infinite recursion).
+        resolve_ref_to_bare_types(
+            "alias_a",
+            &definitions,
+            &def_to_bare,
+            &mut visited,
+            &mut out,
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn resolve_returns_silently_when_target_not_in_definitions() {
+        let definitions = serde_json::Map::new();
+        let mut def_to_bare = BTreeMap::new();
+        def_to_bare.insert("ghost".to_string(), None);
+        let mut visited = HashSet::new();
+        let mut out = BTreeSet::new();
+        resolve_ref_to_bare_types("ghost", &definitions, &def_to_bare, &mut visited, &mut out);
+        assert!(out.is_empty());
+    }
+
+    // ---- markdown rendering branches -------------------------------------
+
+    fn report_with(
+        added_parents: BTreeSet<String>,
+        removed_parents: BTreeSet<String>,
+        per_parent: BTreeMap<String, ParentDrift>,
+        version_changed: bool,
+    ) -> DriftReport {
+        DriftReport {
+            upstream_version: "9.9.9".to_string(),
+            upstream_tarball_sha256: "up-sha".to_string(),
+            local_version: "1.0.0-2026-01-01".to_string(),
+            local_tarball_sha256: "local-sha".to_string(),
+            version_changed,
+            per_parent,
+            added_parents,
+            removed_parents,
+        }
+    }
+
+    #[test]
+    fn render_markdown_renders_added_parents_section() {
+        let added: BTreeSet<String> = std::iter::once("futureNode").map(String::from).collect();
+        let report = report_with(added, BTreeSet::new(), BTreeMap::new(), true);
+        let md = report.render_markdown();
+        assert!(md.contains("New parents (upstream only)"));
+        assert!(md.contains("`futureNode`"));
+        assert!(!md.contains("Removed parents"));
+    }
+
+    #[test]
+    fn render_markdown_renders_removed_parents_section() {
+        let removed: BTreeSet<String> = std::iter::once("oldNode").map(String::from).collect();
+        let report = report_with(BTreeSet::new(), removed, BTreeMap::new(), false);
+        let md = report.render_markdown();
+        assert!(md.contains("Removed parents (local only)"));
+        assert!(md.contains("`oldNode`"));
+        assert!(!md.contains("New parents"));
+    }
+
+    #[test]
+    fn render_markdown_renders_only_added_children_when_no_removed() {
+        let mut per = BTreeMap::new();
+        per.insert(
+            "blockquote".to_string(),
+            ParentDrift {
+                added_children: std::iter::once("newChild").map(String::from).collect(),
+                removed_children: BTreeSet::new(),
+            },
+        );
+        let report = report_with(BTreeSet::new(), BTreeSet::new(), per, false);
+        let md = report.render_markdown();
+        assert!(md.contains("Added children"));
+        assert!(!md.contains("Removed children"));
+        assert!(md.contains("`newChild`"));
+    }
+
+    #[test]
+    fn render_markdown_renders_only_removed_children_when_no_added() {
+        let mut per = BTreeMap::new();
+        per.insert(
+            "panel".to_string(),
+            ParentDrift {
+                added_children: BTreeSet::new(),
+                removed_children: std::iter::once("goneChild").map(String::from).collect(),
+            },
+        );
+        let report = report_with(BTreeSet::new(), BTreeSet::new(), per, false);
+        let md = report.render_markdown();
+        assert!(!md.contains("Added children"));
+        assert!(md.contains("Removed children"));
+        assert!(md.contains("`goneChild`"));
+    }
+
+    // ---- has_any_drift / has_content_drift -------------------------------
+
+    #[test]
+    fn has_any_drift_true_when_only_version_changed() {
+        let report = report_with(BTreeSet::new(), BTreeSet::new(), BTreeMap::new(), true);
+        assert!(!report.has_content_drift());
+        assert!(report.has_any_drift());
+    }
+
+    #[test]
+    fn has_any_drift_true_when_only_added_parents() {
+        let added: BTreeSet<String> = std::iter::once("x").map(String::from).collect();
+        let report = report_with(added, BTreeSet::new(), BTreeMap::new(), false);
+        assert!(report.has_content_drift());
+        assert!(report.has_any_drift());
+    }
+
+    #[test]
+    fn has_any_drift_true_when_only_removed_parents() {
+        let removed: BTreeSet<String> = std::iter::once("x").map(String::from).collect();
+        let report = report_with(BTreeSet::new(), removed, BTreeMap::new(), false);
+        assert!(report.has_content_drift());
+        assert!(report.has_any_drift());
+    }
+
+    // ---- tarball extraction ----------------------------------------------
+
+    fn build_synthetic_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut gz);
+            for (path, body) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(path).unwrap();
+                header.set_size(body.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append(&header, *body).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        gz.finish().unwrap()
+    }
+
+    #[test]
+    fn extract_full_json_succeeds_when_path_present() {
+        let body = serde_json::to_vec(&json!({"definitions": {}})).unwrap();
+        let bytes =
+            build_synthetic_tarball(&[("package/dist/json-schema/v1/full.json", body.as_slice())]);
+        let parsed = extract_full_json_from_tarball(&bytes).unwrap();
+        assert!(parsed.get("definitions").is_some());
+    }
+
+    #[test]
+    fn extract_full_json_errors_when_path_missing() {
+        let bytes = build_synthetic_tarball(&[("package/README.md", b"hello")]);
+        let err = extract_full_json_from_tarball(&bytes).unwrap_err();
+        assert!(err.to_string().contains("does not contain"));
+    }
+
+    #[test]
+    fn extract_full_json_errors_on_invalid_gzip() {
+        let bytes = b"not a gzip stream";
+        let err = extract_full_json_from_tarball(bytes).unwrap_err();
+        // Some error from flate2/tar surfaces as the cause; we only assert
+        // an error is returned.
+        let _ = err;
+    }
+
+    #[test]
+    fn extract_full_json_errors_when_payload_is_not_json() {
+        let bytes =
+            build_synthetic_tarball(&[("package/dist/json-schema/v1/full.json", b"not json{")]);
+        let err = extract_full_json_from_tarball(&bytes).unwrap_err();
+        assert!(err.to_string().contains("parsing full.json"));
+    }
+
+    // ---- end-to-end fetch via wiremock -----------------------------------
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_handles_clean_upstream() {
+        let server = wiremock::MockServer::start().await;
+        let full = synthesise_full_json_from_local();
+        let tarball = build_synthetic_tarball(&[(
+            "package/dist/json-schema/v1/full.json",
+            serde_json::to_vec(&full).unwrap().as_slice(),
+        )]);
+        let tarball_url = format!("{}/-/adf-schema-fixture.tgz", server.uri());
+
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "version": strip_transcription_date(SCHEMA_VERSION),
+                "dist": {"tarball": tarball_url}
+            })))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::path("/-/adf-schema-fixture.tgz"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(tarball))
+            .mount(&server)
+            .await;
+
+        let report = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap();
+        assert!(!report.version_changed);
+        assert!(!report.has_content_drift());
+    }
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_when_metadata_lacks_version() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({"dist": {"tarball": "x"}})),
+            )
+            .mount(&server)
+            .await;
+        let err = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("`version` field"));
+    }
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_when_metadata_lacks_tarball() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(json!({"version": "1.0.0"})),
+            )
+            .mount(&server)
+            .await;
+        let err = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("`dist.tarball` field"));
+    }
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_when_metadata_is_not_json() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string("not json{"),
+            )
+            .mount(&server)
+            .await;
+        let err = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("parsing npm latest dist-tag JSON"));
+    }
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_on_npm_5xx() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(wiremock::ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let err = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("non-2xx status for latest dist-tag"));
+    }
+
+    #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_on_tarball_5xx() {
+        let server = wiremock::MockServer::start().await;
+        let tarball_url = format!("{}/-/x.tgz", server.uri());
+        wiremock::Mock::given(wiremock::matchers::path("/latest"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "version": "1.0.0",
+                "dist": {"tarball": tarball_url}
+            })))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::path("/-/x.tgz"))
+            .respond_with(wiremock::ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let err = fetch_drift_report_from_url(&format!("{}/latest", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("non-2xx status"));
+    }
+}

--- a/src/atlassian/adf_schema/mod.rs
+++ b/src/atlassian/adf_schema/mod.rs
@@ -29,10 +29,23 @@
 //! "exactly one media child") are out of scope; they will be addressed in
 //! follow-up issues.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::LazyLock;
 
 use crate::atlassian::adf::{AdfDocument, AdfNode};
+
+pub mod drift;
+
+/// Crate-internal view of the schema as a `BTreeMap`, used by the drift
+/// detector to diff against an upstream-derived map of the same shape.
+#[must_use]
+pub(crate) fn local_schema_map() -> BTreeMap<&'static str, BTreeSet<&'static str>> {
+    let mut m = BTreeMap::new();
+    for (parent, children) in ENTRIES {
+        m.insert(*parent, children.iter().copied().collect());
+    }
+    m
+}
 
 /// Pinned upstream schema version.
 ///
@@ -133,9 +146,9 @@ const FULL_INLINE_CONTENT: &[&str] = &[
 // expansion.
 
 /// Allowed-children entries, sorted alphabetically by parent.
-type Entry = (&'static str, &'static [&'static str]);
+pub(crate) type Entry = (&'static str, &'static [&'static str]);
 
-const ENTRIES: &[Entry] = &[
+pub(crate) const ENTRIES: &[Entry] = &[
     // blockTaskItem — definitions/blockTaskItem_node
     ("blockTaskItem", &["extension", "paragraph"]),
     // blockquote — definitions/blockquote_node

--- a/src/bin/adf_schema_drift.rs
+++ b/src/bin/adf_schema_drift.rs
@@ -1,0 +1,227 @@
+//! `adf-schema-drift` — fetch the latest `@atlaskit/adf-schema` upstream and
+//! diff it against the locally-encoded snapshot in
+//! `src/atlassian/adf_schema/mod.rs`.
+//!
+//! Used by `.github/workflows/adf-schema-drift.yml` on a weekly schedule.
+//! Writes `drift-report.md` and/or `drift-report.json` to `--output-dir` and
+//! emits `drift=<bool>` and `version_changed=<bool>` to stdout (and to
+//! `$GITHUB_OUTPUT` if set), so the workflow can decide whether to open or
+//! update a tracking issue.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use omni_dev::atlassian::adf_schema::drift::{fetch_latest_drift_report, DriftReport};
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+enum Format {
+    Markdown,
+    Json,
+    Both,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "adf-schema-drift",
+    about = "Detect drift between the local ADF schema snapshot and upstream @atlaskit/adf-schema"
+)]
+struct Cli {
+    /// Output format(s) to write to `--output-dir`.
+    #[arg(long, value_enum, default_value_t = Format::Markdown)]
+    format: Format,
+
+    /// Directory to write report files into. Created if it does not exist.
+    #[arg(long, default_value = ".")]
+    output_dir: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let report = fetch_latest_drift_report().await?;
+    process_report(
+        &report,
+        cli.format,
+        &cli.output_dir,
+        std::env::var("GITHUB_OUTPUT").ok().as_deref(),
+        &mut std::io::stdout().lock(),
+    )
+}
+
+/// Write requested report files, append GitHub-Actions step outputs, and
+/// echo the same signals to `stdout`. Factored out of `main` so it can be
+/// unit-tested without spinning up a real HTTP fetch.
+fn process_report(
+    report: &DriftReport,
+    format: Format,
+    output_dir: &Path,
+    github_output: Option<&str>,
+    stdout: &mut dyn Write,
+) -> Result<()> {
+    fs::create_dir_all(output_dir)
+        .with_context(|| format!("creating output directory {}", output_dir.display()))?;
+
+    let want_md = matches!(format, Format::Markdown | Format::Both);
+    let want_json = matches!(format, Format::Json | Format::Both);
+
+    if want_md {
+        let path = output_dir.join("drift-report.md");
+        fs::write(&path, report.render_markdown())
+            .with_context(|| format!("writing {}", path.display()))?;
+    }
+    if want_json {
+        let path = output_dir.join("drift-report.json");
+        let body = serde_json::to_string_pretty(&report.render_json())
+            .context("serialising drift report to JSON")?;
+        fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+    }
+
+    let drift = report.has_any_drift();
+    writeln!(stdout, "drift={drift}").context("writing drift= to stdout")?;
+    writeln!(stdout, "version_changed={}", report.version_changed)
+        .context("writing version_changed= to stdout")?;
+
+    if let Some(path) = github_output {
+        let mut f = fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+            .with_context(|| format!("opening $GITHUB_OUTPUT at {path}"))?;
+        writeln!(f, "drift={drift}").context("appending drift= to $GITHUB_OUTPUT")?;
+        writeln!(f, "version_changed={}", report.version_changed)
+            .context("appending version_changed= to $GITHUB_OUTPUT")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn fixture_report(version_changed: bool, with_content_drift: bool) -> DriftReport {
+        let mut per_parent = BTreeMap::new();
+        if with_content_drift {
+            per_parent.insert(
+                "blockquote".to_string(),
+                omni_dev::atlassian::adf_schema::drift::ParentDrift {
+                    added_children: std::iter::once("madeUp").map(String::from).collect(),
+                    removed_children: BTreeSet::new(),
+                },
+            );
+        }
+        DriftReport {
+            upstream_version: "99.0.0".to_string(),
+            upstream_tarball_sha256: "sha".to_string(),
+            local_version: "52.9.5-2026-05-10".to_string(),
+            local_tarball_sha256: "localsha".to_string(),
+            version_changed,
+            per_parent,
+            added_parents: BTreeSet::new(),
+            removed_parents: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn cli_defaults_match_documentation() {
+        let cli = Cli::parse_from(["adf-schema-drift"]);
+        assert_eq!(cli.format, Format::Markdown);
+        assert_eq!(cli.output_dir, PathBuf::from("."));
+    }
+
+    #[test]
+    fn cli_accepts_explicit_format_and_output_dir() {
+        let cli = Cli::parse_from([
+            "adf-schema-drift",
+            "--format",
+            "both",
+            "--output-dir",
+            "/tmp/example",
+        ]);
+        assert_eq!(cli.format, Format::Both);
+        assert_eq!(cli.output_dir, PathBuf::from("/tmp/example"));
+    }
+
+    #[test]
+    fn process_report_writes_only_markdown_when_format_is_markdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        process_report(&report, Format::Markdown, dir.path(), None, &mut buf).unwrap();
+
+        assert!(dir.path().join("drift-report.md").exists());
+        assert!(!dir.path().join("drift-report.json").exists());
+        let stdout = String::from_utf8(buf).unwrap();
+        assert!(stdout.contains("drift=false"));
+        assert!(stdout.contains("version_changed=false"));
+    }
+
+    #[test]
+    fn process_report_writes_only_json_when_format_is_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = fixture_report(true, false);
+        let mut buf: Vec<u8> = Vec::new();
+        process_report(&report, Format::Json, dir.path(), None, &mut buf).unwrap();
+
+        assert!(!dir.path().join("drift-report.md").exists());
+        assert!(dir.path().join("drift-report.json").exists());
+        let stdout = String::from_utf8(buf).unwrap();
+        assert!(stdout.contains("drift=true"));
+        assert!(stdout.contains("version_changed=true"));
+    }
+
+    #[test]
+    fn process_report_writes_both_when_format_is_both() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = fixture_report(false, true);
+        let mut buf: Vec<u8> = Vec::new();
+        process_report(&report, Format::Both, dir.path(), None, &mut buf).unwrap();
+
+        assert!(dir.path().join("drift-report.md").exists());
+        assert!(dir.path().join("drift-report.json").exists());
+        let stdout = String::from_utf8(buf).unwrap();
+        // Content drift counts as drift even if version is unchanged.
+        assert!(stdout.contains("drift=true"));
+        assert!(stdout.contains("version_changed=false"));
+    }
+
+    #[test]
+    fn process_report_appends_to_github_output_when_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        let github_output_path = dir.path().join("github_output.txt");
+        // Seed with prior content to verify *append* (not overwrite).
+        std::fs::write(&github_output_path, "existing-line\n").unwrap();
+
+        let report = fixture_report(true, true);
+        let mut buf: Vec<u8> = Vec::new();
+        process_report(
+            &report,
+            Format::Markdown,
+            dir.path(),
+            Some(github_output_path.to_str().unwrap()),
+            &mut buf,
+        )
+        .unwrap();
+
+        let contents = std::fs::read_to_string(&github_output_path).unwrap();
+        assert!(contents.starts_with("existing-line\n"));
+        assert!(contents.contains("drift=true"));
+        assert!(contents.contains("version_changed=true"));
+    }
+
+    #[test]
+    fn process_report_creates_output_dir_if_missing() {
+        let parent = tempfile::tempdir().unwrap();
+        let nested = parent.path().join("does/not/exist/yet");
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        process_report(&report, Format::Markdown, &nested, None, &mut buf).unwrap();
+        assert!(nested.join("drift-report.md").exists());
+    }
+}

--- a/tests/adf_schema_drift_bin_test.rs
+++ b/tests/adf_schema_drift_bin_test.rs
@@ -1,0 +1,149 @@
+//! Integration tests for the `adf-schema-drift` binary.
+//!
+//! Spawns the compiled binary as a subprocess with `OMNI_DEV_ADF_SCHEMA_LATEST_URL`
+//! pointing at a `wiremock` server, exercising end-to-end the fetch flow,
+//! the `process_report` orchestration in `main`, and the `$GITHUB_OUTPUT`
+//! signalling.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::Write;
+use std::process::Command;
+
+use omni_dev::atlassian::adf_schema::drift::NPM_LATEST_URL_ENV;
+use serde_json::json;
+
+fn build_synthetic_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    {
+        let mut builder = tar::Builder::new(&mut gz);
+        for (path, body) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, *body).unwrap();
+        }
+        builder.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+/// Build a minimal upstream-shaped JSON schema with one parent + one leaf.
+/// Drift is "version_changed" (we feed an obviously-different version) but
+/// no content drift if the local map is empty for this parent. We accept
+/// content drift in this test — what we're verifying is the binary's
+/// orchestration, not the schema diff specifics.
+fn minimal_full_json() -> serde_json::Value {
+    json!({
+        "definitions": {
+            "paragraph_node": {
+                "properties": {
+                    "type": {"const": "paragraph"},
+                    "content": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/text_node"}
+                    }
+                }
+            },
+            "text_node": {"properties": {"type": {"const": "text"}}}
+        }
+    })
+}
+
+#[tokio::test]
+async fn binary_fetches_via_env_url_and_writes_outputs() {
+    let server = wiremock::MockServer::start().await;
+    let full = minimal_full_json();
+    let tarball = build_synthetic_tarball(&[(
+        "package/dist/json-schema/v1/full.json",
+        serde_json::to_vec(&full).unwrap().as_slice(),
+    )]);
+    let tarball_url = format!("{}/-/adf-schema-fixture.tgz", server.uri());
+
+    wiremock::Mock::given(wiremock::matchers::path("/latest"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+            "version": "99.0.0",
+            "dist": {"tarball": tarball_url}
+        })))
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::path("/-/adf-schema-fixture.tgz"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(tarball))
+        .mount(&server)
+        .await;
+
+    let workdir = tempfile::tempdir().unwrap();
+    let github_output = workdir.path().join("github_output.txt");
+    // Pre-create so the binary's `append` mode finds an existing file.
+    std::fs::File::create(&github_output)
+        .unwrap()
+        .write_all(b"")
+        .unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_adf-schema-drift");
+    let output = Command::new(exe)
+        .args([
+            "--format",
+            "both",
+            "--output-dir",
+            workdir.path().to_str().unwrap(),
+        ])
+        .env(NPM_LATEST_URL_ENV, format!("{}/latest", server.uri()))
+        .env("GITHUB_OUTPUT", &github_output)
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        output.status.success(),
+        "binary failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Version 99.0.0 != local SCHEMA_VERSION → drift=true.
+    assert!(stdout.contains("drift=true"), "stdout={stdout}");
+    assert!(stdout.contains("version_changed=true"), "stdout={stdout}");
+
+    assert!(workdir.path().join("drift-report.md").exists());
+    assert!(workdir.path().join("drift-report.json").exists());
+
+    let go = std::fs::read_to_string(&github_output).unwrap();
+    assert!(go.contains("drift=true"));
+    assert!(go.contains("version_changed=true"));
+}
+
+#[tokio::test]
+async fn binary_exits_nonzero_on_npm_5xx() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::path("/latest"))
+        .respond_with(wiremock::ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let workdir = tempfile::tempdir().unwrap();
+    let exe = env!("CARGO_BIN_EXE_adf-schema-drift");
+    let output = Command::new(exe)
+        .args(["--output-dir", workdir.path().to_str().unwrap()])
+        .env(NPM_LATEST_URL_ENV, format!("{}/latest", server.uri()))
+        .env_remove("GITHUB_OUTPUT")
+        .output()
+        .expect("spawn binary");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("non-2xx") || stderr.contains("503"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn binary_help_succeeds() {
+    let exe = env!("CARGO_BIN_EXE_adf-schema-drift");
+    let output = Command::new(exe).arg("--help").output().expect("spawn");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("--output-dir"));
+}


### PR DESCRIPTION
## Description

This PR implements automated drift detection between the local `@atlaskit/adf-schema` content-model snapshot (encoded in `src/atlassian/adf_schema`) and the upstream npm package. Previously, the local schema snapshot could silently fall out of sync with upstream releases.

The change introduces a weekly CI job that downloads the latest upstream tarball, parses its `dist/json-schema/v1/full.json`, and diffs it against the local `ENTRIES` table — opening or updating a GitHub tracking issue when drift is detected. This satisfies issue #731's acceptance criterion of detecting upstream changes "within a week of an upstream release" via a Monday-noon UTC cron schedule.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement
- [x] CI/CD changes
- [x] Dependency update

## Related Issue

Fixes #731

## Changes Made

**Core Changes:**
- Refactored `src/atlassian/adf_schema.rs` (monolithic file) into a module: `src/atlassian/adf_schema/mod.rs` (validator + schema table) and `src/atlassian/adf_schema/drift.rs` (drift detection logic). All existing public symbols (`allowed_children`, `permits_child`, `validate_document`, `AdfSchemaViolation`, `SCHEMA_VERSION`, `UPSTREAM_TARBALL_SHA256`) preserved unchanged.
- Added `local_schema_map()` crate-internal function in `mod.rs` that exposes the `ENTRIES` table as a `BTreeMap<&'static str, BTreeSet<&'static str>>` for use by the drift detector.
- Added `src/atlassian/adf_schema/drift.rs` implementing:
  - `ParentDrift` struct — per-parent added/removed children sets
  - `DriftReport` struct — full comparison result including version change, per-parent diffs, added/removed parents, with `render_markdown()` and `render_json()` methods
  - `fetch_latest_drift_report()` async function — fetches npm `latest` dist-tag, downloads tarball, verifies SHA-256, extracts `full.json`, and computes drift
  - `diff_against_upstream_json_schema()` — pure diff function for testing without network access
  - Upstream `full.json` parser handling `anyOf` ref lists, alias definitions (e.g. `table_cell_content`), `allOf` inheritance chains, and marks/attrs subtree exclusion
  - Tarball extraction via `flate2` + `tar` targeting `package/dist/json-schema/v1/full.json`
- Added `src/bin/adf_schema_drift.rs` — standalone binary with `clap` CLI (`--format markdown|json|both`, `--output-dir`) that writes `drift-report.md` and/or `drift-report.json` and emits `drift=<bool>` / `version_changed=<bool>` to stdout and `$GITHUB_OUTPUT`
- Added new Cargo dependencies: `flate2 = "1"`, `tar = "0.4"`, `sha2 = "0.10"`
- Registered `adf-schema-drift` as a `[[bin]]` target in `Cargo.toml`

**CI/CD:**
- Added `.github/workflows/adf-schema-drift.yml` — weekly workflow (Mondays 12:00 UTC, plus `workflow_dispatch`) that builds the binary, runs the drift check, and opens or updates a GitHub issue labelled `adf-schema-drift` when drift is found

**Testing:**
- Added comprehensive unit tests in `src/atlassian/adf_schema/drift.rs` (30+ tests) including:
  - `parses_anyof_refs_into_allowed_children_set` — basic `anyOf` ref parsing
  - `alias_definition_is_flattened_transitively` — `table_cell_content`-style alias resolution
  - `report_is_empty_when_input_matches_local_entries` — round-trip test: synthesise JSON schema from local `ENTRIES`, assert zero drift (covers all 26 parents simultaneously)
  - `report_flags_added_and_removed_children` — mutation test verifying per-parent drift
  - `report_flags_added_and_removed_parents` — mutation test verifying parent-level drift
  - `version_changed_distinguishes_npm_version_from_transcription_date`
  - `render_markdown_is_terse_when_no_drift` / `render_markdown_includes_per_parent_diffs`
  - `render_json_is_serializable`
  - Wiremock-based end-to-end async tests for `fetch_drift_report_from_url` covering clean upstream, missing version, missing tarball URL, and 5xx error responses
  - Tarball extraction tests using synthetic in-memory tarballs
  - Alias cycle protection, `collect_refs` marks/attrs exclusion, and `find_content_subtrees` allOf nesting tests
- Added unit tests in `src/bin/adf_schema_drift.rs` covering CLI defaults, format flag variants, `$GITHUB_OUTPUT` append behaviour, and output directory creation

## Testing

**Automated Testing:**
- [x] All existing tests pass (schema validator tests preserved unchanged in `mod.rs`)
- [x] New tests added for drift detection logic (30+ new tests in `drift.rs` and `adf_schema_drift.rs`)
- [x] Round-trip test synthesises a JSON schema fixture from local `ENTRIES` and asserts zero drift — covers all 26 parents simultaneously
- [x] End-to-end async tests via `wiremock` for the HTTP fetch path

**Manual Testing:**
- [x] Binary builds successfully
- [x] Tested error/edge cases in parser (alias chains, marks subtree exclusion, unknown refs)
- [x] Backward compatibility verified — existing `adf_schema` public API is unchanged

### Test Commands

```bash
# Core test suite (includes new drift tests)
cargo test

# Run only drift-specific tests
cargo test atlassian::adf_schema::drift

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build the new binary
cargo build --release --bin adf-schema-drift

# Run drift check manually (requires network)
./target/release/adf-schema-drift --format both --output-dir /tmp/drift-out
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `adf_schema.rs` split into `mod.rs` + `drift.rs`; all existing public symbols preserved unchanged
- [x] Security implications — the binary makes outbound HTTPS requests to `registry.npmjs.org`; SHA-256 of the downloaded tarball is recorded in the report for auditability; CI workflow runs with minimal permissions (`contents: read`, `issues: write`)
- [x] Error handling — `fetch_latest_drift_report` uses `anyhow::Context` throughout; parser errors surface as structured `Result::Err` rather than silent empty diffs

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact on the main application — the drift detector runs only as a standalone binary in CI, never in the hot path of the main `omni-dev` binary.

## Security Considerations

- [x] Potential security impact — the `adf-schema-drift` binary fetches from `registry.npmjs.org` over HTTPS. The downloaded tarball's SHA-256 is computed and included in the drift report for traceability. The CI workflow runs with minimal permissions (`contents: read`, `issues: write`) and uses only the automatically-provided `GITHUB_TOKEN`; no additional secrets are required.

## Breaking Changes

None. The `adf_schema` module's public API (`allowed_children`, `permits_child`, `validate_document`, `AdfSchemaViolation`, `SCHEMA_VERSION`, `UPSTREAM_TARBALL_SHA256`) is identical to the previous `adf_schema.rs` file. The refactoring is purely structural.

## Deployment Notes

- [x] No special deployment requirements — the workflow uses `GITHUB_TOKEN` (automatically provided) for issue management; no additional secrets are required.

## Additional Notes

**Future Enhancements:**
- The drift parser handles the patterns present in `@atlaskit/adf-schema` 52.9.5. Any layout change in future upstream releases that falls outside the understood patterns will surface as a structured parser error rather than a silent empty diff, ensuring visibility.
- Attribute schema, mark whitelist, and arity validation remain out of scope per the v1 design; they can be layered on top of the existing `ENTRIES` table in follow-up issues.

**Known Limitations:**
- The parser understands `anyOf`/`allOf`/`oneOf` ref flattening and alias chains but does not attempt to parse raw JSON-schema constraints (e.g. `minItems`, `const` on content items) — only the set of reachable bare node types is extracted.