### PR TITLE
fix(atlassian): use inline nodes directly in decisionItem content

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1251,10 +1251,7 @@ fn parse_decision_items(text: &str) -> Vec<AdfNode> {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("- <> ") {
             let inline_nodes = parse_inline(rest);
-            items.push(AdfNode::decision_item(
-                "DECIDED",
-                vec![AdfNode::paragraph(inline_nodes)],
-            ));
+            items.push(AdfNode::decision_item("DECIDED", inline_nodes));
         }
     }
     items
@@ -9426,6 +9423,21 @@ mod tests {
         let items = doc.content[0].content.as_ref().unwrap();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].attrs.as_ref().unwrap()["state"], "DECIDED");
+    }
+
+    // decisionItem is inline-only per ADF schema — its content must be
+    // text/inline nodes, not a paragraph wrapper (issue #753).
+    #[test]
+    fn decision_item_content_is_inline_not_paragraph() {
+        let md = ":::decisions\n- <> Use Rust\n:::";
+        let doc = markdown_to_adf(md).unwrap();
+        let items = doc.content[0].content.as_ref().unwrap();
+        let first_child = &items[0].content.as_ref().unwrap()[0];
+        assert_eq!(
+            first_child.node_type, "text",
+            "decisionItem must contain inline nodes directly, not a paragraph wrapper"
+        );
+        assert_eq!(first_child.text.as_deref(), Some("Use Rust"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a schema violation in the ADF (Atlassian Document Format) conversion of decision items. The `decisionItem` node type requires its content to be inline nodes (text, etc.) directly, not wrapped in a `paragraph` node. The previous implementation incorrectly wrapped inline content in a `paragraph` before passing it to `AdfNode::decision_item`, violating the ADF spec.

This fix removes the paragraph wrapper so that inline nodes are passed directly to `decisionItem`, matching the ADF schema requirements.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #753

## Changes Made

**Core Changes:**
- Removed `AdfNode::paragraph(inline_nodes)` wrapper in `parse_decision_items` in `src/atlassian/convert.rs`
- Pass `inline_nodes` directly to `AdfNode::decision_item` instead of wrapping them in a paragraph

**Testing:**
- Added regression test `decision_item_content_is_inline_not_paragraph` that asserts the first child of a `decisionItem` node is a `text` node, not a `paragraph` node

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested happy path scenarios (decision item with text content renders correctly)
- [x] Backward compatibility verified (existing decision item parsing still works)

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific regression test
cargo test decision_item_content_is_inline_not_paragraph

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the change affects how `decisionItem` content is structured in the ADF output

The key change is in `src/atlassian/convert.rs` around line 1251 in `parse_decision_items`. The old code:
```rust
items.push(AdfNode::decision_item(
    "DECIDED",
    vec![AdfNode::paragraph(inline_nodes)],
));
```
is replaced with:
```rust
items.push(AdfNode::decision_item("DECIDED", inline_nodes));
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

This change affects the ADF output structure for `decisionItem` nodes. Previously generated ADF containing `decisionItem` nodes with `paragraph` children was non-conformant with the ADF schema; this fix brings the output into compliance. Consumers strictly validating ADF against the schema will now receive valid output instead of invalid output.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the paragraph wrapper and adjusting the `AdfNode::decision_item` implementation to unwrap paragraphs — rejected in favour of simply not creating the invalid wrapper in the first place.