### PR TITLE
feat(voice): add voice transcribe subcommand with JSONL and markdown output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "similar 2.7.0",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ mcp = ["dep:rmcp"]
 
 [dev-dependencies]
 tempfile = "3.27"
-insta = "1.47"
+insta = { version = "1.47", features = ["filters"] }
 proptest = "1"
 wiremock = "0.6"
 rmcp = { version = "1.6", features = ["client", "server", "transport-io", "macros"] }

--- a/src/cli/voice.rs
+++ b/src/cli/voice.rs
@@ -1,10 +1,11 @@
 //! Voice-related CLI commands.
 //!
-//! Provider-namespaced (only `capture` today; later: `listen`, `transcribe`).
-//! Per-subcommand argument structs live in submodules to keep help text
-//! and parse logic local to each command.
+//! Provider-namespaced (`capture`, `transcribe` today; later: `listen`,
+//! `review`). Per-subcommand argument structs live in submodules to keep
+//! help text and parse logic local to each command.
 
 pub mod capture;
+pub mod transcribe;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -22,6 +23,8 @@ pub struct VoiceCommand {
 pub enum VoiceSubcommands {
     /// Captures audio from a microphone to a 16 kHz mono WAV file.
     Capture(capture::CaptureCommand),
+    /// Transcribes a 16 kHz mono WAV file to JSONL or markdown.
+    Transcribe(transcribe::TranscribeCommand),
 }
 
 impl VoiceCommand {
@@ -29,6 +32,7 @@ impl VoiceCommand {
     pub fn execute(self) -> Result<()> {
         match self.command {
             VoiceSubcommands::Capture(cmd) => cmd.execute(),
+            VoiceSubcommands::Transcribe(cmd) => cmd.execute(),
         }
     }
 }
@@ -37,6 +41,8 @@ impl VoiceCommand {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    use std::path::PathBuf;
 
     #[test]
     fn voice_subcommands_capture_variant() {
@@ -48,5 +54,17 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, VoiceSubcommands::Capture(_)));
+    }
+
+    #[test]
+    fn voice_subcommands_transcribe_variant() {
+        let cmd = VoiceCommand {
+            command: VoiceSubcommands::Transcribe(transcribe::TranscribeCommand {
+                wav: PathBuf::from("/tmp/x.wav"),
+                backend: None,
+                format: None,
+            }),
+        };
+        assert!(matches!(cmd.command, VoiceSubcommands::Transcribe(_)));
     }
 }

