### PR TITLE
docs(docs): add plan-file status labels and ADR cross-links convention (STYLE-0027)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,10 +45,14 @@ Complete documentation for omni-dev - the intelligent Git commit message toolkit
 
 ### Project Planning & Architecture
 
-- **[Project Plan](plan/project.md)** - Technical architecture and implementation details
-- **[Twiddle Design](plan/twiddle.md)** - Complete design for the twiddle command phases
-- **[Help All Command](plan/help-all-command.md)** - Comprehensive help system design
-- **[Config Internals](plan/config-internals.md)** - How configuration resolution works
+Each file in [`plan/`](plan/) carries a `**Status:**` header (`Built`, `In Progress`, `Aspirational`, or `Historical`) and may cross-link the ADRs that capture its current architecture. Use a plan to **explore** a design before high-level decisions stabilise; promote it to an [ADR](adrs/README.md) once the decisions firm up; document the *current* user-facing behaviour in [user-guide.md](user-guide.md). Once a plan's decisions are fully captured by ADRs, change its status to `Built` (with ADR cross-links) or `Historical` rather than deleting it — the prior reasoning stays discoverable. See [STYLE-0027](STYLE_GUIDE.md#style-0027-plan-file-status-header-and-adr-cross-links) for the full convention.
+
+- **[Project Plan](plan/project.md)** *(Historical)* - Initial CLI architecture predating Atlassian/MCP/AI providers
+- **[Twiddle Design](plan/twiddle.md)** *(In Progress)* - Phases 1 and 2 built; Phase 3 (contextual intelligence) aspirational
+- **[Help All Command](plan/help-all-command.md)** *(Built)* - Comprehensive help system design
+- **[Config Internals](plan/config-internals.md)** *(Built, canonical reference)* - How configuration resolution works · [ADR-0005](adrs/adr-0005.md) · [ADR-0018](adrs/adr-0018.md) · [ADR-0019](adrs/adr-0019.md)
+- **[AI Client](plan/AiClient.md)** *(Built)* - Multi-provider AI abstraction · [ADR-0002](adrs/adr-0002.md) · [ADR-0014](adrs/adr-0014.md)
+- **[Commit Message Check](plan/commit-message-check.md)** *(Built)* - Non-interactive commit message validation
 
 ### Retrospectives
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -27,6 +27,7 @@ which tags apply to the changes and search this file for those tags. Each rule h
 | Suppressing a lint or considering `unsafe`       | `code-style`, `unsafe`                   |
 | Writing or updating an ADR                       | `adrs`                                   |
 | Adding an MCP tool, resource, or param struct    | `api-design`, `module-organization`, `testing` |
+| Adding or modifying a docs/plan/ file            | `documentation`, `adrs`                  |
 | Reviewing code for style compliance              | All tags relevant to the changed code    |
 
 ---
