### PR TITLE
chore(docs): add glama.json registry configuration

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "newhoggy"
+  ]
+}


### PR DESCRIPTION
## Description

This PR adds a `glama.json` registry configuration file to register omni-dev as an MCP server on the [Glama.ai](https://glama.ai) platform. The file follows the Glama MCP server schema and declares the project maintainer, enabling discovery and listing of omni-dev in the Glama MCP registry.

## Type of Change

- [x] Documentation update

## Related Issue

No related issue.

## Changes Made

**Core Changes:**
- Added `glama.json` at the repository root with the Glama MCP server schema reference and maintainer declaration (`newhoggy`)

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Verified `glama.json` is valid JSON and conforms to the `https://glama.ai/mcp/schemas/server.json` schema

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

The `glama.json` file is a lightweight metadata file used by the Glama.ai platform to index and surface MCP servers. Adding it here makes omni-dev discoverable in the Glama MCP registry without any changes to source code or runtime behavior.