### PR TITLE
docs(docs): add AI backends user guide and consolidate backend docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,19 +131,19 @@ The project includes a comprehensive model registry system:
 ### AI Backend Dispatch
 Backends are selected inside `src/claude/client.rs::create_default_claude_client` in this order:
 
-1. `OMNI_DEV_AI_BACKEND=claude-cli` (or `--ai-backend claude-cli`) → `ClaudeCliAiClient` in `src/claude/ai/claude_cli.rs`. Shells out to `claude -p` in a locked-down sandbox (tools disabled, MCP blocked, settings skipped, fresh temp cwd, scrubbed env). Uses JSON output format and parses the `is_error`/`api_error_status`/`result` envelope. `--beta-header` is ignored for this backend.
-2. `USE_OLLAMA=true` → `OpenAiAiClient::new_ollama`.
-3. `USE_OPENAI=true` → `OpenAiAiClient::new_openai`.
-4. `CLAUDE_CODE_USE_BEDROCK=true` → `BedrockAiClient`.
-5. Default → `ClaudeAiClient` (direct Anthropic API).
+1. `OMNI_DEV_AI_BACKEND=claude-cli` (or `--ai-backend claude-cli`) → `ClaudeCliAiClient` in `src/claude/ai/claude_cli.rs`.
+2. `USE_OLLAMA=true` → `OpenAiAiClient::new_ollama` in `src/claude/ai/openai.rs`.
+3. `USE_OPENAI=true` → `OpenAiAiClient::new_openai` in `src/claude/ai/openai.rs`.
+4. `CLAUDE_CODE_USE_BEDROCK=true` → `BedrockAiClient` in `src/claude/ai/bedrock.rs`.
+5. Default → `ClaudeAiClient` in `src/claude/ai/claude.rs` (direct Anthropic API).
 
 Preflight (`src/utils/preflight.rs`) mirrors this switch and must change in lock-step when adding backends.
 
-**Escape hatch (tools).** `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true` or `--claude-cli-allow-tools` removes the `--tools ""` flag from the subprocess argv, letting the nested session use Read/Edit/Write/Bash/Glob/Grep. Other sandbox flags (`--setting-sources ""`, `--disable-slash-commands`, `--no-session-persistence`, temp cwd, scrubbed env) still apply, as does `--strict-mcp-config` unless the MCP escape hatch is also set. A warning is logged every time the escape hatch is active. See `ClaudeCliAiClient::run` for the warn site.
+User-facing details — required env vars, model selection, Claude CLI sandbox semantics, the `--claude-cli-allow-tools` / `--claude-cli-allow-mcp` escape hatches, the `--claude-cli-max-budget-usd` spending cap, and per-backend troubleshooting — live in [docs/ai-backends.md](docs/ai-backends.md). Keep it in sync when changing any of those surfaces.
 
