### PR TITLE
test(atlassian): add error-path coverage for drift fetch and report processing

### DIFF
--- a/src/atlassian/adf_schema/drift.rs
+++ b/src/atlassian/adf_schema/drift.rs
@@ -1426,6 +1426,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_drift_report_from_url_errors_on_connection_refused() {
+        // Bind to find a free local port, then drop the listener so the
+        // port is no longer accepting connections. reqwest's `send().await`
+        // hits a connection-refused error, exercising the underlying error
+        // context wrapper that wiremock 200/4xx/5xx tests can't reach.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let url = format!("http://127.0.0.1:{port}/latest");
+        let err = fetch_drift_report_from_url(&url).await.unwrap_err();
+        assert!(
+            err.to_string().contains("fetching npm registry"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn fetch_drift_report_from_url_errors_on_npm_5xx() {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::path("/latest"))

--- a/src/bin/adf_schema_drift.rs
+++ b/src/bin/adf_schema_drift.rs
@@ -224,4 +224,112 @@ mod tests {
         process_report(&report, Format::Markdown, &nested, None, &mut buf).unwrap();
         assert!(nested.join("drift-report.md").exists());
     }
+
+    #[test]
+    fn process_report_errors_when_output_dir_path_is_blocked_by_file() {
+        // Place a regular file at the path component the binary needs to
+        // create as a directory; `create_dir_all` then fails.
+        let parent = tempfile::tempdir().unwrap();
+        let blocker = parent.path().join("blocker");
+        std::fs::write(&blocker, b"not-a-directory").unwrap();
+        let blocked = blocker.join("would-be-output-dir");
+
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        let err = process_report(&report, Format::Markdown, &blocked, None, &mut buf).unwrap_err();
+        assert!(
+            err.to_string().contains("creating output directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn process_report_errors_when_markdown_write_fails() {
+        // Pre-create `drift-report.md` as a directory so the file write fails.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("drift-report.md")).unwrap();
+
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        let err =
+            process_report(&report, Format::Markdown, dir.path(), None, &mut buf).unwrap_err();
+        assert!(
+            err.to_string().contains("drift-report.md"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn process_report_errors_when_json_write_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("drift-report.json")).unwrap();
+
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        let err = process_report(&report, Format::Json, dir.path(), None, &mut buf).unwrap_err();
+        assert!(
+            err.to_string().contains("drift-report.json"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn process_report_errors_when_github_output_path_is_unopenable() {
+        let parent = tempfile::tempdir().unwrap();
+        // A file whose parent is an existing regular file → can't open as
+        // a writable file (parent isn't a directory).
+        let blocker = parent.path().join("blocker");
+        std::fs::write(&blocker, b"not-a-directory").unwrap();
+        let bad_github_output = blocker.join("github_output.txt");
+
+        let report = fixture_report(false, false);
+        let mut buf: Vec<u8> = Vec::new();
+        let err = process_report(
+            &report,
+            Format::Markdown,
+            parent.path(),
+            Some(bad_github_output.to_str().unwrap()),
+            &mut buf,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("$GITHUB_OUTPUT"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// `Write` impl that always errors — covers stdout-write error contexts.
+    struct AlwaysErroringWriter;
+    impl Write for AlwaysErroringWriter {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("boom"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn always_erroring_writer_methods_behave_as_documented() {
+        // Sanity-check the test helper itself: `write` errors, `flush` is a
+        // no-op `Ok`. Without this, `flush` would be uncovered because
+        // `process_report` uses `writeln!` (which calls `write`/`write_all`)
+        // and never explicitly flushes.
+        let mut w = AlwaysErroringWriter;
+        assert!(w.write(b"data").is_err());
+        assert!(w.flush().is_ok());
+    }
+
+    #[test]
+    fn process_report_errors_when_stdout_write_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = fixture_report(false, false);
+        let mut writer = AlwaysErroringWriter;
+        let err =
+            process_report(&report, Format::Markdown, dir.path(), None, &mut writer).unwrap_err();
+        assert!(
+            err.to_string().contains("stdout"),
+            "unexpected error: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR adds error-path test coverage for the ADF schema drift detection feature, specifically targeting error handling branches in `fetch_drift_report_from_url` and `process_report` that were previously unreachable via wiremock happy-path or HTTP status-code tests. The new tests ensure all error contexts are exercised and produce the expected error messages.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #731

## Changes Made

**Core Changes:**
- No production code changes; purely additive test coverage

**Testing:**
- Added `fetch_drift_report_from_url_errors_on_connection_refused` in `src/atlassian/adf_schema/drift.rs`: binds a free port, drops the listener, and asserts the connection-refused path produces a "fetching npm registry" error context
- Added `process_report_errors_when_output_dir_path_is_blocked_by_file` in `src/bin/adf_schema_drift.rs`: places a regular file where a directory is expected, asserting `create_dir_all` failure produces a "creating output directory" error context
- Added `process_report_errors_when_markdown_write_fails`: pre-creates `drift-report.md` as a directory to trigger file-write failure, asserting the error message contains `drift-report.md`
- Added `process_report_errors_when_json_write_fails`: same technique for `drift-report.json`, asserting the error message contains `drift-report.json`
- Added `process_report_errors_when_github_output_path_is_unopenable`: uses a file blocking the `$GITHUB_OUTPUT` path, asserting the error context contains `$GITHUB_OUTPUT`
- Added `AlwaysErroringWriter` helper struct implementing `Write` that always returns an error, and `process_report_errors_when_stdout_write_fails` test to cover the stdout write-failure error context

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new error-path tests
cargo test fetch_drift_report_from_url_errors_on_connection_refused
cargo test process_report_errors

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] User experience
- [x] Backward compatibility

The key area to review is whether the error context strings asserted in tests (e.g. `"fetching npm registry"`, `"creating output directory"`, `"$GITHUB_OUTPUT"`, `"stdout"`) correctly match the `context()`/`wrap_err()` strings used in the production code, ensuring these tests will catch any future regressions in error messaging.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The connection-refused test relies on a port being freed between `drop(listener)` and `reqwest::send()`. On heavily loaded systems there is a theoretical (very unlikely) race where another process re-binds the same port; this is a standard test pattern for this scenario and is considered acceptable.

**Alternatives Considered:**
- Mocking the HTTP client to simulate connection errors was considered, but the current approach of binding/dropping a real TCP listener is simpler and does not require additional test dependencies.