### PR TITLE
docs(docs): expand content model section in jfm spec

### DIFF
--- a/docs/specs/jfm.md
+++ b/docs/specs/jfm.md
@@ -194,29 +194,52 @@ content.
 ## Content Model Constraints
 
 ADF uses a strict content model: each container node permits only a specific
-set of child node types. Atlassian's APIs reject documents that violate the
-model, often as an opaque HTTP 500 with no indication of which nesting was at
-fault. JFM directives are unaware of these rules — `:::expand` inside
-`:::panel` parses cleanly into ADF, but the API will refuse it.
+set of child node types, and each parent's content sequence is constrained by
+quantifiers (`?`, `*`, `+`, `{n}`, `{m,n}`). Atlassian's APIs reject
+documents that violate the model, often as an opaque HTTP 500 with no
+indication of which nesting was at fault. JFM directives parse permissively —
+`:::expand` inside `:::panel` produces well-formed ADF, but the API will
+refuse it.
 
 ### Source of truth
 
-The full allowed-children table for every container node is encoded in
-`src/atlassian/adf_schema.rs`, transcribed faithfully from the upstream
-`@atlaskit/adf-schema` npm package. The pinned upstream version is recorded
-in the `SCHEMA_VERSION` and `UPSTREAM_TARBALL_SHA256` constants in that file.
-Treat the module as authoritative; the prose below is illustrative.
+The full content model for every container node is encoded in
+[`src/atlassian/adf_schema/mod.rs`](../../src/atlassian/adf_schema/mod.rs),
+transcribed faithfully from the upstream `@atlaskit/adf-schema` npm package
+per [ADR-0023](../adrs/adr-0023.md). The pinned upstream version is recorded
+in the `SCHEMA_VERSION` and `UPSTREAM_TARBALL_SHA256` constants in that
+module. Treat the module as authoritative; the prose below is illustrative.
 
-Three public helpers expose the model:
+Public helpers expose the model:
 
-- `adf_schema::allowed_children(parent)` — returns the allowed direct
-  children for a parent node type, or `None` for leaf / unknown types.
+- `adf_schema::allowed_children(parent)` — returns the union of allowed
+  direct children for a parent node type, or `None` for leaf / unknown
+  types.
+- `adf_schema::content_model(parent)` — returns the full sequence of
+  quantified content terms for a parent (preserves ordering and arity).
 - `adf_schema::permits_child(parent, child)` — `true` if `child` is permitted
   as a direct child of `parent`. Permissive on unknown parents (returns
   `true`) so that future Atlassian node types do not break round-trips.
 - `adf_schema::validate_document(&doc)` — depth-first walker that returns
-  every nesting violation in document order, with `parent_type`,
-  `child_type`, and an index path from the document root.
+  every nesting **and** arity violation in document order, with
+  `parent_type`, `child_type` (or quantifier diagnostic), and an index path
+  from the document root.
+
+### Enforcement on writes
+
+The validator is wired into every JFM-driven write path so violations abort
+locally with a clear diagnosis instead of producing an opaque HTTP 500:
+
+- `adf_validated::ValidatedAdfDocument::try_new` is the only constructor for
+  the `ValidatedAdfDocument` newtype that the Confluence and JIRA write APIs
+  accept, making "I forgot to validate" a compile error.
+- `omni-dev confluence write` and `omni-dev confluence create` (and their
+  MCP tool equivalents) print every violation via the dry-run helper before
+  any network call.
+- On HTTP 500 from a Confluence write that did pass local validation, the
+  client re-runs `validate_document` against the submitted body and attaches
+  the first violation (with a hint from `adf_hints::hint_for`) to the error
+  via `AtlassianError::ApiRequestFailedWithDiagnosis`.
 
 ### Common pitfalls
 
@@ -267,21 +290,28 @@ When the desired nesting is rejected, common rewrites are:
 
 - `unsupportedBlock` and `unsupportedInline` (the runtime preservation
   wrappers behind the `adf-unsupported` fenced block) are accepted under any