-**Escape hatch (MCP).** `OMNI_DEV_CLAUDE_CLI_ALLOW_MCP=true` or `--claude-cli-allow-mcp` removes the `--strict-mcp-config` flag from the subprocess argv, letting the nested session load MCP servers from `~/.claude/settings.json`. Independent of the tool escape hatch — the two can be combined or used separately. A warning is logged every time the escape hatch is active. See `ClaudeCliAiClient::run` for the warn site.
-
-**Spending cap.** `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=<amount>` or `--claude-cli-max-budget-usd <amount>` forwards to `claude -p --max-budget-usd`, aborting the nested session if it exceeds the cap. Every invocation logs `total_cost_usd` from the JSON envelope at INFO level regardless of cap, for cost observability. Non-positive / non-finite values are silently treated as no cap. See `ClaudeCliAiClient::run` for the log site and the post-response warn when cost exceeds the configured cap.
+Dev-only notes:
+- `ClaudeCliAiClient::run` is the warn site for both escape hatches, the INFO-level `total_cost_usd` log, and the post-response WARN when reported cost exceeds the configured cap.
+- `--beta-header` is ignored for the `claude-cli` backend (`claude`'s `--betas` flag has different semantics).
 
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.

--- a/README.md
+++ b/README.md
@@ -612,126 +612,20 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 
 ### AI backend selection
 
-By default, `omni-dev` calls the Anthropic API (or Bedrock/OpenAI/Ollama via
-the `USE_*`/`CLAUDE_CODE_USE_BEDROCK` env vars). As an alternative, you can
-route AI calls through an already-authenticated
-[Claude Code CLI](https://github.com/anthropics/claude-code) session, avoiding
-the need for a separate API key:
+omni-dev supports five AI backends, selected by env var or the
+`--ai-backend` flag (priority order, first match wins):
 
-```bash
-# Per-invocation flag:
-omni-dev --ai-backend claude-cli git commit message twiddle <range>
+1. `--ai-backend claude-cli` / `OMNI_DEV_AI_BACKEND=claude-cli` — sandboxed
+   `claude -p` subprocess that reuses your Claude Code session.
+2. `USE_OLLAMA=true` — local Ollama or LM Studio server.
+3. `USE_OPENAI=true` — OpenAI Chat Completions API.
+4. `CLAUDE_CODE_USE_BEDROCK=true` — AWS Bedrock.
+5. *(default)* direct Anthropic API.
 
-# Or set persistently:
-export OMNI_DEV_AI_BACKEND=claude-cli
-```
-
-The flag takes precedence over the environment variable.
-
-**Model selection** follows the precedence chain
-`--model` → `CLAUDE_MODEL` → `CLAUDE_CODE_MODEL` → `ANTHROPIC_MODEL` → registry
-default. Short aliases (`sonnet`, `opus`, `haiku`) and full identifiers
-(`claude-sonnet-4-6`) are both accepted and forwarded verbatim to
-`claude -p --model`.
-
-**Sandboxing guarantees.** The `claude -p` subprocess is locked down so it
-behaves as a pure prompt→completion service, not a nested agent with
-filesystem or shell access:
-
-- Built-in tools disabled (`--tools ""`).
-- MCP servers blocked (`--strict-mcp-config` with no config).
-- User/project/local settings ignored (`--setting-sources ""`).
-- Slash commands / skills disabled.
-- Session persistence disabled.
-- Subprocess runs in a fresh temp directory (not your repo root).
-- Environment is scrubbed of `CLAUDE_PROJECT_DIR`, `CLAUDE_CODE_*`, and
-  `CLAUDE_PROJECT_*` before spawn.
-
-**Cost baseline.** Because the `claude -p` session still loads a small system
-prompt, each invocation has a floor cost (~$0.007 Haiku, ~$0.03 Sonnet,
-~$0.15 Opus) before any user content. Back-to-back calls within one hour hit
-the prompt cache and are much cheaper. If you pay per token, compare against
-the default HTTP backend which has no such floor.
-
-**Overrides.** Optional environment variables:
-
-- `OMNI_DEV_CLAUDE_CLI_BIN` — path to the `claude` binary (default: resolved
-  from `PATH`).
-- `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS` — subprocess timeout (default: 600).
-- `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES` — stdout cap in bytes (default:
-  4 MiB).
-- `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS` — **escape hatch** (default: disabled).
-  See below.
-- `OMNI_DEV_CLAUDE_CLI_ALLOW_MCP` — **escape hatch** for MCP server pickup
-  (default: disabled). See below.
-- `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD` — per-invocation spending cap in USD
-  (default: none). See below.
-
-The `--beta-header` flag is ignored with this backend (the CLI's `--betas`
-flag is API-key-user-only and has different semantics).
-
-#### Escape hatch: `--claude-cli-allow-tools`
-
-By default the nested `claude -p` session is run with `--tools ""` and
-cannot read, edit, or execute anything on your system. For deliberately
-tool-capable use cases, you can weaken the sandbox:
-
-```bash
-omni-dev --ai-backend claude-cli --claude-cli-allow-tools git branch create pr
-# or:
-export OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true
-```
-
-**When enabled**, the nested session uses the CLI's default built-in tool
-set (Read / Edit / Write / Bash / Glob / Grep). This means the session can
-access your repository and run commands. Only enable it when you want that
-behaviour. When active, omni-dev logs a warning on every invocation.
-
-`--strict-mcp-config` and `--setting-sources ""` still apply unless you
-*also* enable `--claude-cli-allow-mcp` (see below). The two escape hatches
-are independent so you can grant tool access without exposing MCP server
-credentials, and vice-versa.
-
-#### Escape hatch: `--claude-cli-allow-mcp`
-
-By default the nested `claude -p` session is run with `--strict-mcp-config`
-and no `--mcp-config`, blocking every MCP server you have configured in
-`~/.claude/settings.json`. To re-enable MCP server pickup:
-
-```bash
-omni-dev --ai-backend claude-cli --claude-cli-allow-mcp git branch create pr
-# or:
-export OMNI_DEV_CLAUDE_CLI_ALLOW_MCP=true
-```
-
-**When enabled**, the nested session can connect to any MCP server in your
-user settings. Be aware that MCP servers commonly hold OAuth tokens (Gmail,
-Drive, Slack) or expose internal network services; enabling this exposes
-them to the nested session. Only enable it when you want that behaviour.
-When active, omni-dev logs a warning on every invocation.
-
-This flag is independent of `--claude-cli-allow-tools`. Built-in tools
-remain disabled unless you enable that flag separately.
-
-#### Spending cap: `--claude-cli-max-budget-usd`
-
-Pass a per-invocation spending cap in USD:
-
-```bash
-omni-dev --ai-backend claude-cli --claude-cli-max-budget-usd 0.50 \
-  git commit message twiddle HEAD~3..HEAD
-# or:
-export OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=0.50
-```
-
-The value is forwarded to `claude -p --max-budget-usd`. If the nested
-session exceeds the cap, it aborts with an error rather than running away
-with cost. Regardless of whether a cap is set, each invocation's
-`total_cost_usd` is logged at INFO level for observability — run with
-`RUST_LOG=omni_dev=info` to see it.
-
-The cap is ignored when `--ai-backend` is not `claude-cli`. Non-positive,
-non-finite, or non-numeric values are silently treated as no cap.
+See the **[AI Backends Guide](docs/ai-backends.md)** for required env vars,
+model selection, the Claude CLI sandbox and its escape hatches
+(`--claude-cli-allow-tools`, `--claude-cli-allow-mcp`), the
+`--claude-cli-max-budget-usd` spending cap, and per-backend troubleshooting.
 
 ## 🐛 Debugging
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Complete documentation for omni-dev - the intelligent Git commit message toolkit
 - **[Configuration Guide](configuration.md)** - Set up contextual intelligence
 - **[Local Overrides](local-overrides.md)** - Personal configuration customization
 - **[Configuration Best Practices](configuration-best-practices.md)** - Writing effective scopes and guidelines
+- **[AI Backends](ai-backends.md)** - Claude API, Claude CLI, OpenAI, Ollama, and Bedrock setup
 - **[Examples](examples.md)** - Real-world usage examples across different project types
 
 ### Atlassian Integration
@@ -94,6 +95,7 @@ Complete documentation for omni-dev - the intelligent Git commit message toolkit
 | Feature | Primary Documentation | Additional Resources |
 |---------|----------------------|----------------------|
 | **AI-Powered Twiddle** | [User Guide - Twiddle](user-guide.md#twiddle---ai-powered-improvement) | [Examples - Before/After](examples.md#beforeafter-showcases) |
+| **AI Backends** | [AI Backends Guide](ai-backends.md) | [README - AI backend selection](../README.md#ai-backend-selection) |
 | **Contextual Intelligence** | [Configuration Guide](configuration.md#contextual-intelligence) | [User Guide - Context](user-guide.md#contextual-intelligence) |
 | **Project Configuration** | [Configuration Guide - Setup](configuration.md#setting-up-context) | [Examples - Configurations](examples.md#project-specific-examples) |
 | **Local Overrides** | [Local Overrides Guide](local-overrides.md) | [Configuration - Local Setup](configuration.md#local-override-examples) |

--- a/docs/ai-backends.md
+++ b/docs/ai-backends.md
@@ -1,0 +1,471 @@
+# AI Backends
+
+omni-dev's AI features — `twiddle`, PR creation, JIRA/Confluence drafting,
+`ai chat` — call out to a large language model through a pluggable
+**backend**. Five backends are supported and selected at runtime by environment
+variables or a CLI flag.
+
+This guide covers what each backend is, how to wire it up, and how to choose
+between them. For dev-facing notes on the dispatch implementation, see the
+"AI Backend Dispatch" section of [CLAUDE.md](../CLAUDE.md).
+
+## Table of Contents
+
+1. [Backends at a Glance](#backends-at-a-glance)
+2. [Dispatch Order and Model Selection](#dispatch-order-and-model-selection)
+3. [Claude API (default)](#claude-api-default)
+4. [Claude CLI (sandboxed subprocess)](#claude-cli-sandboxed-subprocess)
+5. [OpenAI](#openai)
+6. [Ollama](#ollama)
+7. [AWS Bedrock](#aws-bedrock)
+8. [Claude CLI Deep-dive](#claude-cli-deep-dive)
+9. [Model Registry](#model-registry)
+10. [Choosing a Backend](#choosing-a-backend)
+11. [Troubleshooting](#troubleshooting)
+
+## Backends at a Glance
+
+| Backend       | Selector                                                                         | Required credentials                                                                       | Default model                | Best when                                                            |
+|---------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------|----------------------------------------------------------------------|
+| Claude CLI    | `--ai-backend claude-cli` or `OMNI_DEV_AI_BACKEND=claude-cli`                    | An authenticated `claude` CLI session                                                      | `claude-sonnet-4-6`          | You already use Claude Code and want to reuse its auth and billing.  |
+| Ollama        | `USE_OLLAMA=true`                                                                | None (local server)                                                                        | `llama2`                     | Offline / local-only inference, experimenting with open models.      |
+| OpenAI        | `USE_OPENAI=true`                                                                | `OPENAI_API_KEY` or `OPENAI_AUTH_TOKEN`                                                    | `gpt-5-mini` (registry)      | You're an OpenAI customer or want non-Claude models via OpenAI.      |
+| AWS Bedrock   | `CLAUDE_CODE_USE_BEDROCK=true`                                                   | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BEDROCK_BASE_URL`                                       | `claude-sonnet-4-6`          | Your org runs Anthropic models through AWS Bedrock.                  |
+| Claude API    | *(default — no flag)*                                                            | `CLAUDE_API_KEY` or `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`                          | `claude-sonnet-4-6`          | You have an Anthropic API key. Lowest-friction starting point.       |
+
+## Dispatch Order and Model Selection
+
+Backends are evaluated in a strict priority order — the first match wins.
+The CLI flag or environment variable on the left is what selects the row;
+later rows are ignored once an earlier one matches.
+
+| Priority | Selector                                                | Backend       |
+|----------|---------------------------------------------------------|---------------|
+| 1        | `OMNI_DEV_AI_BACKEND=claude-cli` / `--ai-backend claude-cli` | Claude CLI |
+| 2        | `USE_OLLAMA=true`                                       | Ollama        |
+| 3        | `USE_OPENAI=true`                                       | OpenAI        |
+| 4        | `CLAUDE_CODE_USE_BEDROCK=true`                          | AWS Bedrock   |
+| 5        | *(none of the above)*                                   | Claude API    |
+
+The CLI flag `--ai-backend claude-cli` takes precedence over the environment
+variable when both are set.
+
+**Model resolution.** Every backend resolves the model through the same
+precedence chain, stopping at the first non-empty value:
+
+1. `--model <id>` (CLI flag)
+2. `CLAUDE_MODEL`
+3. `CLAUDE_CODE_MODEL`
+4. `ANTHROPIC_MODEL`
+5. Provider-specific override (`OPENAI_MODEL`, `OLLAMA_MODEL`)
+6. Registry default for the active provider
+
+See the [Model Registry](#model-registry) section below for how to list,
+override, or extend the catalogue.
+
+## Claude API (default)
+
+The default backend calls the Anthropic Messages API over HTTPS. No flags
+required.
+
+**Credentials.** Set one of (checked in order):
+
+```bash
+export CLAUDE_API_KEY="sk-ant-..."
+# or
+export ANTHROPIC_API_KEY="sk-ant-..."
+# or
+export ANTHROPIC_AUTH_TOKEN="sk-ant-..."
+```
+
+Get a key from [console.anthropic.com](https://console.anthropic.com/).
+
+**Model.** Resolved from the precedence chain above. The registry default is
+`claude-sonnet-4-6`. Override per-invocation with `--model`:
+
+```bash
+omni-dev --model claude-opus-4-6 git commit message twiddle 'origin/main..HEAD' --use-context
+```
+
+**Verification.**
+
+```bash
+export CLAUDE_API_KEY="sk-ant-..."
+omni-dev git commit message twiddle 'origin/main..HEAD' --use-context
+```
+
+## Claude CLI (sandboxed subprocess)
+
+Routes AI calls through an already-authenticated
+[Claude Code](https://github.com/anthropics/claude-code) session by shelling
+out to `claude -p` in a locked-down sandbox. This avoids provisioning a
+separate API key when you already have Claude Code installed and signed in.
+
+**Selection.** Either flag or env var works; the flag wins if both are set:
+
+```bash
+omni-dev --ai-backend claude-cli git commit message twiddle 'origin/main..HEAD' --use-context
+# or persistently:
+export OMNI_DEV_AI_BACKEND=claude-cli
+```
+
+**Credentials.** None passed by omni-dev — the nested `claude -p` process
+uses whatever auth your `claude` CLI is configured with. Run `claude` once
+interactively first to confirm it works on its own.
+
+**Model.** Resolved through the standard chain. Short aliases (`sonnet`,
+`opus`, `haiku`) and full identifiers (`claude-sonnet-4-6`) are both accepted
+and forwarded verbatim to `claude -p --model`. The `--beta-header` flag is
+**ignored** for this backend (`claude`'s `--betas` flag has different
+semantics).
+
+**Sandbox.** By default the nested session has no tools, no MCP servers, no
+filesystem access, and a scrubbed environment. The [Claude CLI
+Deep-dive](#claude-cli-deep-dive) section below covers what's blocked, the
+escape hatches, and the spending cap.
+
+**Verification.**
+
+```bash
+claude --version          # confirm the CLI is installed and authenticated
+omni-dev --ai-backend claude-cli git commit message twiddle 'origin/main..HEAD' --use-context
+```
+
+## OpenAI
+
+Calls the OpenAI Chat Completions API.
+
+**Selection.**
+
+```bash
+export USE_OPENAI=true
+```
+
+**Credentials.** Set one of:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+# or
+export OPENAI_AUTH_TOKEN="sk-..."
+```
+
+**Model.** Registry default is `gpt-5-mini`. Override with `OPENAI_MODEL` or
+`--model`:
+
+```bash
+export OPENAI_MODEL="gpt-5"
+# or
+omni-dev --model gpt-5 git commit message twiddle ...
+```
+
+**Endpoint.** Fixed to `https://api.openai.com/v1/chat/completions`. To point
+at an OpenAI-compatible third-party service running on a custom endpoint,
+use the [Ollama](#ollama) backend (which exposes `OLLAMA_BASE_URL`).
+
+**Limitations.**
+
+- omni-dev requests structured output via JSON Schema (`response_format:
+  json_schema`). Older OpenAI models that don't support `json_schema` will
+  fail.
+- GPT-5 series models use `max_completion_tokens` rather than `max_tokens` —
+  omni-dev handles this automatically based on the model identifier.
+
+**Verification.**
+
+```bash
+export USE_OPENAI=true
+export OPENAI_API_KEY="sk-..."
+omni-dev git commit message twiddle 'origin/main..HEAD' --use-context
+```
+
+## Ollama
+
+Calls a local [Ollama](https://ollama.ai/) (or any OpenAI-compatible) server
+over HTTP. No API key required.
+
+**Selection.**
+
+```bash
+export USE_OLLAMA=true
+```
+
+**Endpoint.** Defaults to `http://localhost:11434`. Override with
+`OLLAMA_BASE_URL` to target a remote Ollama server or a compatible service
+like [LM Studio](https://lmstudio.ai/):
+
+```bash
+export OLLAMA_BASE_URL="http://gpu-box.local:11434"
+```
+
+**Model.** Defaults to `llama2`. Override with `OLLAMA_MODEL` or `--model`:
+
+```bash
+export OLLAMA_MODEL="llama3.1:70b"
+```
+
+The model must already be pulled into the local server (`ollama pull
+llama3.1:70b`). omni-dev does not pull on demand.
+
+**Context-length probing.** At startup, omni-dev queries the server for the
+actually-loaded context window — LM Studio's `/api/v0/models` first, then
+Ollama's `/api/show` as a fallback. The probed length is used for token
+budgeting; if probing fails (older Ollama versions, custom servers), the
+registry default applies and a debug log is emitted.
+
+**Limitations.**
+
+- Local models often have much smaller context windows than Claude / GPT —
+  large `twiddle` ranges may need `--concurrency` tuning.
+- Quality varies sharply by model size.
+- JSON-schema enforcement depends on the model's instruction-following; small
+  models may emit invalid YAML.
+
+**Verification.**
+
+```bash
+ollama serve &              # if not already running
+ollama pull llama3.1
+export USE_OLLAMA=true
+export OLLAMA_MODEL="llama3.1"
+omni-dev git commit message twiddle 'HEAD~1..HEAD' --use-context
+```
+
+## AWS Bedrock
+
+Routes Anthropic model calls through AWS Bedrock's bearer-token API.
+
+**Selection.**
+
+```bash
+export CLAUDE_CODE_USE_BEDROCK=true
+```
+
+**Credentials.** Both are required:
+
+```bash
+export ANTHROPIC_AUTH_TOKEN="..."           # bearer token for the Bedrock endpoint
+export ANTHROPIC_BEDROCK_BASE_URL="https://bedrock-runtime.<region>.amazonaws.com"
+```
+
+**Model.** Resolved through the standard chain (registry default
+`claude-sonnet-4-6`). Bedrock identifiers are URL-encoded automatically when
+invoking the API, and regional / provider prefixes are normalised by the
+registry so any of these forms work for token-budget lookup:
+
+- `claude-sonnet-4-6`
+- `anthropic.claude-sonnet-4-6`
+- `us.anthropic.claude-sonnet-4-6-v1:0`
+
+Set whichever form your Bedrock deployment expects:
+
+```bash
+export ANTHROPIC_MODEL="us.anthropic.claude-sonnet-4-6-v1:0"
+```
+
+**Limitations.**
+
+- Bedrock model availability is region-specific — not every Anthropic model
+  is listed in every region.
+- Inference profiles (the `us.`-prefixed regional IDs) may be required by
+  your AWS account; check the Bedrock console.
+
+**Verification.**
+
+```bash
+export CLAUDE_CODE_USE_BEDROCK=true
+export ANTHROPIC_AUTH_TOKEN="..."
+export ANTHROPIC_BEDROCK_BASE_URL="https://bedrock-runtime.us-east-1.amazonaws.com"
+omni-dev git commit message twiddle 'origin/main..HEAD' --use-context
+```
+
+## Claude CLI Deep-dive
+
+The `claude-cli` backend is the only one with sandbox semantics — it spawns
+a real subprocess with elevated capabilities by default, so omni-dev locks
+it down explicitly. This section documents what's blocked and how to relax
+the sandbox when you need to.
+
+### Sandbox defaults
+
+Every invocation of the subprocess runs with this argv suffix and
+environment treatment:
+
+| Constraint                              | Mechanism                                                              |
+|-----------------------------------------|------------------------------------------------------------------------|
+| Built-in tools disabled                 | `--tools ""` (Read / Edit / Write / Bash / Glob / Grep are unavailable) |
+| MCP servers blocked                     | `--strict-mcp-config` with no `--mcp-config`                           |
+| User/project/local settings ignored     | `--setting-sources ""`                                                 |
+| Slash commands and skills disabled      | `--disable-slash-commands`                                             |
+| Session persistence off                 | `--no-session-persistence`                                             |
+| Permission prompts disabled             | `--permission-mode default`                                            |
+| Fresh working directory                 | Subprocess runs in a unique temp dir, not your repo root               |
+| Environment scrubbed                    | `CLAUDE_PROJECT_DIR`, `CLAUDE_CODE_*`, `CLAUDE_PROJECT_*` removed      |
+| Output capped                           | `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES` (default 4 MiB)                 |
+| Wall-clock timeout                      | `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS` (default 600)                       |
+
+A defence-in-depth suffix is also appended to the system prompt instructing
+the model not to emit `function_calls` XML.
+
+### Tuning environment variables
+
+| Variable                                  | Default        | Effect                                                              |
+|-------------------------------------------|----------------|---------------------------------------------------------------------|
+| `OMNI_DEV_CLAUDE_CLI_BIN`                 | `claude` (PATH) | Path to the `claude` binary.                                       |
+| `OMNI_DEV_CLAUDE_CLI_TIMEOUT_SECS`        | `600`          | Wall-clock timeout for one subprocess invocation.                   |
+| `OMNI_DEV_CLAUDE_CLI_STDOUT_MAX_BYTES`    | `4194304`      | Stdout cap; output beyond this aborts the invocation.               |
+
+### Escape hatch: tool access
+
+When the nested session needs filesystem or shell access:
+
+```bash
+omni-dev --ai-backend claude-cli --claude-cli-allow-tools git branch create pr
+# or persistently:
+export OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true
+```
+
+With this flag the `--tools ""` argument is removed from the subprocess argv,
+so the nested session uses Claude Code's default tool set (Read, Edit, Write,
+Bash, Glob, Grep) and can act on your filesystem and shell. All other
+sandbox flags still apply unless you also enable
+[MCP access](#escape-hatch-mcp-access).
+
+A `WARN` log is emitted on every invocation while this is active. Grep for
+it with `RUST_LOG=omni_dev=warn`:
+
+```
+claude -p sandbox weakened: tool-access escape hatch is enabled ...
+```
+
+### Escape hatch: MCP access
+
+When the nested session needs MCP servers from your `~/.claude/settings.json`:
+
+```bash
+omni-dev --ai-backend claude-cli --claude-cli-allow-mcp git branch create pr
+# or:
+export OMNI_DEV_CLAUDE_CLI_ALLOW_MCP=true
+```
+
+With this flag the `--strict-mcp-config` argument is removed, so the nested
+session can load any MCP server you have configured. **Be aware:** MCP
+servers frequently hold OAuth tokens (Gmail, Drive, Slack) or expose internal
+network services — enabling this exposes them to the nested session. Use
+deliberately.
+
+A `WARN` log is emitted on every invocation while this is active:
+
+```
+claude -p sandbox weakened: MCP-access escape hatch is enabled ...
+```
+
+The two escape hatches are independent — enable tools without MCP, MCP
+without tools, both, or neither.
+
+### Spending cap
+
+Pass a per-invocation cap in USD:
+
+```bash
+omni-dev --ai-backend claude-cli --claude-cli-max-budget-usd 0.50 \
+  git commit message twiddle 'HEAD~3..HEAD'
+# or:
+export OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=0.50
+```
+
+The value is forwarded to `claude -p --max-budget-usd`. If the nested
+session exceeds the cap it aborts with an error rather than running away
+with cost. Non-positive, non-finite, or non-numeric values are silently
+treated as no cap. The cap is ignored on backends other than `claude-cli`.
+
+Regardless of whether a cap is set, every invocation's `total_cost_usd` is
+logged at `INFO` level — run with `RUST_LOG=omni_dev=info` to see it:
+
+```
+claude -p invocation cost total_cost_usd=0.0341 max_budget_usd=Some(0.5) model="claude-sonnet-4-6"
+```
+
+If the reported cost ever exceeds the configured cap, an additional `WARN`
+is emitted.
+
+### When to choose the CLI backend
+
+Use `claude-cli` when:
+
+- You're running inside an existing Claude Code session that already holds
+  Anthropic credentials, and you don't want to manage a second API key.
+- You want all Anthropic spend to flow through one billing source.
+- You explicitly want the sandbox semantics described above.
+
+Prefer the direct [Claude API](#claude-api-default) when:
+
+- You're running in CI or another non-interactive environment where the
+  `claude` CLI isn't installed.
+- You care about the per-invocation cost floor — the `claude -p` system
+  prompt has a small fixed cost (~$0.007 Haiku, ~$0.03 Sonnet, ~$0.15 Opus)
+  on each call that the direct API doesn't have.
+
+## Model Registry
+
+omni-dev ships with a built-in catalogue of model identifiers and their
+token limits. Inspect it with:
+
+```bash
+omni-dev config models show              # merged catalogue with source annotations
+omni-dev config models show --embedded-only   # just the built-in entries
+```
+
+**Catalogue precedence** — entries from later files override earlier ones:
+
+1. Built-in [src/templates/models.yaml](../src/templates/models.yaml)
+2. `~/.omni-dev/models.yaml` (user-level)
+3. `./.omni-dev/models.yaml` (project-local)
+4. The path in `OMNI_DEV_MODELS_YAML` (if set — short-circuits user/project)
+
+**Bedrock identifiers** are normalised before lookup: regional prefixes
+(`us.anthropic.…`), provider prefixes (`anthropic.…`), and version suffixes
+(`…-v1:0`) are stripped so the same registry entry serves every form your
+Bedrock deployment might emit.
+
+**Architectural background:**
+[ADR-0011](adrs/adr-0011.md) (superseded) and
+[ADR-0022](adrs/adr-0022.md) (current) — the layered catalogue with user and
+project overrides.
+
+## Choosing a Backend
+
+| Criterion           | Claude CLI                    | Claude API                | OpenAI                | Ollama                  | Bedrock                |
+|---------------------|-------------------------------|---------------------------|-----------------------|-------------------------|------------------------|
+| Setup effort        | Already have Claude Code? Zero | Get an API key           | Get an API key       | Install Ollama + pull model | Configure AWS / endpoint |
+| Latency             | High (subprocess spawn)       | Low                       | Low                   | Depends on hardware     | Low                    |
+| Per-call floor cost | ~$0.007–$0.15 system prompt   | None                      | None                  | Free (local)            | None                   |
+| Sandboxed           | Yes (configurable)            | n/a                       | n/a                   | n/a                     | n/a                    |
+| Offline support     | No                            | No                        | No                    | **Yes**                 | No                     |
+| Best model quality  | Claude flagship               | Claude flagship           | GPT flagship          | Variable                | Claude flagship        |
+| Choose when…        | You already use Claude Code   | Default, simplest path    | OpenAI customer       | Local-only / offline    | AWS shop, Bedrock-only |
+
+Most users should start with the default [Claude API](#claude-api-default)
+backend. Move to `claude-cli` once you have Claude Code installed; move to
+Bedrock or OpenAI when your organisation requires it; reach for Ollama when
+you need offline / local inference.
+
+## Troubleshooting
+
+See the [Troubleshooting Guide](troubleshooting.md) for backend-specific
+errors. The most common cases:
+
+| Error                                           | Likely backend     | See                                                                 |
+|-------------------------------------------------|--------------------|---------------------------------------------------------------------|
+| `CLAUDE_API_KEY not found`                      | Claude API         | [troubleshooting.md](troubleshooting.md#error-claude_api_key-not-found) |
+| `the assistant tried to use a tool …`           | Claude CLI         | [troubleshooting.md](troubleshooting.md#claude-cli-backend-issues)  |
+| `MCP server X not loaded`                       | Claude CLI         | [troubleshooting.md](troubleshooting.md#claude-cli-backend-issues)  |
+| `claude -p exited with cost cap exceeded`       | Claude CLI         | [troubleshooting.md](troubleshooting.md#claude-cli-backend-issues)  |
+| Connection refused on `localhost:11434`         | Ollama             | Start `ollama serve` or set `OLLAMA_BASE_URL`.                      |
+| `401 Unauthorized` from OpenAI                  | OpenAI             | Check `OPENAI_API_KEY` / `OPENAI_AUTH_TOKEN`.                       |
+| `AccessDeniedException` on a model ID           | Bedrock            | Region doesn't have the model, or your IAM policy blocks it.        |
+
+Enable verbose logging when reporting issues:
+
+```bash
+RUST_LOG=omni_dev=debug omni-dev git commit message twiddle 'HEAD~1..HEAD' --use-context
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -715,6 +715,10 @@ Logs go to **stderr** because stdin/stdout are reserved for MCP framing.
 
 ## `claude-cli` Backend Issues
 
+See the [AI Backends Guide](ai-backends.md) for setup, sandbox semantics, and
+the full inventory of `OMNI_DEV_CLAUDE_CLI_*` knobs. The cases below cover
+the most common runtime errors.
+
 ### Error: `the assistant tried to use a tool but tools are disabled`
 
 The `claude-cli` backend runs the nested Claude session with `--tools ""`


### PR DESCRIPTION
## Description

This PR adds a comprehensive `docs/ai-backends.md` user guide covering all five supported AI backends and refactors existing documentation to reference it rather than duplicating inline content.

Previously, backend configuration details were scattered across `README.md` with verbose inline sections. This consolidates all user-facing backend documentation into a single authoritative reference, trims `README.md` to a concise summary with a link to the new guide, and reduces developer-only notes in `CLAUDE.md` to what's relevant for contributors.

## Type of Change
- [x] Documentation update

## Related Issue
Relates to #767

## Changes Made

**New Documentation (`docs/ai-backends.md`):**
- Added full 471-line AI Backends Guide covering all five backends: Claude API, Claude CLI, OpenAI, Ollama, and AWS Bedrock
- Documented per-backend selection env vars/flags, required credentials, model resolution, and verification commands
- Added a "Backends at a Glance" summary table and a dispatch priority order table
- Added deep-dive section on Claude CLI sandbox defaults (tools, MCP, settings, env scrubbing, temp cwd, permission prompts, output cap, wall-clock timeout)
- Documented all three escape hatches: `--claude-cli-allow-tools`, `--claude-cli-allow-mcp`, and `--claude-cli-max-budget-usd` spending cap with examples
- Added backend comparison table (setup effort, latency, per-call floor cost, offline support) and a "Choosing a Backend" decision guide
- Added troubleshooting quick-reference table linking to `troubleshooting.md` anchors for common per-backend errors
- Documented Model Registry catalogue precedence and Bedrock identifier normalisation

**`README.md` (trimmed):**
- Replaced the ~110-line inline backend sections (sandbox details, escape hatch subsections, spending cap subsection) with a concise five-backend summary list
- Added a link to the new `docs/ai-backends.md` for full details

**`CLAUDE.md` (dev-only refactor):**
- Trimmed AI Backend Dispatch section to contributor-relevant notes (warn sites, `--beta-header` caveat, source file references)
- Added a cross-reference to `docs/ai-backends.md` for user-facing details
- Removed duplicated escape hatch and spending cap prose that now lives in the guide

**`docs/README.md` (navigation):**
- Registered `ai-backends.md` in the documentation navigation list
- Added AI Backends row to the feature cross-reference table

**`docs/troubleshooting.md` (cross-reference):**
- Added a pointer to the new AI Backends Guide at the top of the `claude-cli` Backend Issues section

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change, no code tests required)

**Manual Testing:**
- [x] Verified all internal Markdown links resolve correctly (cross-references between `docs/ai-backends.md`, `README.md`, `CLAUDE.md`, `docs/README.md`, and `docs/troubleshooting.md`)
- [x] Confirmed the new guide renders correctly with all tables and code blocks
- [x] Backward compatibility verified — no env vars or CLI flags changed

### Test Commands
```bash
# Code quality checks (no code changes, but ensure docs don't break build)
cargo test
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — accuracy and completeness of backend setup instructions for new users
- [x] Backward compatibility — ensure `README.md` still contains enough info for quick orientation

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- As new backends are added, `docs/ai-backends.md` is the single place to document them — the dispatch table and "Backends at a Glance" table make it easy to extend

**Known Limitations:**
- The troubleshooting table in `docs/ai-backends.md` links to named anchors in `troubleshooting.md`; if those anchor names change, the links will silently break