@@ -41,7 +42,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0027`) and include:
+Assign the next sequential ID (currently next is `STYLE-0028`) and include:
 
 1. A **Tags** line immediately after the heading — a comma-separated list of category labels
    from the tag vocabulary below.
@@ -1373,3 +1374,40 @@ schema predictable; shared error mapping keeps diagnostics legible across
 tools; router splitting keeps modules small and testable; the paired
 unit+integration test requirement means a regression in protocol wiring is
 caught without requiring a live Claude Desktop to reproduce.
+
+---
+
+## STYLE-0027: Plan-file status header and ADR cross-links
+
+**Tags:** `documentation`, `adrs`
+
+### Situation
+
+Adding or substantially editing a file in [`docs/plan/`](plan/).
+
+### Guidance
+
+1. **Status header.** Immediately after the `# Title` heading, add a `**Status:** …` line using one of these four canonical tags:
+
+   | Tag             | Meaning                                                                                          |
+   |-----------------|--------------------------------------------------------------------------------------------------|
+   | `Built`         | The design has shipped. The doc may still be useful as a reference but is not a roadmap.         |
+   | `In Progress`   | Some phases shipped, others ongoing. Specify which phase is current.                             |
+   | `Aspirational`  | Describes intent that is not yet started or has been superseded by a different approach.         |
+   | `Historical`    | Written for context that no longer matches current architecture; kept for institutional memory.  |
+
+   A short qualifier after an em-dash (`— canonical reference`, `— Phase 3 not started`) is encouraged when it adds signal.
+
+2. **ADR cross-links.** When one or more ADRs describe the same decisions, add an `**ADRs:**` line immediately after the Status line, listing each ADR as a relative link separated by ` · ` (middle dot, surrounded by spaces). Example:
+
+   ```markdown
+   **ADRs:** [ADR-0002](../adrs/adr-0002.md) · [ADR-0014](../adrs/adr-0014.md)
+   ```
+
+3. **When to retire.** Once a plan's decisions are captured in one or more ADRs, change its status to `Built` (with ADR cross-links) or `Historical` rather than deleting it — preserving the doc keeps prior reasoning discoverable.
+
+4. **When to promote.** When a plan's high-level decisions stabilise, copy the decision and its rationale into a new ADR (see [STYLE-0022](#style-0022-adr-format)) and update the plan's status to `Built` with a cross-link.
+
+### Motivation
+
+A plan directory that mixes shipped, in-progress, and superseded content with no signalling forces every new contributor to read every file and cross-check the codebase before they can act on it. A one-line status header costs the author nothing and gives the reader an immediate orientation; ADR cross-links make the canonical decision discoverable.

--- a/docs/plan/AiClient.md
+++ b/docs/plan/AiClient.md
@@ -1,5 +1,8 @@
 # AI Client Architecture Plan
 
+**Status:** Built
+**ADRs:** [ADR-0002](../adrs/adr-0002.md) · [ADR-0014](../adrs/adr-0014.md)
+
 ## Overview
 
 This document outlines the plan for refactoring the Claude API client into a more abstract and flexible architecture using the `AiClient` trait. This will allow for multiple AI service implementations while maintaining a consistent interface.

--- a/docs/plan/commit-message-check.md
+++ b/docs/plan/commit-message-check.md
@@ -1,5 +1,7 @@
 # Plan: `omni-dev git commit message check` Command
 
+**Status:** Built
+
 ## Overview
 
 Add a new `omni-dev git commit message check` command that analyzes commit messages against the actual code changes (diffs) and **project-defined commit guidelines**, producing a report of issues without modifying any commits.

--- a/docs/plan/config-internals.md
+++ b/docs/plan/config-internals.md
@@ -1,5 +1,8 @@
 # Config Internals
 
+**Status:** Built — canonical reference for configuration resolution.
+**ADRs:** [ADR-0005](../adrs/adr-0005.md) · [ADR-0018](../adrs/adr-0018.md) · [ADR-0019](../adrs/adr-0019.md)
+
 How omni-dev's configuration resolution system works, for contributors. For
 the user-facing contract — the inventory of recognised `.omni-dev/` files,
 their formats, and validation behaviour — see

--- a/docs/plan/help-all-command.md
+++ b/docs/plan/help-all-command.md
@@ -1,5 +1,7 @@
 # Project Plan: Comprehensive Help Command (`help all`)
 
+**Status:** Built
+
 ## Overview
 Implement a `help all` subcommand that displays the complete CLI help hierarchy for omni-dev in a single output, eliminating the need to run multiple help commands.
 

--- a/docs/plan/project.md
+++ b/docs/plan/project.md
@@ -1,5 +1,7 @@
 # Project Plan: omni-dev CLI Git Tools
 
+**Status:** Historical — describes the initial CLI design before Atlassian, MCP, and AI providers existed; kept for institutional memory.
+
 ## Overview
 
 This project implements a CLI tool that provides the functionality of the existing `.claude/commands/twiddle-msg` bash script but with a Rust-based CLI interface. The tool will support two main subcommands:

--- a/docs/plan/twiddle.md
+++ b/docs/plan/twiddle.md
@@ -1,5 +1,7 @@
 # Twiddle Command Implementation Plan
 
