### PR TITLE
docs(plan): remove pr-creation.md scratchpad stub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,6 @@ Complete documentation for omni-dev - the intelligent Git commit message toolkit
 
 - **[Project Plan](plan/project.md)** - Technical architecture and implementation details
 - **[Twiddle Design](plan/twiddle.md)** - Complete design for the twiddle command phases
-- **[PR Creation](plan/pr-creation.md)** - Pull request creation workflow
 - **[Help All Command](plan/help-all-command.md)** - Comprehensive help system design
 - **[Config Internals](plan/config-internals.md)** - How configuration resolution works
 

--- a/docs/plan/pr-creation.md
+++ b/docs/plan/pr-creation.md
@@ -1,6 +1,0 @@
-git status
-git branch -v
-git log --oneline main..HEAD
-git push -u origin newhoggy/twiddle-msg-test.md
-git diff main...HEAD
-gh pr create --title "refactor: restructure twiddle-msg command system" --body "..."


### PR DESCRIPTION
## Description

Removes the `docs/plan/pr-creation.md` scratchpad file, which was a temporary stub containing raw git and GitHub CLI commands used during early exploration of the PR creation workflow. This file was never intended as permanent documentation and is now superseded by the actual implementation work tracked in issue #762.

The corresponding entry in `docs/README.md` has also been removed to keep the documentation index accurate.

## Type of Change

- [x] Documentation update

## Related Issue

Fixes #762

## Changes Made

**Documentation:**
- Deleted `docs/plan/pr-creation.md` — a scratchpad stub containing exploratory git/gh CLI commands that is no longer needed
- Removed the `PR Creation` link entry from `docs/README.md` to keep the documentation index consistent with actual files

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Verified `docs/README.md` links are consistent with files present in `docs/plan/`

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — confirm no other docs or tooling references `docs/plan/pr-creation.md`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements