### PR TITLE
docs(docs): add ADR-0028, ADR-0029, and ADR-0030 for missing architecture decision records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ Preflight (`src/utils/preflight.rs`) mirrors this switch and must change in lock
 
 User-facing details — required env vars, model selection, Claude CLI sandbox semantics, the `--claude-cli-allow-tools` / `--claude-cli-allow-mcp` escape hatches, the `--claude-cli-max-budget-usd` spending cap, and per-backend troubleshooting — live in [docs/ai-backends.md](docs/ai-backends.md). Keep it in sync when changing any of those surfaces.
 
+Architectural rationale for the sandboxed `claude-cli` subprocess backend — threat model, sandbox flag choices, escape-hatch design, budget-cap enforcement — lives in [ADR-0028](docs/adrs/adr-0028.md).
+
 Dev-only notes:
 - `ClaudeCliAiClient::run` is the warn site for both escape hatches, the INFO-level `total_cost_usd` log, and the post-response WARN when reported cost exceeds the configured cap.
 - `--beta-header` is ignored for the `claude-cli` backend (`claude`'s `--betas` flag has different semantics).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -53,3 +53,4 @@ by Michael Nygard.
 | [ADR-0027](adr-0027.md)  | ✅ Accepted                              | 2026-05-11 | Destructive CLI Commands Confirm by Default with --force and --dry-run Escape Hatches  |
 | [ADR-0028](adr-0028.md)  | ✅ Accepted                              | 2026-05-12 | Sandboxed `claude-cli` Subprocess AI Backend                                           |
 | [ADR-0029](adr-0029.md)  | ✅ Accepted                              | 2026-05-12 | JFM ↔ ADF Converter Strategy                                                           |
+| [ADR-0030](adr-0030.md)  | ✅ Accepted                              | 2026-05-12 | CLI Snapshot Golden Testing for the Help Surface                                       |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -52,3 +52,4 @@ by Michael Nygard.
 | [ADR-0026](adr-0026.md)  | ✅ Accepted                              | 2026-05-10 | Extending the ADF Validator with Quantifiers, Attributes, and Marks                    |
 | [ADR-0027](adr-0027.md)  | ✅ Accepted                              | 2026-05-11 | Destructive CLI Commands Confirm by Default with --force and --dry-run Escape Hatches  |
 | [ADR-0028](adr-0028.md)  | ✅ Accepted                              | 2026-05-12 | Sandboxed `claude-cli` Subprocess AI Backend                                           |
+| [ADR-0029](adr-0029.md)  | ✅ Accepted                              | 2026-05-12 | JFM ↔ ADF Converter Strategy                                                           |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -51,3 +51,4 @@ by Michael Nygard.
 | [ADR-0025](adr-0025.md)  | ✅ Accepted                              | 2026-05-10 | Wire ADF Schema Validator into the API Send Path via `ValidatedAdfDocument`            |
 | [ADR-0026](adr-0026.md)  | ✅ Accepted                              | 2026-05-10 | Extending the ADF Validator with Quantifiers, Attributes, and Marks                    |
 | [ADR-0027](adr-0027.md)  | ✅ Accepted                              | 2026-05-11 | Destructive CLI Commands Confirm by Default with --force and --dry-run Escape Hatches  |
+| [ADR-0028](adr-0028.md)  | ✅ Accepted                              | 2026-05-12 | Sandboxed `claude-cli` Subprocess AI Backend                                           |

--- a/docs/adrs/adr-0028.md
+++ b/docs/adrs/adr-0028.md
@@ -1,0 +1,212 @@
+# ADR-0028: Sandboxed `claude-cli` Subprocess AI Backend
+
+## Status
+
+✅ Accepted (2026-05-12)
+
+## Context
+
+omni-dev's AI integration was originally framed by [ADR-0002](adr-0002.md) as
+a `Box<dyn AiClient>` trait with in-process implementations for the direct
+Anthropic API, AWS Bedrock, OpenAI-compatible endpoints, and Ollama. All four
+require the caller to provision credentials (API key, AWS role, local
+endpoint) before omni-dev can drive a model.
+
+A growing subset of users already runs an authenticated Claude Code session
+on their machine — the `claude` CLI holds an OAuth token bound to their
+Anthropic subscription. Forcing those users to provision a separate
+`ANTHROPIC_API_KEY` (with separate billing, separate rate-limit pool, and a
+second credential surface to leak) is friction without a corresponding gain.
+A subprocess backend that shells out to `claude -p` would reuse that
+authenticated session directly.
+
+The trade-off is that a nested `claude -p` invocation is, by default, *not*
+a constrained operation. The child inherits the parent's environment and
+working directory, can read and write files, can run shell commands, can
+load MCP servers from `~/.claude/settings.json` (with their OAuth tokens),
+and can persist session state to disk. None of those capabilities are
+needed for the structured-prompt-in / structured-response-out use case that
+omni-dev cares about, and several of them are actively hostile to it —
+omni-dev's call sites assume the AI is a pure function of `(system prompt,
+user prompt) → response`, not an agent with side effects on the calling
+environment.
+
+Three further forces shaped the design:
+
+- **Cost containment.** A misbehaving prompt loop with a tool-enabled
+  session can consume unbounded API spend before any external watchdog
+  reacts. The backend needs a per-invocation budget cap with hard kill
+  semantics, not advisory logging.
+
+- **Forward compatibility.** The set of "dangerous" `claude` CLI features
+  grows with each release (new tools, new slash-command skills, new MCP
+  surfaces). The sandbox needs to be opt-out-from-secure-default rather
+  than opt-in-to-secure, so new dangerous features stay disabled until
+  someone reviews them.
+
+- **Observability.** Whatever the cap, operators running at scale need to
+  see the cost of each invocation in their logs without grepping for it.
+
+Issues #633 (orphan Node helper processes outliving timeouts) and #683
+(the MCP-pickup leak path) informed several of the implementation details
+called out below.
+
+## Decision
+
+### A subprocess-based backend, dispatched by env var
+
+A new variant, `ClaudeCliAiClient` ([src/claude/ai/claude_cli.rs](../../src/claude/ai/claude_cli.rs)),
+sits beside the four existing backends. It is selected by setting
+`OMNI_DEV_AI_BACKEND=claude-cli` (or `--ai-backend claude-cli`), which
+short-circuits the dispatch in `create_default_claude_client`
+([src/claude/client.rs](../../src/claude/client.rs)) ahead of the
+`USE_OPENAI` / `USE_OLLAMA` / `CLAUDE_CODE_USE_BEDROCK` checks. Preflight
+([src/utils/preflight.rs](../../src/utils/preflight.rs)) mirrors the same
+ordering: it probes the `claude` binary with `--version` before falling
+through to API-key checks. Adding a future backend must update both sites
+in lock-step.
+
+The subprocess interface is `claude -p --output-format json`. The JSON
+envelope (`is_error`, `api_error_status`, `result`, `total_cost_usd`) is
+the stable contract; everything else (`session_id`, `usage`, model
+metadata) is ignored. We deliberately did **not** wrap the in-process SDK
+on top of the OAuth token store, because:
+
+- Re-implementing the `claude` auth refresh, session handling, and quota
+  routing in Rust would duplicate a moving target.
+- A process boundary is a precondition for several of the sandbox flags
+  below (`--no-session-persistence`, `--setting-sources ""`, cwd
+  isolation). An in-process SDK cannot enforce any of them.
+
+### Secure-by-default sandbox
+
+Every `claude -p` invocation is configured by `build_command_with_schema`
+([claude_cli.rs:254-323](../../src/claude/ai/claude_cli.rs)) with the
+following flags, all of which can only be removed by an explicit escape
+hatch (see below):
+
+| Flag | Effect |
+|------|--------|
+| `--tools ""` | Disable every built-in tool (Read, Edit, Write, Bash, Glob, Grep, …). |
+| `--strict-mcp-config` | Refuse to load MCP servers; nested session cannot reach `~/.claude/settings.json`'s MCP block. |
+| `--setting-sources ""` | Skip user / project / local settings discovery. |
+| `--disable-slash-commands` | Block skill / slash-command invocation. |
+| `--no-session-persistence` | Do not write session state to disk. |
+| `--permission-mode default` | No auto-accept permission prompts. |
+
+Two non-flag mechanisms complete the sandbox:
+
+- **Fresh cwd.** Each invocation creates a `tempfile::TempDir` and sets it
+  as the subprocess `current_dir`. The nested session has no view of the
+  caller's project files even if a tool is somehow re-enabled.
+- **Env scrubbing.** The subprocess inherits the caller's environment
+  (because the Node runtime inside `claude` needs `HOME`, `PATH`, and on
+  macOS sometimes `DYLD_*` entries to function), then removes
+  `CLAUDE_PROJECT_DIR` and any variable with the `CLAUDE_CODE_` or
+  `CLAUDE_PROJECT_` prefix. These are the variables a parent Claude Code
+  session uses to re-scope a child session into the same project; leaving
+  them set would defeat the temp-cwd isolation.
+
+A defence-in-depth detail: the caller's system prompt is suffixed with
+`TOOL_SUPPRESSION_SUFFIX` ([claude_cli.rs:84-86](../../src/claude/ai/claude_cli.rs)),
+which instructs the model not to emit `<function_calls>` XML even though
+the runtime would discard it. This is belt-and-braces against models that
+"know" tools exist and try to drive them anyway.
+
+A process-group concern: on Unix, the child is made its own process-group
+leader (`Command::process_group(0)`) so a timeout can `killpg` the whole
+group. Without this, Node worker processes spawned by `claude` survive a
+direct PID kill and accumulate as orphans (issue #633).
+
+### Two independent escape hatches
+
+The sandbox is not negotiable per-invocation by the model. It is, however,
+negotiable per-deployment by the operator, via two **independent**
+toggles, each defaulting to off:
+
+- `--claude-cli-allow-tools` / `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true` —
+  drops `--tools ""`. The nested session regains the full built-in
+  toolset. Justified only for deliberately tool-capable use cases.
+- `--claude-cli-allow-mcp` / `OMNI_DEV_CLAUDE_CLI_ALLOW_MCP=true` —
+  drops `--strict-mcp-config`. The nested session can load MCP servers
+  from `~/.claude/settings.json`, exposing whatever OAuth tokens or
+  network endpoints those servers hold.
+
+Each toggle that is active logs a `warn!()` line on every invocation
+([claude_cli.rs:357-374](../../src/claude/ai/claude_cli.rs)) describing
+exactly what was relaxed and what the operator is now trusting. Relaxing
+the threat model is loud, not silent. The two toggles are independent
+because the threat models they relax are independent — tool access leaks
+file-system / shell capability into the session; MCP access leaks
+credentials and network endpoints. An operator may legitimately want one
+without the other.
+
+### Hard spending cap
+
+`--claude-cli-max-budget-usd <amount>` /
+`OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD=<amount>` is forwarded verbatim to
+`claude -p --max-budget-usd`. The subprocess itself enforces the cap —
+when it estimates the in-flight invocation will exceed the budget, it
+aborts. This is preferred over an omni-dev-side soft warning because the
+subprocess can stop spending *before* the next round trip, whereas
+omni-dev only sees the cost after the response arrives. Non-positive or
+non-finite values are silently treated as "no cap" (the simplest
+fail-open behaviour for an optional value).
+
+Regardless of cap, `total_cost_usd` from every response is logged at
+`info!()` ([claude_cli.rs:499-520](../../src/claude/ai/claude_cli.rs)) so
+the operating cost is observable in standard tracing output. When a cap
+is set and `claude -p`'s reported cost exceeds it, omni-dev additionally
+logs a `warn!()` as a sanity check against the subprocess's own
+enforcement.
+
+### Out of scope
+
+- We do not attempt to validate the schema of `~/.claude/settings.json`,
+  fingerprint installed MCP servers, or otherwise audit what
+  `--claude-cli-allow-mcp` would expose. The escape hatch is a knob, not
+  a policy engine.
+- The `--beta-header` global flag is ignored for this backend; betas are
+  negotiated by the `claude` CLI itself, not by omni-dev.
+
+## Consequences
+
+**Positive:**
+
+- Users with an existing Claude Code subscription can drive omni-dev's AI
+  features without provisioning a second credential.
+- The threat-model boundary is explicit in code, not in documentation
+  alone. Every escape hatch is a flag with a warning log, not an
+  undocumented env var.
+- Cost is observable per invocation, and `claude -p`'s own hard kill makes
+  the budget cap authoritative.
+- Forward-compatible: if `claude` ships a new dangerous flag, the default
+  set above continues to apply. We opt into new capabilities, never the
+  reverse.
+
+**Negative:**
+
+- Subprocess overhead per call (process spawn, Node startup, JSON
+  envelope marshalling) is non-trivial compared to in-process SDKs. For
+  short prompts the spawn cost can dominate the API round-trip.
+- The backend depends on a `claude` binary at a discoverable path. The
+  preflight check gates this, but a user whose binary moves between
+  invocations will see runtime errors that the other backends do not
+  surface.
+- Escape hatches are footguns when set in shell rc files: a user who
+  exports `OMNI_DEV_CLAUDE_CLI_ALLOW_TOOLS=true` in `.zshrc` weakens the
+  sandbox for every future invocation, with only the per-call `warn!()`
+  to flag it. We accept this — the alternative (per-invocation
+  confirmation) would defeat unattended use cases like CI.
+
+**Neutral:**
+
+- The JSON envelope contract is unilateral. If `claude -p` removes or
+  renames `total_cost_usd` or `is_error`, omni-dev breaks. We accept the
+  coupling because the alternative (parsing free-form text output) is
+  strictly worse, and `claude -p`'s JSON output is documented as stable.
+- `OMNI_DEV_AI_BACKEND=claude-cli` short-circuits the dispatch ahead of
+  the legacy `USE_OPENAI` / `USE_OLLAMA` / `CLAUDE_CODE_USE_BEDROCK`
+  switches. A user with multiple backend env vars set will get the
+  claude-cli backend regardless of the others. The selection order is
+  the contract; collisions are not a bug.

--- a/docs/adrs/adr-0029.md
+++ b/docs/adrs/adr-0029.md
@@ -1,0 +1,221 @@
+# ADR-0029: JFM ↔ ADF Converter Strategy
+
+## Status
+
+✅ Accepted (2026-05-12)
+
+## Context
+
+Atlassian Cloud's REST APIs for Jira issue descriptions and Confluence
+page bodies do not accept Markdown or wiki markup; they accept the
+Atlassian Document Format (ADF) — a versioned JSON tree of typed nodes
+(`paragraph`, `panel`, `expand`, `tableCell`, …) governed by a published
+content model. Authors of those payloads in omni-dev's primary workflows
+(generating PR-context comments, writing release notes, attaching
+investigation reports) are humans and AIs that produce prose. Asking
+those producers to emit ADF JSON directly is poor authoring UX and
+fragile under prompt drift.
+
+Three options were considered for closing the authoring gap:
+
+- **Author ADF directly.** Discarded. Forces every prompt template and
+  every human contributor to learn a Confluence-internal JSON dialect; no
+  diff-friendly source format; round-trip review impossible.
+- **Use Confluence wiki markup as an interchange format.** Discarded.
+  Different products (Jira vs Confluence) have subtly different wiki
+  dialects; wiki ↔ ADF is not bidirectional; the format is on a
+  long-running deprecation arc inside Atlassian.
+- **Define a Markdown dialect with first-class round-trip to ADF.**
+  Selected. [ADR-0020](adr-0020.md) specifies the dialect (JFM — JIRA
+  Flavoured Markdown) including the directive syntax for ADF-specific
+  nodes that have no Markdown equivalent.
+
+[ADR-0020](adr-0020.md) documents JFM-the-format. What it does **not**
+document is the converter system that materialises the round trip — where
+the conversion lives, how it composes with the schema validator stack
+([ADR-0023](adr-0023.md), [ADR-0025](adr-0025.md), [ADR-0026](adr-0026.md)),
+how the upstream content model is tracked, and how a contributor adds
+support for a new ADF node type. This ADR fills that gap.
+
+The validator subsystem and the converter subsystem were introduced in
+overlapping but separate slices: the converter ([convert.rs](../../src/atlassian/convert.rs))
+predates schema-aware validation ([adf_schema](../../src/atlassian/adf_schema/)),
+and at the time of writing two integration tests
+(`nested_expand_inside_panel`, `nested_expand_inside_table_cell` in
+`convert.rs`) document that the converter can emit structurally invalid
+ADF. [ADR-0023](adr-0023.md) accepts that gap as the cost of decoupling
+the two slices. This ADR makes the resulting module boundaries explicit
+so the gap can be closed without re-architecting.
+
+## Decision
+
+### Single public conversion surface
+
+[src/atlassian/convert.rs](../../src/atlassian/convert.rs) is the only
+module that converts between Markdown text and `AdfDocument`. It exposes
+exactly two public entry points:
+
+- `markdown_to_adf(markdown: &str) -> Result<AdfDocument>` — Markdown
+  (JFM) in, unvalidated ADF tree out.
+- `adf_to_markdown(doc: &AdfDocument) -> Result<String>` — ADF tree in,
+  Markdown (JFM) out. A `_with_options` variant takes a `RenderOptions`.
+
+The Markdown parser is a hand-rolled line-oriented state machine
+(`MarkdownParser`); the ADF renderer is a recursive tree walker. Neither
+external state nor side channels (filesystem, network) participate; both
+are pure functions over their inputs.
+
+### Validation is a type-system requirement, not a convention
+
+`AdfDocument` ([adf.rs](../../src/atlassian/adf.rs)) is the unvalidated
+data type. It can hold any tree, including ones the upstream Atlassian
+content model rejects. `ValidatedAdfDocument`
+([adf_validated.rs](../../src/atlassian/adf_validated.rs)) is a newtype
+whose only fallible constructor runs `validate_document` from
+[adf_schema](../../src/atlassian/adf_schema/). Every send-path function
+in `atlassian::client` and `atlassian::confluence_api` accepts
+`&ValidatedAdfDocument`, never `&AdfDocument` — see
+[ADR-0025](adr-0025.md) for the wiring rationale. The compiler refuses
+to call a send function with an unvalidated document. "I forgot to
+validate" is a compile error, not a 500 from Confluence.
+
+The converter does not validate on output. Validation is a separate
+concern carried out by the caller before the document leaves omni-dev.
+This separation is deliberate:
+
+- Multiple callers may want to inspect or transform an `AdfDocument`
+  before it is sent (e.g., redact PII, attach metadata). Forcing
+  validation in the converter would force premature commitment.
+- Auto-fixup decisions (flatten? rewrap? error?) are per-context and
+  belong in the caller, not in a shared utility. See
+  [ADR-0023](adr-0023.md)'s "soft launch" rationale for the same logic
+  applied at the schema layer.
+
+### Schema knowledge lives in `adf_schema/`, refreshed by codegen
+
+[src/atlassian/adf_schema/](../../src/atlassian/adf_schema/) contains:
+
+- `mod.rs` — public `validate_document(&AdfDocument) -> Vec<AdfSchemaViolation>`.
+- `generated.rs` — the upstream content model as a static `ENTRIES`
+  table, written exclusively by the codegen binary.
+- `drift.rs` — drift detection against the pinned upstream version.
+
+The single writer of `generated.rs` is
+[src/bin/adf_schema_codegen.rs](../../src/bin/adf_schema_codegen.rs).
+The refresh workflow when Atlassian ships a new content-model version
+is:
+
+1. Bump the pinned `@atlaskit/adf-schema` version constants in the
+   codegen binary.
+2. Run `cargo run --bin adf_schema_codegen` to regenerate
+   `generated.rs`.
+3. Review the diff line-by-line against the upstream `nodes/*.ts`
+   definitions cited by the per-entry comments — see
+   [ADR-0023](adr-0023.md) for the auditability rationale, and
+   [ADR-0026](adr-0026.md) for the quantifier / mark / attribute
+   extensions the validator now understands.
+4. A separate `adf_schema_drift` binary
+   ([src/bin/adf_schema_drift.rs](../../src/bin/adf_schema_drift.rs))
+   compares the snapshot against an upstream tarball and surfaces
+   newly-added node types so they cannot silently slip past the
+   refresh.
+
+The converter consumes the schema only through `validate_document`. It
+does not reach into `ENTRIES` or `generated.rs` directly. This keeps the
+codegen as a self-contained pipeline whose only public surface is the
+validator API.
+
+### Round-trip guarantees
+
+ADR-0020 commits to a *lossless* round trip for the JFM grammar: a JFM
+source parsed to ADF and rendered back to JFM yields the same Markdown
+modulo cosmetic whitespace. The converter upholds this commitment for
+Tier-1 constructs (paragraphs, headings, ordered/bullet lists, code
+blocks, inline marks — bold, italic, code, strikethrough, links —
+images, tables, blockquotes, task lists, horizontal rules). Round-trip
+tests live alongside the converter in `convert.rs` under `#[cfg(test)]
+mod` and currently cover ~25 distinct constructs:
+`round_trip_simple_document`, `round_trip_code_block_with_language`,
+`round_trip_table`, `round_trip_blockquote`, `round_trip_ordered_list`,
+`round_trip_task_list`, `round_trip_nested_tasklist_preserves_type`,
+`round_trip_emoji`, and so on (see `grep '^\s*fn round_trip'
+src/atlassian/convert.rs` for the full set).
+
+The non-guarantees are equally explicit:
+
+- **Unknown ADF nodes** — node types not in the snapshot are preserved
+  via the `adf-unsupported` fenced block ([ADR-0020](adr-0020.md)'s
+  forward-compatibility mechanism). They survive a round trip but do
+  not gain any Markdown-native syntax. [ADR-0023](adr-0023.md)'s
+  permissive-on-unknown-parents rule complements this at the validator
+  level.
+- **Lossy directives** — JFM constructs that ADF cannot express
+  faithfully (or vice versa) follow ADR-0020's compatibility matrix.
+  This ADR does not re-litigate that matrix.
+
+### Adding a new ADF node type
+
+When Atlassian ships a node type that omni-dev wants to support
+natively (rather than as `adf-unsupported`), the contributor:
+
+1. Refreshes `generated.rs` via the codegen workflow above, so the
+   validator knows the new node's allowed children, attributes, marks,
+   and arity.
+2. Adds directive parsing in `convert.rs::MarkdownParser` (using the
+   container/leaf/inline directive helpers in
+   [src/atlassian/directive.rs](../../src/atlassian/directive.rs)).
+3. Adds reverse rendering in `convert.rs::adf_to_markdown`.
+4. Adds at least one round-trip test in `convert.rs` (`fn
+   round_trip_<node>`).
+5. Updates [docs/specs/jfm.md](../../docs/specs/jfm.md) so the
+   user-visible syntax is in the format reference.
+
+The order is deliberate: refresh the schema first, because the
+validator must accept the new node before any converter test exercising
+it can pass under `ValidatedAdfDocument::try_new`.
+
+### Out of scope
+
+- Authoring tools that operate at the ADF level (e.g., manual JSON
+  editors) — JFM is the supported author-facing format.
+- Validation in the converter itself — see the section above on
+  separation of concerns.
+- Round-trip guarantees beyond Tier-1 — extending the guaranteed set is
+  a per-node decision made when the node graduates from
+  `adf-unsupported`.
+
+## Consequences
+
+**Positive:**
+
+- Authors and AIs produce Markdown, not JSON. The format is
+  diff-friendly, prompt-friendly, and humanly reviewable.
+- Validation cannot be forgotten because the type system rejects
+  unvalidated documents at every send site. The class of "I shipped
+  malformed ADF and got an opaque 500" bugs is closed.
+- Schema knowledge has one writer (the codegen binary), one snapshot
+  (`generated.rs`), and one validator API. Refresh is mechanical and
+  reviewable.
+- New ADF node types have a five-step adoption path; the boundary
+  between "format gap" and "converter gap" is explicit.
+
+**Negative:**
+
+- The schema snapshot can drift between releases of
+  `@atlaskit/adf-schema`; refresh is human-triggered. The drift binary
+  mitigates this but does not eliminate it.
+- The converter is not yet validator-clean: two existing tests
+  document that it emits structurally invalid ADF for `expand` /
+  `nestedExpand` nesting. Closing that gap is tracked by the follow-up
+  to [ADR-0023](adr-0023.md), not this ADR.
+- Round-trip tests cover Tier-1 constructs but not every directive
+  combination. Edge-case losses can slip through code review.
+
+**Neutral:**
+
+- Round-trip tests live alongside the converter rather than in a
+  dedicated test crate. This trades on-disk separation for jump-to-test
+  locality from the function under test.
+- The codegen pipeline has its own binary rather than a `build.rs` step.
+  This trades reproducible-build orthodoxy for explicit, reviewable
+  refresh diffs.

--- a/docs/adrs/adr-0030.md
+++ b/docs/adrs/adr-0030.md
@@ -1,0 +1,186 @@
+# ADR-0030: CLI Snapshot Golden Testing for the Help Surface
+
+## Status
+
+✅ Accepted (2026-05-12)
+
+## Context
+
+omni-dev exposes a hierarchical command-line interface built with Clap
+derive macros ([ADR-0016](adr-0016.md)). The CLI surface — every
+subcommand name, every flag, every short alias, every help-text line —
+is part of the project's public contract: scripts pin against flag
+names, documentation cites them, and users build muscle memory around
+them. Silent regressions on that surface are easy to ship:
+
+- A `#[arg(hide = true)]` flipped during a refactor demotes a flag out
+  of the help output without any code change a reviewer would notice.
+- A subcommand renamed in one place but not in its parent's `Subcommand`
+  enum produces a help tree where the flag exists but is no longer
+  reachable through documented invocations.
+- A flag's help-string lifted into a `const` for reuse drifts when the
+  flag's semantics change but the string does not.
+- A new subcommand added under the wrong parent compiles cleanly,
+  passes unit tests, and only fails when a user types `--help`.
+
+Conventional unit tests do not catch any of these. Hand-asserted
+expected-output strings catch some but require the test author to know
+in advance which lines to assert, which is exactly the failure mode at
+the heart of the problem.
+
+Two complementary commitments shape the response:
+
+- **Coverage proportional to the surface area.** With ~200 visible
+  flags and a multi-level subcommand tree, manual assertions decay into
+  stale partial coverage faster than the surface evolves.
+- **Forced review of intentional changes.** Most CLI surface changes
+  are intentional. The mechanism should not block them — but it must
+  not let them merge without an explicit, reviewer-visible diff of what
+  the surface now looks like.
+
+The project's `help-all` subcommand
+([docs/plan/help-all-command.md](../../docs/plan/help-all-command.md))
+renders the entire Clap command tree in one pass, including hidden
+subcommands and every flag's full description. This already exists, is
+already kept up to date, and produces deterministic output suitable for
+a string-equality assertion.
+
+## Decision
+
+### A single whole-tree golden snapshot
+
+[tests/integration_test.rs](../../tests/integration_test.rs) contains
+the test `help_all_golden`:
+
+```rust
+#[test]
+fn help_all_golden() -> Result<()> {
+    use omni_dev::cli::help::HelpGenerator;
+    let generator = HelpGenerator::new();
+    let help_output = generator.generate_all_help()?;
+    insta::assert_snapshot!("help_all_output", help_output);
+    Ok(())
+}
+```
+
+The asserted snapshot is
+[tests/snapshots/integration_test__help_all_output.snap](../../tests/snapshots/integration_test__help_all_output.snap).
+It is the canonical regression surface for the CLI shape and is
+authoritative: any change to clap derives, flag attributes, subcommand
+docstrings, or help-string constants must be reflected here before the
+change can merge.
+
+The assertion uses the [`insta`](https://insta.rs) crate's
+`assert_snapshot!` macro. Choice rationale: `insta` ships a reviewer
+workflow (`cargo insta accept`, `--review`), separates expected output
+from test source for clean diffs, and is already a project dependency.
+
+### What is asserted vs not asserted
+
+**Asserted by `help_all_output.snap`:**
+
+- Every subcommand name and its position in the tree.
+- Every flag's long name, short alias, value-name, and full help text.
+- Top-level program description and usage line.
+- The tree structure that Clap renders — including hidden / advanced
+  subcommands surfaced by `help-all` specifically (these are *not*
+  visible from a bare `--help`).
+
+**Deliberately not asserted:**
+
+- Runtime behaviour of any command — the snapshot is a static
+  description of the surface, not a behavioural test.
+- Output formatting of business-logic commands (e.g. YAML structure for
+  `git view-commits`) — those have their own per-command tests.
+- Version strings (the binary version changes per release; asserting it
+  would make every release fail this test).
+- Environment-specific paths (the `help-all` generator is invoked in
+  the test process itself, not via `Command::new`, precisely so that
+  the captured output cannot contain shell or path differences).
+
+### Intentional-change workflow
+
+When a CLI change intentionally alters the help surface — adding a
+flag, renaming a subcommand, rewording help text — the contributor
+follows the workflow encoded in the
+[`update-snapshots`](../../.claude/skills/update-snapshots/SKILL.md)
+skill:
+
+1. Make the source change.
+2. Run `cargo test` (or `cargo insta test --test integration_test
+   --review`). The test fails with a diff between the existing
+   `.snap` and the actual output. `insta` writes the new output to a
+   `.snap.new` sibling file.
+3. Inspect the diff: `diff -u
+   tests/snapshots/integration_test__help_all_output.snap{,.new}`.
+4. *Only if* the diff matches the intended change, accept it: `cargo
+   insta accept --test integration_test`. Stage the updated `.snap`
+   alongside the source change in the same commit.
+5. If the diff contains anything the contributor did not intend — an
+   orphaned subcommand, an unexpected flag default, drift from a
+   shared help-string constant — investigate the source change rather
+   than accepting the snapshot.
+
+CLAUDE.md (project AI assistant guide) reinforces step 5 by instructing
+AI contributors not to blindly `cargo insta accept` after a CLI change.
+
+### Why a snapshot rather than hand-asserted strings
+
+Hand-asserted strings require the test author to enumerate exactly the
+lines that matter. On a surface this size, that enumeration is wrong
+within a release cycle. A whole-tree golden makes additions and
+removals equally visible: a new flag adds a line, a removed flag
+deletes one, and reviewers see both classes of change in the same
+form. The `cargo insta accept` step is a forced review gate — there is
+no path to a green build that does not include either the original
+snapshot or an explicit acceptance of the new one.
+
+### Out of scope
+
+- Snapshotting behavioural output of business commands. That is the
+  job of per-command tests; this snapshot is exclusively about the
+  help surface.
+- Snapshotting the surface from `--help` rather than `help-all`. The
+  `help-all` output is a strict superset; asserting on `--help` would
+  miss hidden / advanced subcommands.
+- Snapshotting any output that depends on the host environment
+  (cwd-derived paths, version strings, locale-dependent formatting).
+
+## Consequences
+
+**Positive:**
+
+- Silent CLI regressions are no longer possible: every change to the
+  surface forces a snapshot diff that must be reviewed in the PR.
+- The snapshot doubles as up-to-date CLI documentation. A new
+  contributor can read
+  `tests/snapshots/integration_test__help_all_output.snap` and see the
+  entire user-visible surface in one place.
+- The reviewer signal is in the diff, not in test descriptions. A PR
+  that touches `src/cli/**` and does *not* touch the `.snap` is a red
+  flag the reviewer can see at a glance.
+
+**Negative:**
+
+- Every intentional CLI change carries a snapshot churn cost — the
+  `.snap` is updated in lockstep, and PRs touching widely-shared help
+  strings (e.g., a constant referenced by ten flags) produce diffs
+  proportionate to the reach of the change.
+- Reviewers must read the `.snap` diff, not just the source diff, to
+  verify the user-visible effect of a change. This is a feature, not
+  a bug, but it adds review overhead.
+- A noisy whole-tree snapshot can mask subtle changes when the diff is
+  large (e.g., a global help-string rename). Reviewers must read the
+  full diff rather than glancing at it.
+
+**Neutral:**
+
+- The snapshot is a checked-in file, so its evolution is visible in
+  `git log` against the snapshot path. This is the standard `insta`
+  workflow.
+- The `update-snapshots` skill automates the mechanical part of the
+  workflow; the human review step is non-negotiable.
+- This ADR governs only the `help-all` snapshot at
+  `tests/snapshots/integration_test__help_all_output.snap`. Other
+  `insta` snapshots that future work may add are unaffected by this
+  decision — they each have their own scope and review surface.


### PR DESCRIPTION
## Description

This PR adds three missing Architecture Decision Records (ADRs) that document key design decisions already implemented in the codebase but not yet formally recorded. The branch resolves the gap between live code and its architectural rationale.

- **ADR-0028**: Documents the sandboxed `claude-cli` subprocess AI backend — threat model, sandbox flag choices (`--tools ""`, `--strict-mcp-config`, `--setting-sources ""`, `--disable-slash-commands`, `--no-session-persistence`), the two escape hatches (`--claude-cli-allow-tools`, `--claude-cli-allow-mcp`), budget-cap enforcement via `--claude-cli-max-budget-usd`, and process-group isolation to prevent orphaned Node subprocesses (issues #633, #683).
- **ADR-0029**: Documents the JFM ↔ ADF converter strategy — the single public conversion surface in `src/atlassian/convert.rs`, the type-system enforcement of validation via `ValidatedAdfDocument`, the codegen pipeline for `adf_schema/generated.rs`, round-trip guarantees for Tier-1 constructs, and the five-step workflow for adding new ADF node types.
- **ADR-0030**: Documents CLI snapshot golden testing for the help surface — the `help_all_golden` integration test using `insta::assert_snapshot!`, what is and is not asserted, the intentional-change workflow (`cargo insta accept`), and the rationale for whole-tree golden snapshots over hand-asserted strings.

Additionally, `CLAUDE.md` is updated to cross-reference ADR-0028 for the architectural rationale behind the `claude-cli` backend sandbox design.

## Type of Change

- [x] Documentation update

## Related Issue

Relates to #770 (missing ADRs)

## Changes Made

**New ADR Documents:**
- Added `docs/adrs/adr-0028.md` — Sandboxed `claude-cli` Subprocess AI Backend (212 lines)
- Added `docs/adrs/adr-0029.md` — JFM ↔ ADF Converter Strategy (221 lines)
- Added `docs/adrs/adr-0030.md` — CLI Snapshot Golden Testing for the Help Surface (186 lines)

**ADR Index Updates:**
- Updated `docs/adrs/README.md` to register ADR-0028, ADR-0029, and ADR-0030 in the ADR table with their accepted dates and titles

**Cross-Reference Updates:**
- Updated `CLAUDE.md` to add a paragraph linking the `claude-cli` backend section to ADR-0028 for architectural rationale (threat model, sandbox flag choices, escape-hatch design, budget-cap enforcement)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests required (documentation-only changes)

**Manual Testing:**
- [x] Verified all new ADR files render correctly as Markdown
- [x] Verified all internal cross-references (e.g., links to `adr-0023.md`, `adr-0025.md`, source file paths) resolve correctly
- [x] Confirmed ADR index table in `README.md` is consistent across all three commits

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — reviewers should read the full ADR bodies to confirm the recorded decisions accurately reflect the implemented behaviour

**Specific areas for review:**
- ADR-0028: Confirm the sandbox flag table and escape-hatch semantics match the current implementation in `src/claude/ai/claude_cli.rs`
- ADR-0029: Confirm the round-trip guarantee scope (Tier-1 constructs) and the known gap (two failing `expand`/`nestedExpand` integration tests) are accurately described
- ADR-0030: Confirm the snapshot file path (`tests/snapshots/integration_test__help_all_output.snap`) and the `insta` workflow steps are accurate

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. These are documentation-only additions.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Context:**
These ADRs document decisions that were already made and implemented; this PR is purely a record-keeping exercise to ensure the architectural history is complete and discoverable. Each ADR is marked `✅ Accepted` as of 2026-05-12.

**Future Enhancements:**
- The gap noted in ADR-0029 (converter emitting structurally invalid ADF for `expand`/`nestedExpand` nesting) is tracked as a follow-up to ADR-0023 and is not addressed here.