### PR TITLE
feat(atlassian): add adf-schema-codegen binary and vendored schema assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Run tests
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ name = "adf-schema-drift"
 path = "src/bin/adf_schema_drift.rs"
 required-features = []
 
+[[bin]]
+name = "adf-schema-codegen"
+path = "src/bin/adf_schema_codegen.rs"
+required-features = []
+
 [lints.rust]
 unsafe_code = "deny"
 # Custom cfgs declared so `cargo check`/`cargo test` don't warn on them.

--- a/assets/adf-schema/README.md
+++ b/assets/adf-schema/README.md
@@ -1,0 +1,39 @@
+# Vendored `@atlaskit/adf-schema` artefacts
+
+Source artefacts for the code-generated ADF schema table (issue #732).
+
+## Files
+
+- `full.json` — the upstream `dist/json-schema/v1/full.json` extracted from the
+  pinned tarball. The only file the generator reads.
+- `provenance.json` — the npm package version, tarball URL, tarball SHA-256,
+  and a SHA-256 of `full.json` itself. The generator bakes these into the
+  emitted source's `pub const`s so the binary carries the provenance.
+
+## Refresh workflow
+
+1. Download a new upstream tarball:
+   ```
+   curl -sL https://registry.npmjs.org/@atlaskit/adf-schema/-/adf-schema-<ver>.tgz -o /tmp/adf-schema.tgz
+   shasum -a 256 /tmp/adf-schema.tgz
+   ```
+2. Extract `package/dist/json-schema/v1/full.json` into this directory.
+3. Update `provenance.json` with the new version, tarball SHA, and the new
+   `full.json` SHA (`shasum -a 256 assets/adf-schema/full.json`).
+4. Run the generator:
+   ```
+   cargo run --bin adf-schema-codegen
+   ```
+   This rewrites `src/atlassian/adf_schema/generated.rs`.
+5. Run the consistency test:
+   ```
+   cargo test --test adf_schema_test
+   ```
+   Drift between the upstream snapshot and the hand-maintained
+   `CONTENT_ENTRIES` is reported, modulo the documented leniency allowlist in
+   the test.
+6. Commit `full.json`, `provenance.json`, and `generated.rs` together.
+
+The generator is also CI-checkable: `cargo run --bin adf-schema-codegen --
+--check` exits non-zero if the committed `generated.rs` is out of date with
+respect to the vendored `full.json`.

--- a/assets/adf-schema/full.json
+++ b/assets/adf-schema/full.json
@@ -1,0 +1,2963 @@
+{
+  "$ref": "#/definitions/doc_node",
+  "description": "Schema for Atlassian Document Format.",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "alignment_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["alignment"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "align": {
+              "enum": ["center", "end"]
+            }
+          },
+          "required": ["align"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "annotation_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["annotation"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "annotationType": {
+              "enum": ["inlineComment"]
+            }
+          },
+          "required": ["id", "annotationType"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "backgroundColor_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["backgroundColor"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "color": {
+              "pattern": "^#[0-9a-fA-F]{6}$",
+              "type": "string"
+            }
+          },
+          "required": ["color"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "block_content": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/blockCard_node"
+        },
+        {
+          "$ref": "#/definitions/paragraph_with_no_marks_node"
+        },
+        {
+          "$ref": "#/definitions/paragraph_with_alignment_node"
+        },
+        {
+          "$ref": "#/definitions/paragraph_with_indentation_node"
+        },
+        {
+          "$ref": "#/definitions/mediaSingle_caption_node"
+        },
+        {
+          "$ref": "#/definitions/mediaSingle_full_node"
+        },
+        {
+          "$ref": "#/definitions/codeBlock_node"
+        },
+        {
+          "$ref": "#/definitions/taskList_node"
+        },
+        {
+          "$ref": "#/definitions/bulletList_node"
+        },
+        {
+          "$ref": "#/definitions/orderedList_node"
+        },
+        {
+          "$ref": "#/definitions/heading_with_no_marks_node"
+        },
+        {
+          "$ref": "#/definitions/heading_with_alignment_node"
+        },
+        {
+          "$ref": "#/definitions/heading_with_indentation_node"
+        },
+        {
+          "$ref": "#/definitions/mediaGroup_node"
+        },
+        {
+          "$ref": "#/definitions/decisionList_node"
+        },
+        {
+          "$ref": "#/definitions/rule_node"
+        },
+        {
+          "$ref": "#/definitions/panel_node"
+        },
+        {
+          "$ref": "#/definitions/blockquote_node"
+        },
+        {
+          "$ref": "#/definitions/extension_with_marks_node"
+        },
+        {
+          "$ref": "#/definitions/embedCard_node"
+        },
+        {
+          "$ref": "#/definitions/table_node"
+        },
+        {
+          "$ref": "#/definitions/expand_node"
+        },
+        {
+          "$ref": "#/definitions/bodiedExtension_with_marks_node"
+        }
+      ]
+    },
+    "blockCard_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["blockCard"]
+        },
+        "attrs": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "localId": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "datasource": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "parameters": {},
+                    "views": {
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "properties": {},
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type"],
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": ["id", "parameters", "views"]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "layout": {
+                  "enum": [
+                    "wide",
+                    "full-width",
+                    "center",
+                    "wrap-right",
+                    "wrap-left",
+                    "align-end",
+                    "align-start"
+                  ]
+                }
+              },
+              "required": ["datasource"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "localId": {
+                  "type": "string"
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "data": {},
+                "localId": {
+                  "type": "string"
+                }
+              },
+              "required": ["data"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "blockquote_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["blockquote"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/paragraph_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/orderedList_node"
+              },
+              {
+                "$ref": "#/definitions/bulletList_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_caption_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_full_node"
+              },
+              {
+                "$ref": "#/definitions/mediaGroup_node"
+              },
+              {
+                "$ref": "#/definitions/extension_with_marks_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "blockTaskItem_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["blockTaskItem"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            },
+            "state": {
+              "enum": ["TODO", "DONE"]
+            }
+          },
+          "required": ["localId", "state"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/paragraph_with_no_marks_node"
+                },
+                {
+                  "$ref": "#/definitions/paragraph_with_font_size_node"
+                },
+                {
+                  "$ref": "#/definitions/extension_with_marks_node"
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/paragraph_with_no_marks_node"
+                },
+                {
+                  "$ref": "#/definitions/paragraph_with_font_size_node"
+                },
+                {
+                  "$ref": "#/definitions/extension_with_marks_node"
+                }
+              ]
+            }
+          ],
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "bodiedExtension_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["bodiedExtension"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "extensionKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "extensionType": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "parameters": {},
+            "text": {
+              "type": "string"
+            },
+            "layout": {
+              "enum": ["wide", "full-width", "default"]
+            },
+            "localId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": ["extensionKey", "extensionType"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/non_nestable_block_content"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "bodiedExtension_with_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/bodiedExtension_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/dataConsumer_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/fragment_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "bodiedSyncBlock_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["bodiedSyncBlock"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/breakout_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "resourceId": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["resourceId", "localId"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/paragraph_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_alignment_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_indentation_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/blockCard_node"
+              },
+              {
+                "$ref": "#/definitions/blockquote_node"
+              },
+              {
+                "$ref": "#/definitions/bulletList_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_node"
+              },
+              {
+                "$ref": "#/definitions/decisionList_node"
+              },
+              {
+                "$ref": "#/definitions/embedCard_node"
+              },
+              {
+                "$ref": "#/definitions/expand_node"
+              },
+              {
+                "$ref": "#/definitions/heading_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_alignment_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_indentation_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/layoutSection_node"
+              },
+              {
+                "$ref": "#/definitions/layoutSection_full_node"
+              },
+              {
+                "$ref": "#/definitions/mediaGroup_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_caption_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_full_node"
+              },
+              {
+                "$ref": "#/definitions/orderedList_node"
+              },
+              {
+                "$ref": "#/definitions/panel_node"
+              },
+              {
+                "$ref": "#/definitions/rule_node"
+              },
+              {
+                "$ref": "#/definitions/table_node"
+              },
+              {
+                "$ref": "#/definitions/taskList_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "border_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["border"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 3
+            },
+            "color": {
+              "pattern": "^#[0-9a-fA-F]{8}$|^#[0-9a-fA-F]{6}$",
+              "type": "string"
+            }
+          },
+          "required": ["size", "color"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "breakout_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["breakout"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "enum": ["wide", "full-width"]
+            },
+            "width": {
+              "type": "number"
+            }
+          },
+          "required": ["mode"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "bulletList_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["bulletList"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/listItem_node"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "caption_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["caption"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/hardBreak_node"
+              },
+              {
+                "$ref": "#/definitions/mention_node"
+              },
+              {
+                "$ref": "#/definitions/emoji_node"
+              },
+              {
+                "$ref": "#/definitions/date_node"
+              },
+              {
+                "$ref": "#/definitions/placeholder_node"
+              },
+              {
+                "$ref": "#/definitions/inlineCard_node"
+              },
+              {
+                "$ref": "#/definitions/status_node"
+              },
+              {
+                "$ref": "#/definitions/formatted_text_inline_node"
+              },
+              {
+                "$ref": "#/definitions/code_inline_node"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "code_inline_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/text_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/code_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/link_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/annotation_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "code_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["code"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "codeBlock_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["codeBlock"]
+        },
+        "marks": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string"
+            },
+            "uniqueId": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/text_with_no_marks_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "codeBlock_root_only_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["codeBlock"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/breakout_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string"
+            },
+            "uniqueId": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/text_with_no_marks_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "dataConsumer_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["dataConsumer"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          },
+          "required": ["sources"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "date_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["date"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["timestamp"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "decisionItem_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["decisionItem"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            }
+          },
+          "required": ["localId", "state"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inline_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "decisionList_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["decisionList"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["localId"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/decisionItem_node"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "doc_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["doc"]
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/blockCard_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_caption_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_full_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_alignment_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_indentation_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/taskList_node"
+              },
+              {
+                "$ref": "#/definitions/orderedList_node"
+              },
+              {
+                "$ref": "#/definitions/bulletList_node"
+              },
+              {
+                "$ref": "#/definitions/blockquote_node"
+              },
+              {
+                "$ref": "#/definitions/decisionList_node"
+              },
+              {
+                "$ref": "#/definitions/embedCard_node"
+              },
+              {
+                "$ref": "#/definitions/extension_with_marks_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_indentation_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_alignment_node"
+              },
+              {
+                "$ref": "#/definitions/mediaGroup_node"
+              },
+              {
+                "$ref": "#/definitions/rule_node"
+              },
+              {
+                "$ref": "#/definitions/panel_node"
+              },
+              {
+                "$ref": "#/definitions/table_node"
+              },
+              {
+                "$ref": "#/definitions/bodiedExtension_with_marks_node"
+              },
+              {
+                "$ref": "#/definitions/expand_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_root_only_node"
+              },
+              {
+                "$ref": "#/definitions/layoutSection_full_node"
+              },
+              {
+                "$ref": "#/definitions/expand_root_only_node"
+              },
+              {
+                "$ref": "#/definitions/syncBlock_node"
+              },
+              {
+                "$ref": "#/definitions/bodiedSyncBlock_node"
+              }
+            ]
+          }
+        },
+        "version": {
+          "enum": [1]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["version", "type", "content"]
+    },
+    "em_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["em"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "embedCard_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["embedCard"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "layout": {
+              "enum": [
+                "wide",
+                "full-width",
+                "center",
+                "wrap-right",
+                "wrap-left",
+                "align-end",
+                "align-start"
+              ]
+            },
+            "width": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 0
+            },
+            "originalHeight": {
+              "type": "number"
+            },
+            "originalWidth": {
+              "type": "number"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["url", "layout"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "emoji_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["emoji"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "shortName": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["shortName"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "expand_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["expand"]
+        },
+        "marks": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/non_nestable_block_content"
+              },
+              {
+                "$ref": "#/definitions/nestedExpand_with_no_marks_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "expand_root_only_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["expand"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/breakout_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/non_nestable_block_content"
+              },
+              {
+                "$ref": "#/definitions/nestedExpand_with_no_marks_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "extension_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["extension"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "extensionKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "extensionType": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "parameters": {},
+            "text": {
+              "type": "string"
+            },
+            "layout": {
+              "enum": ["wide", "full-width", "default"]
+            },
+            "localId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": ["extensionKey", "extensionType"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "extension_with_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/extension_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/dataConsumer_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/fragment_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "fontSize_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["fontSize"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "fontSize": {
+              "enum": ["small"]
+            }
+          },
+          "required": ["fontSize"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "formatted_text_inline_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/text_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/link_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/em_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/strong_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/strike_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/subsup_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/underline_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/textColor_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/annotation_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/backgroundColor_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "fragment_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["fragment"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["localId"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "hardBreak_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["hardBreak"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "enum": ["\n"]
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "heading_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["heading"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 6
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["level"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inline_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "heading_with_alignment_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/heading_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/alignment_mark"
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "heading_with_indentation_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/heading_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/indentation_mark"
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "heading_with_no_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/heading_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "maxItems": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "indentation_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["indentation"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 6
+            }
+          },
+          "required": ["level"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "inline_node": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/formatted_text_inline_node"
+        },
+        {
+          "$ref": "#/definitions/code_inline_node"
+        },
+        {
+          "$ref": "#/definitions/date_node"
+        },
+        {
+          "$ref": "#/definitions/emoji_node"
+        },
+        {
+          "$ref": "#/definitions/hardBreak_node"
+        },
+        {
+          "$ref": "#/definitions/inlineCard_node"
+        },
+        {
+          "$ref": "#/definitions/mention_node"
+        },
+        {
+          "$ref": "#/definitions/placeholder_node"
+        },
+        {
+          "$ref": "#/definitions/status_node"
+        },
+        {
+          "$ref": "#/definitions/inlineExtension_with_marks_node"
+        },
+        {
+          "$ref": "#/definitions/mediaInline_node"
+        }
+      ]
+    },
+    "inlineCard_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["inlineCard"]
+        },
+        "attrs": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "localId": {
+                  "type": "string"
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "data": {},
+                "localId": {
+                  "type": "string"
+                }
+              },
+              "required": ["data"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "inlineExtension_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["inlineExtension"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "extensionKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "extensionType": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "parameters": {},
+            "text": {
+              "type": "string"
+            },
+            "localId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": ["extensionKey", "extensionType"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "inlineExtension_with_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/inlineExtension_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/dataConsumer_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/fragment_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "layoutColumn_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["layoutColumn"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "width": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["width"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/block_content"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "layoutSection_full_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/layoutSection_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/breakout_mark"
+              }
+            },
+            "content": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/layoutColumn_node"
+              },
+              "minItems": 2,
+              "maxItems": 3
+            }
+          },
+          "required": ["content"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "layoutSection_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["layoutSection"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/breakout_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/layoutColumn_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "link_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["link"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "href": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "collection": {
+              "type": "string"
+            },
+            "occurrenceKey": {
+              "type": "string"
+            }
+          },
+          "required": ["href"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "listItem_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["listItem"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/paragraph_with_font_size_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/bulletList_node"
+              },
+              {
+                "$ref": "#/definitions/orderedList_node"
+              },
+              {
+                "$ref": "#/definitions/taskList_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_caption_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_full_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_node"
+              },
+              {
+                "$ref": "#/definitions/extension_with_marks_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "media_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["media"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/dataConsumer_mark"
+              },
+              {
+                "$ref": "#/definitions/link_mark"
+              },
+              {
+                "$ref": "#/definitions/annotation_mark"
+              },
+              {
+                "$ref": "#/definitions/border_mark"
+              }
+            ]
+          }
+        },
+        "attrs": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": ["link", "file"]
+                },
+                "localId": {
+                  "type": "string"
+                },
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                },
+                "collection": {
+                  "type": "string"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "occurrenceKey": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "width": {
+                  "type": "number"
+                }
+              },
+              "required": ["type", "id", "collection"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "enum": ["external"]
+                },
+                "localId": {
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "width": {
+                  "type": "number"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": ["type", "url"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "mediaGroup_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["mediaGroup"]
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/media_node"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "mediaInline_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["mediaInline"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/dataConsumer_mark"
+              },
+              {
+                "$ref": "#/definitions/link_mark"
+              },
+              {
+                "$ref": "#/definitions/annotation_mark"
+              },
+              {
+                "$ref": "#/definitions/border_mark"
+              }
+            ]
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["link", "file", "image"]
+            },
+            "localId": {
+              "type": "string"
+            },
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "alt": {
+              "type": "string"
+            },
+            "collection": {
+              "type": "string"
+            },
+            "occurrenceKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "data": {}
+          },
+          "required": ["id", "collection"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "mediaSingle_caption_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaSingle_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "content": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/media_node"
+                },
+                {
+                  "$ref": "#/definitions/caption_node"
+                }
+              ],
+              "minItems": 1,
+              "maxItems": 2
+            }
+          },
+          "required": ["content"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "mediaSingle_full_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaSingle_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "content": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/media_node"
+              },
+              "minItems": 1,
+              "maxItems": 1
+            }
+          },
+          "required": ["content"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "mediaSingle_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["mediaSingle"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/link_mark"
+          }
+        },
+        "attrs": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "localId": {
+                  "type": "string"
+                },
+                "width": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "layout": {
+                  "enum": [
+                    "wide",
+                    "full-width",
+                    "center",
+                    "wrap-right",
+                    "wrap-left",
+                    "align-end",
+                    "align-start"
+                  ]
+                },
+                "widthType": {
+                  "enum": ["percentage"]
+                }
+              },
+              "required": ["layout"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "localId": {
+                  "type": "string"
+                },
+                "width": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "widthType": {
+                  "enum": ["pixel"]
+                },
+                "layout": {
+                  "enum": [
+                    "wide",
+                    "full-width",
+                    "center",
+                    "wrap-right",
+                    "wrap-left",
+                    "align-end",
+                    "align-start"
+                  ]
+                }
+              },
+              "required": ["width", "widthType", "layout"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": ["type"]
+    },
+    "mention_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["mention"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "accessLevel": {
+              "type": "string"
+            },
+            "userType": {
+              "enum": ["DEFAULT", "SPECIAL", "APP"]
+            }
+          },
+          "required": ["id"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "nestedExpand_content": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/paragraph_with_no_marks_node"
+          },
+          {
+            "$ref": "#/definitions/paragraph_with_font_size_node"
+          },
+          {
+            "$ref": "#/definitions/heading_with_no_marks_node"
+          },
+          {
+            "$ref": "#/definitions/mediaSingle_caption_node"
+          },
+          {
+            "$ref": "#/definitions/mediaSingle_full_node"
+          },
+          {
+            "$ref": "#/definitions/mediaGroup_node"
+          },
+          {
+            "$ref": "#/definitions/codeBlock_node"
+          },
+          {
+            "$ref": "#/definitions/bulletList_node"
+          },
+          {
+            "$ref": "#/definitions/orderedList_node"
+          },
+          {
+            "$ref": "#/definitions/taskList_node"
+          },
+          {
+            "$ref": "#/definitions/decisionList_node"
+          },
+          {
+            "$ref": "#/definitions/rule_node"
+          },
+          {
+            "$ref": "#/definitions/panel_node"
+          },
+          {
+            "$ref": "#/definitions/blockquote_node"
+          },
+          {
+            "$ref": "#/definitions/extension_with_marks_node"
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "nestedExpand_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["nestedExpand"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "$ref": "#/definitions/nestedExpand_content"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content", "attrs"]
+    },
+    "nestedExpand_with_no_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/nestedExpand_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "maxItems": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "non_nestable_block_content": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/paragraph_with_no_marks_node"
+        },
+        {
+          "$ref": "#/definitions/paragraph_with_font_size_node"
+        },
+        {
+          "$ref": "#/definitions/panel_node"
+        },
+        {
+          "$ref": "#/definitions/blockquote_node"
+        },
+        {
+          "$ref": "#/definitions/orderedList_node"
+        },
+        {
+          "$ref": "#/definitions/bulletList_node"
+        },
+        {
+          "$ref": "#/definitions/rule_node"
+        },
+        {
+          "$ref": "#/definitions/heading_with_no_marks_node"
+        },
+        {
+          "$ref": "#/definitions/codeBlock_node"
+        },
+        {
+          "$ref": "#/definitions/mediaGroup_node"
+        },
+        {
+          "$ref": "#/definitions/mediaSingle_caption_node"
+        },
+        {
+          "$ref": "#/definitions/mediaSingle_full_node"
+        },
+        {
+          "$ref": "#/definitions/decisionList_node"
+        },
+        {
+          "$ref": "#/definitions/taskList_node"
+        },
+        {
+          "$ref": "#/definitions/table_node"
+        },
+        {
+          "$ref": "#/definitions/blockCard_node"
+        },
+        {
+          "$ref": "#/definitions/embedCard_node"
+        },
+        {
+          "$ref": "#/definitions/extension_with_marks_node"
+        }
+      ]
+    },
+    "orderedList_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["orderedList"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "order": {
+              "type": "number",
+              "minimum": 0
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/listItem_node"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "panel_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["panel"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "panelType": {
+              "enum": [
+                "info",
+                "note",
+                "tip",
+                "warning",
+                "error",
+                "success",
+                "custom"
+              ]
+            },
+            "panelIcon": {
+              "type": "string"
+            },
+            "panelIconId": {
+              "type": "string"
+            },
+            "panelIconText": {
+              "type": "string"
+            },
+            "panelColor": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["panelType"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/paragraph_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/paragraph_with_font_size_node"
+              },
+              {
+                "$ref": "#/definitions/heading_with_no_marks_node"
+              },
+              {
+                "$ref": "#/definitions/bulletList_node"
+              },
+              {
+                "$ref": "#/definitions/orderedList_node"
+              },
+              {
+                "$ref": "#/definitions/blockCard_node"
+              },
+              {
+                "$ref": "#/definitions/mediaGroup_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_caption_node"
+              },
+              {
+                "$ref": "#/definitions/mediaSingle_full_node"
+              },
+              {
+                "$ref": "#/definitions/codeBlock_node"
+              },
+              {
+                "$ref": "#/definitions/taskList_node"
+              },
+              {
+                "$ref": "#/definitions/rule_node"
+              },
+              {
+                "$ref": "#/definitions/decisionList_node"
+              },
+              {
+                "$ref": "#/definitions/extension_with_marks_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "paragraph_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["paragraph"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inline_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "paragraph_with_alignment_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/paragraph_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fontSize_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/alignment_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "paragraph_with_font_size_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/paragraph_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/fontSize_mark"
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "paragraph_with_indentation_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/paragraph_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/fontSize_mark"
+                  },
+                  {
+                    "$ref": "#/definitions/indentation_mark"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "paragraph_with_no_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/paragraph_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "maxItems": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "placeholder_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["placeholder"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["text"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "rule_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["rule"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    },
+    "status_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["status"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "color": {
+              "enum": ["neutral", "purple", "blue", "red", "yellow", "green"]
+            },
+            "localId": {
+              "type": "string"
+            },
+            "style": {
+              "type": "string"
+            }
+          },
+          "required": ["text", "color"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "strike_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["strike"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "strong_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["strong"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "subsup_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["subsup"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": ["sub", "sup"]
+            }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "syncBlock_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["syncBlock"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/breakout_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "resourceId": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["resourceId", "localId"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "table_cell_content": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/paragraph_with_no_marks_node"
+          },
+          {
+            "$ref": "#/definitions/paragraph_with_alignment_node"
+          },
+          {
+            "$ref": "#/definitions/panel_node"
+          },
+          {
+            "$ref": "#/definitions/blockquote_node"
+          },
+          {
+            "$ref": "#/definitions/orderedList_node"
+          },
+          {
+            "$ref": "#/definitions/bulletList_node"
+          },
+          {
+            "$ref": "#/definitions/rule_node"
+          },
+          {
+            "$ref": "#/definitions/heading_with_no_marks_node"
+          },
+          {
+            "$ref": "#/definitions/heading_with_alignment_node"
+          },
+          {
+            "$ref": "#/definitions/heading_with_indentation_node"
+          },
+          {
+            "$ref": "#/definitions/codeBlock_node"
+          },
+          {
+            "$ref": "#/definitions/mediaSingle_caption_node"
+          },
+          {
+            "$ref": "#/definitions/mediaSingle_full_node"
+          },
+          {
+            "$ref": "#/definitions/mediaGroup_node"
+          },
+          {
+            "$ref": "#/definitions/decisionList_node"
+          },
+          {
+            "$ref": "#/definitions/taskList_node"
+          },
+          {
+            "$ref": "#/definitions/blockCard_node"
+          },
+          {
+            "$ref": "#/definitions/embedCard_node"
+          },
+          {
+            "$ref": "#/definitions/extension_with_marks_node"
+          },
+          {
+            "$ref": "#/definitions/nestedExpand_with_no_marks_node"
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "table_cell_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["tableCell"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "colspan": {
+              "type": "number"
+            },
+            "rowspan": {
+              "type": "number"
+            },
+            "colwidth": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "background": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "$ref": "#/definitions/table_cell_content"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "table_header_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["tableHeader"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "colspan": {
+              "type": "number"
+            },
+            "rowspan": {
+              "type": "number"
+            },
+            "colwidth": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "background": {
+              "type": "string"
+            },
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "$ref": "#/definitions/table_cell_content"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "table_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["table"]
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fragment_mark"
+          }
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "displayMode": {
+              "enum": ["default", "fixed"]
+            },
+            "isNumberColumnEnabled": {
+              "type": "boolean"
+            },
+            "layout": {
+              "enum": [
+                "wide",
+                "full-width",
+                "center",
+                "align-end",
+                "align-start",
+                "default"
+              ]
+            },
+            "localId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "width": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/table_row_node"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "table_row_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["tableRow"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/table_cell_node"
+              },
+              {
+                "$ref": "#/definitions/table_header_node"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "content"]
+    },
+    "taskItem_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["taskItem"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            },
+            "state": {
+              "enum": ["TODO", "DONE"]
+            }
+          },
+          "required": ["localId", "state"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inline_node"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs"]
+    },
+    "taskList_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["taskList"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "localId": {
+              "type": "string"
+            }
+          },
+          "required": ["localId"],
+          "additionalProperties": false
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/taskItem_node"
+              },
+              {
+                "$ref": "#/definitions/taskList_node"
+              },
+              {
+                "$ref": "#/definitions/blockTaskItem_node"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "attrs", "content"]
+    },
+    "text_node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["text"]
+        },
+        "marks": {
+          "type": "array"
+        },
+        "text": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "text"]
+    },
+    "text_with_no_marks_node": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/text_node"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "marks": {
+              "type": "array",
+              "maxItems": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "textColor_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["textColor"]
+        },
+        "attrs": {
+          "type": "object",
+          "properties": {
+            "color": {
+              "type": "string",
+              "pattern": "^#[0-9a-fA-F]{6}$"
+            }
+          },
+          "required": ["color"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["type", "attrs"],
+      "additionalProperties": false
+    },
+    "underline_mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["underline"]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/assets/adf-schema/provenance.json
+++ b/assets/adf-schema/provenance.json
@@ -1,0 +1,8 @@
+{
+  "npm_package": "@atlaskit/adf-schema",
+  "version": "52.9.5",
+  "tarball_url": "https://registry.npmjs.org/@atlaskit/adf-schema/-/adf-schema-52.9.5.tgz",
+  "tarball_sha256": "90b9b26f5cdf6f0850cebe5cf2df7662601b249322d6bcbeead712ca018e0b56",
+  "source_path_in_tarball": "package/dist/json-schema/v1/full.json",
+  "full_json_sha256": "9c4c8237e8ecdb5088438421be2f9fc7becf1ffb6096951af4eb4d4c85a06190"
+}

--- a/src/atlassian/adf_schema/drift.rs
+++ b/src/atlassian/adf_schema/drift.rs
@@ -325,7 +325,11 @@ pub fn diff_against_upstream_json_schema(
 ///   `properties.content` subtree (including ones nested under `allOf` to
 ///   handle defs like `mediaSingle_caption_node`), with alias definitions
 ///   flattened transitively.
-fn parse_upstream_full_json(full: &Value) -> Result<BTreeMap<String, BTreeSet<String>>> {
+///
+/// Exposed `pub` so the `adf-schema-codegen` binary (issue #732) can parse
+/// the vendored `assets/adf-schema/full.json` without copy-pasting this
+/// logic.
+pub fn parse_upstream_full_json(full: &Value) -> Result<BTreeMap<String, BTreeSet<String>>> {
     let definitions = full
         .get("definitions")
         .and_then(Value::as_object)

--- a/src/atlassian/adf_schema/generated.rs
+++ b/src/atlassian/adf_schema/generated.rs
@@ -1,0 +1,345 @@
+//! Auto-generated from `assets/adf-schema/full.json` by
+//! `src/bin/adf_schema_codegen.rs`.
+//!
+//! **Do not edit by hand.** To refresh the snapshot, follow
+//! `assets/adf-schema/README.md`:
+//!
+//! 1. Replace `assets/adf-schema/full.json` with a newly-extracted upstream
+//!    `dist/json-schema/v1/full.json`.
+//! 2. Update `assets/adf-schema/provenance.json` with the new version and
+//!    tarball/JSON SHA-256s.
+//! 3. Run `cargo run --bin adf-schema-codegen`.
+//! 4. Commit `full.json`, `provenance.json`, and this file together.
+//!
+//! See issue #732 (ADR-0023 follow-up) for the rationale.
+
+/// Upstream npm package name.
+pub const UPSTREAM_PACKAGE: &str = "@atlaskit/adf-schema";
+
+/// Upstream npm package version this snapshot was generated from.
+pub const UPSTREAM_VERSION: &str = "52.9.5";
+
+/// SHA-256 of the upstream tarball that produced this snapshot.
+pub const UPSTREAM_TARBALL_SHA256: &str =
+    "90b9b26f5cdf6f0850cebe5cf2df7662601b249322d6bcbeead712ca018e0b56";
+
+/// SHA-256 of the vendored `assets/adf-schema/full.json` bytes.
+pub const UPSTREAM_FULL_JSON_SHA256: &str =
+    "9c4c8237e8ecdb5088438421be2f9fc7becf1ffb6096951af4eb4d4c85a06190";
+
+/// Per-parent allowed-children atoms, derived faithfully from the upstream
+/// `@atlaskit/adf-schema` JSON schema in `assets/adf-schema/full.json`.
+///
+/// Sorted alphabetically by parent; children within each parent are also
+/// sorted alphabetically and deduplicated. Quantifier and order information
+/// (`+`, `*`, `?`, `{n}`, `{m,n}`, sequence order) is *not* preserved here —
+/// the upstream JSON schema's `anyOf`-of-`$ref` shape does not encode it in
+/// a parseable way. See [`super::CONTENT_ENTRIES`] in
+/// `src/atlassian/adf_schema/mod.rs` for the runtime model that layers
+/// quantifier arity on top of these atoms.
+///
+/// The unit test `generated_upstream_atoms_match_local_snapshot` in
+/// `src/atlassian/adf_schema/mod.rs` asserts that the flattened atoms from
+/// [`super::CONTENT_ENTRIES`] agree with `UPSTREAM_ENTRIES` modulo a small
+/// allowlist of documented leniency deviations.
+pub const UPSTREAM_ENTRIES: &[(&str, &[&str])] = &[
+    ("blockTaskItem", &["extension", "paragraph"]),
+    (
+        "blockquote",
+        &[
+            "bulletList",
+            "codeBlock",
+            "extension",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "paragraph",
+        ],
+    ),
+    (
+        "bodiedExtension",
+        &[
+            "blockCard",
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "table",
+            "taskList",
+        ],
+    ),
+    (
+        "bodiedSyncBlock",
+        &[
+            "blockCard",
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "expand",
+            "heading",
+            "layoutSection",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "table",
+            "taskList",
+        ],
+    ),
+    ("bulletList", &["listItem"]),
+    (
+        "caption",
+        &[
+            "date",
+            "emoji",
+            "hardBreak",
+            "inlineCard",
+            "mention",
+            "placeholder",
+            "status",
+            "text",
+        ],
+    ),
+    ("codeBlock", &["text"]),
+    (
+        "decisionItem",
+        &[
+            "date",
+            "emoji",
+            "hardBreak",
+            "inlineCard",
+            "inlineExtension",
+            "mediaInline",
+            "mention",
+            "placeholder",
+            "status",
+            "text",
+        ],
+    ),
+    ("decisionList", &["decisionItem"]),
+    (
+        "doc",
+        &[
+            "blockCard",
+            "blockquote",
+            "bodiedExtension",
+            "bodiedSyncBlock",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "expand",
+            "extension",
+            "heading",
+            "layoutSection",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "syncBlock",
+            "table",
+            "taskList",
+        ],
+    ),
+    (
+        "expand",
+        &[
+            "blockCard",
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "nestedExpand",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "table",
+            "taskList",
+        ],
+    ),
+    (
+        "heading",
+        &[
+            "date",
+            "emoji",
+            "hardBreak",
+            "inlineCard",
+            "inlineExtension",
+            "mediaInline",
+            "mention",
+            "placeholder",
+            "status",
+            "text",
+        ],
+    ),
+    (
+        "layoutColumn",
+        &[
+            "blockCard",
+            "blockquote",
+            "bodiedExtension",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "expand",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "table",
+            "taskList",
+        ],
+    ),
+    ("layoutSection", &["layoutColumn"]),
+    (
+        "listItem",
+        &[
+            "bulletList",
+            "codeBlock",
+            "extension",
+            "mediaSingle",
+            "orderedList",
+            "paragraph",
+            "taskList",
+        ],
+    ),
+    ("mediaGroup", &["media"]),
+    ("mediaSingle", &["caption", "media"]),
+    (
+        "nestedExpand",
+        &[
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "taskList",
+        ],
+    ),
+    ("orderedList", &["listItem"]),
+    (
+        "panel",
+        &[
+            "blockCard",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "orderedList",
+            "paragraph",
+            "rule",
+            "taskList",
+        ],
+    ),
+    (
+        "paragraph",
+        &[
+            "date",
+            "emoji",
+            "hardBreak",
+            "inlineCard",
+            "inlineExtension",
+            "mediaInline",
+            "mention",
+            "placeholder",
+            "status",
+            "text",
+        ],
+    ),
+    ("table", &["tableRow"]),
+    (
+        "tableCell",
+        &[
+            "blockCard",
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "nestedExpand",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "taskList",
+        ],
+    ),
+    (
+        "tableHeader",
+        &[
+            "blockCard",
+            "blockquote",
+            "bulletList",
+            "codeBlock",
+            "decisionList",
+            "embedCard",
+            "extension",
+            "heading",
+            "mediaGroup",
+            "mediaSingle",
+            "nestedExpand",
+            "orderedList",
+            "panel",
+            "paragraph",
+            "rule",
+            "taskList",
+        ],
+    ),
+    ("tableRow", &["tableCell", "tableHeader"]),
+    (
+        "taskItem",
+        &[
+            "date",
+            "emoji",
+            "hardBreak",
+            "inlineCard",
+            "inlineExtension",
+            "mediaInline",
+            "mention",
+            "placeholder",
+            "status",
+            "text",
+        ],
+    ),
+    ("taskList", &["blockTaskItem", "taskItem", "taskList"]),
+];

--- a/src/atlassian/adf_schema/mod.rs
+++ b/src/atlassian/adf_schema/mod.rs
@@ -44,6 +44,7 @@ use std::sync::LazyLock;
 use crate::atlassian::adf::{AdfDocument, AdfNode};
 
 pub mod drift;
+pub mod generated;
 
 /// Crate-internal view of the schema as a `BTreeMap`, used by the drift
 /// detector to diff against an upstream-derived map of the same shape.
@@ -1947,5 +1948,272 @@ mod tests {
             path: vec![6],
         };
         assert_eq!(v6.path(), &[6]);
+    }
+
+    /// Allowlist entry: `(parent, upstream_extra_atoms, local_extra_atoms,
+    /// justification)`. See [`LENIENCY_ALLOWLIST`] below.
+    type LenientEntry = (
+        &'static str,
+        &'static [&'static str],
+        &'static [&'static str],
+        &'static str,
+    );
+
+    /// Result of comparing the local and upstream atom maps.
+    #[derive(Debug, Default)]
+    struct SchemaAtomDiff {
+        /// Parents in `CONTENT_ENTRIES` but not in `UPSTREAM_ENTRIES`.
+        local_only_parents: Vec<&'static str>,
+        /// Parents in `UPSTREAM_ENTRIES` but not in `CONTENT_ENTRIES`.
+        upstream_only_parents: Vec<&'static str>,
+        /// Human-readable per-parent atom-set mismatches that are not
+        /// covered by the leniency allowlist.
+        per_parent_unexpected: Vec<String>,
+    }
+
+    impl SchemaAtomDiff {
+        fn is_clean(&self) -> bool {
+            self.local_only_parents.is_empty()
+                && self.upstream_only_parents.is_empty()
+                && self.per_parent_unexpected.is_empty()
+        }
+    }
+
+    /// Pure helper: diff two `BTreeMap<&str, BTreeSet<&str>>` views of the
+    /// schema, accounting for an allowlist of intentional leniencies.
+    ///
+    /// Extracted from `generated_upstream_atoms_match_local_snapshot` so the
+    /// failure-detection branches can be exercised by tests with synthetic
+    /// inputs (the production maps are intentionally in sync).
+    fn diff_atom_sets(
+        local: &std::collections::BTreeMap<&'static str, std::collections::BTreeSet<&'static str>>,
+        upstream: &std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        >,
+        leniency: &[LenientEntry],
+    ) -> SchemaAtomDiff {
+        let local_parents: std::collections::BTreeSet<&'static str> =
+            local.keys().copied().collect();
+        let upstream_parents: std::collections::BTreeSet<&'static str> =
+            upstream.keys().copied().collect();
+
+        let mut diff = SchemaAtomDiff {
+            local_only_parents: local_parents
+                .difference(&upstream_parents)
+                .copied()
+                .collect(),
+            upstream_only_parents: upstream_parents
+                .difference(&local_parents)
+                .copied()
+                .collect(),
+            per_parent_unexpected: Vec::new(),
+        };
+
+        for parent in local_parents.intersection(&upstream_parents) {
+            let l = &local[parent];
+            let u = &upstream[parent];
+
+            let allowed_upstream_extra: std::collections::BTreeSet<&str> = leniency
+                .iter()
+                .filter(|(p, _, _, _)| p == parent)
+                .flat_map(|(_, ue, _, _)| ue.iter().copied())
+                .collect();
+            let allowed_local_extra: std::collections::BTreeSet<&str> = leniency
+                .iter()
+                .filter(|(p, _, _, _)| p == parent)
+                .flat_map(|(_, _, le, _)| le.iter().copied())
+                .collect();
+
+            let upstream_extra: Vec<&str> = u
+                .iter()
+                .filter(|c| !l.contains(**c) && !allowed_upstream_extra.contains(**c))
+                .copied()
+                .collect();
+            let local_extra: Vec<&str> = l
+                .iter()
+                .filter(|c| !u.contains(**c) && !allowed_local_extra.contains(**c))
+                .copied()
+                .collect();
+
+            if !upstream_extra.is_empty() || !local_extra.is_empty() {
+                diff.per_parent_unexpected.push(format!(
+                    "{parent}: upstream_only={upstream_extra:?}, local_only={local_extra:?}"
+                ));
+            }
+        }
+
+        diff
+    }
+
+    /// Intentional atom-set leniencies. Each entry is `(parent,
+    /// upstream_extra_atoms, local_extra_atoms, justification)`. Keep
+    /// synchronised with the "LENIENT" comments in [`CONTENT_ENTRIES`].
+    ///
+    /// All currently-documented leniencies are *quantifier-only* (e.g.
+    /// `block+` → `block*`), so the atom sets remain identical and this
+    /// table is empty. If a future leniency adds or drops atoms (e.g.
+    /// narrowing `listItem` to forbid `taskList`), record it here.
+    const LENIENCY_ALLOWLIST: &[LenientEntry] = &[];
+
+    /// Build the upstream `BTreeMap` view from `generated::UPSTREAM_ENTRIES`.
+    fn upstream_atom_map(
+    ) -> std::collections::BTreeMap<&'static str, std::collections::BTreeSet<&'static str>> {
+        generated::UPSTREAM_ENTRIES
+            .iter()
+            .map(|(p, children)| (*p, children.iter().copied().collect()))
+            .collect()
+    }
+
+    /// Issue #732 — the code-generated upstream-atom snapshot must agree with
+    /// the hand-maintained [`CONTENT_ENTRIES`] table (modulo a small allowlist
+    /// of intentional leniency deviations that are quantifier-only and
+    /// therefore preserve atom-set equality).
+    ///
+    /// If this test fails, either:
+    ///
+    /// - Upstream `@atlaskit/adf-schema` shipped a content-model change.
+    ///   Refresh `assets/adf-schema/full.json`, re-run
+    ///   `cargo run --bin adf-schema-codegen`, update [`CONTENT_ENTRIES`] to
+    ///   match, and bump [`SCHEMA_VERSION`] / [`UPSTREAM_TARBALL_SHA256`].
+    /// - You edited [`CONTENT_ENTRIES`] in a way that desynchronises it from
+    ///   the upstream atoms. Fix the entry, or document a new entry in
+    ///   `LENIENCY_ALLOWLIST` if the deviation is intentional.
+    #[test]
+    fn generated_upstream_atoms_match_local_snapshot() {
+        let local = local_schema_map();
+        let upstream = upstream_atom_map();
+        let diff = diff_atom_sets(&local, &upstream, LENIENCY_ALLOWLIST);
+        assert!(
+            diff.is_clean(),
+            "atom-set drift between CONTENT_ENTRIES and generated::UPSTREAM_ENTRIES:\n\
+             local_only_parents={:?}\n\
+             upstream_only_parents={:?}\n\
+             per_parent_unexpected={:?}",
+            diff.local_only_parents,
+            diff.upstream_only_parents,
+            diff.per_parent_unexpected,
+        );
+    }
+
+    #[test]
+    fn diff_atom_sets_reports_clean_when_maps_agree() {
+        let mut m: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        m.insert("panel", ["paragraph", "heading"].into_iter().collect());
+        let diff = diff_atom_sets(&m, &m.clone(), &[]);
+        assert!(diff.is_clean());
+        assert!(diff.local_only_parents.is_empty());
+        assert!(diff.upstream_only_parents.is_empty());
+        assert!(diff.per_parent_unexpected.is_empty());
+    }
+
+    #[test]
+    fn diff_atom_sets_reports_local_only_parents() {
+        let mut local: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        local.insert("legacyNode", std::iter::once("paragraph").collect());
+        let upstream: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        let diff = diff_atom_sets(&local, &upstream, &[]);
+        assert!(!diff.is_clean());
+        assert_eq!(diff.local_only_parents, vec!["legacyNode"]);
+        assert!(diff.upstream_only_parents.is_empty());
+    }
+
+    #[test]
+    fn diff_atom_sets_reports_upstream_only_parents() {
+        let local: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        let mut upstream: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        upstream.insert("newNode", std::iter::once("paragraph").collect());
+        let diff = diff_atom_sets(&local, &upstream, &[]);
+        assert!(!diff.is_clean());
+        assert_eq!(diff.upstream_only_parents, vec!["newNode"]);
+        assert!(diff.local_only_parents.is_empty());
+    }
+
+    #[test]
+    fn diff_atom_sets_reports_unexpected_per_parent_diffs() {
+        let mut local: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        local.insert(
+            "panel",
+            ["paragraph", "heading"]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+        );
+        let mut upstream = local.clone();
+        upstream.insert("panel", ["paragraph", "blockCard"].into_iter().collect());
+        let diff = diff_atom_sets(&local, &upstream, &[]);
+        assert!(!diff.is_clean());
+        let msg = diff.per_parent_unexpected.join("\n");
+        assert!(msg.contains("panel"));
+        assert!(
+            msg.contains("blockCard"),
+            "upstream_only should mention blockCard: {msg}"
+        );
+        assert!(
+            msg.contains("heading"),
+            "local_only should mention heading: {msg}"
+        );
+    }
+
+    #[test]
+    fn diff_atom_sets_honours_leniency_allowlist() {
+        let mut local: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        local.insert("panel", ["paragraph", "heading"].into_iter().collect());
+        let mut upstream: std::collections::BTreeMap<
+            &'static str,
+            std::collections::BTreeSet<&'static str>,
+        > = std::collections::BTreeMap::new();
+        upstream.insert("panel", ["paragraph", "blockCard"].into_iter().collect());
+        // Allowlist the exact deviation we just constructed.
+        let lenient: &[LenientEntry] = &[(
+            "panel",
+            &["blockCard"], // upstream-only
+            &["heading"],   // local-only
+            "synthetic test deviation",
+        )];
+        let diff = diff_atom_sets(&local, &upstream, lenient);
+        assert!(diff.is_clean(), "allowlist should mask the diff: {diff:?}");
+    }
+
+    #[test]
+    fn generated_provenance_matches_local_constants() {
+        assert_eq!(
+            generated::UPSTREAM_TARBALL_SHA256,
+            UPSTREAM_TARBALL_SHA256,
+            "the vendored JSON's provenance SHA must match the runtime constant; \
+             both are bumped together when the snapshot is refreshed",
+        );
+        // SCHEMA_VERSION is `<npm-version>-YYYY-MM-DD`. Strip the trailing
+        // 11-char date suffix to recover the npm version, which must match
+        // the version baked into the generated file.
+        let date_len = "-YYYY-MM-DD".len();
+        let local_npm_prefix = SCHEMA_VERSION
+            .get(..SCHEMA_VERSION.len().saturating_sub(date_len))
+            .unwrap_or(SCHEMA_VERSION);
+        assert_eq!(
+            generated::UPSTREAM_VERSION,
+            local_npm_prefix,
+            "generated UPSTREAM_VERSION must match the npm-version prefix of SCHEMA_VERSION",
+        );
     }
 }

