### PR TITLE
docs(lib): add rustdoc to public structs in data.rs

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -14,7 +14,16 @@ pub use check::*;
 pub use context::*;
 pub use yaml::*;
 
-/// Complete repository view output structure, generic over commit type.
+/// Root node of the YAML output produced by `view`, `info`, `check`, and the branch
+/// subcommands.
+///
+/// Field presence is runtime-dependent: optional fields are populated only when the
+/// active command and repository state require them, and the embedded
+/// [`FieldExplanation`] reports which fields are actually present in this serialization.
+/// See [ADR-0013](../../docs/adrs/adr-0013.md) for the field-presence contract.
+///
+/// Generic over the commit type so the same shape serves both human-facing output
+/// (`CommitInfo`) and AI-facing output ([`RepositoryViewForAI`], using `CommitInfoForAI`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepositoryView<C = CommitInfo> {
     /// Version information for the omni-dev tool.
@@ -47,7 +56,12 @@ pub struct RepositoryView<C = CommitInfo> {
 /// Enhanced repository view for AI processing with full diff content.
 pub type RepositoryViewForAI = RepositoryView<CommitInfoForAI>;
 
-/// Field explanation for the YAML output.
+/// Self-describing schema metadata embedded under [`RepositoryView::explanation`].
+///
+/// Always present. Carries prose intro text plus a per-field list so an AI consumer can
+/// read a single YAML document and know what every field means and whether it is
+/// populated in this serialization. See [ADR-0013](../../docs/adrs/adr-0013.md) for the
+/// rationale.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldExplanation {
     /// Descriptive text explaining the overall structure.
@@ -56,7 +70,12 @@ pub struct FieldExplanation {
     pub fields: Vec<FieldDocumentation>,
 }
 
-/// Individual field documentation.
+/// Single entry inside [`FieldExplanation::fields`].
+///
+/// Names one YAML field path (e.g. `commits[].analysis.diff_file`), explains it, optionally
+/// links a `git` command that produces the underlying data, and carries a runtime
+/// `present` flag set by [`RepositoryView::update_field_presence`] before serialization.
+/// See [ADR-0013](../../docs/adrs/adr-0013.md).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldDocumentation {
     /// Name of the field being documented.
@@ -70,7 +89,11 @@ pub struct FieldDocumentation {
     pub present: bool,
 }
 
-/// Working directory information.
+/// Working-tree status nested under [`RepositoryView::working_directory`].
+///
+/// Always present. Mirrors `git status` at invocation time: a `clean` flag plus the list of
+/// modified or untracked files. Used by AI consumers to decide whether staged changes
+/// should influence the proposed commit message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkingDirectoryInfo {
     /// Whether the working directory has no changes.
@@ -79,7 +102,11 @@ pub struct WorkingDirectoryInfo {
     pub untracked_changes: Vec<FileStatusInfo>,
 }
 
-/// File status information for working directory.
+/// Entry in [`WorkingDirectoryInfo::untracked_changes`].
+///
+/// One per file with uncommitted or untracked changes, carrying the porcelain status
+/// flags (e.g. `"AM"`, `"??"`, `"M "`) and the repository-relative path. Sourced from
+/// `git status --porcelain`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileStatusInfo {
     /// Git status flags (e.g., "AM", "??", "M ").
@@ -88,28 +115,46 @@ pub struct FileStatusInfo {
     pub file: String,
 }
 
-/// Version information for tools and environment.
+/// Tool version metadata nested under optional [`RepositoryView::versions`].
+///
+/// Present only when the producing command opts to embed version data (the `view`
+/// command does; lightweight commands omit it). Absent in `single_commit_view` /
+/// `multi_commit_view` projections used for AI dispatch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VersionInfo {
     /// Version of the omni-dev tool.
     pub omni_dev: String,
 }
 
-/// AI-related information.
+/// AI integration metadata nested under [`RepositoryView::ai`].
+///
+/// Always present. Exposes the scratch directory path (controlled by the `AI_SCRATCH`
+/// environment variable) so downstream prompts and agents can resolve the per-commit
+/// diff files referenced from `commits[].analysis.diff_file` and `file_diffs[].diff_file`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiInfo {
     /// Path to AI scratch directory.
     pub scratch: String,
 }
 
-/// Branch information for branch-specific commands.
+/// Current-branch context nested under optional [`RepositoryView::branch_info`].
+///
+/// Present only for branch-aware commands (e.g. branch analysis / PR-message
+/// generation); absent on plain `view`. Preserved by `single_commit_view` projections
+/// because the branch name carries useful scope information for per-commit AI dispatch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchInfo {
     /// Current branch name.
     pub branch: String,
 }
 
-/// Pull request information.
+/// GitHub pull-request metadata. Appears as an entry in optional
+/// [`RepositoryView::branch_prs`].
+///
+/// Populated by branch-aware commands when the current branch has been pushed and the
+/// GitHub API resolves one or more PRs against it; absent on local-only branches or when
+/// the lookup fails. Field presence for the `branch_prs[].*` paths is tracked per
+/// [ADR-0013](../../docs/adrs/adr-0013.md).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PullRequest {
     /// PR number.


### PR DESCRIPTION
## Description

This PR adds comprehensive rustdoc comments to all public data structures in `src/data.rs`. The existing one-liner doc comments have been replaced with detailed documentation that explains field-presence semantics, cross-references between types, and the rationale from ADR-0013. This improves the developer experience when navigating the codebase and makes the data model self-documenting for both human developers and AI consumers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #773

## Changes Made

**Documentation:**
- `RepositoryView`: expanded to document runtime-dependent field presence, the generic commit type parameter (`CommitInfo` vs `CommitInfoForAI`), and cross-reference to ADR-0013
- `FieldExplanation`: described its role as self-describing schema metadata embedded for AI consumers, noting it is always present
- `FieldDocumentation`: explained the `present` flag contract set by `update_field_presence` before serialization
- `WorkingDirectoryInfo`: noted always-present status and use by AI consumers when constructing proposed commit messages
- `FileStatusInfo`: clarified porcelain status flags (e.g. `"AM"`, `"??"`, `"M "`) and that data is sourced from `git status --porcelain`
- `VersionInfo`: documented conditional presence — populated by `view` but omitted in lightweight projections
- `AiInfo`: linked scratch directory path to `AI_SCRATCH` environment variable and explained its role in resolving per-commit diff file paths
- `BranchInfo`: explained presence only for branch-aware commands and preservation in `single_commit_view` projections
- `PullRequest`: described when branch PR metadata is populated (pushed branches with resolvable GitHub PRs) vs absent

**Core Changes:**
- No functional changes; all modifications are doc comments only (`src/data.rs`, +54 / -9 lines)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no new tests required)

**Manual Testing:**
- [x] Backward compatibility verified (no functional changes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify rustdoc compiles without warnings
cargo doc --no-deps
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications (none)
- [ ] Performance impact (none)
- [ ] Architecture changes (none)
- [ ] Error handling (none)
- [ ] User experience (none)
- [x] Backward compatibility — doc-only change; no API or behaviour changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable — documentation only)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Similar rustdoc coverage could be extended to the commit-related structs (`CommitInfo`, `CommitInfoForAI`, `CommitAnalysis`, etc.) in subsequent PRs

**Known Limitations:**
- None

**Alternatives Considered:**
- Keeping the existing terse one-liners was rejected because they did not convey field-presence semantics or cross-references needed by AI consumers reading the YAML schema