### PR TITLE
docs(claude,cli): improve rustdoc for ClaudeCliAiClient, AiBackend, Cli, and Commands

### DIFF
--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -110,7 +110,18 @@ struct JsonOutput {
     total_cost_usd: Option<f64>,
 }
 
-/// Claude Code CLI subprocess AI client.
+/// Subprocess-based AI client that shells out to `claude -p` in a
+/// locked-down sandbox.
+///
+/// Selected by `OMNI_DEV_AI_BACKEND=claude-cli` (or `--ai-backend
+/// claude-cli`); see the module-level docs above for the full sandbox
+/// posture and the "AI Backend Dispatch" section of `CLAUDE.md` for
+/// dispatch ordering.
+///
+/// Three runtime knobs weaken or bound the sandbox:
+/// - `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS` — re-enable nested tool use.
+/// - `OMNI_DEV_CLAUDE_CLI_ALLOW_MCP` — re-enable nested MCP server pickup.
+/// - `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD` — per-invocation spending cap in USD.
 pub struct ClaudeCliAiClient {
     /// Model identifier (alias like `sonnet` or full ID like
     /// `claude-sonnet-4-6`). Forwarded verbatim to `claude -p --model`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,12 @@ pub mod help;
 pub mod resources;
 pub mod transcript;
 
-/// AI backend selector.
+/// CLI-side selector for the AI backend dispatched by
+/// [`create_default_claude_client`][crate::claude::client::create_default_claude_client].
+///
+/// `None` (flag omitted) preserves env-var dispatch; an explicit value
+/// overrides `OMNI_DEV_AI_BACKEND`. Propagation to the env var happens
+/// in `Cli::propagate_global_flags`.
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum AiBackend {
@@ -25,7 +30,13 @@ pub enum AiBackend {
     ClaudeCli,
 }
 
-/// omni-dev: A comprehensive development toolkit.
+/// Top-level clap-derived CLI struct; the library entry point for embedding
+/// omni-dev programmatically.
+///
+/// Global flags (`--ai-backend`, `--claude-cli-allow-tools`,
+/// `--claude-cli-allow-mcp`, `--claude-cli-max-budget-usd`, `--models-yaml`)
+/// are propagated to environment variables read by downstream factories
+/// before dispatching to a [`Commands`] variant.
 #[derive(Parser)]
 #[command(name = "omni-dev")]
 #[command(about = "A comprehensive development toolkit", long_about = None)]
@@ -87,7 +98,11 @@ pub struct Cli {
     pub command: Commands,
 }
 
-/// Main command categories.
+/// Top-level subcommand dispatch enum.
+///
+/// Each variant wraps the subcommand-specific argument struct (e.g.
+/// [`ai::AiCommand`], [`git::GitCommand`], [`atlassian::AtlassianCommand`]);
+/// follow the variant's payload type for the per-command argument surface.
 #[derive(Subcommand)]
 pub enum Commands {
     /// AI operations.


### PR DESCRIPTION
## Description

This PR improves rustdoc documentation for several key public types in `src/claude/ai/claude_cli.rs` and `src/cli.rs`. The existing one-line doc comments were replaced with more informative multi-line descriptions that explain the purpose of each type, how it is selected or constructed, and how it interacts with environment variables and other parts of the system.

No functional changes were made — this is a pure documentation cleanup.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #776

## Changes Made

**Documentation (`src/claude/ai/claude_cli.rs`):**
- Expanded the `ClaudeCliAiClient` doc comment from a single line into a multi-paragraph description covering:
  - Selection via `OMNI_DEV_AI_BACKEND=claude-cli` or `--ai-backend claude-cli`
  - References to the module-level sandbox posture docs and the "AI Backend Dispatch" section of `CLAUDE.md`
  - The three runtime knobs that weaken or bound the sandbox (`OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS`, `OMNI_DEV_CLAUDE_CLI_ALLOW_MCP`, `OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD`)

**Documentation (`src/cli.rs`):**
- Expanded the `AiBackend` doc comment to explain it is the CLI-side selector for the backend dispatched by `create_default_claude_client`, how `None` preserves env-var dispatch, how an explicit value overrides `OMNI_DEV_AI_BACKEND`, and where propagation happens (`Cli::propagate_global_flags`).
- Expanded the `Cli` doc comment to describe it as the top-level clap-derived CLI struct and library entry point, and to list the global flags that are propagated to environment variables before dispatching.
- Expanded the `Commands` doc comment to clarify it is the top-level subcommand dispatch enum, with a note directing readers to each variant's payload type for per-command argument surface.

**Testing:**
- No new tests required for documentation-only changes.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A — documentation only)
- [ ] Integration tests updated/added (N/A)
- [ ] Performance tests (N/A)

**Manual Testing:**
- [x] Verified `cargo doc` generates correctly rendered HTML for updated types
- [x] Backward compatibility verified (no functional changes)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build and verify docs render correctly
cargo doc --no-deps --open
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

Reviewers should check that:
- The new doc text accurately describes the runtime behaviour (env var names, flag names, dispatch ordering)
- Cross-references (`create_default_claude_client`, `CLAUDE.md` sections) are correct
- Wording is consistent with the surrounding module-level documentation

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs only)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

This is a targeted rustdoc cleanup for issue #776. Only documentation strings were changed; all logic, public API signatures, and behaviour remain identical.