--- a/src/cli/voice/transcribe.rs
+++ b/src/cli/voice/transcribe.rs
@@ -1,0 +1,275 @@
+//! `omni-dev voice transcribe` — feed a 16 kHz mono WAV file through the
+//! configured [`crate::voice::Transcriber`] and emit JSONL events to stdout
+//! (markdown when stdout is a tty).
+//!
+//! WAV validation is delegated to
+//! [`crate::voice::VecAudioInput::from_wav_path`] — non-16 kHz, non-mono,
+//! non-16-bit-PCM files error with a descriptive message pointing at
+//! `voice capture` as the source of normalised audio.
+
+use std::io::IsTerminal;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::voice::{
+    create_default_transcriber, detect_format, render_jsonl, render_markdown, OutputFormat,
+    VecAudioInput, VoiceOpts,
+};
+
+/// Default chunk size handed to [`VecAudioInput`]. Doesn't affect the
+/// mock backend's output; chosen for parity with the streaming pipeline
+/// (#806) where ~64 ms chunks at 16 kHz keep latency low without
+/// thrashing the inference loop.
+const DEFAULT_CHUNK_SAMPLES: usize = 1024;
+
+/// Transcribes a 16 kHz mono WAV file to JSONL or markdown.
+///
+/// Output format defaults to `md` on a tty and `jsonl` when stdout is
+/// piped; pass `--format` to override. The transcriber backend is chosen
+/// by `--backend`, then `OMNI_DEV_VOICE_BACKEND`, then the default
+/// (`"mock"` until a real ASR backend lands — see ADR-0032).
+#[derive(Parser)]
+pub struct TranscribeCommand {
+    /// Path to a 16 kHz mono 16-bit PCM WAV file. Use `voice capture` to
+    /// produce one — `transcribe` does not resample.
+    pub wav: PathBuf,
+
+    /// Transcriber backend. Currently only `"mock"` is supported; a real
+    /// ASR backend is deferred (see issue #802).
+    #[arg(long)]
+    pub backend: Option<String>,
+
+    /// Output format. Defaults to `md` on a tty, `jsonl` when piped.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormatArg>,
+}
+
+/// `clap` value enum matching [`OutputFormat`].
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum OutputFormatArg {
+    /// JSON Lines — one event per line, machine-readable.
+    Jsonl,
+    /// Markdown — human-readable transcript view.
+    Md,
+}
+
+impl From<OutputFormatArg> for OutputFormat {
+    fn from(value: OutputFormatArg) -> Self {
+        match value {
+            OutputFormatArg::Jsonl => Self::Jsonl,
+            OutputFormatArg::Md => Self::Md,
+        }
+    }
+}
+
+impl TranscribeCommand {
+    /// Executes the transcribe command.
+    ///
+    /// Thin shim around [`Self::run`]: locks stdout and resolves the
+    /// effective format from `--format` plus tty auto-detection, then
+    /// delegates to the writer-generic helper. The split keeps stdout-
+    /// locking and tty-detection out of the testable business logic.
+    pub fn execute(self) -> Result<()> {
+        let format = detect_format(
+            self.format.map(OutputFormat::from),
+            std::io::stdout().is_terminal(),
+        );
+        let mut out = std::io::stdout().lock();
+        self.run(&mut out, format)
+    }
+
+    /// Runs the transcribe pipeline against an arbitrary writer.
+    ///
+    /// Decoupled from stdout so unit tests can drive the error paths
+    /// (writer failures, flush failures, backend-construction failures)
+    /// without spawning a subprocess.
+    fn run<W: Write>(self, w: &mut W, format: OutputFormat) -> Result<()> {
+        let opts = VoiceOpts {
+            backend: self.backend,
+            model: None,
+        };
+        let transcriber = create_default_transcriber(&opts)?;
+        let input = VecAudioInput::from_wav_path(&self.wav, DEFAULT_CHUNK_SAMPLES)?;
+        let stream = transcriber.transcribe(Box::new(input))?;
+
+        match format {
+            OutputFormat::Jsonl => render_jsonl(stream, w)?,
+            OutputFormat::Md => render_markdown(stream, w)?,
+        }
+        w.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        transcribe: TranscribeCommand,
+    }
+
+    #[test]
+    fn parses_required_wav_only() {
+        let cli = TestCli::try_parse_from(["test", "/tmp/x.wav"]).unwrap();
+        assert_eq!(cli.transcribe.wav.to_str().unwrap(), "/tmp/x.wav");
+        assert!(cli.transcribe.backend.is_none());
+        assert!(cli.transcribe.format.is_none());
+    }
+
+    #[test]
+    fn parses_all_flags() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "/tmp/x.wav",
+            "--backend",
+            "mock",
+            "--format",
+            "jsonl",
+        ])
+        .unwrap();
+        assert_eq!(cli.transcribe.backend.as_deref(), Some("mock"));
+        assert!(matches!(
+            cli.transcribe.format,
+            Some(OutputFormatArg::Jsonl)
+        ));
+    }
+
+    #[test]
+    fn parses_md_format() {
+        let cli = TestCli::try_parse_from(["test", "/tmp/x.wav", "--format", "md"]).unwrap();
+        assert!(matches!(cli.transcribe.format, Some(OutputFormatArg::Md)));
+    }
+
+    #[test]
+    fn rejects_missing_wav() {
+        let result = TestCli::try_parse_from(["test"]);
+        assert!(result.is_err(), "wav argument is required");
+    }
+
+    #[test]
+    fn rejects_unknown_format() {
+        let result = TestCli::try_parse_from(["test", "/tmp/x.wav", "--format", "yaml"]);
+        assert!(result.is_err(), "only md/jsonl are valid formats");
+    }
+
+    #[test]
+    fn output_format_arg_maps_to_output_format() {
+        assert_eq!(
+            OutputFormat::from(OutputFormatArg::Jsonl),
+            OutputFormat::Jsonl
+        );
+        assert_eq!(OutputFormat::from(OutputFormatArg::Md), OutputFormat::Md);
+    }
+
+    // ── In-process error-path tests for `TranscribeCommand::run` ──
+    //
+    // These exercise the `?` propagation in `run` directly, bypassing the
+    // subprocess machinery so each error site (backend factory, WAV load,
+    // render write, render flush) is hit deterministically.
+
+    struct AlwaysFailWriter;
+
+    impl Write for AlwaysFailWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("forced write failure"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FlushFailWriter;
+
+    impl Write for FlushFailWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("forced flush failure"))
+        }
+    }
+
+    fn fixture_wav() -> PathBuf {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        manifest.join("tests/fixtures/voice/short_en.wav")
+    }
+
+    fn cmd(wav: PathBuf, backend: Option<&str>) -> TranscribeCommand {
+        TranscribeCommand {
+            wav,
+            backend: backend.map(str::to_string),
+            format: None,
+        }
+    }
+
+    #[test]
+    fn run_propagates_unknown_backend_error() {
+        let mut buf: Vec<u8> = Vec::new();
+        let err = cmd(fixture_wav(), Some("nope"))
+            .run(&mut buf, OutputFormat::Jsonl)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown voice backend"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn run_propagates_missing_wav_error() {
+        let mut buf: Vec<u8> = Vec::new();
+        let err = cmd(PathBuf::from("/nonexistent/should/not/exist.wav"), None)
+            .run(&mut buf, OutputFormat::Jsonl)
+            .unwrap_err();
+        assert!(err.to_string().contains("Failed to open WAV"), "got: {err}");
+    }
+
+    #[test]
+    fn run_propagates_writer_error_jsonl() {
+        let err = cmd(fixture_wav(), None)
+            .run(&mut AlwaysFailWriter, OutputFormat::Jsonl)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("forced write failure"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn run_propagates_writer_error_md() {
+        let err = cmd(fixture_wav(), None)
+            .run(&mut AlwaysFailWriter, OutputFormat::Md)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("forced write failure"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn run_propagates_flush_error() {
+        // FlushFailWriter accepts writes — including the per-event flushes
+        // inside render_jsonl — so this primarily exercises the first
+        // mid-stream flush `?`. The final outer `w.flush()?` in `run` is
+        // only reachable if the inner flushes all succeed, which by design
+        // of FlushFailWriter they don't. The behaviour we're locking in
+        // is "flush errors propagate, full stop" — not which `?` site
+        // catches them first.
+        let err = cmd(fixture_wav(), None)
+            .run(&mut FlushFailWriter, OutputFormat::Jsonl)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("forced flush failure"),
+            "got: {err}"
+        );
+    }
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -14,6 +14,7 @@ pub mod backends;
 pub mod capture;
 pub mod factory;
 pub mod idle;
+pub mod render;
 pub mod transcriber;
 pub mod wav;
 
@@ -22,6 +23,7 @@ pub use capture::{
     install_ctrl_c_handler, run_capture, CaptureOpts, CaptureSummary, TerminationReason,
 };
 pub use factory::{create_default_transcriber, VoiceOpts};
+pub use render::{detect_format, render_jsonl, render_markdown, OutputFormat};
 pub use transcriber::{
     AudioChunk, AudioInput, EndpointKind, EventId, EventStream, SpeakerId, Transcriber,
     TranscriptEvent, VecAudioInput, Word,

--- a/src/voice/render.rs
+++ b/src/voice/render.rs
@@ -1,0 +1,435 @@
+//! Rendering helpers for [`crate::voice::TranscriptEvent`] streams.
+//!
+//! Two output formats are supported, both designed to stream — each event
+//! is flushed as soon as the backend emits it so a slow transcriber gives
+//! incremental feedback on stdout instead of buffering the full transcript.
+//!
+//! * `Jsonl` — one `serde_json` line per event. Stable, machine-readable.
+//! * `Md` — human-readable transcript. Consecutive `Final` events from the
+//!   same speaker collapse into a single paragraph prefixed with
+//!   `[HH:MM:SS] **speaker**: ` (the `**speaker**: ` prefix is omitted
+//!   when no speaker is attached).
+//!
+//! Lives under `src/voice/` rather than `src/cli/voice/` because the
+//! `voice review` command in #804 will reuse `render_markdown`.
+//!
+//! `Partial` and `Endpoint` events are skipped in markdown mode: the batch
+//! backend in #801 emits no partials, and endpoint markers add no signal
+//! to a reader-oriented transcript.
+
+use std::io::Write;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::voice::transcriber::{SpeakerId, TranscriptEvent};
+
+/// Output format selector. The CLI maps `--format md|jsonl` directly onto
+/// this; the default value is chosen at runtime by [`detect_format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// JSON Lines — one event per line, machine-readable.
+    Jsonl,
+    /// Markdown — human-readable transcript view.
+    Md,
+}
+
+/// Resolves the effective output format.
+///
+/// Explicit `--format` always wins. With no flag, stdout-on-a-tty defaults
+/// to markdown; stdout-on-a-pipe defaults to JSONL. Mirrors the design
+/// principle that machine consumers (`| jq`, file redirection) get a
+/// stable schema and humans get prose.
+pub fn detect_format(explicit: Option<OutputFormat>, stdout_is_tty: bool) -> OutputFormat {
+    match explicit {
+        Some(fmt) => fmt,
+        None if stdout_is_tty => OutputFormat::Md,
+        None => OutputFormat::Jsonl,
+    }
+}
+
+/// Streams events as JSON Lines to `w`, flushing after each event.
+///
+/// The flush is deliberate: a streaming backend can emit a `Partial`
+/// half a second before its `Final` and a downstream `tail -f` consumer
+/// should see it without waiting for the next event to push it through
+/// stdio buffering.
+pub fn render_jsonl<I, W>(events: I, w: &mut W) -> Result<()>
+where
+    I: IntoIterator<Item = Result<TranscriptEvent>>,
+    W: Write,
+{
+    for event in events {
+        let event = event?;
+        serde_json::to_writer(&mut *w, &event)?;
+        writeln!(w)?;
+        w.flush()?;
+    }
+    Ok(())
+}
+
+/// Streams events as Markdown to `w`.
+///
+/// Groups consecutive `Final` events by speaker into one paragraph each
+/// (a paragraph being one timestamped line followed by a blank line),
+/// flushing at every speaker-paragraph boundary so the reader sees
+/// transcript output as it commits. `Partial` and `Endpoint` events are
+/// dropped.
+pub fn render_markdown<I, W>(events: I, w: &mut W) -> Result<()>
+where
+    I: IntoIterator<Item = Result<TranscriptEvent>>,
+    W: Write,
+{
+    let mut group: Option<MarkdownParagraph> = None;
+    for event in events {
+        let event = event?;
+        let TranscriptEvent::Final {
+            text,
+            start,
+            speaker,
+            ..
+        } = event
+        else {
+            continue;
+        };
+        match group.as_mut() {
+            Some(existing) if existing.speaker == speaker => {
+                existing.push_segment(&text);
+            }
+            _ => {
+                if let Some(prev) = group.take() {
+                    prev.write(w)?;
+                    w.flush()?;
+                }
+                group = Some(MarkdownParagraph::new(start, speaker, text));
+            }
+        }
+    }
+    if let Some(last) = group {
+        last.write(w)?;
+        w.flush()?;
+    }
+    Ok(())
+}
+
+struct MarkdownParagraph {
+    start: Duration,
+    speaker: Option<SpeakerId>,
+    text: String,
+}
+
+impl MarkdownParagraph {
+    fn new(start: Duration, speaker: Option<SpeakerId>, text: String) -> Self {
+        Self {
+            start,
+            speaker,
+            text,
+        }
+    }
+
+    fn push_segment(&mut self, segment: &str) {
+        // Single space joiner — matches how a human would read aloud
+        // consecutive finals from one speaker. Don't collapse internal
+        // whitespace; the backend's text is authoritative.
+        if !self.text.is_empty() && !segment.is_empty() {
+            self.text.push(' ');
+        }
+        self.text.push_str(segment);
+    }
+
+    fn write<W: Write>(&self, w: &mut W) -> Result<()> {
+        let ts = fmt_timestamp(self.start);
+        match self.speaker.as_deref() {
+            Some(name) => writeln!(w, "[{ts}] **{name}**: {}", self.text)?,
+            None => writeln!(w, "[{ts}] {}", self.text)?,
+        }
+        writeln!(w)?;
+        Ok(())
+    }
+}
+
+/// Formats a stream-relative `Duration` as `HH:MM:SS`, zero-padded, with
+/// hours always shown.
+///
+/// Hours always shown — even for short audio — so the column width is
+/// stable across a transcript and matches the convention used by
+/// `ffmpeg`, `mpv`, and most media players.
+fn fmt_timestamp(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::voice::transcriber::EndpointKind;
+
+    /// `Write` impl that fails on every `write` call. Lets tests exercise
+    /// the first `?` site in any rendering function without depending on
+    /// the exact number of internal writes a formatter issues.
+    struct AlwaysFailWriter;
+
+    impl Write for AlwaysFailWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("forced write failure"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// `Write` impl that accepts all writes but fails on `flush`. Targets
+    /// the post-event `w.flush()?` branches in `render_jsonl` and
+    /// `render_markdown`'s paragraph boundaries.
+    struct FlushFailWriter;
+
+    impl Write for FlushFailWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("forced flush failure"))
+        }
+    }
+
+    fn final_event(text: &str, start_secs: u64, speaker: Option<&str>) -> TranscriptEvent {
+        TranscriptEvent::Final {
+            event_id: ulid::Ulid::from_parts(0, u128::from(start_secs) + 1),
+            text: text.to_string(),
+            start: Duration::from_secs(start_secs),
+            end: Duration::from_secs(start_secs + 1),
+            confidence: 0.9,
+            words: None,
+            speaker: speaker.map(str::to_string),
+            revisable: false,
+        }
+    }
+
+    fn render_md_to_string<I>(events: I) -> String
+    where
+        I: IntoIterator<Item = TranscriptEvent>,
+    {
+        let mut buf: Vec<u8> = Vec::new();
+        render_markdown(events.into_iter().map(Ok), &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn render_jsonl_to_string<I>(events: I) -> String
+    where
+        I: IntoIterator<Item = TranscriptEvent>,
+    {
+        let mut buf: Vec<u8> = Vec::new();
+        render_jsonl(events.into_iter().map(Ok), &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn detect_format_explicit_wins_over_tty() {
+        assert_eq!(
+            detect_format(Some(OutputFormat::Jsonl), true),
+            OutputFormat::Jsonl
+        );
+        assert_eq!(
+            detect_format(Some(OutputFormat::Md), false),
+            OutputFormat::Md
+        );
+    }
+
+    #[test]
+    fn detect_format_tty_defaults_to_md() {
+        assert_eq!(detect_format(None, true), OutputFormat::Md);
+    }
+
+    #[test]
+    fn detect_format_pipe_defaults_to_jsonl() {
+        assert_eq!(detect_format(None, false), OutputFormat::Jsonl);
+    }
+
+    #[test]
+    fn fmt_timestamp_pads_zero() {
+        assert_eq!(fmt_timestamp(Duration::from_secs(0)), "00:00:00");
+        assert_eq!(fmt_timestamp(Duration::from_secs(7)), "00:00:07");
+        assert_eq!(fmt_timestamp(Duration::from_secs(75)), "00:01:15");
+        assert_eq!(fmt_timestamp(Duration::from_secs(3_600)), "01:00:00");
+        assert_eq!(
+            fmt_timestamp(Duration::from_secs(3_600 + 23 * 60 + 45)),
+            "01:23:45"
+        );
+    }
+
+    #[test]
+    fn fmt_timestamp_truncates_subsecond() {
+        // 1.9s reads as 00:00:01 (whole seconds only, matching media-player
+        // convention).
+        assert_eq!(fmt_timestamp(Duration::from_millis(1_900)), "00:00:01");
+    }
+
+    #[test]
+    fn render_jsonl_emits_one_line_per_event_and_flushes() {
+        let out = render_jsonl_to_string([
+            final_event("hello", 0, None),
+            TranscriptEvent::Endpoint {
+                at: Duration::from_millis(1_500),
+                kind: EndpointKind::StreamEnd,
+            },
+        ]);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with(r#"{"type":"final""#));
+        assert!(lines[0].contains(r#""text":"hello""#));
+        assert!(lines[1].starts_with(r#"{"type":"endpoint""#));
+        assert!(lines[1].contains(r#""at":1.5"#));
+        // Trailing newline after the last event.
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn render_jsonl_propagates_stream_error() {
+        let events: Vec<Result<TranscriptEvent>> = vec![Err(anyhow::anyhow!("backend exploded"))];
+        let mut buf: Vec<u8> = Vec::new();
+        let err = render_jsonl(events, &mut buf).unwrap_err();
+        assert!(err.to_string().contains("backend exploded"));
+    }
+
+    #[test]
+    fn render_markdown_propagates_stream_error() {
+        let events: Vec<Result<TranscriptEvent>> = vec![Err(anyhow::anyhow!("backend exploded"))];
+        let mut buf: Vec<u8> = Vec::new();
+        let err = render_markdown(events, &mut buf).unwrap_err();
+        assert!(err.to_string().contains("backend exploded"));
+    }
+
+    #[test]
+    fn render_markdown_handles_empty_text_segment_in_group() {
+        // Two consecutive same-speaker finals where the *second* has empty
+        // text. The push_segment joiner must skip the leading space; the
+        // output should be a single paragraph with the first final's text
+        // unchanged.
+        let out = render_md_to_string([
+            final_event("hello", 0, Some("alice")),
+            final_event("", 2, Some("alice")),
+        ]);
+        assert_eq!(out, "[00:00:00] **alice**: hello\n\n");
+    }
+
+    #[test]
+    fn render_markdown_skips_partial_and_endpoint() {
+        let out = render_md_to_string([
+            TranscriptEvent::Partial {
+                text: "ignored".into(),
+                start: Duration::from_secs(0),
+                end: Duration::from_secs(1),
+                words: None,
+                speaker: None,
+            },
+            final_event("kept", 0, None),
+            TranscriptEvent::Endpoint {
+                at: Duration::from_secs(2),
+                kind: EndpointKind::StreamEnd,
+            },
+        ]);
+        assert!(!out.contains("ignored"));
+        assert!(out.contains("kept"));
+        // No timestamp from the endpoint should bleed through.
+        assert!(!out.contains("[00:00:02]"));
+    }
+
+    #[test]
+    fn render_markdown_groups_consecutive_same_speaker_finals() {
+        let out = render_md_to_string([
+            final_event("hello", 0, Some("alice")),
+            final_event("world", 2, Some("alice")),
+            final_event("hi", 4, Some("bob")),
+        ]);
+        // alice's two segments merge onto one line; bob is a new paragraph.
+        let expected = "[00:00:00] **alice**: hello world\n\n[00:00:04] **bob**: hi\n\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn render_markdown_groups_consecutive_none_speaker_finals() {
+        let out =
+            render_md_to_string([final_event("alpha", 0, None), final_event("beta", 3, None)]);
+        // Two consecutive None-speaker finals collapse into one paragraph
+        // with no speaker prefix.
+        assert_eq!(out, "[00:00:00] alpha beta\n\n");
+    }
+
+    #[test]
+    fn render_markdown_speaker_change_starts_new_paragraph() {
+        let out = render_md_to_string([
+            final_event("a", 0, Some("alice")),
+            final_event("b", 1, None),
+            final_event("c", 2, Some("alice")),
+        ]);
+        // None → alice → None all distinct paragraphs.
+        let expected = "[00:00:00] **alice**: a\n\n[00:00:01] b\n\n[00:00:02] **alice**: c\n\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn render_jsonl_propagates_writer_error() {
+        let events = [Ok(final_event("a", 0, None))];
+        let err = render_jsonl(events, &mut AlwaysFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced write failure"));
+    }
+
+    #[test]
+    fn render_jsonl_propagates_flush_error() {
+        let events = [Ok(final_event("a", 0, None))];
+        let err = render_jsonl(events, &mut FlushFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced flush failure"));
+    }
+
+    #[test]
+    fn render_markdown_propagates_writer_error_with_speaker() {
+        // Exercises the paragraph-write `?` plus the with-speaker writeln
+        // arm inside MarkdownParagraph::write.
+        let events = [Ok(final_event("a", 0, Some("alice")))];
+        let err = render_markdown(events, &mut AlwaysFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced write failure"));
+    }
+
+    #[test]
+    fn render_markdown_propagates_writer_error_no_speaker() {
+        // Same as above, but exercises the no-speaker writeln arm.
+        let events = [Ok(final_event("a", 0, None))];
+        let err = render_markdown(events, &mut AlwaysFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced write failure"));
+    }
+
+    #[test]
+    fn render_markdown_propagates_flush_error_at_paragraph_end() {
+        // FlushFailWriter accepts the paragraph's writes (content +
+        // blank line), then fails on the trailing per-paragraph flush.
+        let events = [Ok(final_event("a", 0, None))];
+        let err = render_markdown(events, &mut FlushFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced flush failure"));
+    }
+
+    #[test]
+    fn render_markdown_propagates_writer_error_at_paragraph_break() {
+        // Two different-speaker finals exercise the mid-stream
+        // `prev.write(w)?` path (line 101) when the group changes.
+        // AlwaysFailWriter trips that branch on the first paragraph's
+        // writeln, before the speaker change is even reached — close
+        // enough to exercise the second-paragraph entry; the regression
+        // we want to catch is "errors mid-stream don't get swallowed."
+        let events = [
+            Ok(final_event("a", 0, Some("alice"))),
+            Ok(final_event("b", 1, Some("bob"))),
+        ];
+        let err = render_markdown(events, &mut AlwaysFailWriter).unwrap_err();
+        assert!(err.to_string().contains("forced write failure"));
+    }
+
+    #[test]
+    fn render_markdown_empty_input_writes_nothing() {
+        let out = render_md_to_string::<[TranscriptEvent; 0]>([]);
+        assert_eq!(out, "");
+    }
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2679,8 +2679,9 @@ Voice capture and processing operations
 Usage: voice <COMMAND>
 
 Commands:
-  capture  Captures audio from a microphone to a 16 kHz mono WAV file
-  help     Print this message or the help of the given subcommand(s)
+  capture     Captures audio from a microphone to a 16 kHz mono WAV file
+  transcribe  Transcribes a 16 kHz mono WAV file to JSONL or markdown
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -2699,3 +2700,20 @@ Options:
       --output <OUTPUT>          Destination WAV path. Defaults to `~/.omni-dev/voice/captures/<UTC-timestamp>.wav`
       --device <DEVICE>          Audio input device name. Defaults to the system default input. Matching is exact against the platform-reported device name; an unknown name errors with a list of detected devices
   -h, --help                     Print help
+
+
+================================================================================
+
+omni-dev voice transcribe - Transcribes a 16 kHz mono WAV file to JSONL or markdown
+
+Transcribes a 16 kHz mono WAV file to JSONL or markdown
+
+Usage: transcribe [OPTIONS] <WAV>
+
+Arguments:
+  <WAV>  Path to a 16 kHz mono 16-bit PCM WAV file. Use `voice capture` to produce one — `transcribe` does not resample
+
+Options:
+      --backend <BACKEND>  Transcriber backend. Currently only `"mock"` is supported; a real ASR backend is deferred (see issue #802)
+      --format <FORMAT>    Output format. Defaults to `md` on a tty, `jsonl` when piped [possible values: jsonl, md]
+  -h, --help               Print help (see more with '--help')

--- a/tests/snapshots/voice_transcribe_cli_test__voice_transcribe_cli_jsonl.snap
+++ b/tests/snapshots/voice_transcribe_cli_test__voice_transcribe_cli_jsonl.snap
@@ -1,0 +1,7 @@
+---
+source: tests/voice_transcribe_cli_test.rs
+expression: out
+---
+{"type":"final","event_id":"<ULID>","text":"[mock transcriber] segment 1","start":0.0,"end":2.0,"confidence":1.0,"revisable":false}
+{"type":"final","event_id":"<ULID>","text":"[mock transcriber] segment 2","start":2.0,"end":5.0,"confidence":1.0,"revisable":false}
+{"type":"endpoint","at":11.6879375,"kind":"stream_end"}

--- a/tests/snapshots/voice_transcribe_cli_test__voice_transcribe_cli_md.snap
+++ b/tests/snapshots/voice_transcribe_cli_test__voice_transcribe_cli_md.snap
@@ -1,0 +1,5 @@
+---
+source: tests/voice_transcribe_cli_test.rs
+expression: out
+---
+[00:00:00] [mock transcriber] segment 1 [mock transcriber] segment 2

--- a/tests/voice_transcribe_cli_test.rs
+++ b/tests/voice_transcribe_cli_test.rs
@@ -1,0 +1,87 @@
+//! End-to-end snapshot tests for the `omni-dev voice transcribe` CLI.
+//!
+//! Spawns the compiled binary against the committed
+//! `tests/fixtures/voice/short_en.wav` fixture and pins both `--format
+//! jsonl` and `--format md` outputs. Distinct from the trait-level test
+//! in `tests/voice_transcribe_test.rs`, which exercises `MockTranscriber`
+//! through a deterministic-RNG seam — this test goes through the
+//! production factory (`create_default_transcriber`), which seeds the
+//! mock with `SystemUlidRng`. The `event_id` ULIDs are redacted via
+//! `insta`'s filter so the snapshot is byte-stable across runs.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+
+fn fixture_path() -> PathBuf {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.join("tests/fixtures/voice/short_en.wav")
+}
+
+fn run_transcribe(format: &str) -> String {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .args([
+            "voice",
+            "transcribe",
+            fixture_path().to_str().unwrap(),
+            "--format",
+            format,
+        ])
+        .output()
+        .expect("failed to run omni-dev voice transcribe");
+    assert!(
+        output.status.success(),
+        "voice transcribe --format {format} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout was not UTF-8")
+}
+
+#[test]
+fn voice_transcribe_jsonl_format() {
+    let out = run_transcribe("jsonl");
+    insta::with_settings!({
+        filters => vec![
+            // The production factory seeds MockTranscriber with
+            // SystemUlidRng, so event_id is real and varies per run.
+            // Redact it to keep the snapshot byte-stable.
+            (r#""event_id":"[0-9A-Z]{26}""#, r#""event_id":"<ULID>""#),
+        ],
+    }, {
+        insta::assert_snapshot!("voice_transcribe_cli_jsonl", out);
+    });
+}
+
+#[test]
+fn voice_transcribe_md_format() {
+    let out = run_transcribe("md");
+    insta::assert_snapshot!("voice_transcribe_cli_md", out);
+}
+
+#[test]
+fn voice_transcribe_rejects_missing_wav() {
+    // Exercises the WAV-load error path in TranscribeCommand::execute. The
+    // error message comes from VecAudioInput::from_wav_path and points the
+    // user back at `voice capture` for normalised audio.
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .args([
+            "voice",
+            "transcribe",
+            "/nonexistent/path/should-not-exist.wav",
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .expect("failed to run omni-dev voice transcribe");
+    assert!(
+        !output.status.success(),
+        "missing WAV should exit non-zero; got stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to open WAV"),
+        "stderr should surface the WAV-open error, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Description

This PR implements `omni-dev voice transcribe` — a new CLI subcommand that feeds a 16 kHz mono WAV file through the configured transcriber backend and streams the resulting transcript to stdout in either JSONL or markdown format.

Output format defaults to `md` when stdout is a tty (human-readable, speaker-attributed paragraphs) and `jsonl` when stdout is piped (stable, machine-readable, one event per line). Users can override this with `--format jsonl|md`. The transcriber backend is selected via `--backend`, then `OMNI_DEV_VOICE_BACKEND`, then the default (`"mock"` until a real ASR backend lands — see issue #802).

This is the batch-file transcription building block for the broader voice pipeline (#802). The `render_markdown` helper is placed in `src/voice/render.rs` (rather than under `src/cli/`) so it can be reused by the upcoming `voice review` command (#804).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [x] Dependency update

## Related Issue
Relates to #802

## Changes Made

**Core Changes:**
- Added `src/cli/voice/transcribe.rs` with `TranscribeCommand` struct, `OutputFormatArg` clap value enum (`jsonl`/`md`), and `execute()` wiring through `create_default_transcriber`, `VecAudioInput`, and the render helpers
- Added `src/voice/render.rs` with `render_jsonl`, `render_markdown`, `detect_format`, and `OutputFormat`; markdown groups consecutive `Final` events from the same speaker into timestamped paragraphs (`[HH:MM:SS] **speaker**: text`), skipping `Partial` and `Endpoint` events; JSONL emits one `serde_json` line per event with flush-after-each for streaming consumers
- Registered `Transcribe` variant in `VoiceSubcommands` and dispatched in `VoiceCommand::execute` in `src/cli/voice.rs`
- Wired `pub mod render` and re-exported `detect_format`, `render_jsonl`, `render_markdown`, `OutputFormat` from `src/voice.rs`

**Dependencies:**
- Enabled `insta` `filters` feature in `Cargo.toml` to support ULID redaction in snapshot tests

**Testing:**
- Added end-to-end snapshot tests in `tests/voice_transcribe_cli_test.rs` covering `--format jsonl` and `--format md` against `tests/fixtures/voice/short_en.wav`; ULIDs in `event_id` are redacted via `insta` filters to keep snapshots byte-stable across runs
- Added unit tests in `src/voice/render.rs` for `render_jsonl`, `render_markdown`, `detect_format`, and `fmt_timestamp` covering speaker grouping, partial/endpoint skipping, stream error propagation, and timestamp formatting
- Added unit tests in `src/cli/voice/transcribe.rs` for clap argument parsing (required wav, optional backend/format flags, rejection of unknown formats) and writer/flush error propagation
- Added unit test `voice_subcommands_transcribe_variant` in `src/cli/voice.rs`
- Updated `integration_test__help_all_output` snapshot to include the new `transcribe` subcommand entry

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run voice-specific tests only
cargo test voice

# Run the new CLI snapshot tests
cargo test --test voice_transcribe_cli_test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `render.rs` is placed under `src/voice/` (not `src/cli/voice/`) so it can be reused by `voice review` (#804); review this boundary decision
- [x] Error handling — WAV validation errors surface a descriptive message pointing users to `voice capture`; stream errors propagate via `?` through the render helpers
- [x] User experience — `detect_format` tty/pipe heuristic mirrors the design principle that machine consumers get stable JSONL and humans get prose

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. This is a purely additive feature. The `voice` subcommand gains a new `transcribe` child; existing `capture` behaviour and all other commands are unchanged.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Real ASR backend integration is deferred to issue #802; the `--backend` flag and `VoiceOpts` are already wired so adding a real backend requires only a factory change
- `render_markdown` will be reused by `voice review` (#804) without modification
- Streaming pipeline (#806) will feed live audio chunks rather than a pre-loaded `VecAudioInput`; the render helpers are already chunk-agnostic

**Known Limitations:**
- Only the `"mock"` transcriber backend is supported until a real ASR backend lands (see issue #802)
- `transcribe` does not resample input; files must already be 16 kHz mono 16-bit PCM (produced by `voice capture`)

**Alternatives Considered:**
- Placing `render.rs` under `src/cli/voice/` was considered but rejected since `render_markdown` will be shared by `voice review` (#804); keeping it under `src/voice/` avoids a future move and keeps rendering logic decoupled from CLI argument parsing