### PR TITLE
feat(voice): implement `omni-dev voice capture` microphone-to-WAV pipeline (#800)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         toolchain: ${{ matrix.rust }}
         components: rustfmt
     - uses: Swatinem/rust-cache@v2
+    - name: Install ALSA headers for cpal
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Run tests
       run: |
         if [ -z "${{ matrix.features }}" ]; then
@@ -45,6 +47,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+    - name: Install ALSA headers for cpal
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Build omni-dev-mcp (release)
       run: cargo build --release --features mcp --bin omni-dev-mcp
 
@@ -73,6 +77,8 @@ jobs:
       with:
         components: clippy
     - uses: Swatinem/rust-cache@v2
+    - name: Install ALSA headers for cpal
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Run clippy
       run: |
         if [ -z "${{ matrix.features }}" ]; then
@@ -88,6 +94,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+    - name: Install ALSA headers for cpal
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Build docs
       run: cargo doc --no-deps --document-private-items
 
@@ -100,6 +108,8 @@ jobs:
       with:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
+    - name: Install ALSA headers for cpal
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +197,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -375,6 +403,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,12 +461,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -461,6 +535,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "deadpool"
@@ -532,6 +612,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -854,7 +944,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -946,6 +1036,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
@@ -1077,7 +1173,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1335,7 +1431,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -1405,6 +1501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,12 +1563,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1476,6 +1610,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1498,6 +1661,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "omni-dev"
 version = "0.26.0"
 dependencies = [
@@ -1506,24 +1763,29 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "cpal",
  "crossterm",
  "dirs",
  "flate2",
  "futures",
  "git2",
  "globset",
+ "hound",
  "insta",
  "mime_guess",
  "nix",
  "proptest",
  "regex",
  "reqwest",
+ "ringbuf",
  "rmcp",
+ "rubato",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
+ "signal-hook",
  "similar 3.1.0",
  "ssh2-config",
  "tar",
@@ -1635,6 +1897,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1940,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,7 +1974,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1806,12 +2101,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1933,6 +2237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
 name = "rmcp"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2284,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,12 +2311,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2151,7 +2492,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2348,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e5a3352c5c624ed815d37c1c4c760aeaa119352091ca93ca5566f4ad48562c"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "dirs",
  "git2",
  "glob",
@@ -2362,6 +2703,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -2412,7 +2759,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2597,6 +2944,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,7 +2994,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2700,6 +3077,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -2950,7 +3337,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3023,6 +3410,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,7 +3438,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -3070,8 +3477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3315,6 +3731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,7 +3820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ mime_guess = "2"
 flate2 = "1"
 tar = "0.4"
 sha2 = "0.11"
+cpal = "0.16"
+rubato = "0.16"
+hound = "3.5"
+signal-hook = "0.3"
+ringbuf = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -54,3 +54,4 @@ by Michael Nygard.
 | [ADR-0028](adr-0028.md)  | ✅ Accepted                              | 2026-05-12 | Sandboxed `claude-cli` Subprocess AI Backend                                           |
 | [ADR-0029](adr-0029.md)  | ✅ Accepted                              | 2026-05-12 | JFM ↔ ADF Converter Strategy                                                           |
 | [ADR-0030](adr-0030.md)  | ✅ Accepted                              | 2026-05-12 | CLI Snapshot Golden Testing for the Help Surface                                       |
+| [ADR-0031](adr-0031.md)  | ✅ Accepted                              | 2026-05-13 | AudioSource Trait Boundary for Real-Time Audio Capture Testability                     |

--- a/docs/adrs/adr-0031.md
+++ b/docs/adrs/adr-0031.md
@@ -1,0 +1,170 @@
+# ADR-0031: AudioSource Trait Boundary for Real-Time Audio Capture Testability
+
+## Status
+
+✅ Accepted (2026-05-13)
+
+## Context
+
+Issue #800 added the first audio-capture surface to omni-dev:
+`omni-dev voice capture`, a `cpal`-backed microphone-to-WAV pipeline. The
+pipeline is short — mono mixdown, `rubato` resampling to 16 kHz, RMS-based
+idle detection, trailing-silence trim, `hound` WAV writer — but the
+backbone is a real-time audio path: cpal delivers samples via a callback
+running on the OS audio thread, and the consumer side has to drain and
+process those samples without dropping any.
+
+That backbone is hostile to CI testing:
+
+- **No audio device.** CI runners have no microphone and no audio host
+  context. `cpal::Host::default_input_device()` returns `None` (or
+  panics on some hosts), so any test that touches the cpal types is
+  unrunnable in CI.
+- **No determinism.** Even on developer machines, cpal samples arrive at
+  the device's own cadence with content the test cannot predict.
+  Assertions on timing or content are inherently flaky.
+- **No mockability.** cpal's types (`Host`, `Device`, `Stream`,
+  `StreamConfig`) are concrete structs without trait abstractions a test
+  can substitute. A mock cpal layer would be a substantial parallel
+  implementation, and would couple test correctness to cpal version
+  bumps.
+- **Platform-specific Send semantics.** cpal's `Stream` is not `Send` on
+  macOS (it wraps a CoreAudio `AudioUnit` containing raw pointers).
+  Any abstraction over cpal has to account for that without forcing
+  awkward platform-conditional bounds onto all sources.
+
+The capture pipeline behind the audio path is *not* hostile to testing
+— resampling, idle detection, trimming, and WAV writing are pure
+data-in / data-out functions over `f32` samples. The only obstacle is
+that the production source (`cpal`) cannot drive them in tests.
+
+This is the first issue in the umbrella #799 build order. Several
+follow-up issues (`voice listen`, file-input capture, hotkey-driven
+capture, multi-device capture) will land additional sources behind the
+same pipeline. The seam that separates "untestable hardware I/O" from
+"testable pipeline" needs a stable, written contract now, before the
+pattern is copy-pasted four more times.
+
+Two rejected alternatives:
+
+- **Mock cpal directly.** Introduce a trait that mirrors cpal's `Host`,
+  `Device`, and `Stream`, and write a no-op implementation for tests.
+  This couples test code to cpal's API shape (which changes), forces
+  every future source to fake the cpal call sequence, and tests only
+  the cpal interaction — not the pipeline behaviour the issue actually
+  cares about.
+- **Test at the CLI level only.** Drive `omni-dev voice capture --output
+  /tmp/out.wav` against a fixture audio device under `cargo test`.
+  Requires a fixture audio device (none exists in CI), asserts only on
+  observable WAV file output (no insight into intermediate stages like
+  resampler chunk boundaries or idle detector window classification),
+  and forces every regression into a full end-to-end reproduction.
+
+## Decision
+
+We will define an `AudioSource` trait at the boundary between hardware
+capture and the rest of the capture pipeline. The trait carries
+exactly enough surface to drive the pipeline: a chunk-yielding
+`next_chunk` that returns interleaved f32 frames, plus `sample_rate`
+and `channels` accessors.
+
+```rust
+pub trait AudioSource {
+    fn next_chunk(&mut self) -> Option<Vec<f32>>;
+    fn sample_rate(&self) -> u32;
+    fn channels(&self) -> u16;
+}
+```
+
+Two implementations live behind the trait:
+
+- **`CpalAudioSource`** — the production source. Opens the default
+  input device (or a `--device`-named match), starts a cpal input
+  stream, and pushes f32-coerced samples through a lock-free SPSC ring
+  buffer to the consumer side. Carries a single `#[ignore]`-gated
+  smoke test that requires real hardware, runnable locally via
+  `cargo test -- --ignored`.
+- **`FileAudioSource`** — the test source. Reads a fixture WAV (or an
+  in-memory `Vec<f32>`) via `hound` and replays it in
+  caller-specified chunk sizes. Decodes integer PCM at any bit depth
+  into f32 `[-1.0, 1.0]`, so a single fixture can stand in for any
+  capture-side input rate the pipeline needs to exercise.
+
+The pipeline orchestrator `run_capture<S: AudioSource>(source: S, …)`
+is generic over the trait. Every stage downstream of the source —
+mixdown, resampler, idle detector, trimmer, WAV writer — is tested
+via `FileAudioSource` with synthesised or fixture inputs. The
+`CpalAudioSource` carries only the cpal-specific concerns: device
+enumeration, sample-format coercion, ring-buffer sizing, stream-error
+surface. Those concerns are deliberately kept small and
+non-conditional on the pipeline stages.
+
+The trait is intentionally not `Send`. cpal's macOS `Stream` is
+`!Send`, and the capture pipeline runs synchronously on its owning
+thread — the cpal callback is the only thing that crosses a thread
+boundary, and it does so internally to cpal via the SPSC ring
+buffer. Adding `Send` would force `CpalAudioSource` into an awkward
+indirection (a dedicated owner thread or an `unsafe impl Send`
+wrapper) to satisfy a bound the pipeline doesn't actually need.
+
+The same trait applies to every future source landing in the #799
+umbrella: `FileInputAudioSource` (transcribe an existing recording),
+`HotkeyAudioSource` (capture controlled by a global hotkey),
+`SystemAudioSource` (system-audio capture rather than mic), and so on.
+Each new source provides its own `next_chunk` implementation;
+nothing else in the pipeline changes.
+
+## Consequences
+
+**Positive:**
+
+- The capture pipeline is fully exercised in CI through
+  `FileAudioSource`-driven integration tests. Resampler chunk
+  boundaries, idle detector window classification, trailing-silence
+  trim correctness, and WAV writer round-tripping all have unit
+  tests that run on every push.
+- New audio-source implementations (`voice listen`, hotkey capture,
+  file capture) plug into the existing pipeline without re-deriving
+  the test harness. The pattern is documented here once, applied N
+  times.
+- The cpal-specific code is narrowly scoped to `CpalAudioSource` and
+  is the only thing changing when cpal version bumps land.
+- The error-on-no-audio guard in the orchestrator (which catches
+  muted-mic surprises by checking `IdleDetector::has_any_voice`)
+  was validated against synthesised silence-only fixtures during
+  development, not by waiting to ship and watching a user hit it in
+  the wild.
+
+**Negative:**
+
+- The `f32 Vec<f32>` chunk return type per call allocates on every
+  pull. For the v1 sync orchestrator this is well below the
+  throughput ceiling (each call is hundreds of microseconds at most),
+  but if `voice listen` ever needs a tighter loop the trait will
+  grow a `next_chunk_into(&mut Vec<f32>)` variant. The current
+  shape is a deliberate v1 simplification.
+- `CpalAudioSource` has a thin smoke test only. Regressions in the
+  cpal interaction (wrong sample format, ring-buffer overrun, missed
+  device name) surface only when run locally with `--ignored`. We
+  accept this — CI cannot fix it, and a smoke test plus careful
+  error-message ergonomics (listing detected devices when a name
+  doesn't match) catches the common failure modes.
+- The trait is not `Send`. If a future issue needs to move a source
+  across threads, the bound will have to be widened conditionally
+  (e.g. `pub trait AudioSource: MaybeSend` with a cfg-gated alias),
+  or per-source rather than at the trait level. We will pay that
+  cost when a concrete use case arises.
+
+**Neutral:**
+
+- `FileAudioSource` is `pub` and lives alongside `CpalAudioSource` in
+  `src/voice/audio.rs` rather than under `#[cfg(test)]`. This is
+  deliberate: downstream issues will want to use it for non-test
+  scenarios too (e.g., a "transcribe an existing WAV" command), and
+  keeping it in production code avoids a later `pub(crate)`-to-`pub`
+  break.
+- Test fixtures are generated programmatically in each test rather
+  than committed to disk. Synthetic sine waves and silence are
+  trivial to produce in-process, and the byte-stability argument for
+  committed fixtures applies to *goldens*, not to *inputs* whose
+  exact bit pattern doesn't matter.

--- a/docs/adrs/adr-0031.md
+++ b/docs/adrs/adr-0031.md
@@ -168,3 +168,34 @@ nothing else in the pipeline changes.
   trivial to produce in-process, and the byte-stability argument for
   committed fixtures applies to *goldens*, not to *inputs* whose
   exact bit pattern doesn't matter.
+
+## Coverage expectations
+
+The seam this ADR establishes has a direct, quantifiable consequence
+for line coverage: roughly 100–120 lines of hardware-bound code in
+`CpalAudioSource` (`new`, the f32/i16/u16 callback closures, the
+`take_stream_error` polling loop, `find_input_device`'s happy path)
+and the CLI `execute()` methods that construct it cannot run in CI.
+The `#[ignore]`-gated `cpal_default_input_produces_samples` smoke
+test does exercise this code locally, but coverage tools record it
+as uncovered by default.
+
+The following gaps are **by design** per this ADR and should not be
+chased with additional tests:
+
+| Surface | Why uncovered |
+|---|---|
+| `CpalAudioSource::new` (stream construction, callback closures) | Needs a working cpal input device. |
+| `CpalAudioSource::next_chunk` (polling loop, stream-error path) | Needs in-flight samples from the cpal callback. |
+| `find_input_device` happy path | Needs at least one detected device that matches a known name; the unknown-device error path *is* covered. |
+| `CaptureCommand::execute` (in `src/cli/voice/capture.rs`) | Constructs `CpalAudioSource`; same hardware constraint. |
+| `VoiceCommand::execute` dispatch | Same — its only branch delegates to `CaptureCommand::execute`. |
+| `Commands::Voice` dispatch in `src/cli.rs` | Same — its only branch delegates to `VoiceCommand::execute`. |
+| `install_ctrl_c_handler` registration failure | `signal-hook` registration can fail only under conditions a test cannot reliably synthesise (signal table corruption). |
+| `default_output_path` `dirs::home_dir() == None` branch | Would require unsetting `HOME` globally; racy under parallel tests. |
+
+All *other* code paths in `src/voice/**` and `src/cli/voice/**` should
+have unit tests driven by `FileAudioSource` or by direct calls to the
+helper functions. When a coverage gap appears in those files that
+isn't on the list above, the right response is to add a test, not to
+extend this exception list.

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
           openssl
           zlib
           libgit2
+        ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+          alsa-lib
         ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
           libiconv
         ];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub mod git;
 pub mod help;
 pub mod resources;
 pub mod transcript;
+pub mod voice;
 
 /// CLI-side selector for the AI backend dispatched by
 /// [`create_default_claude_client`][crate::claude::client::create_default_claude_client].
@@ -119,6 +120,8 @@ pub enum Commands {
     Datadog(datadog::DatadogCommand),
     /// Transcript and caption fetching from media platforms.
     Transcript(transcript::TranscriptCommand),
+    /// Voice capture and processing operations.
+    Voice(voice::VoiceCommand),
     /// Embedded reference resources (specs, etc.).
     Resources(resources::ResourcesCommand),
     /// Displays comprehensive help for all commands.
@@ -167,6 +170,7 @@ impl Cli {
             Commands::Atlassian(cmd) => cmd.execute().await,
             Commands::Datadog(cmd) => cmd.execute().await,
             Commands::Transcript(cmd) => cmd.execute().await,
+            Commands::Voice(cmd) => cmd.execute(),
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::Resources(resources_cmd) => resources_cmd.execute(),
             Commands::HelpAll(help_cmd) => help_cmd.execute(),

--- a/src/cli/voice.rs
+++ b/src/cli/voice.rs
@@ -1,0 +1,52 @@
+//! Voice-related CLI commands.
+//!
+//! Provider-namespaced (only `capture` today; later: `listen`, `transcribe`).
+//! Per-subcommand argument structs live in submodules to keep help text
+//! and parse logic local to each command.
+
+pub mod capture;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Voice capture and processing operations.
+#[derive(Parser)]
+pub struct VoiceCommand {
+    /// The voice subcommand to execute.
+    #[command(subcommand)]
+    pub command: VoiceSubcommands,
+}
+
+/// Voice subcommands.
+#[derive(Subcommand)]
+pub enum VoiceSubcommands {
+    /// Captures audio from a microphone to a 16 kHz mono WAV file.
+    Capture(capture::CaptureCommand),
+}
+
+impl VoiceCommand {
+    /// Dispatches to the selected voice subcommand.
+    pub fn execute(self) -> Result<()> {
+        match self.command {
+            VoiceSubcommands::Capture(cmd) => cmd.execute(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn voice_subcommands_capture_variant() {
+        let cmd = VoiceCommand {
+            command: VoiceSubcommands::Capture(capture::CaptureCommand {
+                idle_after: 5,
+                output: None,
+                device: None,
+            }),
+        };
+        assert!(matches!(cmd.command, VoiceSubcommands::Capture(_)));
+    }
+}

--- a/src/cli/voice/capture.rs
+++ b/src/cli/voice/capture.rs
@@ -74,18 +74,22 @@ fn default_output_path() -> Result<PathBuf> {
 }
 
 fn print_summary(summary: &CaptureSummary) {
+    eprintln!("{}", format_summary(summary));
+}
+
+fn format_summary(summary: &CaptureSummary) -> String {
     let reason = match summary.terminated_by {
         TerminationReason::Idle => "silence threshold reached",
         TerminationReason::SourceExhausted => "audio source ended",
         TerminationReason::Signal => "Ctrl-C",
     };
     let seconds = samples_to_seconds(summary.samples_written);
-    eprintln!(
+    format!(
         "Captured {seconds:.2}s ({} samples; {} trimmed; stopped: {reason}) → {}",
         summary.samples_written,
         summary.trimmed_samples,
         summary.output.display()
-    );
+    )
 }
 
 fn samples_to_seconds(samples: u64) -> f64 {
@@ -156,5 +160,61 @@ mod tests {
         assert!(s.contains("voice"));
         assert!(s.contains("captures"));
         assert!(s.ends_with(".wav"));
+    }
+
+    fn summary(reason: TerminationReason, written: u64, trimmed: u64) -> CaptureSummary {
+        CaptureSummary {
+            output: PathBuf::from("/tmp/out.wav"),
+            samples_written: written,
+            trimmed_samples: trimmed,
+            terminated_by: reason,
+        }
+    }
+
+    #[test]
+    fn format_summary_idle_termination_mentions_silence() {
+        let s = format_summary(&summary(TerminationReason::Idle, 16_000, 3_200));
+        assert!(s.contains("silence threshold reached"));
+        assert!(
+            s.contains("1.00s"),
+            "16000 samples @ 16kHz = 1.00s; got: {s}"
+        );
+        assert!(s.contains("16000 samples"));
+        assert!(s.contains("3200 trimmed"));
+        assert!(s.contains("/tmp/out.wav"));
+    }
+
+    #[test]
+    fn format_summary_signal_termination_mentions_ctrl_c() {
+        let s = format_summary(&summary(TerminationReason::Signal, 48_000, 0));
+        assert!(s.contains("Ctrl-C"));
+        assert!(
+            s.contains("3.00s"),
+            "48000 samples @ 16kHz = 3.00s; got: {s}"
+        );
+        assert!(s.contains("0 trimmed"));
+    }
+
+    #[test]
+    fn format_summary_source_exhausted_mentions_source() {
+        let s = format_summary(&summary(TerminationReason::SourceExhausted, 8_000, 0));
+        assert!(s.contains("audio source ended"));
+        assert!(s.contains("0.50s"));
+    }
+
+    #[test]
+    fn samples_to_seconds_zero_samples() {
+        assert!((samples_to_seconds(0) - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn samples_to_seconds_exact_one_second() {
+        assert!((samples_to_seconds(16_000) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn samples_to_seconds_fractional() {
+        // 8000 samples @ 16kHz = 0.5s
+        assert!((samples_to_seconds(8_000) - 0.5).abs() < f64::EPSILON);
     }
 }

--- a/src/cli/voice/capture.rs
+++ b/src/cli/voice/capture.rs
@@ -1,0 +1,160 @@
+//! `omni-dev voice capture` — record microphone audio to a 16 kHz mono WAV file.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use clap::Parser;
+
+use crate::voice::capture::{
+    install_ctrl_c_handler, run_capture, CaptureOpts, CaptureSummary, TerminationReason,
+};
+use crate::voice::CpalAudioSource;
+
+/// Default idle-after threshold in seconds. Matches the issue spec.
+pub const DEFAULT_IDLE_AFTER_SECS: u32 = 5;
+
+/// Captures audio from a microphone to a 16 kHz mono WAV file.
+///
+/// Auto-stops after `--idle-after` seconds of trailing silence (default 5 s)
+/// or when Ctrl-C is pressed. The output WAV is 16 kHz mono 16-bit signed
+/// PCM (whisper.cpp convention).
+#[derive(Parser)]
+pub struct CaptureCommand {
+    /// Stop after this many seconds of trailing silence. `0` disables
+    /// auto-stop — capture runs until Ctrl-C.
+    #[arg(long, default_value_t = DEFAULT_IDLE_AFTER_SECS)]
+    pub idle_after: u32,
+
+    /// Destination WAV path. Defaults to
+    /// `~/.omni-dev/voice/captures/<UTC-timestamp>.wav`.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// Audio input device name. Defaults to the system default input.
+    /// Matching is exact against the platform-reported device name; an
+    /// unknown name errors with a list of detected devices.
+    #[arg(long)]
+    pub device: Option<String>,
+}
+
+impl CaptureCommand {
+    /// Executes the capture command.
+    pub fn execute(self) -> Result<()> {
+        let output = match self.output {
+            Some(path) => path,
+            None => default_output_path()?,
+        };
+        let opts = CaptureOpts::new(output, self.idle_after);
+        let stop = install_ctrl_c_handler()?;
+        let source = CpalAudioSource::new(self.device.as_deref())?;
+
+        eprintln!(
+            "Recording to {} (idle-after: {}s, Ctrl-C to stop)…",
+            opts.output.display(),
+            opts.idle_after_secs
+        );
+        let summary = run_capture(source, opts, stop)?;
+        print_summary(&summary);
+        Ok(())
+    }
+}
+
+/// Resolves the default output path used when `--output` is not supplied:
+/// `~/.omni-dev/voice/captures/<YYYYMMDDTHHMMSSZ>.wav`.
+fn default_output_path() -> Result<PathBuf> {
+    let home = dirs::home_dir()
+        .context("Failed to resolve the user's home directory for default --output path")?;
+    let timestamp = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    Ok(home
+        .join(".omni-dev")
+        .join("voice")
+        .join("captures")
+        .join(format!("{timestamp}.wav")))
+}
+
+fn print_summary(summary: &CaptureSummary) {
+    let reason = match summary.terminated_by {
+        TerminationReason::Idle => "silence threshold reached",
+        TerminationReason::SourceExhausted => "audio source ended",
+        TerminationReason::Signal => "Ctrl-C",
+    };
+    let seconds = samples_to_seconds(summary.samples_written);
+    eprintln!(
+        "Captured {seconds:.2}s ({} samples; {} trimmed; stopped: {reason}) → {}",
+        summary.samples_written,
+        summary.trimmed_samples,
+        summary.output.display()
+    );
+}
+
+fn samples_to_seconds(samples: u64) -> f64 {
+    samples as f64 / f64::from(crate::voice::wav::TARGET_SAMPLE_RATE)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        capture: CaptureCommand,
+    }
+
+    #[test]
+    fn parses_defaults() {
+        let cli = TestCli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.capture.idle_after, DEFAULT_IDLE_AFTER_SECS);
+        assert!(cli.capture.output.is_none());
+        assert!(cli.capture.device.is_none());
+    }
+
+    #[test]
+    fn parses_all_flags() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "--idle-after",
+            "10",
+            "--output",
+            "/tmp/x.wav",
+            "--device",
+            "MacBook Pro Microphone",
+        ])
+        .unwrap();
+        assert_eq!(cli.capture.idle_after, 10);
+        assert_eq!(
+            cli.capture.output.as_deref().map(|p| p.to_str().unwrap()),
+            Some("/tmp/x.wav")
+        );
+        assert_eq!(
+            cli.capture.device.as_deref(),
+            Some("MacBook Pro Microphone")
+        );
+    }
+
+    #[test]
+    fn parses_idle_after_zero() {
+        let cli = TestCli::try_parse_from(["test", "--idle-after", "0"]).unwrap();
+        assert_eq!(cli.capture.idle_after, 0);
+    }
+
+    #[test]
+    fn rejects_negative_idle_after() {
+        let result = TestCli::try_parse_from(["test", "--idle-after", "-1"]);
+        assert!(result.is_err(), "negative idle-after should be rejected");
+    }
+
+    #[test]
+    fn default_output_path_uses_utc_timestamp() {
+        let path = default_output_path().unwrap();
+        let s = path.to_string_lossy();
+        assert!(s.contains(".omni-dev"));
+        assert!(s.contains("voice"));
+        assert!(s.contains("captures"));
+        assert!(s.ends_with(".wav"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod mcp;
 pub mod resources;
 pub mod transcript;
 pub mod utils;
+pub mod voice;
 
 #[cfg(test)]
 mod test_support;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -11,4 +11,5 @@
 
 pub mod audio;
 pub mod capture;
+pub mod idle;
 pub mod wav;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -13,3 +13,8 @@ pub mod audio;
 pub mod capture;
 pub mod idle;
 pub mod wav;
+
+pub use audio::{AudioSource, CpalAudioSource, FileAudioSource};
+pub use capture::{
+    install_ctrl_c_handler, run_capture, CaptureOpts, CaptureSummary, TerminationReason,
+};

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,0 +1,14 @@
+//! Voice capture: microphone-to-WAV pipeline.
+//!
+//! The library half of `omni-dev voice capture`. The CLI entry point lives in
+//! [`crate::cli::voice`]. This module is intentionally CLI-free so the audio
+//! pipeline (source → mixdown → resample → idle-detect → trim → write) can be
+//! unit-tested against fixture WAVs without a real microphone.
+//!
+//! The `AudioSource` trait in [`mod@audio`] is the test seam: production code
+//! uses [`audio::CpalAudioSource`], tests use [`audio::FileAudioSource`].
+//! See [ADR-0031](../../docs/adrs/adr-0031.md) for the rationale.
+
+pub mod audio;
+pub mod capture;
+pub mod wav;

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -1,4 +1,252 @@
 //! Audio source abstraction.
 //!
-//! Populated incrementally — the trait lands here in step 2; concrete sources
-//! follow in steps 2 ([`FileAudioSource`]) and 7 ([`CpalAudioSource`]).
+//! The [`AudioSource`] trait is the seam between hardware capture (real cpal
+//! callbacks) and the rest of the pipeline. Production code uses
+//! [`CpalAudioSource`] (step 7); tests drive the same pipeline through
+//! [`FileAudioSource`], which replays samples from a fixture WAV.
+//!
+//! See ADR-0031 for the rationale behind keeping this seam at the f32-frame
+//! level (rather than mocking cpal directly or asserting only at the CLI
+//! level).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Source of raw interleaved f32 audio samples at a fixed sample rate and
+/// channel count.
+///
+/// Each call to [`AudioSource::next_chunk`] returns a freshly-allocated
+/// `Vec<f32>` of interleaved frames (i.e. for stereo, samples alternate
+/// L/R/L/R/…). `None` signals end-of-stream — the source is exhausted
+/// (file end, cpal stream stopped, …) and will not produce more samples.
+///
+/// Implementations must be `Send` so the pipeline can drive them from a
+/// background thread.
+pub trait AudioSource: Send {
+    /// Returns the next chunk of interleaved samples, or `None` when the
+    /// source is exhausted.
+    fn next_chunk(&mut self) -> Option<Vec<f32>>;
+    /// The source's sample rate in Hz.
+    fn sample_rate(&self) -> u32;
+    /// Channel count (1 = mono, 2 = stereo, …).
+    fn channels(&self) -> u16;
+}
+
+/// Test [`AudioSource`] that replays a fixture WAV in fixed-size chunks.
+///
+/// Samples are converted to f32 in `[-1.0, 1.0]` regardless of the fixture's
+/// bit depth, so a single fixture can stand in for any capture-side input
+/// rate the pipeline needs to exercise.
+pub struct FileAudioSource {
+    samples: Vec<f32>,
+    cursor: usize,
+    chunk_frames: usize,
+    sample_rate: u32,
+    channels: u16,
+}
+
+impl FileAudioSource {
+    /// Loads a WAV file and prepares it for chunked playback.
+    ///
+    /// `chunk_frames` is the number of *frames* (not samples) returned per
+    /// [`AudioSource::next_chunk`] call — i.e. for stereo at
+    /// `chunk_frames = 1024`, each chunk contains 2048 interleaved samples.
+    pub fn from_path(path: impl AsRef<Path>, chunk_frames: usize) -> Result<Self> {
+        let path = path.as_ref();
+        let mut reader = hound::WavReader::open(path)
+            .with_context(|| format!("Failed to open fixture WAV at {}", path.display()))?;
+        let spec = reader.spec();
+        let samples = read_all_samples_as_f32(&mut reader, spec)
+            .with_context(|| format!("Failed to read samples from {}", path.display()))?;
+        Ok(Self {
+            samples,
+            cursor: 0,
+            chunk_frames: chunk_frames.max(1),
+            sample_rate: spec.sample_rate,
+            channels: spec.channels,
+        })
+    }
+
+    /// Builds a fixture source directly from an in-memory sample buffer.
+    /// Useful for synthesising test signals (sine waves, silence, …) without
+    /// hitting disk.
+    pub fn from_samples(
+        samples: Vec<f32>,
+        sample_rate: u32,
+        channels: u16,
+        chunk_frames: usize,
+    ) -> Self {
+        Self {
+            samples,
+            cursor: 0,
+            chunk_frames: chunk_frames.max(1),
+            sample_rate,
+            channels,
+        }
+    }
+}
+
+impl AudioSource for FileAudioSource {
+    fn next_chunk(&mut self) -> Option<Vec<f32>> {
+        if self.cursor >= self.samples.len() {
+            return None;
+        }
+        let samples_per_chunk = self.chunk_frames * self.channels as usize;
+        let end = (self.cursor + samples_per_chunk).min(self.samples.len());
+        let chunk = self.samples[self.cursor..end].to_vec();
+        self.cursor = end;
+        Some(chunk)
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn channels(&self) -> u16 {
+        self.channels
+    }
+}
+
+fn read_all_samples_as_f32<R: std::io::Read>(
+    reader: &mut hound::WavReader<R>,
+    spec: hound::WavSpec,
+) -> Result<Vec<f32>> {
+    match spec.sample_format {
+        hound::SampleFormat::Float => reader
+            .samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to decode f32 PCM samples"),
+        hound::SampleFormat::Int => {
+            let scale = i32_pcm_scale(spec.bits_per_sample);
+            reader
+                .samples::<i32>()
+                .map(|res| res.map(|s| s as f32 / scale))
+                .collect::<Result<Vec<_>, _>>()
+                .context("Failed to decode integer PCM samples")
+        }
+    }
+}
+
+fn i32_pcm_scale(bits_per_sample: u16) -> f32 {
+    // `hound` decodes integer PCM as sign-extended i32 regardless of the
+    // declared bit depth, so the divisor is always `2^(bits-1)`.
+    let shift = bits_per_sample.saturating_sub(1);
+    (1u64 << shift) as f32
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    fn write_fixture_wav(
+        dir: &TempDir,
+        name: &str,
+        sample_rate: u32,
+        channels: u16,
+        bits: u16,
+        samples_i16: &[i16],
+    ) -> Result<std::path::PathBuf> {
+        let path = dir.path().join(name);
+        let spec = hound::WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: bits,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec)?;
+        for s in samples_i16 {
+            writer.write_sample(*s)?;
+        }
+        writer.finalize()?;
+        Ok(path)
+    }
+
+    #[test]
+    fn file_source_returns_samples_in_chunks() -> Result<()> {
+        let tmp = TempDir::new()?;
+        // 12 mono i16 samples; 5 frames per chunk → 5, 5, 2.
+        let path = write_fixture_wav(
+            &tmp,
+            "mono.wav",
+            16_000,
+            1,
+            16,
+            &[
+                100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200,
+            ],
+        )?;
+        let mut src = FileAudioSource::from_path(&path, 5)?;
+        assert_eq!(src.sample_rate(), 16_000);
+        assert_eq!(src.channels(), 1);
+        let c1 = src.next_chunk().expect("first chunk");
+        let c2 = src.next_chunk().expect("second chunk");
+        let c3 = src.next_chunk().expect("third chunk");
+        assert_eq!(c1.len(), 5);
+        assert_eq!(c2.len(), 5);
+        assert_eq!(c3.len(), 2);
+        assert!(src.next_chunk().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn file_source_chunk_size_is_frames_not_samples_for_stereo() -> Result<()> {
+        let tmp = TempDir::new()?;
+        // 4 frames * 2 channels = 8 interleaved samples; chunk_frames = 2.
+        let path = write_fixture_wav(&tmp, "stereo.wav", 48_000, 2, 16, &[1, 2, 3, 4, 5, 6, 7, 8])?;
+        let mut src = FileAudioSource::from_path(&path, 2)?;
+        assert_eq!(src.channels(), 2);
+        let c1 = src.next_chunk().expect("chunk");
+        assert_eq!(c1.len(), 4, "2 frames * 2 channels = 4 samples");
+        let c2 = src.next_chunk().expect("chunk");
+        assert_eq!(c2.len(), 4);
+        assert!(src.next_chunk().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn file_source_decodes_i16_to_unit_range() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let path = write_fixture_wav(&tmp, "edges.wav", 8000, 1, 16, &[i16::MAX, 0, i16::MIN])?;
+        let mut src = FileAudioSource::from_path(&path, 16)?;
+        let chunk = src.next_chunk().expect("chunk");
+        // i16::MAX (32767) / 32768.0 ≈ 0.99997
+        assert!((chunk[0] - 0.999_969_5).abs() < 1e-4);
+        assert!((chunk[1] - 0.0).abs() < 1e-6);
+        // i16::MIN (-32768) / 32768.0 = -1.0
+        assert!((chunk[2] + 1.0).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn from_samples_round_trips_without_disk() {
+        let samples = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
+        let mut src = FileAudioSource::from_samples(samples.clone(), 16_000, 1, 4);
+        let c1 = src.next_chunk().expect("first chunk");
+        let c2 = src.next_chunk().expect("second chunk");
+        assert_eq!(c1, samples[..4]);
+        assert_eq!(c2, samples[4..]);
+        assert!(src.next_chunk().is_none());
+    }
+
+    #[test]
+    fn from_samples_yields_none_when_exhausted() {
+        let mut src = FileAudioSource::from_samples(vec![0.0; 0], 16_000, 1, 32);
+        assert!(src.next_chunk().is_none());
+    }
+
+    #[test]
+    fn zero_chunk_size_is_treated_as_one_frame() {
+        let mut src = FileAudioSource::from_samples(vec![0.1, 0.2, 0.3], 16_000, 1, 0);
+        // chunk_frames clamped to 1 — one sample per chunk.
+        let c1 = src.next_chunk().expect("c1");
+        assert_eq!(c1, vec![0.1]);
+        assert_eq!(src.next_chunk(), Some(vec![0.2]));
+        assert_eq!(src.next_chunk(), Some(vec![0.3]));
+        assert!(src.next_chunk().is_none());
+    }
+}

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -1,0 +1,4 @@
+//! Audio source abstraction.
+//!
+//! Populated incrementally — the trait lands here in step 2; concrete sources
+//! follow in steps 2 ([`FileAudioSource`]) and 7 ([`CpalAudioSource`]).

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -10,8 +10,14 @@
 //! level).
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{Sample, SampleFormat, Stream, StreamConfig};
+use ringbuf::traits::{Consumer, Producer, Split};
+use ringbuf::{HeapCons, HeapRb};
 
 /// Source of raw interleaved f32 audio samples at a fixed sample rate and
 /// channel count.
@@ -21,9 +27,13 @@ use anyhow::{Context, Result};
 /// L/R/L/R/…). `None` signals end-of-stream — the source is exhausted
 /// (file end, cpal stream stopped, …) and will not produce more samples.
 ///
-/// Implementations must be `Send` so the pipeline can drive them from a
-/// background thread.
-pub trait AudioSource: Send {
+/// The trait is intentionally not `Send`: on macOS, cpal's `Stream` is
+/// not `Send` (it holds a CoreAudio `AudioUnit` containing raw pointers),
+/// so requiring `Send` here would force `CpalAudioSource` into an
+/// awkward indirection. The capture pipeline runs synchronously on the
+/// owning thread — the cpal callback runs on cpal's own audio thread and
+/// communicates through a lock-free SPSC ring buffer.
+pub trait AudioSource {
     /// Returns the next chunk of interleaved samples, or `None` when the
     /// source is exhausted.
     fn next_chunk(&mut self) -> Option<Vec<f32>>;
@@ -133,6 +143,189 @@ fn i32_pcm_scale(bits_per_sample: u16) -> f32 {
     // declared bit depth, so the divisor is always `2^(bits-1)`.
     let shift = bits_per_sample.saturating_sub(1);
     (1u64 << shift) as f32
+}
+
+/// Maximum samples per [`AudioSource::next_chunk`] call for `CpalAudioSource`.
+/// Sized to amortise the SPSC drain cost while staying well below the
+/// resampler's chunk size (so each `next_chunk` produces at most one
+/// resampler chunk's worth of work).
+const CPAL_DRAIN_CHUNK_SAMPLES: usize = 2048;
+
+/// How long [`AudioSource::next_chunk`] sleeps when the ring buffer is
+/// empty before retrying. Short enough that ~5 s of idle silence is
+/// detected within one window (100 ms) of slack.
+const CPAL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// One-second ring-buffer at the worst common configuration we expect
+/// (192 kHz × 8 channels). Sized in samples (not frames) because the cpal
+/// callback delivers interleaved samples.
+const CPAL_RING_CAPACITY_SAMPLES: usize = 192_000 * 8;
+
+/// Production [`AudioSource`] backed by a `cpal` input stream.
+///
+/// Opens the default input device (or the named device matching `--device`),
+/// builds a stream at the device's default config, and feeds the f32-coerced
+/// samples through a lock-free SPSC ring buffer to the consumer side. The
+/// cpal callback runs on cpal's own audio thread and must never block;
+/// resampling/idle detection/writing all happen on the consumer side.
+pub struct CpalAudioSource {
+    consumer: HeapCons<f32>,
+    sample_rate: u32,
+    channels: u16,
+    stream_error: Arc<Mutex<Option<String>>>,
+    /// Held to keep the cpal stream alive. Dropped before the writer is
+    /// finalised so all in-flight callback samples have flushed through
+    /// the ring buffer.
+    _stream: Stream,
+}
+
+impl CpalAudioSource {
+    /// Opens the default input device (or the device matching
+    /// `device_name`, if provided) and starts a stream at its native rate
+    /// and channel count.
+    ///
+    /// `device_name` matching is exact (case-sensitive) against
+    /// `Device::name()` — cpal reports platform-native names which differ
+    /// across macOS/Linux/Windows, so users get an error listing every
+    /// detected device when no match is found.
+    pub fn new(device_name: Option<&str>) -> Result<Self> {
+        let host = cpal::default_host();
+        let device = match device_name {
+            None => host
+                .default_input_device()
+                .ok_or_else(|| anyhow!("No default input device available on this host"))?,
+            Some(name) => find_input_device(&host, name)?,
+        };
+        let resolved_name = device
+            .name()
+            .unwrap_or_else(|_| "<unnamed device>".to_string());
+        let supported = device
+            .default_input_config()
+            .with_context(|| format!("Failed to query default input config for {resolved_name}"))?;
+        let sample_format = supported.sample_format();
+        let config: StreamConfig = supported.config();
+        let sample_rate = config.sample_rate.0;
+        let channels = config.channels;
+
+        let rb = HeapRb::<f32>::new(CPAL_RING_CAPACITY_SAMPLES);
+        let (mut producer, consumer) = rb.split();
+        let stream_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let error_clone = stream_error.clone();
+        let err_fn = move |err: cpal::StreamError| {
+            if let Ok(mut slot) = error_clone.lock() {
+                *slot = Some(err.to_string());
+            }
+        };
+
+        let stream = match sample_format {
+            SampleFormat::F32 => device
+                .build_input_stream(
+                    &config,
+                    move |data: &[f32], _| {
+                        producer.push_slice(data);
+                    },
+                    err_fn,
+                    None,
+                )
+                .with_context(|| format!("Failed to build f32 input stream on {resolved_name}"))?,
+            SampleFormat::I16 => device
+                .build_input_stream(
+                    &config,
+                    move |data: &[i16], _| {
+                        for sample in data {
+                            let _ = producer.try_push(sample.to_float_sample());
+                        }
+                    },
+                    err_fn,
+                    None,
+                )
+                .with_context(|| format!("Failed to build i16 input stream on {resolved_name}"))?,
+            SampleFormat::U16 => device
+                .build_input_stream(
+                    &config,
+                    move |data: &[u16], _| {
+                        for sample in data {
+                            let _ = producer.try_push(sample.to_float_sample());
+                        }
+                    },
+                    err_fn,
+                    None,
+                )
+                .with_context(|| format!("Failed to build u16 input stream on {resolved_name}"))?,
+            other => anyhow::bail!(
+                "Unsupported cpal sample format {other:?} on {resolved_name} \
+                 (only F32, I16, U16 are wired up — file an issue if you need others)"
+            ),
+        };
+        stream
+            .play()
+            .with_context(|| format!("Failed to start input stream on {resolved_name}"))?;
+
+        Ok(Self {
+            consumer,
+            sample_rate,
+            channels,
+            stream_error,
+            _stream: stream,
+        })
+    }
+
+    fn take_stream_error(&self) -> Option<String> {
+        self.stream_error.lock().ok().and_then(|mut s| s.take())
+    }
+}
+
+impl AudioSource for CpalAudioSource {
+    fn next_chunk(&mut self) -> Option<Vec<f32>> {
+        if let Some(err) = self.take_stream_error() {
+            tracing::warn!("cpal stream error: {err}");
+            return None;
+        }
+        // Poll until samples arrive — cpal callbacks deliver in bursts at
+        // the device's buffer cadence. Returning empty Vecs every poll
+        // would burn CPU on the consumer side without producing useful
+        // work.
+        let mut buf = vec![0.0_f32; CPAL_DRAIN_CHUNK_SAMPLES];
+        loop {
+            let popped = self.consumer.pop_slice(&mut buf);
+            if popped > 0 {
+                buf.truncate(popped);
+                return Some(buf);
+            }
+            if let Some(err) = self.take_stream_error() {
+                tracing::warn!("cpal stream error: {err}");
+                return None;
+            }
+            std::thread::sleep(CPAL_POLL_INTERVAL);
+        }
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn channels(&self) -> u16 {
+        self.channels
+    }
+}
+
+fn find_input_device(host: &cpal::Host, name: &str) -> Result<<cpal::Host as HostTrait>::Device> {
+    let devices = host
+        .input_devices()
+        .context("Failed to enumerate input devices")?;
+    let mut available: Vec<String> = Vec::new();
+    for device in devices {
+        let device_name = device
+            .name()
+            .unwrap_or_else(|_| "<unnamed device>".to_string());
+        if device_name == name {
+            return Ok(device);
+        }
+        available.push(device_name);
+    }
+    Err(anyhow!(
+        "Input device {name:?} not found. Available: {available:?}"
+    ))
 }
 
 #[cfg(test)]
@@ -248,5 +441,37 @@ mod tests {
         assert_eq!(src.next_chunk(), Some(vec![0.2]));
         assert_eq!(src.next_chunk(), Some(vec![0.3]));
         assert!(src.next_chunk().is_none());
+    }
+
+    #[test]
+    #[ignore = "requires a working audio input device (local hardware only)"]
+    fn cpal_default_input_produces_samples() -> Result<()> {
+        let mut src = CpalAudioSource::new(None)?;
+        assert!(src.sample_rate() > 0);
+        assert!(src.channels() > 0);
+        let chunk = src
+            .next_chunk()
+            .expect("default input should produce at least one chunk");
+        assert!(!chunk.is_empty(), "default input chunk should not be empty");
+        Ok(())
+    }
+
+    #[test]
+    fn cpal_unknown_device_lists_alternatives() {
+        let result = CpalAudioSource::new(Some(
+            "this-device-name-definitely-does-not-exist-on-anyone-system",
+        ));
+        let Err(err) = result else {
+            panic!("expected unknown device to error");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found"),
+            "error message should say 'not found': {msg}"
+        );
+        assert!(
+            msg.contains("Available"),
+            "error message should list available devices: {msg}"
+        );
     }
 }

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -457,6 +457,59 @@ mod tests {
     }
 
     #[test]
+    fn file_source_decodes_f32_fixtures() -> Result<()> {
+        // Exercise the SampleFormat::Float branch in read_all_samples_as_f32.
+        // Most capture-side cpal configs are f32, so a fixture in that format
+        // is a realistic stand-in.
+        let tmp = TempDir::new()?;
+        let path = tmp.path().join("float.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec)?;
+        for s in [0.0_f32, 0.25, -0.25, 0.5, -0.5] {
+            writer.write_sample(s)?;
+        }
+        writer.finalize()?;
+
+        let mut src = FileAudioSource::from_path(&path, 16)?;
+        let chunk = src.next_chunk().expect("chunk");
+        assert_eq!(chunk.len(), 5);
+        assert!((chunk[0] - 0.0).abs() < 1e-6);
+        assert!((chunk[1] - 0.25).abs() < 1e-6);
+        assert!((chunk[2] + 0.25).abs() < 1e-6);
+        assert!((chunk[3] - 0.5).abs() < 1e-6);
+        assert!((chunk[4] + 0.5).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn file_source_open_missing_path_errors() {
+        let Err(err) = FileAudioSource::from_path("/this/path/does/not/exist.wav", 16) else {
+            panic!("expected open of missing file to error");
+        };
+        assert!(
+            err.to_string().contains("Failed to open fixture WAV"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn i32_pcm_scale_matches_bit_depth() {
+        // 16-bit: divisor is 2^15 = 32768
+        assert!((i32_pcm_scale(16) - 32768.0).abs() < f32::EPSILON);
+        // 24-bit: divisor is 2^23 = 8_388_608
+        assert!((i32_pcm_scale(24) - 8_388_608.0).abs() < f32::EPSILON);
+        // 32-bit: divisor is 2^31
+        assert!((i32_pcm_scale(32) - (1u64 << 31) as f32).abs() < f32::EPSILON);
+        // 0-bit nonsense input clamps to shift = 0, divisor = 1 (no panic)
+        assert!((i32_pcm_scale(0) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
     fn cpal_unknown_device_lists_alternatives() {
         let result = CpalAudioSource::new(Some(
             "this-device-name-definitely-does-not-exist-on-anyone-system",

--- a/src/voice/capture.rs
+++ b/src/voice/capture.rs
@@ -1,5 +1,355 @@
 //! End-to-end capture pipeline orchestrator.
 //!
-//! Populated in step 6: glues an [`AudioSource`](super::audio) implementation
-//! through mixdown → resample → idle-detection → trailing-silence trim →
-//! [`hound`] writer, with signal-driven termination wired up in step 8.
+//! Glues an [`AudioSource`] through the write-path stages (mixdown →
+//! resample → idle detection → trailing-silence trim → WAV write) and
+//! reports a structured [`CaptureSummary`] when done. The signal-driven
+//! termination path is wired up in step 8.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+
+use super::audio::AudioSource;
+use super::idle::{trim_trailing_silence, IdleDetector};
+use super::wav::{mono_mixdown, Resampler, WavWriter};
+
+/// Options for a single capture session.
+#[derive(Debug, Clone)]
+pub struct CaptureOpts {
+    /// Destination WAV path.
+    pub output: PathBuf,
+    /// Seconds of trailing silence that auto-stop capture. `0` disables
+    /// auto-stop (capture runs until the source is exhausted or a stop
+    /// signal arrives).
+    pub idle_after_secs: u32,
+}
+
+impl CaptureOpts {
+    /// Creates a new options struct with the given output path and
+    /// idle-after threshold.
+    #[must_use]
+    pub fn new(output: impl Into<PathBuf>, idle_after_secs: u32) -> Self {
+        Self {
+            output: output.into(),
+            idle_after_secs,
+        }
+    }
+}
+
+/// Why capture stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationReason {
+    /// The idle (silence) detector fired its `idle_after_secs` budget.
+    Idle,
+    /// The [`AudioSource`] returned `None` (file end, stream closed).
+    SourceExhausted,
+    /// An external stop signal flipped the supplied `AtomicBool` to true
+    /// (Ctrl-C in production).
+    Signal,
+}
+
+/// Structured summary of a capture session for tests and logging.
+#[derive(Debug, Clone)]
+pub struct CaptureSummary {
+    /// Path the WAV was written to.
+    pub output: PathBuf,
+    /// Samples actually written to disk (post-trim).
+    pub samples_written: u64,
+    /// Samples that were dropped from the tail by trailing-silence trim.
+    /// Always 0 for [`TerminationReason::Signal`] (user-driven stops are
+    /// not trimmed — the user chose where to stop).
+    pub trimmed_samples: u64,
+    /// Why capture stopped.
+    pub terminated_by: TerminationReason,
+}
+
+/// Drives `source` through the pipeline and writes a 16 kHz mono 16-bit
+/// PCM WAV at `opts.output`.
+///
+/// Termination conditions, in priority order each loop iteration:
+///
+/// 1. `stop_signal` set to true → [`TerminationReason::Signal`].
+/// 2. Idle detector fires → [`TerminationReason::Idle`].
+/// 3. Source returns `None` → [`TerminationReason::SourceExhausted`].
+///
+/// On [`TerminationReason::Idle`] the trailing silence that caused the
+/// trigger is trimmed before the WAV header is finalised. On
+/// [`TerminationReason::Signal`] nothing is trimmed (the user chose the
+/// cutoff). On [`TerminationReason::SourceExhausted`] the entire
+/// resampled stream is written verbatim.
+///
+/// Returns an error if no voiced window was ever observed — emitting a
+/// near-empty WAV would just crash downstream Whisper anyway, so we
+/// fail loudly instead. The output file is removed on this path so the
+/// caller never sees a malformed WAV on disk.
+pub fn run_capture<S: AudioSource>(
+    mut source: S,
+    opts: CaptureOpts,
+    stop_signal: Arc<AtomicBool>,
+) -> Result<CaptureSummary> {
+    let mut resampler = Resampler::new(source.sample_rate())
+        .with_context(|| format!("Failed to build resampler at {} Hz", source.sample_rate()))?;
+    let mut detector = IdleDetector::new(opts.idle_after_secs);
+    let mut buffer: Vec<f32> = Vec::new();
+    let channels = source.channels();
+    let termination = loop {
+        if stop_signal.load(Ordering::Relaxed) {
+            break TerminationReason::Signal;
+        }
+        let Some(chunk) = source.next_chunk() else {
+            break TerminationReason::SourceExhausted;
+        };
+        let mono = mono_mixdown(&chunk, channels);
+        let resampled = resampler.push(&mono)?;
+        detector.push(&resampled);
+        buffer.extend_from_slice(&resampled);
+        if detector.is_idle() {
+            break TerminationReason::Idle;
+        }
+    };
+
+    // Drain the resampler tail when the source exhausted naturally. We
+    // skip this on Signal-driven shutdown to keep the cut crisp.
+    if matches!(
+        termination,
+        TerminationReason::SourceExhausted | TerminationReason::Idle
+    ) {
+        let tail = resampler.flush()?;
+        detector.push(&tail);
+        buffer.extend_from_slice(&tail);
+    }
+
+    // Trim trailing silence only when the idle detector fired.
+    let (samples_to_write, trimmed): (&[f32], u64) = if termination == TerminationReason::Idle {
+        let tail = detector.trailing_silence_samples();
+        let trimmed = trim_trailing_silence(&buffer, tail);
+        let dropped = (buffer.len() - trimmed.len()) as u64;
+        (trimmed, dropped)
+    } else {
+        (buffer.as_slice(), 0)
+    };
+
+    // No-audio guard: on natural termination (idle / source exhausted) we
+    // require at least one voiced window. On signal-driven termination the
+    // user explicitly stopped, so we instead just require *some* samples
+    // to write — Ctrl-C before anything was captured is also a hard error,
+    // but a quiet recording the user chose to keep is not.
+    match termination {
+        TerminationReason::Idle | TerminationReason::SourceExhausted => {
+            if !detector.has_any_voice() {
+                return Err(anyhow!(
+                    "No audio detected — every window of the {:.1}s capture was below the \
+                     silence threshold. Is the microphone muted or routed to a different device?",
+                    elapsed_seconds(buffer.len())
+                ));
+            }
+        }
+        TerminationReason::Signal => {
+            if samples_to_write.is_empty() {
+                return Err(anyhow!(
+                    "Stopped before any audio was captured — the stop signal arrived before \
+                     the first sample reached the writer."
+                ));
+            }
+        }
+    }
+
+    let mut writer = WavWriter::create(&opts.output)?;
+    writer.write_samples(samples_to_write)?;
+    let samples_written = writer.samples_written();
+    writer.finalize()?;
+
+    Ok(CaptureSummary {
+        output: opts.output,
+        samples_written,
+        trimmed_samples: trimmed,
+        terminated_by: termination,
+    })
+}
+
+fn elapsed_seconds(samples_at_16k: usize) -> f32 {
+    samples_at_16k as f32 / super::wav::TARGET_SAMPLE_RATE as f32
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use std::f32::consts::TAU;
+
+    use crate::voice::audio::FileAudioSource;
+
+    fn voiced_then_silent(rate: u32, voiced_s: f32, silent_s: f32, amplitude: f32) -> Vec<f32> {
+        let voiced_n = (rate as f32 * voiced_s) as usize;
+        let silent_n = (rate as f32 * silent_s) as usize;
+        let mut out: Vec<f32> = (0..voiced_n)
+            .map(|i| amplitude * (TAU * 440.0 * i as f32 / rate as f32).sin())
+            .collect();
+        out.extend(std::iter::repeat_n(0.0, silent_n));
+        out
+    }
+
+    fn write_to_temp(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join(format!("{prefix}.wav"));
+        (tmp, path)
+    }
+
+    fn stop_flag(value: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(value))
+    }
+
+    #[test]
+    fn idle_termination_trims_trailing_silence() -> Result<()> {
+        // 1 s voiced @ 0.4 amp, then 3 s silence. idle_after_secs=2 → fires
+        // after 2 s of silence; one extra second of silence remains in the
+        // buffer that should be trimmed.
+        let source_rate = 48_000;
+        let samples = voiced_then_silent(source_rate, 1.0, 3.0, 0.4);
+        let source = FileAudioSource::from_samples(samples, source_rate, 1, 4800);
+        let (_tmp, path) = write_to_temp("idle");
+        let summary = run_capture(source, CaptureOpts::new(&path, 2), stop_flag(false))?;
+
+        assert_eq!(summary.terminated_by, TerminationReason::Idle);
+        assert!(
+            summary.trimmed_samples > 0,
+            "tail silence should be trimmed"
+        );
+
+        let reader = hound::WavReader::open(&path)?;
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, 16_000);
+        assert_eq!(spec.bits_per_sample, 16);
+
+        let frame_count = reader.duration() as usize;
+        // Expected ≈ 1 s of voiced content at 16 kHz (~16_000 samples).
+        // Sinc warm-up and window-alignment slack mean ±2_000 frames is
+        // routine. The hard contract is that *some* of the 3 s of silence
+        // was trimmed.
+        assert!(
+            (14_000..=20_000).contains(&frame_count),
+            "unexpected frame count after trim: {frame_count}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn source_exhausted_writes_everything() -> Result<()> {
+        // 0.5 s voiced @ 0.4 amp. idle_after_secs huge → never fires; source
+        // runs out naturally.
+        let source_rate = 16_000; // identity path through resampler
+        let voiced_n = 8000;
+        let samples: Vec<f32> = (0..voiced_n)
+            .map(|i| 0.4 * (TAU * 440.0 * i as f32 / source_rate as f32).sin())
+            .collect();
+        let source = FileAudioSource::from_samples(samples, source_rate, 1, 1024);
+        let (_tmp, path) = write_to_temp("exhausted");
+        let summary = run_capture(source, CaptureOpts::new(&path, 60), stop_flag(false))?;
+
+        assert_eq!(summary.terminated_by, TerminationReason::SourceExhausted);
+        assert_eq!(summary.trimmed_samples, 0);
+        assert_eq!(summary.samples_written, voiced_n as u64);
+        Ok(())
+    }
+
+    /// Test-only [`AudioSource`] that wraps another source and flips the
+    /// supplied stop signal after `flip_after_chunks` calls. Lets us
+    /// exercise the signal-termination path deterministically without
+    /// race conditions.
+    struct SignalFlippingSource<S: AudioSource> {
+        inner: S,
+        stop: Arc<AtomicBool>,
+        chunks_returned: u32,
+        flip_after_chunks: u32,
+    }
+
+    impl<S: AudioSource> AudioSource for SignalFlippingSource<S> {
+        fn next_chunk(&mut self) -> Option<Vec<f32>> {
+            let chunk = self.inner.next_chunk();
+            if chunk.is_some() {
+                self.chunks_returned += 1;
+                if self.chunks_returned >= self.flip_after_chunks {
+                    self.stop.store(true, Ordering::Relaxed);
+                }
+            }
+            chunk
+        }
+        fn sample_rate(&self) -> u32 {
+            self.inner.sample_rate()
+        }
+        fn channels(&self) -> u16 {
+            self.inner.channels()
+        }
+    }
+
+    #[test]
+    fn signal_termination_does_not_trim() -> Result<()> {
+        // Long voiced source; signal flips after the first chunk reaches
+        // the loop body, so some voiced audio always lands in the buffer.
+        let source_rate = 16_000;
+        let samples: Vec<f32> = (0..160_000)
+            .map(|i| 0.4 * (TAU * 440.0 * i as f32 / source_rate as f32).sin())
+            .collect();
+        let inner = FileAudioSource::from_samples(samples, source_rate, 1, 4000);
+        let stop = stop_flag(false);
+        let source = SignalFlippingSource {
+            inner,
+            stop: stop.clone(),
+            chunks_returned: 0,
+            flip_after_chunks: 1,
+        };
+        let (_tmp, path) = write_to_temp("signal");
+        let summary = run_capture(source, CaptureOpts::new(&path, 5), stop)?;
+
+        assert_eq!(summary.terminated_by, TerminationReason::Signal);
+        assert_eq!(
+            summary.trimmed_samples, 0,
+            "signal termination must not trim"
+        );
+        assert!(
+            summary.samples_written > 0,
+            "should have captured something"
+        );
+        // File exists and is readable.
+        let reader = hound::WavReader::open(&path)?;
+        assert_eq!(reader.spec().sample_rate, 16_000);
+        Ok(())
+    }
+
+    #[test]
+    fn signal_termination_with_no_captured_audio_fails_loudly() {
+        // Pre-flip the signal: the loop's top-of-iteration check exits
+        // before reading anything. The orchestrator must error rather
+        // than write a zero-sample WAV.
+        let source_rate = 16_000;
+        let source = FileAudioSource::from_samples(vec![0.0; 16_000], source_rate, 1, 16);
+        let stop = stop_flag(true);
+        let (_tmp, path) = write_to_temp("signal_empty");
+        let err = run_capture(source, CaptureOpts::new(&path, 5), stop).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Stopped before any audio was captured"),
+            "expected loud failure, got: {err}"
+        );
+    }
+
+    #[test]
+    fn silence_only_input_fails_loudly() {
+        let source_rate = 16_000;
+        let silence = vec![0.0_f32; 16_000 * 6]; // 6 s of silence
+        let source = FileAudioSource::from_samples(silence, source_rate, 1, 1024);
+        let (_tmp, path) = write_to_temp("silent");
+        let err = run_capture(source, CaptureOpts::new(&path, 2), stop_flag(false)).unwrap_err();
+        assert!(
+            err.to_string().contains("No audio detected"),
+            "expected loud failure, got: {err}"
+        );
+        // The output file may have been created and then is overwritten by
+        // a later run, but it should not have been finalised — assert the
+        // error path didn't accidentally succeed and return a summary.
+    }
+}

--- a/src/voice/capture.rs
+++ b/src/voice/capture.rs
@@ -1,0 +1,5 @@
+//! End-to-end capture pipeline orchestrator.
+//!
+//! Populated in step 6: glues an [`AudioSource`](super::audio) implementation
+//! through mixdown → resample → idle-detection → trailing-silence trim →
+//! [`hound`] writer, with signal-driven termination wired up in step 8.

--- a/src/voice/capture.rs
+++ b/src/voice/capture.rs
@@ -2,8 +2,9 @@
 //!
 //! Glues an [`AudioSource`] through the write-path stages (mixdown →
 //! resample → idle detection → trailing-silence trim → WAV write) and
-//! reports a structured [`CaptureSummary`] when done. The signal-driven
-//! termination path is wired up in step 8.
+//! reports a structured [`CaptureSummary`] when done. Signal-driven
+//! termination is wired up via [`install_ctrl_c_handler`], which the CLI
+//! entry point calls before delegating to [`run_capture`].
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -171,6 +172,25 @@ pub fn run_capture<S: AudioSource>(
 
 fn elapsed_seconds(samples_at_16k: usize) -> f32 {
     samples_at_16k as f32 / super::wav::TARGET_SAMPLE_RATE as f32
+}
+
+/// Installs a SIGINT (Ctrl-C) handler that flips the returned flag on
+/// receipt, and returns a fresh `Arc<AtomicBool>` initialised to false.
+///
+/// The flag is the one [`run_capture`] polls each iteration; flipping it
+/// causes the pipeline to terminate with [`TerminationReason::Signal`].
+/// On Unix this uses `signal-hook` (safe, no global state hijack). On
+/// Windows the same `signal-hook` API targets `SIGINT` via the
+/// console-control handler; the call is portable.
+///
+/// Safe to call once per process. A second call adds a *second* handler
+/// that also flips the flag — harmless but redundant. The capture loop
+/// already terminates on the first flip.
+pub fn install_ctrl_c_handler() -> Result<Arc<AtomicBool>> {
+    let flag = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, flag.clone())
+        .context("Failed to register SIGINT handler")?;
+    Ok(flag)
 }
 
 #[cfg(test)]

--- a/src/voice/idle.rs
+++ b/src/voice/idle.rs
@@ -1,0 +1,254 @@
+//! Idle (silence) detection and trailing-silence trimming.
+//!
+//! Operates on the post-resample 16 kHz mono stream. Uses RMS over fixed
+//! windows; classifies each window as voiced or silent at a -40 dBFS
+//! threshold and tracks how many consecutive silent windows have arrived.
+//! The capture loop terminates when that streak reaches the
+//! `idle_after_secs` budget. A trim pass then drops the trailing silence
+//! before the WAV header is finalised — Whisper hallucinates badly on
+//! silence at the end of an input clip.
+
+use super::wav::TARGET_SAMPLE_RATE;
+
+/// Length of one RMS window. 100 ms at 16 kHz = 1600 samples.
+pub const WINDOW_SAMPLES: usize = 1600;
+
+/// `f32` amplitude corresponding to -40 dBFS, used as the silent/voiced
+/// threshold. `10^(-40/20) = 0.01`.
+pub const SILENCE_THRESHOLD_RMS: f32 = 0.01;
+
+/// Classification of a single RMS window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowClass {
+    /// Window RMS at or below the silence threshold.
+    Silent,
+    /// Window RMS above the silence threshold.
+    Voiced,
+}
+
+/// Streaming idle detector over 16 kHz mono samples.
+///
+/// Feed samples via [`IdleDetector::push`]; it buffers partial windows
+/// internally and only classifies a window once it is fully filled.
+/// [`IdleDetector::is_idle`] returns true once enough consecutive silent
+/// windows have accumulated. The detector also remembers whether *any*
+/// voiced window has ever been seen — the orchestrator uses that flag to
+/// fail loudly on all-silence recordings (muted mic, etc.) rather than
+/// emit a near-empty WAV that downstream Whisper would crash on.
+pub struct IdleDetector {
+    idle_after_secs: u32,
+    pending: Vec<f32>,
+    consecutive_silent: u32,
+    any_voiced: bool,
+}
+
+impl IdleDetector {
+    /// Builds a detector that fires after `idle_after_secs` seconds of
+    /// uninterrupted silence on the 16 kHz stream.
+    #[must_use]
+    pub fn new(idle_after_secs: u32) -> Self {
+        Self {
+            idle_after_secs,
+            pending: Vec::with_capacity(WINDOW_SAMPLES * 2),
+            consecutive_silent: 0,
+            any_voiced: false,
+        }
+    }
+
+    /// Returns the configured idle-after threshold in seconds.
+    #[must_use]
+    pub fn idle_after_secs(&self) -> u32 {
+        self.idle_after_secs
+    }
+
+    /// Feeds new samples; processes whatever windows are complete and
+    /// updates internal state. Returns the classifications of windows
+    /// completed by this call (oldest first) so callers can log or
+    /// instrument them.
+    pub fn push(&mut self, samples: &[f32]) -> Vec<WindowClass> {
+        self.pending.extend_from_slice(samples);
+        let mut classifications = Vec::new();
+        while self.pending.len() >= WINDOW_SAMPLES {
+            let class = classify_window(&self.pending[..WINDOW_SAMPLES]);
+            classifications.push(class);
+            match class {
+                WindowClass::Silent => self.consecutive_silent += 1,
+                WindowClass::Voiced => {
+                    self.consecutive_silent = 0;
+                    self.any_voiced = true;
+                }
+            }
+            self.pending.drain(..WINDOW_SAMPLES);
+        }
+        classifications
+    }
+
+    /// Returns true once `idle_after_secs` consecutive silent windows have
+    /// arrived. (At 100 ms per window, that's `10 * idle_after_secs`
+    /// windows.) Always false before `idle_after_secs == 0` — a zero
+    /// threshold disables auto-stop.
+    #[must_use]
+    pub fn is_idle(&self) -> bool {
+        if self.idle_after_secs == 0 {
+            return false;
+        }
+        let needed = u64::from(self.idle_after_secs) * windows_per_second_u64();
+        u64::from(self.consecutive_silent) >= needed
+    }
+
+    /// Returns true if at least one voiced window has been observed since
+    /// construction.
+    #[must_use]
+    pub fn has_any_voice(&self) -> bool {
+        self.any_voiced
+    }
+
+    /// Number of samples to drop from the tail of the stream when the
+    /// detector has fired — exactly the silent window streak that caused
+    /// `is_idle` to flip true.
+    #[must_use]
+    pub fn trailing_silence_samples(&self) -> usize {
+        self.consecutive_silent as usize * WINDOW_SAMPLES
+    }
+}
+
+fn classify_window(window: &[f32]) -> WindowClass {
+    if rms(window) > SILENCE_THRESHOLD_RMS {
+        WindowClass::Voiced
+    } else {
+        WindowClass::Silent
+    }
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt()
+}
+
+const fn windows_per_second_u64() -> u64 {
+    TARGET_SAMPLE_RATE as u64 / WINDOW_SAMPLES as u64
+}
+
+/// Trims `tail_samples` from the end of `samples`, never below zero length.
+///
+/// Returns a borrowed slice; callers that need an owned `Vec` should
+/// `.to_vec()` afterwards. If `tail_samples` exceeds the buffer length,
+/// the result is the empty slice — the orchestrator catches that case
+/// upstream by checking [`IdleDetector::has_any_voice`].
+#[must_use]
+pub fn trim_trailing_silence(samples: &[f32], tail_samples: usize) -> &[f32] {
+    let end = samples.len().saturating_sub(tail_samples);
+    &samples[..end]
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn silence_only_input_fires_at_exact_window_budget() {
+        let mut det = IdleDetector::new(2); // 2 s ⇒ 20 windows
+        let one_window = vec![0.0_f32; WINDOW_SAMPLES];
+        // 19 silent windows: not yet idle.
+        for _ in 0..19 {
+            det.push(&one_window);
+        }
+        assert!(!det.is_idle(), "should not be idle at 19 silent windows");
+        det.push(&one_window);
+        assert!(det.is_idle(), "should be idle at 20 silent windows");
+        assert!(
+            !det.has_any_voice(),
+            "no voiced window should have been seen"
+        );
+        assert_eq!(det.trailing_silence_samples(), 20 * WINDOW_SAMPLES);
+    }
+
+    #[test]
+    fn voiced_window_resets_silent_streak() {
+        let mut det = IdleDetector::new(1); // 1 s ⇒ 10 windows
+        let silent = vec![0.0_f32; WINDOW_SAMPLES];
+        // Loud window: amplitude 0.5, RMS = 0.5 ≫ threshold.
+        let loud = vec![0.5_f32; WINDOW_SAMPLES];
+        for _ in 0..9 {
+            det.push(&silent);
+        }
+        assert!(!det.is_idle());
+        det.push(&loud); // resets
+        assert!(det.has_any_voice());
+        for _ in 0..9 {
+            det.push(&silent);
+        }
+        assert!(!det.is_idle(), "9 < 10 silent windows after the reset");
+        det.push(&silent);
+        assert!(det.is_idle(), "10 silent windows after the reset");
+    }
+
+    #[test]
+    fn voiced_only_input_never_goes_idle() {
+        let mut det = IdleDetector::new(1);
+        let loud = vec![0.5_f32; WINDOW_SAMPLES];
+        for _ in 0..50 {
+            det.push(&loud);
+        }
+        assert!(!det.is_idle());
+        assert!(det.has_any_voice());
+        assert_eq!(det.trailing_silence_samples(), 0);
+    }
+
+    #[test]
+    fn partial_window_is_buffered_until_full() {
+        let mut det = IdleDetector::new(1);
+        let half = vec![0.0_f32; WINDOW_SAMPLES / 2];
+        // Two half-windows complete one window.
+        let c1 = det.push(&half);
+        assert!(c1.is_empty(), "first half does not complete a window");
+        let c2 = det.push(&half);
+        assert_eq!(c2, vec![WindowClass::Silent]);
+    }
+
+    #[test]
+    fn rms_boundary_classification() {
+        // Sample value v with RMS = v (constant signal). 0.0099 < threshold, 0.0101 > threshold.
+        let below = vec![0.0099_f32; WINDOW_SAMPLES];
+        let above = vec![0.0101_f32; WINDOW_SAMPLES];
+        assert_eq!(classify_window(&below), WindowClass::Silent);
+        assert_eq!(classify_window(&above), WindowClass::Voiced);
+    }
+
+    #[test]
+    fn idle_after_zero_disables_autostop() {
+        let mut det = IdleDetector::new(0);
+        let silent = vec![0.0_f32; WINDOW_SAMPLES];
+        for _ in 0..100 {
+            det.push(&silent);
+        }
+        assert!(
+            !det.is_idle(),
+            "idle_after_secs=0 should never trigger auto-stop"
+        );
+    }
+
+    #[test]
+    fn trim_trailing_silence_drops_exactly_the_tail() {
+        let samples: Vec<f32> = (0..1000).map(|i| i as f32).collect();
+        let trimmed = trim_trailing_silence(&samples, 300);
+        assert_eq!(trimmed.len(), 700);
+        // Float comparisons are safe here: every sample is `i as f32`
+        // for small integers, which round-trips exactly.
+        assert!((trimmed[0] - 0.0).abs() < f32::EPSILON);
+        assert!((trimmed[1] - 1.0).abs() < f32::EPSILON);
+        assert!((trimmed[2] - 2.0).abs() < f32::EPSILON);
+        assert!((trimmed[699] - 699.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn trim_trailing_silence_clamps_to_empty_on_overshoot() {
+        let samples = vec![1.0, 2.0, 3.0];
+        let trimmed = trim_trailing_silence(&samples, 99);
+        assert!(trimmed.is_empty());
+    }
+}

--- a/src/voice/idle.rs
+++ b/src/voice/idle.rs
@@ -251,4 +251,21 @@ mod tests {
         let trimmed = trim_trailing_silence(&samples, 99);
         assert!(trimmed.is_empty());
     }
+
+    #[test]
+    fn rms_empty_samples_returns_zero() {
+        assert!((rms(&[]) - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn push_consumes_multiple_windows_in_one_call() {
+        let mut det = IdleDetector::new(1);
+        // 2.5 windows of silence in one push — should classify 2 windows
+        // immediately and buffer the 0.5-window remainder.
+        let chunk = vec![0.0_f32; WINDOW_SAMPLES * 5 / 2];
+        let classifications = det.push(&chunk);
+        assert_eq!(classifications.len(), 2);
+        assert_eq!(classifications[0], WindowClass::Silent);
+        assert_eq!(classifications[1], WindowClass::Silent);
+    }
 }

--- a/src/voice/wav.rs
+++ b/src/voice/wav.rs
@@ -1,0 +1,4 @@
+//! WAV writer + resampler.
+//!
+//! Populated in steps 3–5: mono mixdown, `rubato`-backed resampler, idle/RMS
+//! detection with trailing-silence trim, `hound` WAV writer.

--- a/src/voice/wav.rs
+++ b/src/voice/wav.rs
@@ -1,4 +1,300 @@
-//! WAV writer + resampler.
+//! Mixdown, resampling, idle detection, and WAV writing.
 //!
-//! Populated in steps 3–5: mono mixdown, `rubato`-backed resampler, idle/RMS
-//! detection with trailing-silence trim, `hound` WAV writer.
+//! The write-path half of the capture pipeline:
+//!
+//! 1. [`mono_mixdown`] collapses N interleaved channels into a single mono
+//!    stream by averaging.
+//! 2. [`Resampler`] rate-converts mono f32 from the device-native rate to
+//!    `16_000` Hz via `rubato`'s sinc interpolator. Identity-passthrough is
+//!    used when the input is already 16 kHz so the pipeline stays
+//!    bit-exact in that common case.
+//!
+//! The idle detector, trailing-silence trim, and `hound` WAV writer are
+//! added incrementally in steps 4–5.
+
+use anyhow::{Context, Result};
+use rubato::{
+    Resampler as _, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+};
+
+/// Target sample rate for the capture pipeline (whisper.cpp convention).
+pub const TARGET_SAMPLE_RATE: u32 = 16_000;
+
+/// Number of input frames fed to the resampler per call. Sized to amortise
+/// the sinc filter overhead without making the streaming API feel chunky.
+/// At 48 kHz input this is ~85 ms of audio.
+pub const RESAMPLER_CHUNK_FRAMES: usize = 4096;
+
+/// Averages N interleaved channels into a single mono stream.
+///
+/// `samples.len()` must be a multiple of `channels`; any trailing partial
+/// frame is silently dropped (cpal callbacks never produce partial frames,
+/// but the guard lets fixture sources be sloppy without panicking).
+///
+/// When `channels == 1` the input is returned as-is (no copy round-trip
+/// through arithmetic), which preserves bit-exact behaviour for fixtures
+/// that are already mono.
+#[must_use]
+pub fn mono_mixdown(samples: &[f32], channels: u16) -> Vec<f32> {
+    if channels <= 1 {
+        return samples.to_vec();
+    }
+    let channels = channels as usize;
+    let frame_count = samples.len() / channels;
+    let mut out = Vec::with_capacity(frame_count);
+    let inv = 1.0_f32 / channels as f32;
+    for frame in samples.chunks_exact(channels) {
+        let sum: f32 = frame.iter().copied().sum();
+        out.push(sum * inv);
+    }
+    out
+}
+
+/// Streaming resampler from an arbitrary input rate to
+/// [`TARGET_SAMPLE_RATE`] (16 kHz), mono.
+///
+/// The wrapper buffers input frames until it has enough for one
+/// fixed-size `rubato` chunk, processes that chunk, and accumulates the
+/// variable-length output. Callers feed mono f32 via [`Resampler::push`]
+/// and drain a single tail batch via [`Resampler::flush`] at end-of-stream.
+///
+/// At 16 kHz input the resampler is bypassed entirely — input is forwarded
+/// to output verbatim, with zero sinc-filter latency.
+pub struct Resampler {
+    input_rate: u32,
+    inner: Option<Inner>,
+}
+
+struct Inner {
+    resampler: SincFixedIn<f32>,
+    /// Pending input frames not yet large enough for one chunk.
+    pending: Vec<f32>,
+    /// Required input frames per call (constant for `SincFixedIn`).
+    chunk_frames: usize,
+}
+
+impl Resampler {
+    /// Builds a resampler that converts `input_rate` Hz mono f32 to
+    /// 16 kHz mono f32. Returns an error if the rate is zero or the
+    /// `rubato` constructor rejects the configuration.
+    pub fn new(input_rate: u32) -> Result<Self> {
+        if input_rate == 0 {
+            anyhow::bail!("Resampler input rate must be > 0");
+        }
+        if input_rate == TARGET_SAMPLE_RATE {
+            return Ok(Self {
+                input_rate,
+                inner: None,
+            });
+        }
+        let ratio = f64::from(TARGET_SAMPLE_RATE) / f64::from(input_rate);
+        let params = SincInterpolationParameters {
+            sinc_len: 256,
+            f_cutoff: 0.95,
+            oversampling_factor: 128,
+            interpolation: SincInterpolationType::Linear,
+            window: WindowFunction::BlackmanHarris2,
+        };
+        let resampler = SincFixedIn::<f32>::new(ratio, 1.0, params, RESAMPLER_CHUNK_FRAMES, 1)
+            .with_context(|| {
+                format!("Failed to build resampler for {input_rate} Hz → {TARGET_SAMPLE_RATE} Hz")
+            })?;
+        Ok(Self {
+            input_rate,
+            inner: Some(Inner {
+                resampler,
+                pending: Vec::with_capacity(RESAMPLER_CHUNK_FRAMES * 2),
+                chunk_frames: RESAMPLER_CHUNK_FRAMES,
+            }),
+        })
+    }
+
+    /// The configured input sample rate in Hz.
+    #[must_use]
+    pub fn input_rate(&self) -> u32 {
+        self.input_rate
+    }
+
+    /// Output sample rate (constant — always [`TARGET_SAMPLE_RATE`]).
+    #[must_use]
+    pub fn output_rate(&self) -> u32 {
+        TARGET_SAMPLE_RATE
+    }
+
+    /// Feeds mono samples and returns any 16 kHz output produced this call.
+    ///
+    /// Partial input that doesn't fill a full chunk is buffered internally
+    /// and emitted on a subsequent `push` or `flush`.
+    pub fn push(&mut self, mono: &[f32]) -> Result<Vec<f32>> {
+        let Some(inner) = self.inner.as_mut() else {
+            return Ok(mono.to_vec());
+        };
+        inner.pending.extend_from_slice(mono);
+        let mut out = Vec::new();
+        while inner.pending.len() >= inner.chunk_frames {
+            let drained = inner
+                .resampler
+                .process(&[&inner.pending[..inner.chunk_frames]], None)
+                .context("Resampler chunk processing failed")?;
+            inner.pending.drain(..inner.chunk_frames);
+            if let Some(channel) = drained.into_iter().next() {
+                out.extend_from_slice(&channel);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Flushes any buffered samples at end-of-stream using `process_partial`
+    /// (zero-pads internally). Call at most once after the source is
+    /// exhausted.
+    pub fn flush(&mut self) -> Result<Vec<f32>> {
+        let Some(inner) = self.inner.as_mut() else {
+            return Ok(Vec::new());
+        };
+        let tail = std::mem::take(&mut inner.pending);
+        let input: Option<&[Vec<f32>]> = if tail.is_empty() {
+            None
+        } else {
+            Some(std::slice::from_ref(&tail))
+        };
+        let drained = inner
+            .resampler
+            .process_partial(input, None)
+            .context("Resampler flush failed")?;
+        Ok(drained.into_iter().next().unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use std::f32::consts::TAU;
+
+    #[test]
+    fn mono_mixdown_passes_through_mono_untouched() {
+        let input = vec![0.1, -0.2, 0.3, -0.4];
+        assert_eq!(mono_mixdown(&input, 1), input);
+    }
+
+    #[test]
+    fn mono_mixdown_averages_stereo_to_zero_for_inverted_signal() {
+        // L = 1.0, R = -1.0 → mean = 0.0 for every frame.
+        let input = vec![1.0, -1.0, 1.0, -1.0, 1.0, -1.0];
+        let out = mono_mixdown(&input, 2);
+        assert_eq!(out, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn mono_mixdown_averages_quad_channel() {
+        // 4-channel frame averages: (1+2+3+4)/4 = 2.5, (5+6+7+8)/4 = 6.5
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let out = mono_mixdown(&input, 4);
+        assert_eq!(out, vec![2.5, 6.5]);
+    }
+
+    #[test]
+    fn mono_mixdown_drops_trailing_partial_frame() {
+        // 7 samples / 2 channels = 3 full frames, 1 stranded sample.
+        let input = vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 99.0];
+        let out = mono_mixdown(&input, 2);
+        assert_eq!(out, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn resampler_identity_path_returns_input_verbatim() -> Result<()> {
+        let mut r = Resampler::new(TARGET_SAMPLE_RATE)?;
+        assert_eq!(r.input_rate(), TARGET_SAMPLE_RATE);
+        assert_eq!(r.output_rate(), TARGET_SAMPLE_RATE);
+        let input: Vec<f32> = (0..100).map(|i| (i as f32 / 100.0) - 0.5).collect();
+        let out = r.push(&input)?;
+        assert_eq!(out, input);
+        let flushed = r.flush()?;
+        assert!(flushed.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn resampler_rejects_zero_input_rate() {
+        let err = Resampler::new(0).err().expect("must reject zero rate");
+        assert!(err.to_string().contains("> 0"));
+    }
+
+    fn sine_wave(rate: u32, freq_hz: f32, duration_s: f32, amplitude: f32) -> Vec<f32> {
+        let n = (rate as f32 * duration_s) as usize;
+        (0..n)
+            .map(|i| amplitude * (TAU * freq_hz * i as f32 / rate as f32).sin())
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        if samples.is_empty() {
+            return 0.0;
+        }
+        let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+        (sum_sq / samples.len() as f32).sqrt()
+    }
+
+    #[test]
+    fn resampler_48k_to_16k_preserves_signal_rms() -> Result<()> {
+        // 2 s of a 440 Hz sine at amplitude 0.5 — well below Nyquist at both rates.
+        let input = sine_wave(48_000, 440.0, 2.0, 0.5);
+        let mut r = Resampler::new(48_000)?;
+        let mut output = r.push(&input)?;
+        output.extend(r.flush()?);
+        // 2 s @ 16 kHz ≈ 32_000 samples. The flush() call zero-pads any
+        // residual input to one full rubato chunk, so the output can run
+        // up to one chunk's worth of resampled frames long. Trailing-
+        // silence trim (step 4) is responsible for cleaning that up.
+        let expected_len: usize = 32_000;
+        let max_overrun = (RESAMPLER_CHUNK_FRAMES as f64 * 16_000.0 / 48_000.0).ceil() as usize;
+        assert!(
+            output.len() >= expected_len.saturating_sub(256),
+            "output too short: got {}, expected ≥ {}",
+            output.len(),
+            expected_len - 256
+        );
+        assert!(
+            output.len() <= expected_len + max_overrun + 256,
+            "output too long: got {}, expected ≤ {}",
+            output.len(),
+            expected_len + max_overrun + 256
+        );
+        // Ignore the first ~50 ms transient (sinc filter warm-up); compare RMS over the steady-state.
+        let warmup = 800; // 50 ms @ 16k
+        let in_rms = rms(&input);
+        let out_rms = rms(&output[warmup..]);
+        assert!(
+            (in_rms - out_rms).abs() < 0.02,
+            "RMS drift too large: in={in_rms}, out={out_rms}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resampler_chunked_and_one_shot_match() -> Result<()> {
+        // Two resamplers, identical input, different chunking — outputs must agree.
+        let input = sine_wave(48_000, 261.6, 1.0, 0.3);
+        let mut one_shot = Resampler::new(48_000)?;
+        let mut a = one_shot.push(&input)?;
+        a.extend(one_shot.flush()?);
+
+        let mut chunked = Resampler::new(48_000)?;
+        let mut b = Vec::new();
+        for chunk in input.chunks(977) {
+            // odd chunk size — exercises boundary handling
+            b.extend(chunked.push(chunk)?);
+        }
+        b.extend(chunked.flush()?);
+
+        assert_eq!(a.len(), b.len(), "chunked and one-shot length disagree");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                (x - y).abs() < 1e-5,
+                "sample {i}: chunked={y}, one-shot={x}"
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/voice/wav.rs
+++ b/src/voice/wav.rs
@@ -453,4 +453,37 @@ mod tests {
         assert!(path.exists());
         Ok(())
     }
+
+    #[test]
+    fn mono_mixdown_passes_through_zero_channels_unchanged() {
+        // channels == 0 hits the `<= 1` branch and returns the input as-is;
+        // documents the no-op behaviour rather than letting it silently
+        // change.
+        let input = vec![0.1, 0.2, 0.3];
+        assert_eq!(mono_mixdown(&input, 0), input);
+    }
+
+    #[test]
+    fn resampler_push_empty_returns_empty() -> Result<()> {
+        let mut r = Resampler::new(48_000)?;
+        let out = r.push(&[])?;
+        assert!(out.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn resampler_flush_with_no_pending_input_is_empty() -> Result<()> {
+        // Identity path: no inner resampler, flush always returns empty.
+        let mut r = Resampler::new(TARGET_SAMPLE_RATE)?;
+        assert!(r.flush()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn resampler_identity_push_empty_returns_empty() -> Result<()> {
+        let mut r = Resampler::new(TARGET_SAMPLE_RATE)?;
+        let out = r.push(&[])?;
+        assert!(out.is_empty());
+        Ok(())
+    }
 }

--- a/src/voice/wav.rs
+++ b/src/voice/wav.rs
@@ -1,4 +1,4 @@
-//! Mixdown, resampling, idle detection, and WAV writing.
+//! Mixdown, resampling, and WAV writing.
 //!
 //! The write-path half of the capture pipeline:
 //!
@@ -8,11 +8,20 @@
 //!    `16_000` Hz via `rubato`'s sinc interpolator. Identity-passthrough is
 //!    used when the input is already 16 kHz so the pipeline stays
 //!    bit-exact in that common case.
+//! 3. [`WavWriter`] serialises 16 kHz mono f32 to 16-bit signed PCM WAV via
+//!    `hound`, with clamp-on-cast to handle resampler overshoot at the
+//!    extremes of `[-1.0, 1.0]`.
 //!
-//! The idle detector, trailing-silence trim, and `hound` WAV writer are
-//! added incrementally in steps 4–5.
+//! Idle detection and trailing-silence trimming live in
+//! [`super::idle`] — they operate on the post-resample 16 kHz stream
+//! and are independent of the writer.
+
+use std::fs::{self, File};
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use hound::{SampleFormat, WavSpec};
 use rubato::{
     Resampler as _, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
 };
@@ -165,6 +174,88 @@ impl Resampler {
     }
 }
 
+/// Bit depth of the output WAV (whisper.cpp convention).
+pub const OUTPUT_BITS_PER_SAMPLE: u16 = 16;
+
+/// Streaming WAV writer that accepts mono 16 kHz f32 samples and emits
+/// 16-bit signed PCM.
+///
+/// Samples are clamped into `[-1.0, 1.0]` before the cast to `i16`.
+/// [`WavWriter::finalize`] must be called to flush the header; on drop
+/// without finalisation the file is left with an invalid header (size
+/// field unwritten) — the orchestrator therefore always calls
+/// `finalize`, even on signal-driven shutdown.
+pub struct WavWriter {
+    inner: hound::WavWriter<BufWriter<File>>,
+    path: PathBuf,
+    samples_written: u64,
+}
+
+impl WavWriter {
+    /// Creates a WAV file at `path`, with parent directories created if
+    /// they do not exist. The header is written eagerly; the size field
+    /// is patched up by [`WavWriter::finalize`].
+    pub fn create(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create parent directory {}", parent.display())
+                })?;
+            }
+        }
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: TARGET_SAMPLE_RATE,
+            bits_per_sample: OUTPUT_BITS_PER_SAMPLE,
+            sample_format: SampleFormat::Int,
+        };
+        let inner = hound::WavWriter::create(&path, spec)
+            .with_context(|| format!("Failed to create WAV file at {}", path.display()))?;
+        Ok(Self {
+            inner,
+            path,
+            samples_written: 0,
+        })
+    }
+
+    /// Writes a chunk of mono samples. Values outside `[-1.0, 1.0]` are
+    /// clamped (resampler overshoot near 0 dBFS).
+    pub fn write_samples(&mut self, samples: &[f32]) -> Result<()> {
+        for s in samples {
+            let clamped = s.clamp(-1.0, 1.0);
+            let scaled = (clamped * f32::from(i16::MAX)).round() as i16;
+            self.inner
+                .write_sample(scaled)
+                .with_context(|| format!("Failed to write sample to {}", self.path.display()))?;
+        }
+        self.samples_written += samples.len() as u64;
+        Ok(())
+    }
+
+    /// Number of samples written so far (not counting any clamped value
+    /// any differently).
+    #[must_use]
+    pub fn samples_written(&self) -> u64 {
+        self.samples_written
+    }
+
+    /// Path the WAV was created at.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Flushes the WAV header so the file is playable. Consumes `self` so
+    /// double-finalisation cannot occur. Always call this — including on
+    /// signal-driven shutdown — or the on-disk file will be malformed.
+    pub fn finalize(self) -> Result<()> {
+        self.inner
+            .finalize()
+            .with_context(|| format!("Failed to finalize WAV file at {}", self.path.display()))
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -295,6 +386,71 @@ mod tests {
                 "sample {i}: chunked={y}, one-shot={x}"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn wav_writer_round_trips_samples() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let path = tmp.path().join("out.wav");
+        let mut writer = WavWriter::create(&path)?;
+        let samples: Vec<f32> = (0..1000)
+            .map(|i| (TAU * 440.0 * i as f32 / 16_000.0).sin() * 0.25)
+            .collect();
+        writer.write_samples(&samples)?;
+        assert_eq!(writer.samples_written(), 1000);
+        writer.finalize()?;
+
+        let mut reader = hound::WavReader::open(&path)?;
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, TARGET_SAMPLE_RATE);
+        assert_eq!(spec.bits_per_sample, OUTPUT_BITS_PER_SAMPLE);
+        assert_eq!(spec.sample_format, SampleFormat::Int);
+        let decoded: Vec<f32> = reader
+            .samples::<i16>()
+            .map(|s| f32::from(s.unwrap()) / f32::from(i16::MAX))
+            .collect();
+        assert_eq!(decoded.len(), 1000);
+        // Round-trip drift bounded by 1 lsb of 16-bit quantisation.
+        for (i, (orig, got)) in samples.iter().zip(decoded.iter()).enumerate() {
+            assert!(
+                (orig - got).abs() < 1.0 / f32::from(i16::MAX),
+                "sample {i}: orig={orig}, got={got}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn wav_writer_clamps_samples_to_int_range() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let path = tmp.path().join("clamp.wav");
+        let mut writer = WavWriter::create(&path)?;
+        // Values outside [-1.0, 1.0] should clamp, not wrap.
+        writer.write_samples(&[2.0, -2.0, 0.5, -0.5])?;
+        writer.finalize()?;
+
+        let mut reader = hound::WavReader::open(&path)?;
+        let decoded: Vec<i16> = reader.samples::<i16>().map(|s| s.unwrap()).collect();
+        assert_eq!(decoded[0], i16::MAX, "2.0 should clamp to i16::MAX");
+        // -1.0 * i16::MAX = -32767, not i16::MIN (-32768) — we scale by
+        // i16::MAX, not i16::MIN.abs(), so symmetric range.
+        assert_eq!(decoded[1], -i16::MAX, "-2.0 should clamp to -i16::MAX");
+        // 0.5 * 32767 ≈ 16383, with rounding.
+        assert!((decoded[2] - 16384).abs() <= 1);
+        assert!((decoded[3] + 16384).abs() <= 1);
+        Ok(())
+    }
+
+    #[test]
+    fn wav_writer_creates_parent_dirs() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let nested = tmp.path().join("a").join("b").join("c");
+        let path = nested.join("nested.wav");
+        let writer = WavWriter::create(&path)?;
+        writer.finalize()?;
+        assert!(path.exists());
         Ok(())
     }
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -16,6 +16,7 @@ Commands:
   atlassian   Atlassian: JIRA and Confluence operations
   datadog     Datadog: read-only API operations
   transcript  Transcript and caption fetching from media platforms
+  voice       Voice capture and processing operations
   resources   Embedded reference resources (specs, etc.)
   help-all    Displays comprehensive help for all commands
   help        Print this message or the help of the given subcommand(s)
@@ -2667,3 +2668,34 @@ Arguments:
 Options:
       --output <OUTPUT>  Output format [default: table] [possible values: table, json]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev voice - Voice capture and processing operations
+
+Voice capture and processing operations
+
+Usage: voice <COMMAND>
+
+Commands:
+  capture  Captures audio from a microphone to a 16 kHz mono WAV file
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev voice capture - Captures audio from a microphone to a 16 kHz mono WAV file
+
+Captures audio from a microphone to a 16 kHz mono WAV file
+
+Usage: capture [OPTIONS]
+
+Options:
+      --idle-after <IDLE_AFTER>  Stop after this many seconds of trailing silence. `0` disables auto-stop — capture runs until Ctrl-C [default: 5]
+      --output <OUTPUT>          Destination WAV path. Defaults to `~/.omni-dev/voice/captures/<UTC-timestamp>.wav`
+      --device <DEVICE>          Audio input device name. Defaults to the system default input. Matching is exact against the platform-reported device name; an unknown name errors with a list of detected devices
+  -h, --help                     Print help


### PR DESCRIPTION
## Description

This PR implements the `omni-dev voice capture` command, a complete microphone-to-WAV capture pipeline for issue #800. Users can now record audio from their system microphone directly to a 16 kHz mono 16-bit PCM WAV file (whisper.cpp convention), with automatic silence-based auto-stop and clean Ctrl-C termination.

The pipeline is structured as a layered, independently-testable set of stages: AudioSource → mono mixdown → rubato resampler → RMS idle detector → trailing-silence trim → hound WAV writer. The `AudioSource` trait (documented in ADR-0031) acts as the test seam between the untestable cpal hardware layer and the fully CI-testable pipeline stages, allowing every processing step to be exercised with synthesised or fixture WAVs without a microphone.

Usage:
```
omni-dev voice capture [--idle-after <secs>] [--output <path>] [--device <name>]
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement
- [x] Dependency update

## Related Issue
Fixes #800

## Changes Made

**Dependencies (`Cargo.toml` / `Cargo.lock`):**
- Added `cpal = "0.16"` for cross-platform audio capture
- Added `rubato = "0.16"` for high-quality sinc-based resampling
- Added `hound = "3.5"` for WAV reading/writing
- Added `signal-hook = "0.3"` for portable SIGINT handling
- Added `ringbuf = "0.4"` for the lock-free SPSC ring buffer between the cpal callback thread and the consumer

**Audio Abstraction (`src/voice/audio.rs`):**
- Defined `AudioSource` trait with `next_chunk() -> Option<Vec<f32>>`, `sample_rate() -> u32`, and `channels() -> u16`; intentionally not `Send` because cpal's macOS `Stream` is `!Send`
- Implemented `FileAudioSource` for tests: replays WAV fixtures or in-memory `Vec<f32>` in configurable chunk sizes, decoding integer PCM at any bit depth into f32 `[-1.0, 1.0]`
- Implemented `CpalAudioSource`: opens the default input device (or `--device`-named match), pushes F32/I16/U16 samples through a 1-second SPSC ring buffer; device-name errors include a full list of detected devices

**Write-Path Stages (`src/voice/wav.rs`):**
- `mono_mixdown(&[f32], channels: u16) -> Vec<f32>`: averages N interleaved channels to mono with a fast zero-copy path for already-mono input
- `Resampler`: wraps `rubato::SincFixedIn` with a streaming `push`/`flush` API converting any input rate to 16 kHz; identity passthrough (zero filter latency) when the input is already 16 kHz
- `WavWriter`: streaming 16 kHz mono 16-bit signed PCM writer backed by `hound`; clamps resampler overshoot before the i16 cast; `finalize()` consumes `self` to prevent double-finalisation

**Idle Detection (`src/voice/idle.rs`):**
- `IdleDetector`: streaming RMS over 100 ms windows at -40 dBFS threshold; fires after `idle_after_secs` consecutive silent windows; tracks `has_any_voice()` so the orchestrator can reject all-silent (muted mic) recordings
- `trim_trailing_silence(&[f32], tail_samples) -> &[f32]`: drops the silent window streak that caused the idle trigger before WAV finalisation

**Pipeline Orchestrator (`src/voice/capture.rs`):**
- `run_capture<S: AudioSource>(source, opts, stop_signal)`: threads the source through all write-path stages and returns a `CaptureSummary`
- Three termination paths: `Idle` (silence budget exhausted, tail trimmed), `SourceExhausted` (source returned `None`, resampler flushed), `Signal` (AtomicBool flipped by Ctrl-C, no trim)
- No-audio guard: errors with a descriptive message on muted-mic or pre-flip-signal captures rather than emitting a zero-sample WAV
- `install_ctrl_c_handler()`: registers SIGINT via `signal-hook` and returns the `Arc<AtomicBool>` polled by the capture loop

**CLI (`src/cli/voice.rs`, `src/cli/voice/capture.rs`):**
- `VoiceCommand` top-level subcommand registered in `src/cli.rs`
- `CaptureCommand` with `--idle-after` (default 5 s), `--output` (default `~/.omni-dev/voice/captures/<UTC>.wav`), and `--device` flags
- Prints a one-line capture summary to stderr on completion (samples, trim, termination reason, output path)

**Documentation:**
- Added ADR-0031 (`docs/adrs/adr-0031.md`): documents the rationale for the `AudioSource` trait boundary, the rejected alternatives (mock cpal, CLI-level only), the intentional `!Send` decision, and how the pattern scales to upcoming #799 umbrella issues
- Updated `docs/adrs/README.md` with the new ADR entry

**Tests:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` with the new `voice` and `voice capture` help sections

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added (help-all snapshot)

Unit tests cover:
- `FileAudioSource`: chunked playback, stereo frame-vs-sample sizing, i16→f32 decoding, in-memory round-trip, exhaustion, zero-chunk-size clamping
- `mono_mixdown`: mono passthrough, stereo inversion, quad averaging, partial-frame drop
- `Resampler`: identity passthrough, zero-rate rejection, 48k→16k RMS preservation, chunked-vs-one-shot output equivalence
- `IdleDetector`: exact window budget firing, voiced-window reset, all-voiced never-idle, partial-window buffering, RMS boundary classification, idle_after_secs=0 disables auto-stop
- `trim_trailing_silence`: exact drop, clamp-to-empty on overshoot
- `WavWriter`: round-trip accuracy (within 1 LSB), clamp-on-cast, parent directory creation
- `run_capture` integration: idle trim, source-exhausted full write, signal no-trim, signal-before-audio error, silence-only muted-mic error
- `CpalAudioSource`: unknown-device-name lists alternatives (CI-safe); default-input smoke test is `#[ignore]`-gated for local hardware runs
- `CaptureCommand` CLI parsing: defaults, all flags, idle-after=0, negative rejection, default output path format

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Hardware-only smoke test (requires a working audio input device)
cargo test -- --ignored
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `AudioSource` trait seam and the decision to make it `!Send` (see ADR-0031)
- [x] Error handling — no-audio guard paths in `run_capture`, device-not-found listing in `CpalAudioSource::new`
- [x] Performance impact — SPSC ring buffer sizing (1 s at 192 kHz × 8 ch), resampler chunk size (4096 frames), poll interval (10 ms)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Potential performance impact (describe below)

The capture loop polls the ring buffer every 10 ms when empty, consuming negligible CPU during silence. Each `next_chunk` call allocates a `Vec<f32>` of up to 2048 samples; this is well within budget for a 16 kHz pipeline (each call represents ≤128 ms at 16 kHz after downsampling). The rubato sinc filter (`sinc_len=256`, `oversampling_factor=128`) is CPU-intensive for the first chunk due to warm-up but amortises over the 4096-frame processing window (~85 ms at 48 kHz). When input is already 16 kHz the resampler is bypassed entirely.

## Security Considerations
- [x] No security implications

The SIGINT handler uses `signal-hook`'s safe flag-based API (no `unsafe` signal handler code). Audio data is written to a local file path with no network I/O.

## Breaking Changes

None. This is a purely additive feature. The new `voice` subcommand appears in `omni-dev --help` but does not affect any existing command behaviour.

## Deployment Notes
- [x] No special deployment requirements

The new `cpal` dependency links against platform audio libraries (`ALSA` on Linux, `CoreAudio` on macOS, WASAPI on Windows) at build time. No new environment variables, configuration files, or service restarts are required.

## Additional Notes

**Future Enhancements:**
- Additional `AudioSource` implementations for the #799 umbrella: `voice listen` (continuous), hotkey-gated capture, system-audio (loopback) capture, and transcribe-from-file
- The `Vec<f32>` allocation per `next_chunk` call is a deliberate v1 simplification; a `next_chunk_into(&mut Vec<f32>)` variant can be added if `voice listen` requires a tighter loop
- Additional OAuth2 providers can follow the same `AudioSource` trait pattern for new hardware types

**Known Limitations:**
- `CpalAudioSource` supports F32, I16, and U16 sample formats only; exotic formats (e.g., I24 packed) will produce an error with a clear message to file an issue
- The `#[ignore]`-gated cpal smoke test cannot run in CI; regressions in device enumeration or stream setup are caught only on local runs
- The `AudioSource` trait is `!Send`; sources that need to cross threads will require a future bound widening

**Alternatives Considered:**
- Mock cpal types directly: rejected because it couples tests to cpal's API shape and doesn't test the pipeline behaviour the issue cares about (see ADR-0031)
- Test at the CLI level only: rejected because it requires real hardware in CI and provides no insight into intermediate stages