### PR TITLE
docs(docs): add omni-dev-directory.md canonical reference and cross-link from existing docs

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -368,7 +368,9 @@ Writing a commit message.
 
 Follow [`.omni-dev/commit-guidelines.md`](../.omni-dev/commit-guidelines.md) for the full
 specification including types, scopes, subject line rules, body guidelines, and breaking
-change conventions.
+change conventions. See [`omni-dev-directory.md`](omni-dev-directory.md#commit-guidelinesmd)
+for the file's format contract, validation behaviour, and how it is resolved relative to
+local overrides and the global fallback.
 
 The commit guidelines must themselves follow **Conventional Commits** and remain consistent
 with the scope definitions in `.omni-dev/scopes.yaml`:
@@ -1164,8 +1166,9 @@ After creating one or more commits and before pushing or opening a pull request.
 ### Guidance
 
 After every `git commit`, invoke the `commit-twiddle` skill to validate and fix the
-message against the guidelines in `.omni-dev/commit-guidelines.md`. The skill calls
-`omni-dev git commit message view` to analyse the commit, then
+message against the guidelines in
+[`.omni-dev/commit-guidelines.md`](omni-dev-directory.md#commit-guidelinesmd). The skill
+calls `omni-dev git commit message view` to analyse the commit, then
 `omni-dev git commit message amend` to rewrite the message if needed.
 
 **Constraints to observe:**

--- a/docs/adrs/adr-0004.md
+++ b/docs/adrs/adr-0004.md
@@ -97,7 +97,9 @@ single source of truth.
 
 - **Commit guidelines have a runtime override path.** `claude::prompts` only falls back to
   `DEFAULT_COMMIT_GUIDELINES` when `context.project.commit_guidelines` is `None`. Projects
-  can provide their own `.omni-dev/commit-guidelines.md` to override the embedded default.
-  No other template type currently has an equivalent override mechanism. This asymmetry is
-  intentional: command templates are already written to disk (where users can edit them), and
-  the model registry is a versioned data structure that should match the binary's expectations.
+  can provide their own `.omni-dev/commit-guidelines.md` to override the embedded default
+  (see [`omni-dev-directory.md`](../omni-dev-directory.md#commit-guidelinesmd) for the
+  current format and precedence contract). No other template type currently has an equivalent
+  override mechanism. This asymmetry is intentional: command templates are already written
+  to disk (where users can edit them), and the model registry is a versioned data structure
+  that should match the binary's expectations.

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -103,8 +103,9 @@ The `--strict` flag is part of the public CLI contract. It is also used internal
 
 - **Per-project override is built in.** Because severity is defined in the guidelines
   file rather than in code, any project can promote or demote a section's severity by
-  supplying a custom `.omni-dev/commit-guidelines.md`. No configuration keys or
-  application changes are required.
+  supplying a custom `.omni-dev/commit-guidelines.md` (see
+  [`omni-dev-directory.md`](../omni-dev-directory.md#commit-guidelinesmd) for the file's
+  current contract). No configuration keys or application changes are required.
 
 - **The pattern is immediately familiar.** Developers who have used ESLint, TypeScript,
   mypy, or GCC with `-Werror` already understand the mental model. Onboarding friction

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,12 @@ export CLAUDE_API_KEY="your-api-key-here"
 
 ## Configuration Files
 
+> See [`omni-dev-directory.md`](omni-dev-directory.md) for the formal
+> contract: the full inventory of recognised files under `.omni-dev/`, their
+> precedence rules, and the exact validation messages omni-dev emits when a
+> file is malformed. This page is the narrative walkthrough; that page is the
+> spec.
+
 ### Local Override Support
 
 All configuration files support local overrides. If a file exists in
@@ -75,7 +81,10 @@ guidance on writing effective configuration files.
 
 ### 1. Scope Definitions (`.omni-dev/scopes.yaml`)
 
-**Purpose**: Define project-specific scopes and their meanings for use in conventional commit messages.
+**Purpose**: Define project-specific scopes and their meanings for use in
+conventional commit messages. See
+[`omni-dev-directory.md`](omni-dev-directory.md#scopesyaml) for the format
+contract, required fields, and validation behaviour.
 
 #### What are Scopes?
 
@@ -282,7 +291,9 @@ scopes:
 
 ### 2. Commit Guidelines (`.omni-dev/commit-guidelines.md`)
 
-**Purpose**: Document your project's commit message conventions.
+**Purpose**: Document your project's commit message conventions. See
+[`omni-dev-directory.md`](omni-dev-directory.md#commit-guidelinesmd) for the
+file's format contract and validation behaviour.
 
 **Template**:
 
@@ -735,6 +746,10 @@ echo "See [.omni-dev/commit-guidelines.md](.omni-dev/commit-guidelines.md) for c
 echo "- [ ] Commits follow [project guidelines](.omni-dev/commit-guidelines.md)" >> .github/pull_request_template.md
 ```
 
+The format and validation contract for `.omni-dev/commit-guidelines.md`
+itself is documented in
+[`omni-dev-directory.md`](omni-dev-directory.md#commit-guidelinesmd).
+
 ### 5. Version Your Configuration
 
 Track configuration changes:
@@ -832,7 +847,7 @@ export CLAUDE_API_KEY="team-shared-key-or-individual-key"
 # 3. Test configuration
 omni-dev git commit message view HEAD --use-context
 
-# 4. Review project guidelines
+# 4. Review project guidelines (see omni-dev-directory.md for the format contract)
 cat .omni-dev/commit-guidelines.md
 ```
 
@@ -939,7 +954,9 @@ If you're currently writing commit messages manually:
 
 **Guidelines Not Loading**:
 
-1. Ensure `.omni-dev/commit-guidelines.md` exists
+1. Ensure `.omni-dev/commit-guidelines.md` exists at one of the locations
+   listed in
+   [`omni-dev-directory.md`](omni-dev-directory.md#chain-a--hierarchical-resolution)
 2. Check file permissions
 3. Verify markdown formatting
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -88,6 +88,9 @@ webapp/
 
 ### Configuration (`.omni-dev/scopes.yaml`)
 
+See [`omni-dev-directory.md`](omni-dev-directory.md#scopesyaml) for the format
+contract; the example below shows how it applies in practice.
+
 ```yaml
 scopes:
   - name: "auth"

--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -15,8 +15,10 @@ Local overrides are the highest-priority tier in the full resolution chain:
 3. `$XDG_CONFIG_HOME/omni-dev/{filename}` - XDG global config
 4. `$HOME/.omni-dev/{filename}` - Legacy global fallback
 
-See [Configuration Guide](configuration.md) for the full resolution chain
-including config directory selection (walk-up discovery, env var, CLI flag).
+See [Configuration Guide](configuration.md) for the narrative walkthrough
+and [`omni-dev-directory.md`](omni-dev-directory.md#chain-a--hierarchical-resolution)
+for the formal precedence contract, including config-directory selection
+(walk-up discovery, env var, CLI flag) and the per-file validation behaviour.
 
 ## Supported Override Files
 

--- a/docs/omni-dev-directory.md
+++ b/docs/omni-dev-directory.md
@@ -1,0 +1,355 @@
+# `.omni-dev/` Directory Contract
+
+This document is the canonical reference for the `.omni-dev/` directory: the
+inventory of recognised files, their formats, the precedence rules that decide
+which copy wins when more than one exists, and the validation behaviour
+omni-dev exhibits when a file is missing or malformed.
+
+If you came here from a passing mention of `.omni-dev/commit-guidelines.md` (or
+any other `.omni-dev/<file>`), this is the spec.
+
+## Overview
+
+`.omni-dev/` is the configuration directory omni-dev uses to learn about a
+project. It is normally placed at the repository root, but discovery walks up
+from the current working directory so omni-dev keeps working from anywhere
+inside a repository tree.
+
+Two distinct precedence systems are at work, depending on which file is being
+loaded:
+
+- **Chain A** — for `commit-guidelines.md`, `pr-guidelines.md`, `scopes.yaml`,
+  and feature contexts. Resolves through `local/` overrides, project scope,
+  XDG, and a legacy `~/.omni-dev/` fallback. Discussed in
+  [Chain A — hierarchical resolution](#chain-a--hierarchical-resolution).
+- **Chain B** — for `models.yaml`. A layered merge with deep-merge semantics
+  driven by ADR-0022. Discussed in
+  [Chain B — layered model catalog](#chain-b--layered-model-catalog).
+
+Credentials in `~/.omni-dev/settings.json` are home-only and use neither
+chain — see [settings.json](#settingsjson).
+
+## Recognised files
+
+| File | Purpose | Format | Scope | Precedence | Source |
+|---|---|---|---|---|---|
+| `commit-guidelines.md` | Commit-message rules consumed by `git commit message check` / `twiddle` | Markdown | project / user / XDG / `~/.omni-dev/` | Chain A | [`src/claude/context/discovery.rs:456`](../src/claude/context/discovery.rs#L456) |
+| `pr-guidelines.md` | PR title / body rules consumed by `git pr` flows | Markdown | same as above | Chain A | [`src/claude/context/discovery.rs:471`](../src/claude/context/discovery.rs#L471) |
+| `scopes.yaml` | Commit/PR scope vocabulary; merged with ecosystem defaults | YAML | same as above | Chain A | [`src/claude/context/discovery.rs:486`](../src/claude/context/discovery.rs#L486) |
+| `models.yaml` | AI model catalog overrides | YAML | project / user / embedded | Chain B | [`src/claude/model_config.rs:178`](../src/claude/model_config.rs#L178) |
+| `context/feature-contexts/*.yaml` | Per-feature AI prompt context fragments | YAML | inside the active `.omni-dev/` (plus `local/` override) | Chain A (variant) | [`src/claude/context/discovery.rs:502`](../src/claude/context/discovery.rs#L502) |
+| `local/<any>` | Gitignored personal overrides for any of the above | follows the underlying file | personal | top of Chain A | [`src/claude/context/discovery.rs:44`](../src/claude/context/discovery.rs#L44) |
+| `~/.omni-dev/settings.json` | API credentials and env-var fallbacks (Atlassian / Datadog / etc.) | JSON | user (home) only | none — single path | [`src/utils/settings.rs:52`](../src/utils/settings.rs#L52) |
+
+Missing files are not an error. Each loader falls through to a lower-precedence
+tier (or to the embedded default, where one exists) and omni-dev continues.
+
+## Precedence
+
+### Chain A — hierarchical resolution
+
+Used for `commit-guidelines.md`, `pr-guidelines.md`, `scopes.yaml`, and the
+`context/feature-contexts/` files. Implemented by `resolve_config_file` in
+[`src/claude/context/discovery.rs:43-72`](../src/claude/context/discovery.rs#L43-L72).
+The first existing file wins:
+
+| Priority | Location | Purpose |
+|---|---|---|
+| 1 | `{dir}/local/{filename}` | Gitignored personal override |
+| 2 | `{dir}/{filename}` | Shared project config |
+| 3 | `$XDG_CONFIG_HOME/omni-dev/{filename}` | XDG global config (defaults to `~/.config/omni-dev/`) |
+| 4 | `$HOME/.omni-dev/{filename}` | Legacy global fallback |
+
+`{dir}` is itself resolved by `resolve_context_dir_with_source` in
+[`src/claude/context/discovery.rs:128-147`](../src/claude/context/discovery.rs#L128-L147):
+
+| Priority | Source | Description |
+|---|---|---|
+| 1 | `--context-dir` CLI flag | Explicit override; disables walk-up |
+| 2 | `OMNI_DEV_CONFIG_DIR` env var | Environment override; disables walk-up |
+| 3 | Walk-up discovery | Nearest `.omni-dev/` from CWD up to the repo root (`.git` boundary) |
+| 4 | `.omni-dev` | Default fallback relative to CWD |
+
+Walk-up stops at the first directory containing a `.git` entry (file or
+directory) — discovery does not escape the repository. See
+[ADR-0005](adrs/adr-0005.md).
+
+### Chain B — layered model catalog
+
+Used **only** for `models.yaml`. Implemented by
+`ModelRegistry::load_layered_from_paths` in
+[`src/claude/model_config.rs:195-227`](../src/claude/model_config.rs#L195-L227).
+
+Unlike Chain A, layers are **deep-merged** rather than first-match. The
+embedded catalog is always present, and higher-precedence layers override
+individual model entries (matched by `api_identifier`) and provider settings
+without forcing the user to redeclare the whole file.
+
+| Priority | Layer | Notes |
+|---|---|---|
+| 1 (highest) | `OMNI_DEV_MODELS_YAML` env override | Short-circuits both project and user layers. Missing file falls back to embedded with a warning. |
+| 2 | `./.omni-dev/models.yaml` (project, **CWD-relative**) | No walk-up; resolved by `default_project_path` at [`src/claude/model_config.rs:494-498`](../src/claude/model_config.rs#L494-L498). |
+| 3 | `~/.omni-dev/models.yaml` (user) | Resolved by `default_user_path` at [`src/claude/model_config.rs:501-503`](../src/claude/model_config.rs#L501-L503). |
+| 4 (lowest) | Embedded [`src/templates/models.yaml`](../src/templates/models.yaml) | Compile-time include via `include_str!`; cannot be removed. |
+
+> **Caveat — no walk-up for `models.yaml`.** Chain B resolves the project
+> layer from the current working directory only. If you `cd` into a
+> sub-directory that does not itself contain `.omni-dev/models.yaml`, the
+> project-layer overrides will not apply, even though Chain A's walk-up would
+> have found the same `.omni-dev/`. Run omni-dev from the project root, or
+> use `OMNI_DEV_MODELS_YAML` to point at the file explicitly.
+
+See [ADR-0022](adrs/adr-0022.md) for the rationale behind the layered-merge
+design.
+
+### Settings (`~/.omni-dev/settings.json`)
+
+`Settings::get_settings_path` in
+[`src/utils/settings.rs:49-53`](../src/utils/settings.rs#L49-L53) returns a
+single path: `$HOME/.omni-dev/settings.json`. There is no walk-up, no
+project-scoped equivalent, and no XDG fallback. This is intentional:
+credentials are personal and should never be checked into a project's
+`.omni-dev/`.
+
+## File specs
+
+### `commit-guidelines.md`
+
+Markdown describing the commit-message conventions the project enforces. Read
+verbatim into the AI prompt; omni-dev does not parse it for structure. The
+spec-by-example lives at
+[`src/templates/default-commit-guidelines.md`](../src/templates/default-commit-guidelines.md);
+the default is used when no project, XDG, or home copy exists.
+
+A minimally useful file declares severity levels and a list of accepted types:
+
+```markdown
+## Severity Levels
+
+| Severity | Sections                              |
+|----------|---------------------------------------|
+| error    | Commit Format, Types, Subject Line    |
+| warning  | Body Guidelines                       |
+| info     | Subject Line Style                    |
+
+## Commit Format
+
+Use conventional commit format: `<type>(<scope>): <description>`
+
+## Types
+
+| Type    | Use for                |
+|---------|------------------------|
+| `feat`  | New features           |
+| `fix`   | Bug fixes              |
+| `docs`  | Documentation changes  |
+
+## Subject Line
+
+- Imperative mood ("add", not "added")
+- No trailing period
+```
+
+The `## Severity Levels` table is the single source of truth for whether a
+section is `error`, `warning`, or `info` — see
+[ADR-0012](adrs/adr-0012.md).
+
+### `pr-guidelines.md`
+
+Markdown describing PR title and body conventions. Same loading semantics as
+`commit-guidelines.md`. There is no embedded default — the file is optional;
+when absent, omni-dev falls back to behaviour driven solely by
+`commit-guidelines.md` and ecosystem defaults. See this repository's own
+[`.omni-dev/pr-guidelines.md`](../.omni-dev/pr-guidelines.md) for a
+worked example.
+
+### `scopes.yaml`
+
+YAML enumerating valid commit/PR scopes for the project. Loaded into
+`ScopesConfig` in
+[`src/claude/context/discovery.rs:245`](../src/claude/context/discovery.rs#L245),
+then merged with ecosystem defaults via
+`merge_ecosystem_scopes` (see [ADR-0019](adrs/adr-0019.md)).
+
+Minimal valid example:
+
+```yaml
+scopes:
+  - name: "auth"
+    description: "Authentication and authorization"
+    examples:
+      - "auth: add OAuth2 login"
+      - "auth: fix session timeout"
+    file_patterns:
+      - "src/auth/**"
+      - "auth/**"
+```
+
+All four fields (`name`, `description`, `examples`, `file_patterns`) are
+required per scope. Extra fields are ignored.
+
+### `models.yaml`
+
+YAML overriding the embedded model catalog. The schema version is currently
+`"1"` (constant `MODELS_SCHEMA_VERSION` at
+[`src/claude/model_config.rs:26`](../src/claude/model_config.rs#L26)). Two
+top-level keys are treated specially during merge:
+
+- `models:` — a sequence; entries are matched by `api_identifier` and
+  deep-merged with the corresponding embedded entry, or appended if new.
+- `providers:` — a mapping; merged per provider name, so a user file can
+  override just `default_model` without redeclaring every tier.
+
+All other top-level keys are last-writer-wins.
+
+Minimal valid example — overrides Anthropic's default model and adds one
+provider-specific entry:
+
+```yaml
+version: "1"
+
+providers:
+  claude:
+    default_model: "claude-opus-4-7"
+
+models:
+  - provider: "claude"
+    model: "Claude Opus 4.7"
+    api_identifier: "claude-opus-4-7"
+    max_output_tokens: 64000
+    input_context: 200000
+    generation: 4.7
+    tier: "flagship"
+```
+
+`api_identifier` is the only strictly-required field per model entry — entries
+without it are skipped (see [Validation behaviour](#validation-behaviour)).
+The full schema, including provider defaults and tier descriptions, is
+documented by example in
+[`src/templates/models.yaml`](../src/templates/models.yaml).
+
+See [ADR-0022](adrs/adr-0022.md) for the design rationale.
+
+### `settings.json`
+
+JSON file at `~/.omni-dev/settings.json` containing an `env` map. Each key
+corresponds to an environment variable name that omni-dev (or one of its
+sub-clients) consults; values are used **as a fallback** for the actual
+environment — real environment variables always win. See
+[`src/utils/settings.rs:56-65`](../src/utils/settings.rs#L56-L65).
+
+Minimal valid example:
+
+```json
+{
+  "env": {}
+}
+```
+
+Recognised keys written by built-in flows:
+
+| Key | Written by | Read by |
+|---|---|---|
+| `ATLASSIAN_INSTANCE_URL` | `omni-dev atlassian auth login` ([`src/atlassian/auth.rs:151`](../src/atlassian/auth.rs#L151)) | [`load_credentials`](../src/atlassian/auth.rs#L40) |
+| `ATLASSIAN_EMAIL` | same | same |
+| `ATLASSIAN_API_TOKEN` | same | same |
+| `DATADOG_API_KEY` | `omni-dev datadog auth login` ([`src/datadog/auth.rs:178`](../src/datadog/auth.rs#L178)) | [`load_credentials`](../src/datadog/auth.rs#L85) |
+| `DATADOG_APP_KEY` | same | same |
+| `DATADOG_SITE` | same | same |
+
+Any other environment variable consulted via `Settings::get_env_var` can also
+be set under the same `env` map (including API keys for `CLAUDE_API_KEY`,
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
+
+### `local/`
+
+`{dir}/local/` is a gitignored sub-directory that mirrors the layout of
+`{dir}/` itself: any file under `local/` (e.g.
+`.omni-dev/local/commit-guidelines.md`,
+`.omni-dev/local/scopes.yaml`,
+`.omni-dev/local/context/feature-contexts/*.yaml`) shadows the file at the
+same relative path one level up. The repo root
+[`.gitignore`](../.gitignore) contains a `.omni-dev/local/` entry that you
+should mirror in any project that adopts this convention.
+
+This is the intended escape hatch for personal overrides that should never
+ship to teammates — for example, a per-developer override of
+`commit-guidelines.md` for experimentation, or a `models.yaml` that points
+the project at a different model provider locally. (Note that `models.yaml`
+uses Chain B, not Chain A, so `local/models.yaml` is **not** consulted —
+use `OMNI_DEV_MODELS_YAML` for a personal model override instead.)
+
+### `context/feature-contexts/*.yaml`
+
+Per-feature prompt context fragments. Files are loaded from both
+`{dir}/context/feature-contexts/` and `{dir}/local/context/feature-contexts/`;
+local entries override standard entries with the same filename. Implemented
+by `load_feature_contexts` at
+[`src/claude/context/discovery.rs:570-610`](../src/claude/context/discovery.rs#L570-L610).
+Only `.yaml` and `.yml` files are picked up; the filename (minus extension)
+becomes the feature key.
+
+## Validation behaviour
+
+omni-dev favours silent fallback over hard failure: missing files are
+expected (defaults exist); malformed files log a warning and fall through to
+the next tier. The strings below are the actual messages emitted by the
+current source — you can grep your logs against them verbatim.
+
+### `models.yaml`
+
+| File:line | Level | Trigger | Message |
+|---|---|---|---|
+| [`src/claude/model_config.rs:207-210`](../src/claude/model_config.rs#L207-L210) | `warn!` | `OMNI_DEV_MODELS_YAML` points at a missing or unreadable file | `{OMNI_DEV_MODELS_YAML_ENV} points at {} but the file is missing or unreadable; falling back to embedded catalog` |
+| [`src/claude/model_config.rs:246-248`](../src/claude/model_config.rs#L246-L248) | hard error (`anyhow!`) | Embedded YAML is malformed at compile time (compile-time invariant — only triggers if a build ships a broken `src/templates/models.yaml`) | `Embedded models.yaml is malformed at compile time: {e}` |
+| [`src/claude/model_config.rs:250-252`](../src/claude/model_config.rs#L250-L252) | `error!` | User or project `models.yaml` has invalid YAML — non-fatal, falls through | `Malformed {source} models.yaml: {e}. Falling through to lower-precedence layers.` |
+| [`src/claude/model_config.rs:514-517`](../src/claude/model_config.rs#L514-L517) | `error!` | Read error (permissions, I/O) on user or project `models.yaml` | `Failed to read {}: {e}. Falling through to lower-precedence layers.` |
+| [`src/claude/model_config.rs:600-602`](../src/claude/model_config.rs#L600-L602) | `warn!` | A model entry lacks the required `api_identifier` field | `` Skipping model entry without `api_identifier` from {source} models.yaml `` |
+| [`src/claude/model_config.rs:685-687`](../src/claude/model_config.rs#L685-L687) | `warn!` | User or project `models.yaml` has no `version:` field | `` {source} models.yaml has no `version:` field; assuming compatibility with schema version {MODELS_SCHEMA_VERSION}. Add `version: "{MODELS_SCHEMA_VERSION}"` to silence this warning. `` |
+| [`src/claude/model_config.rs:691-693`](../src/claude/model_config.rs#L691-L693) | `warn!` | Declared schema version differs from `MODELS_SCHEMA_VERSION` | `{source} models.yaml declares schema version {v}; this build understands {MODELS_SCHEMA_VERSION}. Continuing — unrecognised fields may be ignored.` |
+
+### `scopes.yaml`
+
+| File:line | Level | Trigger | Message |
+|---|---|---|---|
+| [`src/claude/context/discovery.rs:241`](../src/claude/context/discovery.rs#L241) | `warn!` | File exists but cannot be read (permissions, I/O) — `load_project_scopes` returns `vec![]` | `Cannot read scopes file {}: {e}` |
+| [`src/claude/context/discovery.rs:248-251`](../src/claude/context/discovery.rs#L248-L251) | `warn!` | File exists but is malformed YAML — `load_project_scopes` returns `vec![]` | `Ignoring malformed scopes file {}: {e}` |
+| [`src/claude/context/discovery.rs:494-497`](../src/claude/context/discovery.rs#L494-L497) | `warn!` | Same condition, but encountered while loading the wider `.omni-dev/` config — `load_omni_dev_config` skips the scopes update | `Ignoring malformed scopes file {}: {e}` |
+
+### Feature contexts
+
+| File:line | Level | Trigger | Message |
+|---|---|---|---|
+| [`src/claude/context/discovery.rs:578-581`](../src/claude/context/discovery.rs#L578-L581) | `warn!` | Feature contexts directory is unreadable — directory is skipped | `Cannot read feature contexts dir {}: {e}` |
+| [`src/claude/context/discovery.rs:600-603`](../src/claude/context/discovery.rs#L600-L603) | `warn!` | A `.yaml` / `.yml` file in the directory fails to deserialise as `FeatureContext` — that one file is skipped | `Ignoring malformed feature context {}: {e}` |
+
+### `settings.json`
+
+| File:line | Level | Trigger | Message |
+|---|---|---|---|
+| [`src/utils/settings.rs:41-42`](../src/utils/settings.rs#L41-L42) | `Result::Err` (propagated via `anyhow::Context`) | File exists but cannot be read | `Failed to read settings file: {}` |
+| [`src/utils/settings.rs:44-45`](../src/utils/settings.rs#L44-L45) | `Result::Err` (propagated via `anyhow::Context`) | File exists but is not valid JSON or does not match the `Settings` schema | `Failed to parse settings file: {}` |
+
+Missing `~/.omni-dev/settings.json` is silent (see
+[`src/utils/settings.rs:34-37`](../src/utils/settings.rs#L34-L37)) — `load`
+returns an empty `Settings { env: {} }`.
+
+### `commit-guidelines.md` / `pr-guidelines.md`
+
+No file-specific validation. Read errors during
+`fs::read_to_string` are propagated as `Result::Err` via the standard
+`anyhow` chain. Missing files are silent; the context loader simply leaves
+`context.commit_guidelines` / `context.pr_guidelines` as `None` and the AI
+prompt falls back to
+[`src/templates/default-commit-guidelines.md`](../src/templates/default-commit-guidelines.md)
+(`commit-guidelines.md` only — `pr-guidelines.md` has no embedded default).
+
+## See also
+
+- [ADR-0005](adrs/adr-0005.md) — Hierarchical Configuration Resolution with Walk-Up Discovery (Chain A).
+- [ADR-0018](adrs/adr-0018.md) — Automatic Context Detection for Adaptive AI Prompts.
+- [ADR-0019](adrs/adr-0019.md) — Ecosystem-Aware Scope Auto-Detection (`scopes.yaml` merge).
+- [ADR-0022](adrs/adr-0022.md) — Layered Model Catalog with User and Project Overrides (Chain B).
+- [Configuration Guide](configuration.md) — narrative walkthrough with worked examples.
+- [User Guide](user-guide.md) — end-to-end setup including `.omni-dev/` bootstrap.
+- [Style Guide](STYLE_GUIDE.md) — commit-message-authoring conventions for this repository.

--- a/docs/plan/commit-message-check.md
+++ b/docs/plan/commit-message-check.md
@@ -28,7 +28,7 @@ This means:
 
 ## Commit Guidelines Structure
 
-Projects define their commit guidelines in `.omni-dev/commit-guidelines.md`. The check command reads and enforces these. Guidelines should specify severity levels for violations.
+Projects define their commit guidelines in `.omni-dev/commit-guidelines.md` (see [`omni-dev-directory.md`](../omni-dev-directory.md#commit-guidelinesmd) for the format contract). The check command reads and enforces these. Guidelines should specify severity levels for violations.
 
 ### Example Commit Guidelines File
 

--- a/docs/plan/config-internals.md
+++ b/docs/plan/config-internals.md
@@ -1,6 +1,9 @@
 # Config Internals
 
-How omni-dev's configuration resolution system works, for contributors.
+How omni-dev's configuration resolution system works, for contributors. For
+the user-facing contract — the inventory of recognised `.omni-dev/` files,
+their formats, and validation behaviour — see
+[`omni-dev-directory.md`](../omni-dev-directory.md).
 
 ## Table of Contents
 

--- a/docs/plan/twiddle.md
+++ b/docs/plan/twiddle.md
@@ -390,6 +390,10 @@ pub fn generate_contextual_system_prompt(context: &CommitContext) -> String {
 
 #### 5.4. Configuration File Examples
 
+> For the full format contract — recognised fields, precedence, and validation
+> behaviour — see
+> [`omni-dev-directory.md`](../omni-dev-directory.md#file-specs).
+
 **.omni-dev/commit-guidelines.md**:
 ```markdown
 # Project Commit Guidelines

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1153,7 +1153,9 @@ mkdir .omni-dev
 
 #### 2. Define Project Scopes (`.omni-dev/scopes.yaml`)
 
-Tell omni-dev about your project's areas:
+Tell omni-dev about your project's areas. See
+[`omni-dev-directory.md`](omni-dev-directory.md#scopesyaml) for the file's
+format contract and validation behaviour.
 
 ```yaml
 scopes:
@@ -1200,7 +1202,11 @@ scopes:
 
 #### 3. Set Commit Guidelines (`.omni-dev/commit-guidelines.md`)
 
-Define your project's commit message standards:
+Define your project's commit message standards. See
+[`omni-dev-directory.md`](omni-dev-directory.md#commit-guidelinesmd) for the
+full format contract — including precedence between project-scope, user-scope,
+and global fallbacks — and the validation messages omni-dev emits on a
+malformed file.
 
 ```markdown
 # Project Commit Guidelines


### PR DESCRIPTION
## Description

This PR adds `docs/omni-dev-directory.md` as the canonical reference document for the `.omni-dev/` directory contract and updates all existing documentation pages to link to it.

Previously, references to `.omni-dev/` files were scattered across multiple docs without a single authoritative source for their formats, precedence rules, and validation behaviour. This PR establishes that single source of truth and ensures all existing docs point to it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #765

## Changes Made

**New Document (`docs/omni-dev-directory.md`):**
- Inventories all recognised files under `.omni-dev/` with their formats, scopes, and precedence systems
- Documents **Chain A** (hierarchical resolution for `commit-guidelines.md`, `pr-guidelines.md`, `scopes.yaml`, and feature contexts) with full priority table and source file references (`src/claude/context/discovery.rs`)
- Documents **Chain B** (layered deep-merge for `models.yaml`) including the no-walk-up caveat and the `OMNI_DEV_MODELS_YAML` override (`src/claude/model_config.rs`)
- Provides per-file specs with minimal valid examples for `commit-guidelines.md`, `pr-guidelines.md`, `scopes.yaml`, `models.yaml`, `settings.json`, `local/`, and `context/feature-contexts/`
- Lists exact warning/error messages and source file:line references for validation behaviour of each file type

**Cross-link updates to existing docs (10 files modified):**
- `docs/STYLE_GUIDE.md` — links commit-guidelines references to the new spec
- `docs/adrs/adr-0004.md` — links override-path note to the format contract
- `docs/adrs/adr-0012.md` — links per-project override note to the contract
- `docs/configuration.md` — adds spec callout at top of Configuration Files section and inline links from scope/guidelines descriptions and examples
- `docs/examples.md` — adds format-contract callout before scopes example
- `docs/local-overrides.md` — updates resolution-chain link to point at the formal precedence contract
- `docs/plan/commit-message-check.md` — inline link from guidelines mention
- `docs/plan/config-internals.md` — adds user-facing contract pointer
- `docs/plan/twiddle.md` — adds format-contract callout before file examples
- `docs/user-guide.md` — adds spec links to scopes and commit-guidelines setup steps

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation only — no code changes)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified all cross-links point to valid anchors in `omni-dev-directory.md`
- [x] Confirmed relative link paths are correct across docs subdirectories (`docs/`, `docs/adrs/`, `docs/plan/`)
- [x] Backward compatibility verified — no existing doc content removed, only links added

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience — the new doc is the entry point for anyone trying to understand `.omni-dev/` file formats; check clarity and completeness
- [x] Backward compatibility — existing docs should not have lost content, only gained links

**Specific areas to review:**
- The Chain A vs Chain B distinction in `omni-dev-directory.md` — particularly the walk-up caveat for `models.yaml` which differs from all other files
- Accuracy of source file:line references against the current codebase
- Relative link paths from `docs/adrs/*.md` and `docs/plan/*.md` which use `../omni-dev-directory.md` vs root-level docs which use `omni-dev-directory.md`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation only)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a purely additive documentation change.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Design decisions:**
- The new document deliberately separates narrative (left to `configuration.md` and `user-guide.md`) from spec (the new `omni-dev-directory.md`). Cross-links explicitly call this out with language like "This page is the narrative walkthrough; that page is the spec."
- Source file:line references in the tables are kept as relative links so they remain navigable in GitHub's file browser without requiring an absolute URL.
- The Chain B walk-up caveat for `models.yaml` is highlighted in a blockquote callout because it is the most common source of confusion when working from a subdirectory.

**Future Enhancements:**
- As new `.omni-dev/` files are introduced, `omni-dev-directory.md` should be updated as the first-class spec document before other docs reference the new file.