### PR TITLE
docs(docs): show supersession link in ADR inventory status column

### DIFF
--- a/.claude/skills/update-adr-inventory/SKILL.md
+++ b/.claude/skills/update-adr-inventory/SKILL.md
@@ -13,7 +13,7 @@ This skill updates the inventory table in `docs/adrs/README.md` to reflect the c
 2. **Extract** from each file:
    - **ADR number** from the filename (e.g., `adr-0003.md` -> `ADR-0003`)
    - **Title** from the `# ADR-NNNN: <Title>` heading on line 1
-   - **Status** from the `## Status` section (line after the heading, e.g., `✅ Accepted`)
+   - **Status** from the `## Status` section (line after the heading, e.g., `✅ Accepted`). If the line ends with a trailing parenthesized date (e.g., `🔄 Superseded by [ADR-0022](adr-0022.md) (2026-05-06)`), strip that trailing ` (YYYY-MM-DD)` — the supersession date already appears in the Date column. Preserve the rest verbatim, including any successor link.
 3. **Date**: Use the git log to find the commit date when the file was first added:
    ```bash
    git log --diff-filter=A --format=%as -- docs/adrs/adr-NNNN.md
@@ -36,12 +36,12 @@ The inventory table uses this structure:
 
 ### Column Details
 
-| Column | Source                              | Example                             |
-|--------|-------------------------------------|-------------------------------------|
-| ADR    | Filename, linked: `[ADR-NNNN](...)` | `[ADR-0000](adr-0000.md)`           |
-| Status | Status section with emoji prefix    | `✅ Accepted`                        |
-| Date   | Git first-commit date or today      | `2026-02-10`                        |
-| Title  | H1 heading after `ADR-NNNN: `       | `Use Architecture Decision Records` |
+| Column | Source                                      | Example                                                   |
+|--------|---------------------------------------------|-----------------------------------------------------------|
+| ADR    | Filename, linked: `[ADR-NNNN](...)`         | `[ADR-0000](adr-0000.md)`                                 |
+| Status | Status section, trailing ` (date)` stripped | `✅ Accepted` / `🔄 Superseded by [ADR-NNNN](adr-NNNN.md)`  |
+| Date   | Git first-commit date or today              | `2026-02-10`                                              |
+| Title  | H1 heading after `ADR-NNNN: `               | `Use Architecture Decision Records`                       |
 
 ## Instructions
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -21,33 +21,33 @@ by Michael Nygard.
 
 ## Inventory
 
-| ADR                      | Status        | Date       | Title                                                                                 |
-|--------------------------|---------------|------------|---------------------------------------------------------------------------------------|
-| [ADR-0000](adr-0000.md)  | ✅ Accepted   | 2026-02-10 | Use Architecture Decision Records                                                      |
-| [ADR-0001](adr-0001.md)  | ✅ Accepted   | 2026-02-10 | YAML as Primary Human Data Exchange Format                                             |
-| [ADR-0002](adr-0002.md)  | ✅ Accepted   | 2026-02-20 | Multi-Provider AI Abstraction via Trait Objects                                        |
-| [ADR-0003](adr-0003.md)  | ✅ Accepted   | 2026-02-20 | Hybrid Git Integration — git2 for Reads, Shell for Complex Mutations                   |
-| [ADR-0004](adr-0004.md)  | ✅ Accepted   | 2026-02-21 | Embedded Templates via `include_str!`                                                  |
-| [ADR-0005](adr-0005.md)  | ✅ Accepted   | 2026-02-21 | Hierarchical Configuration Resolution with Walk-Up Discovery                           |
-| [ADR-0006](adr-0006.md)  | ✅ Accepted   | 2026-02-22 | Two-View Repository Data Model via Generics and Composition                            |
-| [ADR-0007](adr-0007.md)  | ✅ Accepted   | 2026-02-22 | Preflight Validation Pattern                                                           |
-| [ADR-0008](adr-0008.md)  | ✅ Accepted   | 2026-02-22 | Deterministic Pre-Validation Before AI Analysis                                        |
-| [ADR-0009](adr-0009.md)  | ✅ Accepted   | 2026-02-22 | Token-Budget-Aware Batch Planning                                                      |
-| [ADR-0010](adr-0010.md)  | ✅ Accepted   | 2026-02-22 | Multi-Layer Retry Strategy                                                             |
-| [ADR-0011](adr-0011.md)  | 🔄 Superseded | 2026-02-23 | Compile-Time Model Registry with Identifier Normalization                              |
-| [ADR-0012](adr-0012.md)  | ✅ Accepted   | 2026-02-23 | Three-Level Issue Severity with `--strict` Exit-Code Promotion                         |
-| [ADR-0013](adr-0013.md)  | ✅ Accepted   | 2026-02-23 | Self-Describing YAML Output with Field Presence Tracking                               |
-| [ADR-0014](adr-0014.md)  | ✅ Accepted   | 2026-02-23 | Provider-Specific Prompt Engineering                                                   |
-| [ADR-0015](adr-0015.md)  | ✅ Accepted   | 2026-02-23 | Dual Error Handling Strategy — `thiserror` for Domain Errors, `anyhow` for Propagation |
-| [ADR-0016](adr-0016.md)  | ✅ Accepted   | 2026-02-24 | Clap Derive Macros with Hierarchical Subcommand Structure                              |
-| [ADR-0017](adr-0017.md)  | ✅ Accepted   | 2026-02-25 | Per-File Diff Splitting for Token Budget Fitting                                       |
-| [ADR-0018](adr-0018.md)  | ✅ Accepted   | 2026-02-25 | Automatic Context Detection for Adaptive AI Prompts                                    |
-| [ADR-0019](adr-0019.md)  | ✅ Accepted   | 2026-02-25 | Ecosystem-Aware Scope Auto-Detection                                                   |
-| [ADR-0020](adr-0020.md)  | ✅ Proposed   | 2026-04-16 | JFM — A Markdown Dialect for Bidirectional ADF Interchange                             |
-| [ADR-0021](adr-0021.md)  | ✅ Accepted   | 2026-04-18 | MCP Server via Second Binary with `rmcp`                                                |
-| [ADR-0022](adr-0022.md)  | ✅ Accepted   | 2026-05-06 | Layered Model Catalog with User and Project Overrides                                  |
-| [ADR-0023](adr-0023.md)  | ✅ Accepted   | 2026-05-10 | Data-Driven ADF Content-Model Schema and Validator                                     |
-| [ADR-0024](adr-0024.md)  | ✅ Accepted   | 2026-05-10 | TTL-Bounded In-Memory Cache for Near-Static JIRA Catalogues                            |
-| [ADR-0025](adr-0025.md)  | ✅ Accepted   | 2026-05-10 | Wire ADF Schema Validator into the API Send Path via `ValidatedAdfDocument`            |
-| [ADR-0026](adr-0026.md)  | ✅ Accepted   | 2026-05-10 | Extending the ADF Validator with Quantifiers, Attributes, and Marks                    |
-| [ADR-0027](adr-0027.md)  | ✅ Accepted   | 2026-05-11 | Destructive CLI Commands Confirm by Default with --force and --dry-run Escape Hatches  |
+| ADR                      | Status                                   | Date       | Title                                                                                 |
+|--------------------------|------------------------------------------|------------|---------------------------------------------------------------------------------------|
+| [ADR-0000](adr-0000.md)  | ✅ Accepted                              | 2026-02-10 | Use Architecture Decision Records                                                      |
+| [ADR-0001](adr-0001.md)  | ✅ Accepted                              | 2026-02-10 | YAML as Primary Human Data Exchange Format                                             |
+| [ADR-0002](adr-0002.md)  | ✅ Accepted                              | 2026-02-20 | Multi-Provider AI Abstraction via Trait Objects                                        |
+| [ADR-0003](adr-0003.md)  | ✅ Accepted                              | 2026-02-20 | Hybrid Git Integration — git2 for Reads, Shell for Complex Mutations                   |
+| [ADR-0004](adr-0004.md)  | ✅ Accepted                              | 2026-02-21 | Embedded Templates via `include_str!`                                                  |
+| [ADR-0005](adr-0005.md)  | ✅ Accepted                              | 2026-02-21 | Hierarchical Configuration Resolution with Walk-Up Discovery                           |
+| [ADR-0006](adr-0006.md)  | ✅ Accepted                              | 2026-02-22 | Two-View Repository Data Model via Generics and Composition                            |
+| [ADR-0007](adr-0007.md)  | ✅ Accepted                              | 2026-02-22 | Preflight Validation Pattern                                                           |
+| [ADR-0008](adr-0008.md)  | ✅ Accepted                              | 2026-02-22 | Deterministic Pre-Validation Before AI Analysis                                        |
+| [ADR-0009](adr-0009.md)  | ✅ Accepted                              | 2026-02-22 | Token-Budget-Aware Batch Planning                                                      |
+| [ADR-0010](adr-0010.md)  | ✅ Accepted                              | 2026-02-22 | Multi-Layer Retry Strategy                                                             |
+| [ADR-0011](adr-0011.md)  | 🔄 Superseded by [ADR-0022](adr-0022.md) | 2026-02-23 | Compile-Time Model Registry with Identifier Normalization                              |
+| [ADR-0012](adr-0012.md)  | ✅ Accepted                              | 2026-02-23 | Three-Level Issue Severity with `--strict` Exit-Code Promotion                         |
+| [ADR-0013](adr-0013.md)  | ✅ Accepted                              | 2026-02-23 | Self-Describing YAML Output with Field Presence Tracking                               |
+| [ADR-0014](adr-0014.md)  | ✅ Accepted                              | 2026-02-23 | Provider-Specific Prompt Engineering                                                   |
+| [ADR-0015](adr-0015.md)  | ✅ Accepted                              | 2026-02-23 | Dual Error Handling Strategy — `thiserror` for Domain Errors, `anyhow` for Propagation |
+| [ADR-0016](adr-0016.md)  | ✅ Accepted                              | 2026-02-24 | Clap Derive Macros with Hierarchical Subcommand Structure                              |
+| [ADR-0017](adr-0017.md)  | ✅ Accepted                              | 2026-02-25 | Per-File Diff Splitting for Token Budget Fitting                                       |
+| [ADR-0018](adr-0018.md)  | ✅ Accepted                              | 2026-02-25 | Automatic Context Detection for Adaptive AI Prompts                                    |
+| [ADR-0019](adr-0019.md)  | ✅ Accepted                              | 2026-02-25 | Ecosystem-Aware Scope Auto-Detection                                                   |
+| [ADR-0020](adr-0020.md)  | ✅ Proposed                              | 2026-04-16 | JFM — A Markdown Dialect for Bidirectional ADF Interchange                             |
+| [ADR-0021](adr-0021.md)  | ✅ Accepted                              | 2026-04-18 | MCP Server via Second Binary with `rmcp`                                               |
+| [ADR-0022](adr-0022.md)  | ✅ Accepted                              | 2026-05-06 | Layered Model Catalog with User and Project Overrides                                  |
+| [ADR-0023](adr-0023.md)  | ✅ Accepted                              | 2026-05-10 | Data-Driven ADF Content-Model Schema and Validator                                     |
+| [ADR-0024](adr-0024.md)  | ✅ Accepted                              | 2026-05-10 | TTL-Bounded In-Memory Cache for Near-Static JIRA Catalogues                            |
+| [ADR-0025](adr-0025.md)  | ✅ Accepted                              | 2026-05-10 | Wire ADF Schema Validator into the API Send Path via `ValidatedAdfDocument`            |
+| [ADR-0026](adr-0026.md)  | ✅ Accepted                              | 2026-05-10 | Extending the ADF Validator with Quantifiers, Attributes, and Marks                    |
+| [ADR-0027](adr-0027.md)  | ✅ Accepted                              | 2026-05-11 | Destructive CLI Commands Confirm by Default with --force and --dry-run Escape Hatches  |


### PR DESCRIPTION
## Description

This PR improves the ADR inventory table in `docs/adrs/README.md` by displaying the full supersession relationship in the Status column, rather than showing a bare "🔄 Superseded" label. ADR-0011 (Compile-Time Model Registry with Identifier Normalization) is now shown as "🔄 Superseded by [ADR-0022](adr-0022.md)", making the relationship between ADRs immediately visible without requiring the reader to open ADR-0011 to discover which decision superseded it.

The `update-adr-inventory` Claude skill is updated to preserve successor links verbatim while stripping trailing ` (YYYY-MM-DD)` date suffixes from status lines, since the supersession date already appears in the Date column. The column-details documentation table in the skill is also expanded to document the two canonical status formats.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #760

## Changes Made

**ADR Inventory (`docs/adrs/README.md`):**
- Updated ADR-0011 Status cell from bare `🔄 Superseded` to `🔄 Superseded by [ADR-0022](adr-0022.md)`, linking directly to the superseding decision
- Reformatted table column widths to accommodate the wider Status column

**Claude Skill (`.claude/skills/update-adr-inventory/SKILL.md`):**
- Updated the Status extraction rule to strip trailing ` (YYYY-MM-DD)` date suffixes from status lines while preserving any successor link (e.g., `🔄 Superseded by [ADR-0022](adr-0022.md)`) verbatim
- Expanded the Column Details reference table to document both canonical status formats: `✅ Accepted` and `🔄 Superseded by [ADR-NNNN](adr-NNNN.md)`

**Documentation:**
- No additional documentation changes beyond the two files above

**Testing:**
- No automated tests required; changes are documentation-only

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A — documentation-only change)

**Manual Testing:**
- [x] Verified ADR-0011 row in `docs/adrs/README.md` renders correctly with the linked supersession status
- [x] Confirmed the skill instructions accurately describe the new stripping-and-preserving logic for status lines

### Test Commands
```bash
# Code quality checks (no Rust changes in this PR)
cargo fmt --check
cargo clippy -- -D warnings
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications — not applicable
- [ ] Performance impact — not applicable
- [x] User experience — the supersession link in the Status column makes ADR relationships immediately discoverable in the inventory table
- [x] Backward compatibility — the skill update changes how status lines are processed; ensure no other ADR status lines contain parenthesized suffixes that should not be stripped

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The skill could be extended to validate that any successor ADR referenced in a "Superseded by" link actually exists in the inventory

**Known Limitations:**
- The stripping logic targets the specific ` (YYYY-MM-DD)` pattern; status lines using other trailing parenthetical formats would not be stripped

**Alternatives Considered:**
- Keeping a separate "Superseded By" column was considered but rejected in favour of inline linking in the Status column to avoid table width bloat