### PR TITLE
docs(docs): add contributor extension recipes for MCP tools, AI backends, and ADF schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,12 @@ Documentation improvements are always welcome:
 - Improve API documentation
 - Update outdated information
 
+## Extension recipes
+
+For the three extension points most likely to come up — adding an MCP tool,
+adding an AI backend, or extending the ADF schema with a new node type —
+see [docs/contributing/](docs/contributing/) for short, worked recipes.
+
 ## Code of Conduct
 
 This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,17 @@
+# Extension recipes
+
+Short, task-oriented guides for the three extension points contributors most
+often reach for. Each recipe assumes you have already read
+[`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) (build/test/release basics)
+and follows the same skeleton: *files you'll touch → walkthrough → testing →
+ADRs → gotchas*.
+
+| Recipe | When you need it |
+|---|---|
+| [Adding an MCP tool](adding-an-mcp-tool.md) | You want to expose a new operation to MCP clients (a new `git_*`, `jira_*`, `confluence_*`, or other tool). |
+| [Adding an AI backend](adding-an-ai-backend.md) | You want omni-dev to drive a new model provider (a new sibling of [`src/claude/ai/claude.rs`](../../src/claude/ai/claude.rs), [`openai.rs`](../../src/claude/ai/openai.rs), [`bedrock.rs`](../../src/claude/ai/bedrock.rs), [`claude_cli.rs`](../../src/claude/ai/claude_cli.rs)). |
+| [Extending the ADF schema](extending-the-adf-schema.md) | You want to support a new Atlassian Document Format (ADF) node or mark — both on the wire and in the JIRA-Flavoured Markdown (JFM) dialect. |
+
+These recipes document the **current** code path. If a path or symbol has
+moved by the time you read this, fix the recipe in the same PR as your
+extension — don't work around it.

--- a/docs/contributing/adding-an-ai-backend.md
+++ b/docs/contributing/adding-an-ai-backend.md
@@ -1,0 +1,232 @@
+# Adding an AI backend
+
+omni-dev talks to AI providers through the `AiClient` trait and a runtime
+factory that selects an implementation based on environment variables. The
+overall design is recorded in [ADR-0002](../adrs/adr-0002.md). This recipe
+walks you through adding a hypothetical new backend (say, "Mistral"),
+mirroring the existing
+[`src/claude/ai/openai.rs`](../../src/claude/ai/openai.rs) for an HTTP-based
+provider.
+
+## Files you'll touch
+
+| File | Edit |
+|---|---|
+| [`src/claude/ai/mistral.rs`](../../src/claude/ai/) (new) | The new backend module. |
+| [`src/claude/ai.rs`](../../src/claude/ai.rs) | Add `pub mod mistral;` and re-export if needed. |
+| [`src/claude/client.rs`](../../src/claude/client.rs) | Add a dispatch branch to `create_default_claude_client`. |
+| [`src/utils/preflight.rs`](../../src/utils/preflight.rs) | Add a matching branch to `check_ai_credentials` and a variant to `AiProvider`. |
+| [`src/templates/models.yaml`](../../src/templates/models.yaml) | Register the provider's models in the registry. |
+| [`docs/adrs/adr-0002.md`](../adrs/adr-0002.md) | Add a row to the backend table. |
+
+## The trait
+
+```rust
+pub trait AiClient: Send + Sync {
+    fn send_request<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>>;
+
+    fn get_metadata(&self) -> AiClientMetadata;
+
+    fn capabilities(&self) -> AiClientCapabilities { /* default: all disabled */ }
+
+    fn send_request_with_options<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+        _options: RequestOptions,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> { /* default delegates */ }
+}
+```
+
+Defined in [`src/claude/ai.rs:222`](../../src/claude/ai.rs#L222). The trait
+lives in `ai.rs`, **not** `client.rs` — only the factory `ClaudeClient`
+wrapper lives in `client.rs`.
+
+## Walkthrough
+
+### 1. The backend module
+
+Create [`src/claude/ai/mistral.rs`](../../src/claude/ai/) following the
+shape of [`openai.rs`](../../src/claude/ai/openai.rs):
+
+```rust
+use std::pin::Pin;
+use std::future::Future;
+use anyhow::Result;
+use reqwest::Client;
+
+use super::{
+    build_http_client, check_error_response, log_response_success,
+    registry_model_limits, AiClient, AiClientMetadata,
+};
+
+pub struct MistralAiClient {
+    client: Client,
+    model: String,
+    api_key: String,
+    base_url: String,
+    active_beta: Option<(String, String)>,
+}
+
+impl MistralAiClient {
+    pub fn new(
+        model: String,
+        api_key: String,
+        active_beta: Option<(String, String)>,
+    ) -> Result<Self> {
+        Ok(Self {
+            client: build_http_client()?,
+            model,
+            api_key,
+            base_url: "https://api.mistral.ai/v1".to_string(),
+            active_beta,
+        })
+    }
+}
+
+impl AiClient for MistralAiClient {
+    fn send_request<'a>(
+        &'a self,
+        system_prompt: &'a str,
+        user_prompt: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        Box::pin(async move {
+            // POST {base_url}/chat/completions
+            // Parse response, call check_error_response on non-2xx,
+            // call log_response_success on success.
+            todo!()
+        })
+    }
+
+    fn get_metadata(&self) -> AiClientMetadata {
+        let limits = registry_model_limits(&self.model, "mistral");
+        AiClientMetadata {
+            provider: "mistral".to_string(),
+            model: self.model.clone(),
+            max_context_length: limits.input_context,
+            max_response_length: limits.max_output_tokens,
+            active_beta: self.active_beta.clone(),
+        }
+    }
+}
+```
+
+**Reuse the shared helpers** in [`src/claude/ai.rs`](../../src/claude/ai.rs):
+
+- `build_http_client()` — applies the project-wide 5-minute timeout.
+- `registry_model_limits(model, provider)` / `registry_max_output_tokens(...)` — looks up token limits from `models.yaml`.
+- `check_error_response(...)` — flattens non-2xx HTTP responses into a useful `anyhow::Error`.
+- `log_response_success(...)` — emits the standard `tracing` event.
+
+Don't roll your own — that's how you avoid the rest of the codebase
+noticing your backend exists.
+
+### 2. Wire it into the factory
+
+Add a dispatch branch to `create_default_claude_client` in
+[`src/claude/client.rs:1618`](../../src/claude/client.rs#L1618). The current
+order is:
+
+1. `OMNI_DEV_AI_BACKEND=claude-cli` → [`ClaudeCliAiClient`](../../src/claude/ai/claude_cli.rs)
+2. `USE_OLLAMA=true` → `OpenAiAiClient::new_ollama`
+3. `USE_OPENAI=true` → `OpenAiAiClient::new_openai`
+4. `CLAUDE_CODE_USE_BEDROCK=true` → [`BedrockAiClient`](../../src/claude/ai/bedrock.rs)
+5. Default → [`ClaudeAiClient`](../../src/claude/ai/claude.rs)
+
+Pick an env-var convention consistent with the table above
+(`USE_MISTRAL=true`) and slot your branch in before the default. The
+existing branches at lines 1676–1748 show the pattern: resolve the model
+name from registry/env, call `validate_beta_header`, look up the API key,
+construct the client, return `Ok(ClaudeClient::new(Box::new(ai_client)))`.
+
+### 3. Mirror it in preflight — **same PR, lock-step**
+
+[`src/utils/preflight.rs:52`](../../src/utils/preflight.rs#L52) — the
+`check_ai_credentials` function mirrors the same five-way switch and runs
+**before** any backend is constructed. Failing to update preflight is the
+single most common cause of "my backend works in dev but the binary errors
+out at startup".
+
+Add a variant to the `AiProvider` enum at
+[`src/utils/preflight.rs:22`](../../src/utils/preflight.rs#L22), then add a
+branch that:
+
+1. Checks the same env var your factory branch checks.
+2. Resolves the model name the same way.
+3. Verifies the API key with the same `get_env_vars(...)` lookup.
+4. Returns `Ok(AiCredentialInfo { provider: AiProvider::Mistral, model })`.
+
+### 4. Register models
+
+Add rows to [`src/templates/models.yaml`](../../src/templates/models.yaml)
+for each supported Mistral model, with the same fields the Claude/OpenAI
+rows use (`provider`, `model`, `api_identifier`, `max_output_tokens`,
+`input_context`, `tier`). The model registry — see
+[ADR-0022](../adrs/adr-0022.md) — picks these up automatically and the
+`omni-dev config models show` command surfaces them to users.
+
+### 5. Update ADR-0002
+
+[ADR-0002](../adrs/adr-0002.md) has a table of supported backends. Add a
+row for the new HTTP backend. A **sandboxed-subprocess** backend (like
+`claude_cli`) is structurally different enough to warrant its own ADR —
+file one and link to ADR-0002 from it.
+
+## Testing
+
+Inline backend tests follow two patterns:
+
+**Mock the trait, not the network.** For tests of code that *consumes* the
+trait (e.g. amendment parsing), use the inline mocks at
+[`src/claude/client.rs:1777-1880`](../../src/claude/client.rs#L1777-L1880):
+
+- `MockAiClient` — returns an empty string.
+- `SchemaRecordingMockAiClient` — records the `RequestOptions` it receives
+  so you can assert structured-output schemas are forwarded correctly.
+
+**Dispatch tests.** [`src/claude/client.rs:3965+`](../../src/claude/client.rs#L3965)
+uses an `EnvGuard` helper to manipulate `OMNI_DEV_AI_BACKEND`, `USE_*`,
+etc., then calls `create_default_claude_client(...).await` and asserts on
+`get_metadata().provider`. Add at least one test per new backend that
+proves it's selectable.
+
+**Preflight tests.** [`src/utils/preflight.rs`](../../src/utils/preflight.rs)
+(around lines 336–556) uses the same `EnvGuard` pattern and, for the
+claude-cli backend, a `make_version_shim()` helper that creates a fake
+`claude --version` script. Reuse `EnvGuard`; reach for `make_version_shim`
+only if your backend also probes an external binary.
+
+No `wiremock`-based tests for the HTTP backends currently exist — they're
+exercised end-to-end in CI against real APIs (or skipped). Adding wiremock
+coverage is welcome but not required.
+
+## Gotchas
+
+- **Preflight must change in lock-step.** `CLAUDE.md` calls this out
+  explicitly; it's the rule the codebase enforces by convention rather
+  than by compiler. The two switches must list backends in the same order
+  for the same env vars.
+- **Beta headers are Anthropic-specific.** The factory calls
+  `validate_beta_header(&model, &beta_header)?` for HTTP backends. Models
+  with no beta-header table just get a no-op validation. For backends that
+  ignore beta headers entirely (e.g. `claude_cli`), log a warning and drop
+  it — see [`src/claude/client.rs:1636-1641`](../../src/claude/client.rs#L1636-L1641).
+- **Provider-specific prompt shaping** is documented in
+  [ADR-0014](../adrs/adr-0014.md). Don't reshape prompts inside the
+  backend module unless the API genuinely needs it (e.g. OpenAI's
+  `messages[0]` system role vs. Anthropic's top-level `system` field).
+- **Selection is env-var only.** There's no `--ai-backend` CLI flag; per-
+  backend flags (`--claude-cli-allow-tools`, `--claude-cli-max-budget-usd`)
+  live on individual subcommands. Don't invent a global selector flag —
+  it's been considered and intentionally deferred.
+
+## ADRs
+
+- [ADR-0002](../adrs/adr-0002.md) — Multi-Provider AI Abstraction via Trait Objects (primary; add a row).
+- [ADR-0007](../adrs/adr-0007.md) — Preflight Validation Pattern (governs the preflight integration).
+- [ADR-0014](../adrs/adr-0014.md) — Provider-Specific Prompt Engineering.
+- [ADR-0022](../adrs/adr-0022.md) — Layered Model Catalog with User and Project Overrides.

--- a/docs/contributing/adding-an-mcp-tool.md
+++ b/docs/contributing/adding-an-mcp-tool.md
@@ -1,0 +1,183 @@
+# Adding an MCP tool
+
+omni-dev's MCP server exposes operations to LLM clients via `rmcp`-generated
+tool routers. The server architecture is recorded in
+[ADR-0021](../adrs/adr-0021.md). This recipe walks you through adding one new
+tool end-to-end, mirroring the existing `git_*` tools in
+[`src/mcp/git_tools.rs`](../../src/mcp/git_tools.rs).
+
+## Files you'll touch
+
+| File | Edit |
+|---|---|
+| [`src/mcp/<area>_tools.rs`](../../src/mcp/) (new or existing) | Add a parameter struct and a tool handler method. |
+| [`src/mcp/server.rs`](../../src/mcp/server.rs) | Wire the new router into `OmniDevServer::new()` (only if the module is new). |
+| Tests inline or in [`tests/mcp_integration_test.rs`](../../tests/mcp_integration_test.rs) | Exercise the handler. |
+
+## Walkthrough
+
+Suppose we want a `git_log_oneline` tool that returns the recent commit log
+as YAML. The pattern below matches every existing handler in
+[`git_tools.rs`](../../src/mcp/git_tools.rs).
+
+### 1. Parameter struct
+
+```rust
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GitLogOnelineParams {
+    /// Maximum number of commits to return. Defaults to 20.
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Path to the git repository. Defaults to the current working directory.
+    #[serde(default)]
+    pub repo_path: Option<String>,
+}
+```
+
+Conventions enforced across the codebase:
+
+- Derive `Debug, Deserialize, schemars::JsonSchema`. Doc comments on each
+  field become the JSON-schema descriptions the MCP client sees.
+- Use `#[serde(default)]` + `Option<T>` for optional fields. Don't invent
+  custom validation logic; centralised helpers like `validate_range` and
+  `validate_repo_path` live in [`src/mcp/validate.rs`](../../src/mcp/validate.rs).
+
+### 2. Handler
+
+Add the method to the `#[tool_router]` impl block — the one starting at
+[`src/mcp/git_tools.rs:103`](../../src/mcp/git_tools.rs#L103):
+
+```rust
+/// Tool: return the recent commit log as YAML.
+#[tool(
+    description = "Return the recent commit log (oneline-style) as YAML. \
+                   Mirrors `git log --oneline`."
+)]
+pub async fn git_log_oneline(
+    &self,
+    Parameters(params): Parameters<GitLogOnelineParams>,
+) -> Result<CallToolResult, McpError> {
+    let limit = params.limit.unwrap_or(20);
+    let repo_path = params.repo_path.clone();
+
+    let yaml = tokio::task::spawn_blocking(move || {
+        crate::cli::git::run_log_oneline(limit, repo_path.as_deref())
+    })
+    .await
+    .map_err(|e| tool_error(anyhow::anyhow!("join error: {e}")))?
+    .map_err(tool_error)?;
+
+    Ok(CallToolResult::success(vec![Content::text(yaml)]))
+}
+```
+
+Conventions:
+
+- **Signature**: `async fn name(&self, Parameters(params): Parameters<T>) -> Result<CallToolResult, McpError>`.
+  The `Parameters<T>` wrapper comes from `rmcp::handler::server::wrapper`.
+- **Return**: `Ok(CallToolResult::success(vec![Content::text(yaml_string)]))`.
+- **Errors**: wrap any `anyhow::Error` via `tool_error(...)` from
+  [`src/mcp/error.rs`](../../src/mcp/error.rs) — it walks the `source` chain
+  and flattens to a single message so MCP clients see full diagnostics.
+- **Blocking work**: wrap in `tokio::task::spawn_blocking`. Long-running
+  tools that should be cancellable use
+  `spawn_blocking_cancellable(&cancellation, ...)` and accept a
+  `CancellationToken` parameter — see `git_view_commits` at
+  [`src/mcp/git_tools.rs:110`](../../src/mcp/git_tools.rs#L110).
+- **Large responses**: use `build_truncated_result(yaml)` (see
+  [`src/mcp/git_tools.rs:243`](../../src/mcp/git_tools.rs#L243)). It emits a
+  second `Content::text` JSON payload with `{"truncated": true, ...}` when
+  the response exceeds `DEFAULT_MAX_RESPONSE_BYTES`.
+- **Mirror the CLI**: tool handlers should delegate to the same `run_*`
+  function the CLI uses (e.g. `crate::cli::git::run_view`). Don't duplicate
+  logic — MCP is a transport, not a fork.
+
+### 3. Register the router (only for a new module)
+
+If the new tool lives in an existing `*_tools.rs` module, nothing further is
+needed — the `#[tool_router(router = X, vis = "pub")]` macro re-discovers all
+`#[tool]`-annotated methods in that impl block.
+
+If you've added a new module (say, `src/mcp/foo_tools.rs` with
+`#[tool_router(router = foo_tool_router, vis = "pub")]`), wire it into the
+combined router in
+[`src/mcp/server.rs:43-50`](../../src/mcp/server.rs#L43-L50):
+
+```rust
+tool_router: Self::git_tool_router()
+    + Self::jira_tool_router()
+    + ...
+    + Self::foo_tool_router(),
+```
+
+The `#[tool_handler(router = self.tool_router)]` on
+[`src/mcp/server.rs:56`](../../src/mcp/server.rs#L56) dispatches calls to
+the combined router automatically.
+
+## Exposing a resource (optional)
+
+Tools take parameters and return content; **resources** are URI-addressable
+content an MCP client fetches without a tool call (e.g.
+`omni-dev://specs/jfm`, `git://repo/commits/HEAD`). If your extension is
+better modelled as a resource than a tool:
+
+1. Add a variant to `ResourceUri` and a parse arm in `ResourceUri::parse()`
+   in [`src/mcp/resources.rs`](../../src/mcp/resources.rs).
+2. Add a dispatch arm in `read_resource()` in the same file.
+3. Add a `ResourceTemplate` row to `list_resource_templates_result()`.
+4. For embedded reference docs (like `omni-dev://specs/<name>`), add a
+   `pub const SPEC_X: &str = include_str!("...")` and a `lookup` arm in
+   [`src/mcp/specs.rs`](../../src/mcp/specs.rs). Specs are embedded at
+   compile time so installed builds don't read from disk.
+
+## Testing
+
+The codebase uses two complementary patterns — pick whichever fits.
+
+**Direct-handler unit tests** are the lightest: construct an `OmniDevServer`
+and call the handler. See
+[`src/mcp/git_tools.rs:292-470`](../../src/mcp/git_tools.rs#L292-L470):
+
+```rust
+#[tokio::test]
+async fn git_branch_info_returns_yaml() {
+    let server = OmniDevServer::new();
+    let result = server
+        .git_branch_info(Parameters(GitBranchInfoParams {
+            branch: None,
+            repo_path: Some(test_repo_path()),
+        }))
+        .await
+        .unwrap();
+    // assert on result.content
+}
+```
+
+**End-to-end integration tests** spin up the server over an in-memory
+transport and call it through a real `rmcp` client — see
+[`tests/mcp_integration_test.rs`](../../tests/mcp_integration_test.rs)
+(the `TestRepo` fixture and `tokio::io::duplex()` transport).
+
+**Tools that hit external APIs** (JIRA, Confluence, Datadog) test the
+underlying YAML-helper layer against a `wiremock::MockServer`, not the MCP
+handler itself — see top of
+[`src/mcp/jira_tools.rs`](../../src/mcp/jira_tools.rs). This avoids needing
+credentials in CI.
+
+## Gotchas
+
+- The `#[tool_router]` macro requires both `router = <name>` **and**
+  `vis = "pub"` — without `vis`, the generated fn is private and won't
+  compose with `+` in `server.rs`.
+- The `#[allow(missing_docs)]` above each `#[tool_router]` impl block is
+  load-bearing — the macro generates a public fn without a doc comment.
+- Don't add a `serde(deny_unknown_fields)` to parameter structs — MCP
+  clients may pass forward-compat fields and you want to ignore them.
+- The MCP boundary is non-interactive: tools must never prompt or open an
+  editor. `git_twiddle_commits` documents the `--auto-apply` workaround in
+  its `dry_run` field doc — copy that pattern if your tool wraps a CLI
+  command that's normally interactive.
+
+## ADRs
+
+- [ADR-0021](../adrs/adr-0021.md) — MCP Server via Second Binary with `rmcp`.

--- a/docs/contributing/extending-the-adf-schema.md
+++ b/docs/contributing/extending-the-adf-schema.md
@@ -1,0 +1,177 @@
+# Extending the ADF schema
+
+omni-dev round-trips between Atlassian Document Format (ADF) and JIRA-
+Flavoured Markdown (JFM, see [ADR-0020](../adrs/adr-0020.md)). Three layers
+have to agree for a new ADF node type to work end-to-end:
+
+1. **Vendored upstream schema** at [`assets/adf-schema/`](../../assets/adf-schema/) — the JSON snapshot from `@atlaskit/adf-schema` npm.
+2. **Hand-maintained quantifier table** at [`src/atlassian/adf_schema/mod.rs`](../../src/atlassian/adf_schema/mod.rs) — encodes arity (`+`, `*`, `?`) the upstream JSON loses ([ADR-0023](../adrs/adr-0023.md)).
+3. **JFM converter and spec** at [`src/atlassian/convert.rs`](../../src/atlassian/convert.rs) and [`docs/specs/jfm.md`](../specs/jfm.md) — define how the node renders to/from markdown.
+
+This recipe walks you through adding a new node type (we'll use
+`inlineCard` as the running example) and wiring it into all three layers.
+
+## Files you'll touch
+
+| File | Edit |
+|---|---|
+| [`src/atlassian/adf.rs`](../../src/atlassian/adf.rs) | Add `impl AdfNode { pub fn inline_card(...) }` constructor. |
+| [`src/atlassian/convert.rs`](../../src/atlassian/convert.rs) | Add a parse arm in `try_container_directive` or `try_leaf_directive`; add `from-adf` rendering. |
+| [`src/atlassian/adf_schema/mod.rs`](../../src/atlassian/adf_schema/mod.rs) | Add a `CONTENT_ENTRIES` tuple for the new parent (if any) and add the atom to allowed-children sets where it can legally appear. |
+| [`docs/specs/jfm.md`](../specs/jfm.md) | Add a row to *Supported Block Nodes* or *Supported Inline Nodes* (around lines 120–178). |
+| [`tests/adf_schema_test.rs`](../../tests/adf_schema_test.rs) | Add validator tests for round-trip and nesting rules. |
+
+If the upstream `@atlaskit/adf-schema` package has been refreshed and your
+node is newly present in `full.json`, you may also need to **re-pin and
+regenerate** (see *Refreshing the vendored schema* below).
+
+## Walkthrough
+
+### 1. Node constructor
+
+Add an ergonomic constructor to
+[`src/atlassian/adf.rs`](../../src/atlassian/adf.rs) so call sites
+elsewhere don't have to assemble the JSON by hand. Follow the pattern of
+existing constructors on `AdfNode` — same field-shape, same defaults.
+
+### 2. JFM converter
+
+The converter routes container directives (`:::name`) and leaf directives
+(`::name`) into AST nodes. Entry points:
+
+- [`MarkdownParser::try_container_directive`](../../src/atlassian/convert.rs#L505) — block-level `:::` syntax.
+- [`MarkdownParser::try_leaf_directive`](../../src/atlassian/convert.rs#L865) — leaf `::` syntax for inline-ish blocks.
+- Inline marks/nodes are parsed elsewhere in the same file; grep for the
+  pattern that matches the closest existing node type.
+
+Conversion is **bidirectional**: also add a rendering arm in the `from-adf`
+path so an `inlineCard` node round-trips back to its JFM directive. Inline
+test modules nearby (`nested_expand_inside_panel`, etc.) show the
+roundtrip-assertion pattern.
+
+### 3. Content model — `CONTENT_ENTRIES`
+
+[`src/atlassian/adf_schema/mod.rs:597`](../../src/atlassian/adf_schema/mod.rs#L597)
+holds the alphabetically-sorted list of `(parent, &[ContentTerm])` tuples.
+Two edits, usually:
+
+- **If your node is a parent** (it has children), add a tuple defining the
+  allowed atoms and quantifier:
+
+  ```rust
+  // myNewNode — definitions/myNewNode_node
+  // upstream: paragraph+
+  (
+      "myNewNode",
+      &[ContentTerm {
+          atoms: &["paragraph"],
+          quant: Quantifier::OneOrMore,
+      }],
+  ),
+  ```
+
+  `Quantifier` variants are `OneOrMore`, `ZeroOrMore`, `ZeroOrOne`, `Exactly`.
+  Keep the tuple alphabetised by parent name.
+
+- **If your node is a child** (it can appear inside other nodes), add the
+  atom to each parent's `atoms` array that should permit it. Walk the
+  upstream JSON schema definition (in
+  [`assets/adf-schema/full.json`](../../assets/adf-schema/full.json)) and
+  copy what it says — don't guess.
+
+The hand-maintained table is reconciled against the upstream JSON by
+[`tests/adf_schema_drift_bin_test.rs`](../../tests/adf_schema_drift_bin_test.rs)
+— if you miss a parent or add an atom upstream doesn't allow, that test
+fails. Inline comments in `mod.rs` (search for "LENIENT") flag a small
+allowlist of deliberate deviations; mirror that style if you have a
+documented reason to diverge.
+
+### 4. JFM spec
+
+Add a row in [`docs/specs/jfm.md`](../specs/jfm.md) under *Supported Block
+Nodes* (lines 120–144) or *Supported Inline Nodes* (lines 145–158). Each
+row names the ADF type, the JFM directive syntax, and any notable
+constraints. If your node has unusual nesting rules, add a short note
+under *Common pitfalls* (around line 244).
+
+The spec is **served as an MCP resource** at `omni-dev://specs/jfm` — see
+[`src/mcp/specs.rs`](../../src/mcp/specs.rs). It's `include_str!`'d at
+compile time, so your change ships in the same binary that supports the
+new node.
+
+### 5. Tests
+
+Three layers, three tests:
+
+1. **Schema validator test** in
+   [`tests/adf_schema_test.rs`](../../tests/adf_schema_test.rs) — assert
+   that an `inlineCard` inside a disallowed parent is flagged
+   (`DisallowedChild` violation) and that an `inlineCard` inside an
+   allowed parent passes. Look at `expand_inside_panel_is_flagged_via_public_api`
+   for the shape.
+2. **Round-trip test** as an inline `#[cfg(test)]` in
+   [`src/atlassian/convert.rs`](../../src/atlassian/convert.rs) — JFM →
+   ADF → JFM should be lossless. The neighbouring `nested_expand_*` tests
+   are good models.
+3. **Drift-detector** runs automatically — no new test needed, but it
+   will fail if your `CONTENT_ENTRIES` edits desync from
+   `UPSTREAM_ENTRIES`. The fix is usually to re-run codegen (see below).
+
+## Refreshing the vendored schema
+
+Most contributors won't need this — only when the upstream
+`@atlaskit/adf-schema` npm package has been bumped and your new node lives
+in the new version. The full workflow is in
+[`assets/adf-schema/README.md`](../../assets/adf-schema/README.md). Short
+version:
+
+1. Pull the new tarball, extract `dist/json-schema/v1/full.json` into
+   `assets/adf-schema/full.json`.
+2. Update [`assets/adf-schema/provenance.json`](../../assets/adf-schema/provenance.json)
+   with the new version, URL, and SHA-256s.
+3. Run `cargo run --bin adf-schema-codegen` to regenerate
+   [`src/atlassian/adf_schema/generated.rs`](../../src/atlassian/adf_schema/generated.rs).
+4. Run `cargo run --bin adf-schema-codegen -- --check` to confirm the
+   committed file matches what codegen now produces. CI runs this same
+   check.
+
+## Validation is type-level
+
+All write paths take `&ValidatedAdfDocument`, not `&AdfDocument`. The only
+fallible constructor is `ValidatedAdfDocument::try_new(...)` at
+[`src/atlassian/adf_validated.rs:240`](../../src/atlassian/adf_validated.rs#L240),
+which runs `adf_schema::validate_document` under the hood. This makes "I
+forgot to validate" a compile error — see
+[ADR-0025](../adrs/adr-0025.md).
+
+Standalone conversion paths (the `convert to-adf` CLI, dry-run printers,
+some round-trip tests) intentionally bypass validation so they can echo
+arbitrary ADF including legacy-test fixtures. **Don't perpetuate this for
+new node types** — your tests should always exercise the validator on the
+new node.
+
+## Gotchas
+
+- **Don't edit `generated.rs` by hand.** It's regenerated by
+  `cargo run --bin adf-schema-codegen` from the vendored JSON.
+- **The drift detector is your friend.** If you add an entry to
+  `CONTENT_ENTRIES` that upstream doesn't have, the drift test in
+  [`tests/adf_schema_drift_bin_test.rs`](../../tests/adf_schema_drift_bin_test.rs)
+  will tell you which atoms are misaligned. Read its error message before
+  changing anything else.
+- **Legacy tests intentionally produce invalid ADF.** Inline tests like
+  `nested_expand_inside_panel` document the converter's pre-ADR-0023
+  behaviour and assert on structurally invalid output. Don't copy that
+  pattern for new node types — the goal is the opposite.
+- **Permissive on unknowns.** Per [ADR-0023](../adrs/adr-0023.md), parents
+  the validator doesn't know about are treated as opaque, preserving the
+  `adf-unsupported` escape hatch from [ADR-0020](../adrs/adr-0020.md). A
+  brand-new upstream node will round-trip silently until you encode it
+  here — so a missing recipe step manifests as "my new node works in JSON
+  but the converter ignores it", not a hard error.
+
+## ADRs
+
+- [ADR-0020](../adrs/adr-0020.md) — JFM: A Markdown Dialect for Bidirectional ADF Interchange.
+- [ADR-0023](../adrs/adr-0023.md) — Data-Driven ADF Content-Model Schema and Validator.
+- [ADR-0025](../adrs/adr-0025.md) — Wire ADF Schema Validator into the API Send Path via `ValidatedAdfDocument`.


### PR DESCRIPTION
## Description

This PR adds a `docs/contributing/` directory containing three task-oriented recipes covering the extension points contributors most commonly reach for. These guides walk contributors through adding a new MCP tool, wiring a new AI provider backend, and extending the ADF schema with a new node type — each following the same structure: files to touch → walkthrough → testing → ADRs → gotchas.

`CONTRIBUTING.md` is updated to point contributors to `docs/contributing/` for these extension-point recipes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #772

## Changes Made

**Documentation:**
- Added `docs/contributing/README.md` — index page with a table linking the three recipes and a one-line description of when each applies
- Added `docs/contributing/adding-an-mcp-tool.md` — end-to-end walkthrough for adding a new MCP tool handler, covering parameter struct conventions, the `#[tool_router]` macro, router registration in `server.rs`, resource exposure, and testing patterns (direct-handler unit tests and end-to-end integration tests via `rmcp` in-memory transport)
- Added `docs/contributing/adding-an-ai-backend.md` — walkthrough for wiring a new AI provider through the `AiClient` trait, factory dispatch in `client.rs`, preflight credential validation in `preflight.rs`, model registry entries in `models.yaml`, and the required ADR-0002 update
- Added `docs/contributing/extending-the-adf-schema.md` — guide for adding a new ADF node type across all three layers: the vendored upstream JSON schema, the hand-maintained quantifier table in `adf_schema/mod.rs`, and the JFM converter/spec in `convert.rs` and `docs/specs/jfm.md`

**Core Changes:**
- Updated `CONTRIBUTING.md` to add an "Extension recipes" section pointing to `docs/contributing/` for the three recipes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience
- [x] Backward compatibility

The recipes reference specific line numbers and symbol paths in the codebase (e.g. `src/claude/client.rs:1618`, `src/mcp/git_tools.rs:103`). Please verify these references are accurate against the current state of the code, as they will drift as the codebase evolves. The recipes themselves note: "If a path or symbol has moved by the time you read this, fix the recipe in the same PR as your extension."

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional recipes could be added for other common extension points (e.g. adding a new CLI subcommand, adding a new Confluence tool, adding a new JFM directive)
- Line-number references in the recipes will need updating as the codebase evolves; a CI lint that checks doc references against actual code could help

**Known Limitations:**
- Specific line-number references (e.g. `client.rs:1618`, `git_tools.rs:103`) will drift as the codebase changes. Contributors are expected to fix stale references in the same PR as their extension.

**Alternatives Considered:**
- Embedding the recipes directly in `CONTRIBUTING.md` — rejected to keep that file focused on build/test/release basics and avoid making it unwieldy