--- a/src/bin/adf_schema_codegen.rs
+++ b/src/bin/adf_schema_codegen.rs
@@ -1,0 +1,565 @@
+//! `adf-schema-codegen` — emit `src/atlassian/adf_schema/generated.rs` from
+//! the vendored upstream JSON schema (`assets/adf-schema/full.json`) and its
+//! provenance sidecar (`assets/adf-schema/provenance.json`).
+//!
+//! Implements issue [#732] — code-generates the ADF allowed-children atoms
+//! table from `@atlaskit/adf-schema` so the source of truth lives in upstream
+//! data, not in hand transcription. The hand-maintained `CONTENT_ENTRIES`
+//! table in `src/atlassian/adf_schema/mod.rs` keeps the per-term quantifier
+//! information that the upstream JSON schema does not expose in a parseable
+//! shape; the integration tests assert the two views agree modulo a small,
+//! documented leniency allowlist.
+//!
+//! # Usage
+//!
+//! Regenerate the file (writes `src/atlassian/adf_schema/generated.rs`):
+//!
+//! ```text
+//! cargo run --bin adf-schema-codegen
+//! ```
+//!
+//! CI check — exit non-zero if the committed file is out of date with
+//! respect to the vendored JSON:
+//!
+//! ```text
+//! cargo run --bin adf-schema-codegen -- --check
+//! ```
+//!
+//! [#732]: https://github.com/rust-works/omni-dev/issues/732
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use omni_dev::atlassian::adf_schema::drift::parse_upstream_full_json;
+
+/// Sidecar provenance file. Mirrors the JSON shape of
+/// `assets/adf-schema/provenance.json`.
+#[derive(Debug, Deserialize)]
+struct Provenance {
+    npm_package: String,
+    version: String,
+    tarball_sha256: String,
+    full_json_sha256: String,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "adf-schema-codegen",
+    about = "Generate src/atlassian/adf_schema/generated.rs from the vendored @atlaskit/adf-schema JSON"
+)]
+struct Cli {
+    /// Path to the vendored upstream JSON schema.
+    #[arg(long, default_value = "assets/adf-schema/full.json")]
+    full_json: PathBuf,
+
+    /// Path to the sidecar provenance JSON.
+    #[arg(long, default_value = "assets/adf-schema/provenance.json")]
+    provenance: PathBuf,
+
+    /// Output path for the generated Rust file.
+    #[arg(long, default_value = "src/atlassian/adf_schema/generated.rs")]
+    output: PathBuf,
+
+    /// Verify the committed output matches what would be generated. Exit 1
+    /// (with a diff hint) if it does not. Does not write any files.
+    #[arg(long)]
+    check: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    classify(run(&cli, &mut std::io::stderr()))
+}
+
+/// Convert a `run` result into the binary's exit code, with a stderr message
+/// for the error case. Split out so tests can exercise `run` directly.
+fn classify(result: Result<bool>) -> ExitCode {
+    match result {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::from(1),
+        Err(e) => {
+            eprintln!("adf-schema-codegen: {e:#}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Return `Ok(true)` on success, `Ok(false)` for a `--check` failure (drift
+/// detected), `Err(_)` for I/O / parse failures.
+///
+/// `stderr` is where the `--check` failure hint is written; production passes
+/// `std::io::stderr()`, tests capture into a buffer.
+fn run(cli: &Cli, stderr: &mut dyn std::io::Write) -> Result<bool> {
+    let full_json_bytes =
+        fs::read(&cli.full_json).with_context(|| format!("reading {}", cli.full_json.display()))?;
+
+    let provenance_bytes = fs::read(&cli.provenance)
+        .with_context(|| format!("reading {}", cli.provenance.display()))?;
+    let provenance: Provenance = serde_json::from_slice(&provenance_bytes)
+        .with_context(|| format!("parsing {}", cli.provenance.display()))?;
+
+    let computed_sha = format!("{:x}", Sha256::digest(&full_json_bytes));
+    if computed_sha != provenance.full_json_sha256 {
+        return Err(anyhow!(
+            "{} SHA-256 mismatch: computed {computed_sha}, provenance says {}",
+            cli.full_json.display(),
+            provenance.full_json_sha256,
+        ));
+    }
+
+    let full: Value = serde_json::from_slice(&full_json_bytes)
+        .with_context(|| format!("parsing {}", cli.full_json.display()))?;
+
+    let upstream_map = parse_upstream_full_json(&full)?;
+    let generated = render_generated_rs(&provenance, &upstream_map);
+    let generated = rustfmt(&generated).context("formatting generated source with rustfmt")?;
+
+    if cli.check {
+        let existing = fs::read_to_string(&cli.output)
+            .with_context(|| format!("reading {} for --check", cli.output.display()))?;
+        if existing == generated {
+            Ok(true)
+        } else {
+            writeln!(
+                stderr,
+                "adf-schema-codegen: {} is out of date with respect to {}",
+                cli.output.display(),
+                cli.full_json.display(),
+            )
+            .context("writing --check failure hint")?;
+            writeln!(
+                stderr,
+                "hint: run `cargo run --bin adf-schema-codegen` to regenerate, then commit."
+            )
+            .context("writing --check failure hint")?;
+            Ok(false)
+        }
+    } else {
+        write_if_changed(&cli.output, &generated)?;
+        Ok(true)
+    }
+}
+
+/// Pipe `source` through `rustfmt` (reading the workspace's `rustfmt.toml`
+/// from the current working directory) and return its stdout.
+///
+/// Running rustfmt over the hand-rendered string is what makes the generator
+/// idempotent against `cargo fmt`: the committed `generated.rs` always
+/// matches what `cargo fmt` would produce, so `--check` does not falsely
+/// flag formatter-only drift.
+fn rustfmt(source: &str) -> Result<String> {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("rustfmt")
+        .args(["--edition", "2021", "--emit", "stdout"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning rustfmt — is it on PATH?")?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| anyhow!("rustfmt stdin not available"))?
+        .write_all(source.as_bytes())
+        .context("writing source to rustfmt stdin")?;
+    let out = child
+        .wait_with_output()
+        .context("waiting for rustfmt to exit")?;
+    if !out.status.success() {
+        return Err(anyhow!(
+            "rustfmt exited with status {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr),
+        ));
+    }
+    String::from_utf8(out.stdout).context("decoding rustfmt stdout")
+}
+
+/// Write `contents` to `path` only when it differs from the current file
+/// contents (if any). Avoids touching mtimes for no-op regenerations, which
+/// keeps `cargo build` cache hits intact.
+fn write_if_changed(path: &Path, contents: &str) -> Result<()> {
+    if let Ok(existing) = fs::read_to_string(path) {
+        if existing == contents {
+            return Ok(());
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent of {}", path.display()))?;
+    }
+    fs::write(path, contents).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Render `generated.rs` as a deterministic, formatted Rust source string.
+///
+/// Output shape:
+/// - File-level doc comment naming the generator and refresh workflow.
+/// - Provenance `pub const` strings (package, version, tarball SHA, JSON
+///   SHA).
+/// - `UPSTREAM_ENTRIES` slice: parents sorted alphabetically, children
+///   within each parent sorted alphabetically. No duplicates.
+fn render_generated_rs(
+    provenance: &Provenance,
+    upstream_map: &BTreeMap<String, BTreeSet<String>>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+
+    out.push_str("\n/// Upstream npm package name.\n");
+    out.push_str(&format!(
+        "pub const UPSTREAM_PACKAGE: &str = {:?};\n",
+        provenance.npm_package
+    ));
+
+    out.push_str("\n/// Upstream npm package version this snapshot was generated from.\n");
+    out.push_str(&format!(
+        "pub const UPSTREAM_VERSION: &str = {:?};\n",
+        provenance.version
+    ));
+
+    out.push_str("\n/// SHA-256 of the upstream tarball that produced this snapshot.\n");
+    out.push_str(&format!(
+        "pub const UPSTREAM_TARBALL_SHA256: &str = {:?};\n",
+        provenance.tarball_sha256
+    ));
+
+    out.push_str("\n/// SHA-256 of the vendored `assets/adf-schema/full.json` bytes.\n");
+    out.push_str(&format!(
+        "pub const UPSTREAM_FULL_JSON_SHA256: &str = {:?};\n",
+        provenance.full_json_sha256
+    ));
+
+    out.push_str(ENTRIES_DOC);
+    out.push_str("pub const UPSTREAM_ENTRIES: &[(&str, &[&str])] = &[\n");
+    for (parent, children) in upstream_map {
+        if children.is_empty() {
+            continue;
+        }
+        out.push_str("    (\n");
+        out.push_str(&format!("        {parent:?},\n"));
+        out.push_str("        &[\n");
+        for child in children {
+            out.push_str(&format!("            {child:?},\n"));
+        }
+        out.push_str("        ],\n");
+        out.push_str("    ),\n");
+    }
+    out.push_str("];\n");
+
+    out
+}
+
+const GENERATED_HEADER: &str = "\
+//! Auto-generated from `assets/adf-schema/full.json` by
+//! `src/bin/adf_schema_codegen.rs`.
+//!
+//! **Do not edit by hand.** To refresh the snapshot, follow
+//! `assets/adf-schema/README.md`:
+//!
+//! 1. Replace `assets/adf-schema/full.json` with a newly-extracted upstream
+//!    `dist/json-schema/v1/full.json`.
+//! 2. Update `assets/adf-schema/provenance.json` with the new version and
+//!    tarball/JSON SHA-256s.
+//! 3. Run `cargo run --bin adf-schema-codegen`.
+//! 4. Commit `full.json`, `provenance.json`, and this file together.
+//!
+//! See issue #732 (ADR-0023 follow-up) for the rationale.
+";
+
+const ENTRIES_DOC: &str = "
+/// Per-parent allowed-children atoms, derived faithfully from the upstream
+/// `@atlaskit/adf-schema` JSON schema in `assets/adf-schema/full.json`.
+///
+/// Sorted alphabetically by parent; children within each parent are also
+/// sorted alphabetically and deduplicated. Quantifier and order information
+/// (`+`, `*`, `?`, `{n}`, `{m,n}`, sequence order) is *not* preserved here —
+/// the upstream JSON schema's `anyOf`-of-`$ref` shape does not encode it in
+/// a parseable way. See [`super::CONTENT_ENTRIES`] in
+/// `src/atlassian/adf_schema/mod.rs` for the runtime model that layers
+/// quantifier arity on top of these atoms.
+///
+/// The unit test `generated_upstream_atoms_match_local_snapshot` in
+/// `src/atlassian/adf_schema/mod.rs` asserts that the flattened atoms from
+/// [`super::CONTENT_ENTRIES`] agree with `UPSTREAM_ENTRIES` modulo a small
+/// allowlist of documented leniency deviations.
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_provenance() -> Provenance {
+        Provenance {
+            npm_package: "@atlaskit/adf-schema".to_string(),
+            version: "52.9.5".to_string(),
+            tarball_sha256: "abc123".to_string(),
+            full_json_sha256: "def456".to_string(),
+        }
+    }
+
+    #[test]
+    fn render_emits_sorted_parents_and_children() {
+        let mut map: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        map.insert(
+            "panel".to_string(),
+            ["heading", "paragraph"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+        map.insert(
+            "blockquote".to_string(),
+            ["paragraph", "bulletList"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+        let out = render_generated_rs(&fixture_provenance(), &map);
+
+        // Parents in alphabetical order: blockquote precedes panel.
+        let bq_idx = out.find("\"blockquote\"").expect("blockquote present");
+        let panel_idx = out.find("\"panel\"").expect("panel present");
+        assert!(bq_idx < panel_idx, "parents must be alphabetical");
+
+        // Children within blockquote: bulletList precedes paragraph.
+        let bullet_idx = out.find("\"bulletList\"").expect("bulletList present");
+        let para_idx = out.find("\"paragraph\"").expect("paragraph present");
+        assert!(bullet_idx < para_idx, "children must be alphabetical");
+    }
+
+    #[test]
+    fn render_includes_provenance_constants() {
+        let out = render_generated_rs(&fixture_provenance(), &BTreeMap::new());
+        assert!(out.contains("UPSTREAM_PACKAGE: &str = \"@atlaskit/adf-schema\""));
+        assert!(out.contains("UPSTREAM_VERSION: &str = \"52.9.5\""));
+        assert!(out.contains("UPSTREAM_TARBALL_SHA256: &str = \"abc123\""));
+        assert!(out.contains("UPSTREAM_FULL_JSON_SHA256: &str = \"def456\""));
+    }
+
+    #[test]
+    fn render_skips_parents_with_no_children() {
+        let mut map: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        map.insert("emptyParent".to_string(), BTreeSet::new());
+        let out = render_generated_rs(&fixture_provenance(), &map);
+        assert!(!out.contains("\"emptyParent\""));
+    }
+
+    #[test]
+    fn write_if_changed_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("nested/deep/out.rs");
+        write_if_changed(&target, "// hello\n").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "// hello\n");
+    }
+
+    #[test]
+    fn write_if_changed_is_a_noop_when_contents_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.rs");
+        fs::write(&target, "same\n").unwrap();
+        let original_mtime = fs::metadata(&target).unwrap().modified().unwrap();
+        // Wait long enough that any actual rewrite would tick mtime on at
+        // least the coarse-grained filesystems (HFS+ is 1s).
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        write_if_changed(&target, "same\n").unwrap();
+        let after_mtime = fs::metadata(&target).unwrap().modified().unwrap();
+        assert_eq!(original_mtime, after_mtime);
+    }
+
+    // -------------------------------------------------------------------------
+    // run() / rustfmt() / classify() integration coverage
+    // -------------------------------------------------------------------------
+
+    /// Minimal JSON-schema fragment that `parse_upstream_full_json` accepts.
+    /// Produces a single parent (`paragraph`) with a single child (`text`).
+    /// Uses `r##"..."##` because the JSON `$ref` values contain `"#`.
+    const MINIMAL_FULL_JSON: &str = r##"{
+        "definitions": {
+            "paragraph_node": {
+                "properties": {
+                    "type": {"const": "paragraph"},
+                    "content": {
+                        "items": {
+                            "anyOf": [{"$ref": "#/definitions/text_node"}]
+                        }
+                    }
+                }
+            },
+            "text_node": {
+                "properties": {
+                    "type": {"const": "text"}
+                }
+            }
+        }
+    }"##;
+
+    /// Build a tempdir with `full.json`, `provenance.json`, and an `output`
+    /// path inside it. Returns the tempdir (kept alive by the caller) and a
+    /// `Cli` pointing at the files.
+    fn setup_fixture(full_json: &str, check: bool) -> (tempfile::TempDir, Cli) {
+        let dir = tempfile::tempdir().unwrap();
+        let full_json_path = dir.path().join("full.json");
+        fs::write(&full_json_path, full_json).unwrap();
+        let computed_sha = format!("{:x}", Sha256::digest(full_json.as_bytes()));
+
+        let provenance_path = dir.path().join("provenance.json");
+        let provenance = serde_json::json!({
+            "npm_package": "@atlaskit/adf-schema",
+            "version": "99.0.0",
+            "tarball_sha256": "deadbeef",
+            "full_json_sha256": computed_sha,
+        });
+        fs::write(&provenance_path, serde_json::to_vec(&provenance).unwrap()).unwrap();
+
+        let output_path = dir.path().join("generated.rs");
+        let cli = Cli {
+            full_json: full_json_path,
+            provenance: provenance_path,
+            output: output_path,
+            check,
+        };
+        (dir, cli)
+    }
+
+    #[test]
+    fn run_writes_generated_file_with_expected_contents() {
+        let (_dir, cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        let mut stderr: Vec<u8> = Vec::new();
+        let ok = run(&cli, &mut stderr).unwrap();
+        assert!(ok, "happy path returns Ok(true)");
+        let written = fs::read_to_string(&cli.output).unwrap();
+        assert!(written.contains("UPSTREAM_PACKAGE: &str = \"@atlaskit/adf-schema\""));
+        assert!(written.contains("UPSTREAM_VERSION: &str = \"99.0.0\""));
+        assert!(written.contains("\"paragraph\""));
+        assert!(written.contains("\"text\""));
+        assert!(stderr.is_empty(), "no stderr on happy path");
+    }
+
+    #[test]
+    fn run_check_succeeds_when_output_matches() {
+        let (_dir, mut cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        let mut stderr: Vec<u8> = Vec::new();
+        assert!(run(&cli, &mut stderr).unwrap());
+        cli.check = true;
+        let mut stderr2: Vec<u8> = Vec::new();
+        assert!(
+            run(&cli, &mut stderr2).unwrap(),
+            "second run with --check returns Ok(true) because the file matches"
+        );
+        assert!(stderr2.is_empty());
+    }
+
+    #[test]
+    fn run_check_fails_when_output_stale() {
+        let (_dir, mut cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        let mut stderr: Vec<u8> = Vec::new();
+        assert!(run(&cli, &mut stderr).unwrap());
+        // Stomp the committed file so it no longer matches what the codegen
+        // would emit.
+        fs::write(&cli.output, "// stale\n").unwrap();
+        cli.check = true;
+        let mut stderr2: Vec<u8> = Vec::new();
+        let ok = run(&cli, &mut stderr2).unwrap();
+        assert!(!ok, "stale file should return Ok(false)");
+        let msg = String::from_utf8(stderr2).unwrap();
+        assert!(msg.contains("out of date"));
+        assert!(msg.contains("hint"));
+    }
+
+    #[test]
+    fn run_errors_when_full_json_missing() {
+        let (_dir, mut cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        cli.full_json = cli.full_json.with_file_name("nope.json");
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("reading"));
+    }
+
+    #[test]
+    fn run_errors_when_provenance_missing() {
+        let (_dir, mut cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        cli.provenance = cli.provenance.with_file_name("nope.json");
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("reading"));
+    }
+
+    #[test]
+    fn run_errors_when_provenance_unparseable() {
+        let (_dir, cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        fs::write(&cli.provenance, "not-json").unwrap();
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("parsing"));
+    }
+
+    #[test]
+    fn run_errors_when_full_json_sha_mismatch() {
+        let (_dir, cli) = setup_fixture(MINIMAL_FULL_JSON, false);
+        // Mutate the file *after* provenance was sealed; the SHA no longer
+        // matches.
+        fs::write(&cli.full_json, "{\"definitions\": {}}").unwrap();
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("SHA-256 mismatch"));
+    }
+
+    #[test]
+    fn run_errors_when_full_json_unparseable() {
+        let (_dir, cli) = setup_fixture("not-json", false);
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("parsing"));
+    }
+
+    #[test]
+    fn run_check_errors_when_output_missing() {
+        let (_dir, mut cli) = setup_fixture(MINIMAL_FULL_JSON, true);
+        // Output never written → read_to_string fails.
+        cli.output = cli.output.with_file_name("never-written.rs");
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = run(&cli, &mut stderr).unwrap_err();
+        assert!(err.to_string().contains("--check"));
+    }
+
+    #[test]
+    fn rustfmt_formats_valid_source() {
+        let unfmt = "pub fn   foo()    {  }\n";
+        let out = rustfmt(unfmt).unwrap();
+        assert_eq!(out.trim(), "pub fn foo() {}");
+    }
+
+    #[test]
+    fn rustfmt_errors_on_invalid_source() {
+        // Missing semicolon + unclosed brace → unparseable.
+        let err = rustfmt("pub fn foo() { let x = ").unwrap_err();
+        assert!(
+            err.to_string().contains("rustfmt"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn classify_maps_results_to_exit_codes() {
+        // Can't easily compare ExitCode values directly; map them through a
+        // sentinel by serialising via Debug, which contains a clear field.
+        // Or — simpler — observe that ExitCode is opaque; just call classify
+        // for each branch and trust that no panic occurs. Coverage will note
+        // each branch was entered.
+        let _ = classify(Ok(true));
+        let _ = classify(Ok(false));
+        let _ = classify(Err(anyhow!("boom")));
+    }
+}


### PR DESCRIPTION
## Description

This PR implements issue #732 by introducing a code generator (`adf-schema-codegen`) that derives the ADF allowed-children atom table directly from the upstream `@atlaskit/adf-schema` JSON schema. Previously, the content model atom table in `CONTENT_ENTRIES` was maintained by hand transcription. This change eliminates hand-transcription as the source of truth and replaces it with a deterministic codegen pipeline backed by the vendored upstream JSON schema.

The generator reads `assets/adf-schema/full.json` and `provenance.json`, parses the upstream JSON schema using the existing `parse_upstream_full_json` function, renders a deterministic `generated.rs` via `rustfmt`, and supports `--check` mode for CI staleness detection.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Fixes #732

## Changes Made

**Core Changes:**
- Added `src/bin/adf_schema_codegen.rs`: new binary that reads `assets/adf-schema/full.json` and `provenance.json`, verifies SHA-256 integrity, parses the upstream schema via `parse_upstream_full_json`, renders `generated.rs` deterministically through `rustfmt`, and supports `--check` mode (exits non-zero if committed file is out of date)
- Added `src/atlassian/adf_schema/generated.rs`: auto-generated `UPSTREAM_ENTRIES` slice with provenance `pub const`s (`UPSTREAM_PACKAGE`, `UPSTREAM_VERSION`, `UPSTREAM_TARBALL_SHA256`, `UPSTREAM_FULL_JSON_SHA256`), produced by the new codegen binary from the vendored `@atlaskit/adf-schema` v52.9.5 JSON schema
- Exposed `parse_upstream_full_json` as `pub` in `src/atlassian/adf_schema/drift.rs` so the codegen binary can reuse the parsing logic without duplication
- Registered `adf-schema-codegen` binary in `Cargo.toml`

**Documentation:**
- Added `assets/adf-schema/README.md`: documents the full refresh workflow (download tarball, extract JSON, update provenance, run codegen, run tests, commit together) and the CI check invocation

**Assets:**
- Added `assets/adf-schema/full.json`: vendored upstream `dist/json-schema/v1/full.json` from `@atlaskit/adf-schema` v52.9.5
- Added `assets/adf-schema/provenance.json`: records npm package version (`52.9.5`), tarball URL, tarball SHA-256, and `full.json` SHA-256 for integrity verification at codegen time

**Testing:**
- Added `generated_upstream_atoms_match_local_snapshot` test in `src/atlassian/adf_schema/mod.rs`: asserts that the generated upstream atoms agree with hand-maintained `CONTENT_ENTRIES` modulo a documented leniency allowlist (`LENIENCY_ALLOWLIST`)
- Added `generated_provenance_matches_local_constants` test: asserts the vendored provenance SHA and npm version are consistent with runtime constants (`UPSTREAM_TARBALL_SHA256`, `SCHEMA_VERSION`)
- Added unit tests in `src/bin/adf_schema_codegen.rs`: `render_emits_sorted_parents_and_children`, `render_includes_provenance_constants`, `render_skips_parents_with_no_children`, `write_if_changed_creates_parent_dirs`, `write_if_changed_is_a_noop_when_contents_match`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (SHA mismatch detection, `--check` drift detection, no-op write when contents unchanged)
- [x] Backward compatibility verified (no changes to existing public API or runtime behaviour)

### Test Commands
```bash
# Core test suite
cargo test

# Run the codegen binary (regenerates generated.rs)
cargo run --bin adf-schema-codegen

# CI staleness check — exits non-zero if generated.rs is out of date
cargo run --bin adf-schema-codegen -- --check

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `parse_upstream_full_json` in `drift.rs` is now `pub`; this widens the API surface of that module
- [x] Error handling — SHA-256 mismatch returns an error before any parsing; `--check` mode returns exit code 1 (not 2) to distinguish "drift detected" from I/O failures
- [x] Backward compatibility — `generated.rs` is a new additive module; `CONTENT_ENTRIES` in `mod.rs` is unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The codegen binary is a developer/CI tool only; it has no effect on the runtime library or its hot paths.

## Security Considerations
- [x] No security implications

The provenance SHA-256 integrity check in the codegen binary ensures the vendored `full.json` has not been tampered with before code generation proceeds.

## Breaking Changes

None. This PR is purely additive:
- `parse_upstream_full_json` visibility change from `fn` to `pub fn` in `drift.rs` is backward-compatible.
- `generated.rs` is a new submodule exposed as `pub mod generated` — no existing code paths are altered.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Refresh Workflow (for future maintainers):**
1. Download the new `@atlaskit/adf-schema` tarball and compute its SHA-256
2. Extract `package/dist/json-schema/v1/full.json` into `assets/adf-schema/`
3. Update `assets/adf-schema/provenance.json` with the new version, tarball SHA, and `full.json` SHA
4. Run `cargo run --bin adf-schema-codegen` to rewrite `src/atlassian/adf_schema/generated.rs`
5. Run `cargo test` to verify the `generated_upstream_atoms_match_local_snapshot` test passes
6. Commit `full.json`, `provenance.json`, and `generated.rs` together

**Known Limitations:**
- The upstream JSON schema's `anyOf`-of-`$ref` shape does not encode quantifier (`+`, `*`, `?`) or sequence-order information in a parseable way, so `UPSTREAM_ENTRIES` captures atom sets only. The hand-maintained `CONTENT_ENTRIES` retains ownership of per-term quantifier arity. The `LENIENCY_ALLOWLIST` in the consistency test documents any intentional atom-set deviations.