+**Status:** In Progress — Phases 1 and 2 Built; Phase 3 (contextual intelligence) Aspirational. See the **Implementation Status** section below for the current phase breakdown.
+
 ## Implementation Status
 
 **Phase 1: Core Implementation** - ✅ **COMPLETED** (2025-01-07)


### PR DESCRIPTION
## Description

This PR establishes a formal convention for `docs/plan/` files by introducing status headers and ADR cross-links (STYLE-0027), then retrofits all existing plan files with the appropriate status labels. The goal is to eliminate the ambiguity that arises when a contributor opens the `plan/` directory and cannot tell which documents describe shipped features, ongoing work, or superseded architecture — without reading every file and cross-checking the codebase.

The new `**Status:**` header uses four canonical tags (`Built`, `In Progress`, `Aspirational`, `Historical`), and an optional `**ADRs:**` line links back to the ADRs that capture the same decisions. This makes the plan directory immediately navigable for new contributors.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #771

## Changes Made

**Style Guide:**
- Added STYLE-0027 to `docs/STYLE_GUIDE.md` defining the plan-file status header and ADR cross-link convention, including the four canonical status tags, formatting rules for ADR links, guidance on when to retire vs. promote a plan, and motivation for the convention
- Incremented the "next sequential ID" hint from `STYLE-0027` to `STYLE-0028`
- Added `Adding or modifying a docs/plan/ file` row to the tag look-up table pointing at `documentation`, `adrs`

**README:**
- Updated `docs/README.md` Project Planning section to explain the new status-header convention and link to STYLE-0027
- Annotated each plan-file entry in the index with its current status and relevant ADR cross-links
- Added previously unlisted plan files (`AiClient.md`, `commit-message-check.md`) to the index

**Plan Files (status headers applied):**
- `docs/plan/AiClient.md` — `**Status:** Built` + ADR-0002 · ADR-0014
- `docs/plan/commit-message-check.md` — `**Status:** Built`
- `docs/plan/config-internals.md` — `**Status:** Built — canonical reference` + ADR-0005 · ADR-0018 · ADR-0019
- `docs/plan/help-all-command.md` — `**Status:** Built`
- `docs/plan/project.md` — `**Status:** Historical — describes the initial CLI design before Atlassian, MCP, and AI providers`
- `docs/plan/twiddle.md` — `**Status:** In Progress — Phases 1 and 2 Built; Phase 3 (contextual intelligence) Aspirational`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality — N/A (documentation-only change)
- [ ] Integration tests updated/added — N/A
- [ ] Performance tests (if applicable) — N/A

**Manual Testing:**
- [x] Reviewed all modified plan files for correct status labels and valid ADR link targets
- [x] Verified README index entries match plan-file status headers
- [x] Confirmed STYLE-0027 guidance is self-consistent and matches the changes applied to existing plan files

### Test Commands
```bash
# Code quality checks (no Rust changes in this PR)
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications — none
- [ ] Performance impact — none
- [ ] Architecture changes — none
- [x] User experience — the four status tag choices and their meanings should be unambiguous to a new contributor
- [x] Backward compatibility — existing plan files gain headers but are otherwise unchanged

**Specific areas for reviewer attention:**
- The wording of the four status tags in STYLE-0027 — do `Aspirational` and `Historical` clearly cover their intended cases without overlap?
- The status assigned to `docs/plan/twiddle.md` (`In Progress`) — is the phase breakdown in the qualifier accurate?
- The ADR cross-links in `config-internals.md` — confirm ADR-0005, ADR-0018, and ADR-0019 are the right three references

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (documentation only)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- As new plan files are added, authors should apply STYLE-0027 from the start rather than retrofitting later
- Consider adding a lint check (e.g. in CI) that verifies every file under `docs/plan/` contains a `**Status:**` line

**Alternatives Considered:**
- Using a YAML front-matter block for status metadata — rejected in favour of plain Markdown headers to keep the files human-readable without tooling