-  parent by the validator, regardless of the parent's allowed-children set.
-  This preserves the round-trip guarantee for nodes the snapshot does not
-  yet model.
+  parent by the validator, regardless of the parent's allowed-children set,
+  and count toward the parent's arity. This preserves the round-trip
+  guarantee from [ADR-0020](../adrs/adr-0020.md) for nodes the snapshot
+  does not yet model.
 - Unknown parent node types are treated permissively: their subtrees are
   not walked. A future Atlassian node type therefore does not become a
   validation failure until its content model is added to the schema.
 
-### Soft-launch caveat
+### Coverage and limits
 
-The validator is library-only as of `SCHEMA_VERSION 52.9.5-2026-05-10`. The
-JFM-to-ADF converter does **not** yet reject invalid nestings before sending
-them to the API; this section is preventive guidance for authors and tools
-producing JFM. Wiring the validator into the write path is tracked
-separately, as is broader coverage (arity, mark whitelists, attribute-value
-constraints) beyond direct-child nesting.
+As of `SCHEMA_VERSION 52.9.5-2026-05-10`, the validator covers:
+
+- Allowed-children sets for every container node type.
+- Per-term quantifiers and content-term sequences (e.g. empty `bulletList`,
+  two-`media` `mediaSingle`, or a `layoutSection` with one column are all
+  reported as `AdfSchemaViolation::Arity`).
+
+Out of scope and not enforced:
+
+- Mark whitelists (which marks may apply to which nodes).
+- Attribute-value schemas (allowed values for `panel.type`, `status.color`,
+  etc.).
 
 ## Generic Directive System
 


### PR DESCRIPTION
## Description

This PR expands the Content Model Constraints section of the JFM specification (`docs/specs/jfm.md`) to accurately reflect the current state of the ADF schema validator and its integration into the write path. The documentation was previously describing a "soft-launch" state where the validator was library-only; it now documents the fully wired enforcement on every JFM-driven write.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #716

## Changes Made

**Documentation (`docs/specs/jfm.md`):**
- Updated source of truth reference from `src/atlassian/adf_schema.rs` to `src/atlassian/adf_schema/mod.rs` with a hyperlink and ADR-0023 citation
- Documented the new `adf_schema::content_model(parent)` helper that returns quantified content term sequences (preserving ordering and arity)
- Expanded `adf_schema::validate_document` description to cover arity violations (`AdfSchemaViolation::Arity`) in addition to nesting violations
- Added "Enforcement on writes" subsection covering:
  - `adf_validated::ValidatedAdfDocument::try_new` as the sole constructor, making skipped validation a compile error
  - CLI dry-run output for `omni-dev confluence write` and `omni-dev confluence create` (and MCP equivalents)
  - HTTP 500 re-diagnosis via `AtlassianError::ApiRequestFailedWithDiagnosis` using `adf_hints::hint_for`
- Replaced the outdated "Soft-launch caveat" subsection with a "Coverage and limits" subsection that lists what the validator now covers (allowed-children sets, per-term quantifiers) and what remains out of scope (mark whitelists, attribute-value schemas)
- Updated `unsupportedBlock`/`unsupportedInline` note to mention arity counting and link ADR-0020

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Documentation reviewed for accuracy against the current codebase
- [x] Verified all ADR cross-references (ADR-0020, ADR-0023) are accurate
- [x] Confirmed hyperlinks to source files are correct

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility — the "Coverage and limits" section correctly documents what is and is not enforced so users of the spec are not misled

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only; no code changed)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Enforce mark whitelists (which marks may apply to which inline node types)
- Enforce attribute-value schemas (allowed values for `panel.type`, `status.color`, etc.)

**Known Limitations:**
- The validator does not yet enforce mark whitelists or attribute-value schemas; these are explicitly called out in the new "Coverage and limits" subsection