### PR TITLE
feat(voice): implement voice reflect command for transcript-to-events pipeline

### DIFF
--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -45,6 +45,18 @@ impl ClaudeClient {
         self.ai_client.get_metadata()
     }
 
+    /// Consumes the wrapper and returns the inner [`AiClient`].
+    ///
+    /// `ClaudeClient` is the commit-message-improvement entry point —
+    /// callers that want to drive the AI directly for unrelated workflows
+    /// (e.g. `voice reflect`) extract the underlying client via this
+    /// method rather than reimplementing the backend-dispatch ladder in
+    /// [`create_default_claude_client`].
+    #[must_use]
+    pub fn into_ai_client(self) -> Box<dyn AiClient> {
+        self.ai_client
+    }
+
     /// Adjusts a structured-call system prompt for the active backend's
     /// response format.
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -174,7 +174,7 @@ impl Cli {
             Commands::Atlassian(cmd) => cmd.execute().await,
             Commands::Datadog(cmd) => cmd.execute().await,
             Commands::Transcript(cmd) => cmd.execute().await,
-            Commands::Voice(cmd) => cmd.execute(),
+            Commands::Voice(cmd) => cmd.execute().await,
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::Resources(resources_cmd) => resources_cmd.execute(),
             Commands::Completions(completions_cmd) => completions_cmd.execute(),

--- a/src/cli/voice.rs
+++ b/src/cli/voice.rs
@@ -5,6 +5,7 @@
 //! help text and parse logic local to each command.
 
 pub mod capture;
+pub mod reflect;
 pub mod transcribe;
 
 use anyhow::Result;
@@ -25,14 +26,21 @@ pub enum VoiceSubcommands {
     Capture(capture::CaptureCommand),
     /// Transcribes a 16 kHz mono WAV file to JSONL or markdown.
     Transcribe(transcribe::TranscribeCommand),
+    /// Reflects on a transcript and emits reflection events.
+    Reflect(reflect::ReflectCommand),
 }
 
 impl VoiceCommand {
     /// Dispatches to the selected voice subcommand.
-    pub fn execute(self) -> Result<()> {
+    ///
+    /// Async because `reflect` invokes Claude via an async
+    /// [`crate::claude::ai::AiClient`]. Sync arms just `.await` an
+    /// immediately-ready value via `async {…}`.
+    pub async fn execute(self) -> Result<()> {
         match self.command {
             VoiceSubcommands::Capture(cmd) => cmd.execute(),
             VoiceSubcommands::Transcribe(cmd) => cmd.execute(),
+            VoiceSubcommands::Reflect(cmd) => cmd.execute().await,
         }
     }
 }
@@ -66,5 +74,16 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, VoiceSubcommands::Transcribe(_)));
+    }
+
+    #[test]
+    fn voice_subcommands_reflect_variant() {
+        let cmd = VoiceCommand {
+            command: VoiceSubcommands::Reflect(reflect::ReflectCommand {
+                transcript: Some(PathBuf::from("/tmp/t.jsonl")),
+                session: None,
+            }),
+        };
+        assert!(matches!(cmd.command, VoiceSubcommands::Reflect(_)));
     }
 }

--- a/src/cli/voice/reflect.rs
+++ b/src/cli/voice/reflect.rs
@@ -1,0 +1,163 @@
+//! `omni-dev voice reflect` — feed a `transcript.jsonl` through the
+//! configured [`AiClient`](crate::claude::ai::AiClient) and emit
+//! reflection events (per the #799 schema) to `events.jsonl`.
+//!
+//! Input precedence: `<transcript>` path arg → `--session <id>` →
+//! stdin. A literal `-` as the path also means stdin. When `--session`
+//! is given, events are appended to that session's `events.jsonl` and
+//! `meta.last_reflected_event_id` is advanced; otherwise events stream
+//! to stdout.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use clap::Parser;
+
+use crate::claude::client::create_default_claude_client;
+use crate::voice::clock::SystemClock;
+use crate::voice::det::SystemUlidRng;
+use crate::voice::reflect::{run_reflect, ReflectOptions, TranscriptSource};
+
+/// Reflects on a transcript and emits reflection events.
+///
+/// The transcript source is resolved in this order: positional
+/// `<transcript>` argument → `--session <id>` (reads
+/// `~/.omni-dev/voice/<id>/transcript.jsonl` incrementally) → stdin.
+/// A literal `-` as the positional argument also means stdin.
+///
+/// When `--session` is given, the resulting events are appended to that
+/// session's `events.jsonl` and `meta.last_reflected_event_id` is
+/// advanced so the next invocation only reflects on newly-arrived
+/// transcript events; otherwise events stream to stdout.
+#[derive(Parser)]
+pub struct ReflectCommand {
+    /// Path to a `transcript.jsonl` file. Pass `-` for stdin. Omit to
+    /// fall back to `--session` or stdin.
+    #[arg(value_name = "TRANSCRIPT")]
+    pub transcript: Option<PathBuf>,
+
+    /// Reflect against a named voice session under
+    /// `~/.omni-dev/voice/<id>/`. Mutually exclusive with a positional
+    /// transcript path.
+    #[arg(long)]
+    pub session: Option<String>,
+}
+
+impl ReflectCommand {
+    /// Executes the reflect command. Async because the AI invocation
+    /// is async; the caller dispatches inside `#[tokio::main]`.
+    pub async fn execute(self) -> Result<()> {
+        let source = resolve_source(self.transcript, self.session)?;
+        // Fail fast on missing input before paying the AI-client
+        // construction cost — otherwise a typo'd path is masked by
+        // unrelated credential errors ("API key not found", etc.) on
+        // hosts without the configured AI backend.
+        if let TranscriptSource::Path(p) = &source {
+            if !p.exists() {
+                bail!("transcript file does not exist: {}", p.display());
+            }
+        }
+        let ai = create_default_claude_client(None, None)
+            .await?
+            .into_ai_client();
+        let opts = ReflectOptions {
+            source,
+            ulid_rng: Box::new(SystemUlidRng),
+            clock: Box::new(SystemClock),
+            ai,
+            session_root_override: None,
+        };
+        // Buffer events in memory rather than holding the StdoutLock
+        // across the AI await — the lock guard is `!Send`, which
+        // poisons this future for use in a multi-thread Tokio runtime.
+        // For session-backed runs the buffer stays empty (events go to
+        // events.jsonl, not stdout).
+        let mut buf: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut buf).await?;
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(&buf)?;
+        stdout.flush()?;
+        Ok(())
+    }
+}
+
+fn resolve_source(
+    transcript: Option<PathBuf>,
+    session: Option<String>,
+) -> Result<TranscriptSource> {
+    match (transcript, session) {
+        (Some(_), Some(_)) => {
+            bail!("voice reflect: pass either a transcript path or --session, not both")
+        }
+        (Some(path), None) => {
+            if path.as_os_str() == "-" {
+                Ok(TranscriptSource::Stdin)
+            } else {
+                Ok(TranscriptSource::Path(path))
+            }
+        }
+        (None, Some(id)) => Ok(TranscriptSource::Session(id)),
+        (None, None) => Ok(TranscriptSource::Stdin),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        reflect: ReflectCommand,
+    }
+
+    #[test]
+    fn parses_no_args_defaults_to_stdin() {
+        let cli = TestCli::try_parse_from(["test"]).unwrap();
+        assert!(cli.reflect.transcript.is_none());
+        assert!(cli.reflect.session.is_none());
+        let source = resolve_source(cli.reflect.transcript, cli.reflect.session).unwrap();
+        assert!(matches!(source, TranscriptSource::Stdin));
+    }
+
+    #[test]
+    fn parses_positional_path() {
+        let cli = TestCli::try_parse_from(["test", "/tmp/t.jsonl"]).unwrap();
+        let source = resolve_source(cli.reflect.transcript, cli.reflect.session).unwrap();
+        assert!(
+            matches!(source, TranscriptSource::Path(p) if p == std::path::Path::new("/tmp/t.jsonl"))
+        );
+    }
+
+    #[test]
+    fn parses_dash_as_stdin() {
+        let cli = TestCli::try_parse_from(["test", "-"]).unwrap();
+        let source = resolve_source(cli.reflect.transcript, cli.reflect.session).unwrap();
+        assert!(matches!(source, TranscriptSource::Stdin));
+    }
+
+    #[test]
+    fn parses_session_flag() {
+        let cli = TestCli::try_parse_from(["test", "--session", "morning"]).unwrap();
+        let source = resolve_source(cli.reflect.transcript, cli.reflect.session).unwrap();
+        match source {
+            TranscriptSource::Session(s) => assert_eq!(s, "morning"),
+            other => panic!("expected Session, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_both_transcript_and_session() {
+        let cli =
+            TestCli::try_parse_from(["test", "/tmp/t.jsonl", "--session", "morning"]).unwrap();
+        let err = resolve_source(cli.reflect.transcript, cli.reflect.session).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("either a transcript path or --session, not both"),
+            "got: {err}"
+        );
+    }
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -12,9 +12,14 @@
 pub mod audio;
 pub mod backends;
 pub mod capture;
+pub mod clock;
+pub mod det;
+pub mod events;
 pub mod factory;
 pub mod idle;
+pub mod reflect;
 pub mod render;
+pub mod session;
 pub mod transcriber;
 pub mod wav;
 
@@ -22,6 +27,8 @@ pub use audio::{AudioSource, CpalAudioSource, FileAudioSource};
 pub use capture::{
     install_ctrl_c_handler, run_capture, CaptureOpts, CaptureSummary, TerminationReason,
 };
+pub use clock::{Clock, FixedClock, SystemClock};
+pub use det::{CountingUlidRng, SystemUlidRng, UlidRng};
 pub use factory::{create_default_transcriber, VoiceOpts};
 pub use render::{detect_format, render_jsonl, render_markdown, OutputFormat};
 pub use transcriber::{

--- a/src/voice/backends/mock.rs
+++ b/src/voice/backends/mock.rs
@@ -14,15 +14,16 @@
 //!
 //! The `event_id` source is pluggable via [`UlidRng`] so tests can pin
 //! down deterministic ULIDs for snapshotting. Production uses
-//! [`SystemUlidRng`] (`Ulid::new()`); tests use [`CountingUlidRng`] from
-//! the same module.
+//! [`SystemUlidRng`] (`Ulid::new()`); tests use [`CountingUlidRng`]. The
+//! trait and its implementations live in [`crate::voice::det`] and are
+//! re-exported here for backwards compatibility.
 
 use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::Result;
-use ulid::Ulid;
 
+pub use crate::voice::det::{CountingUlidRng, SystemUlidRng, UlidRng};
 use crate::voice::transcriber::{
     AudioInput, EndpointKind, EventId, EventStream, Transcriber, TranscriptEvent,
 };
@@ -40,50 +41,6 @@ pub struct MockSegment {
     pub end: Duration,
     /// Confidence in `[0.0, 1.0]` to attach to the emitted `Final`.
     pub confidence: f32,
-}
-
-/// Source of [`EventId`]s. Pluggable so tests can pin ULIDs while
-/// production uses real entropy.
-pub trait UlidRng: Send + Sync {
-    /// Returns the next ULID. Each call must produce a value strictly
-    /// greater than the previous one to preserve event-id monotonicity.
-    fn next_ulid(&mut self) -> Ulid;
-}
-
-/// Production RNG: defers to `Ulid::new()`.
-#[derive(Debug, Default)]
-pub struct SystemUlidRng;
-
-impl UlidRng for SystemUlidRng {
-    fn next_ulid(&mut self) -> Ulid {
-        Ulid::new()
-    }
-}
-
-/// Deterministic RNG for tests.
-///
-/// Returns `Ulid::from_parts(0, counter)` for an increasing counter
-/// starting at 1. The encoded form is lexicographically ordered, so a
-/// sequence of ULIDs from this RNG is monotonically increasing — exactly
-/// the property snapshot tests rely on.
-#[derive(Debug, Default)]
-pub struct CountingUlidRng {
-    counter: u128,
-}
-
-impl CountingUlidRng {
-    /// Builds a new counting RNG starting at zero — the first ULID it
-    /// returns has random bits `1`, the second `2`, and so on.
-    pub fn new() -> Self {
-        Self { counter: 0 }
-    }
-}
-
-impl UlidRng for CountingUlidRng {
-    fn next_ulid(&mut self) -> Ulid {
-        self.counter += 1;
-        Ulid::from_parts(0, self.counter)
-    }
 }
 
 /// A canned-script Transcriber used as a placeholder until a real ASR
@@ -305,15 +262,6 @@ mod tests {
     }
 
     #[test]
-    fn system_ulid_rng_produces_unique_values() {
-        let mut rng = SystemUlidRng;
-        let a = rng.next_ulid();
-        let b = rng.next_ulid();
-        // Different ULIDs minted milliseconds apart should not collide.
-        assert_ne!(a, b);
-    }
-
-    #[test]
     fn default_script_yields_two_segments() {
         let script = MockTranscriber::default_script();
         assert_eq!(script.len(), 2);
@@ -330,7 +278,7 @@ mod tests {
 
         struct PanickingRng;
         impl UlidRng for PanickingRng {
-            fn next_ulid(&mut self) -> Ulid {
+            fn next_ulid(&mut self) -> ulid::Ulid {
                 panic!("test-induced panic");
             }
         }

--- a/src/voice/clock.rs
+++ b/src/voice/clock.rs
@@ -1,0 +1,75 @@
+//! Pluggable wall clock for deterministic timestamps in tests.
+//!
+//! Mirrors the [`UlidRng`](super::det::UlidRng) pattern: production code
+//! uses [`SystemClock`], tests inject [`FixedClock`] so snapshot output is
+//! byte-stable.
+
+use chrono::{DateTime, Utc};
+
+/// Source of wall-clock time.
+pub trait Clock: Send + Sync {
+    /// Returns the current UTC time.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// Production clock: defers to `Utc::now()`.
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Test clock: always returns the same instant.
+#[derive(Debug, Clone)]
+pub struct FixedClock(pub DateTime<Utc>);
+
+impl FixedClock {
+    /// Parses an RFC3339 timestamp into a fixed clock. Panics if `s` is
+    /// not a valid RFC3339 string — intended for test-only use, where a
+    /// hard-coded constant string is the input.
+    #[must_use]
+    #[allow(clippy::expect_used, clippy::missing_panics_doc)]
+    pub fn from_rfc3339(s: &str) -> Self {
+        let dt = DateTime::parse_from_rfc3339(s)
+            .expect("FixedClock::from_rfc3339: invalid RFC3339 timestamp")
+            .with_timezone(&Utc);
+        Self(dt)
+    }
+}
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_clock_returns_same_instant_repeatedly() {
+        let clock = FixedClock::from_rfc3339("2026-01-01T00:00:00Z");
+        let a = clock.now();
+        let b = clock.now();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fixed_clock_from_rfc3339_parses_utc() {
+        let clock = FixedClock::from_rfc3339("2026-01-01T00:00:00Z");
+        assert_eq!(clock.0.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn system_clock_returns_recent_time() {
+        let clock = SystemClock;
+        let now = clock.now();
+        let real_now = Utc::now();
+        let delta = (real_now - now).num_seconds().abs();
+        assert!(delta < 2, "SystemClock should be close to Utc::now()");
+    }
+}

--- a/src/voice/det.rs
+++ b/src/voice/det.rs
@@ -1,0 +1,82 @@
+//! Pluggable RNG for [`EventId`](super::EventId) (ULID) generation.
+//!
+//! Lives at `voice/` scope rather than under `backends/mock.rs` because
+//! the same trait is consumed by [`voice reflect`](super::reflect) for
+//! deterministic event minting in snapshot tests. Production code uses
+//! [`SystemUlidRng`]; tests use [`CountingUlidRng`].
+
+use ulid::Ulid;
+
+/// Source of [`Ulid`]s. Pluggable so tests can pin ULIDs while production
+/// uses real entropy.
+pub trait UlidRng: Send + Sync {
+    /// Returns the next ULID. Each call must produce a value strictly
+    /// greater than the previous one to preserve event-id monotonicity.
+    fn next_ulid(&mut self) -> Ulid;
+}
+
+/// Production RNG: defers to `Ulid::new()`.
+#[derive(Debug, Default)]
+pub struct SystemUlidRng;
+
+impl UlidRng for SystemUlidRng {
+    fn next_ulid(&mut self) -> Ulid {
+        Ulid::new()
+    }
+}
+
+/// Deterministic RNG for tests.
+///
+/// Returns `Ulid::from_parts(0, counter)` for an increasing counter
+/// starting at 1. The encoded form is lexicographically ordered, so a
+/// sequence of ULIDs from this RNG is monotonically increasing — exactly
+/// the property snapshot tests rely on.
+#[derive(Debug, Default)]
+pub struct CountingUlidRng {
+    counter: u128,
+}
+
+impl CountingUlidRng {
+    /// Builds a new counting RNG starting at zero — the first ULID it
+    /// returns has random bits `1`, the second `2`, and so on.
+    pub fn new() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl UlidRng for CountingUlidRng {
+    fn next_ulid(&mut self) -> Ulid {
+        self.counter += 1;
+        Ulid::from_parts(0, self.counter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_ulid_rng_produces_unique_values() {
+        let mut rng = SystemUlidRng;
+        let a = rng.next_ulid();
+        let b = rng.next_ulid();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn counting_ulid_rng_starts_at_one() {
+        let mut rng = CountingUlidRng::new();
+        let first = rng.next_ulid();
+        assert_eq!(first, Ulid::from_parts(0, 1));
+    }
+
+    #[test]
+    fn counting_ulid_rng_is_monotonic() {
+        let mut rng = CountingUlidRng::new();
+        let a = rng.next_ulid();
+        let b = rng.next_ulid();
+        let c = rng.next_ulid();
+        assert!(a < b);
+        assert!(b < c);
+    }
+}

--- a/src/voice/events.rs
+++ b/src/voice/events.rs
@@ -1,0 +1,788 @@
+//! Reflection event schema (the `events.jsonl` contract from #799).
+//!
+//! These types form the wire format for the append-only reflection log
+//! produced by `voice reflect` (this issue) and consumed by `voice review`
+//! (#804). The shape is the load-bearing contract — see the umbrella
+//! issue #799 for the full design rationale and reconciliation
+//! invariants. The [`project`] helper here implements the subset of those
+//! invariants that `voice reflect` itself needs (to render the
+//! `<current_state>` block in its prompt). TTL eviction lives in `voice
+//! review` and is not implemented here.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tracing::warn;
+
+use crate::voice::EventId;
+
+/// Identifier for an item (todo / research / question).
+pub type ItemId = ulid::Ulid;
+
+/// Identifier for a recorded decision.
+pub type DecisionId = ulid::Ulid;
+
+/// Identifier for a standalone research note.
+pub type NoteId = ulid::Ulid;
+
+/// Identifies the reflection invocation that produced a batch of events.
+///
+/// `Ulid(_)` for events emitted by `voice reflect`; `Review` for events
+/// written by reconciliation (`voice review`, #804) — currently just
+/// `item.expire { reason: ttl }`. Serialised on the wire as either a
+/// ULID string or the literal `"review"`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReflectionId {
+    /// A specific reflection invocation.
+    Ulid(ulid::Ulid),
+    /// Emitted by reconciliation, not by a reflection.
+    Review,
+}
+
+impl Serialize for ReflectionId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Ulid(u) => s.serialize_str(&u.to_string()),
+            Self::Review => s.serialize_str("review"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ReflectionId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        if s == "review" {
+            Ok(Self::Review)
+        } else {
+            ulid::Ulid::from_string(&s)
+                .map(Self::Ulid)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+/// Range of consumed `TranscriptEvent::Final` IDs that motivated an event.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TranscriptSpan {
+    /// First `Final` event in the consumed transcript range.
+    pub start_event_id: EventId,
+    /// Last `Final` event in the consumed transcript range.
+    pub end_event_id: EventId,
+}
+
+/// What motivated an event — for audit and reconciliation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Provenance {
+    /// Range of transcript events this reflection consumed.
+    pub transcript_span: TranscriptSpan,
+    /// Model identifier (null for review-emitted events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Prompt-template fingerprint (null for review-emitted events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_version: Option<String>,
+}
+
+/// Class of an item — present-tense intent the user expressed.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemClass {
+    /// A thing the user wants done.
+    Todo,
+    /// Background context worth keeping but not actionable.
+    Research,
+    /// An open question the user wants answered.
+    Question,
+}
+
+/// Priority of an item.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    /// Bumped above the rest of the list.
+    High,
+    /// The default.
+    Normal,
+    /// Demoted below the rest of the list.
+    Low,
+}
+
+/// Why an item expired.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpireReason {
+    /// User explicitly retracted the item.
+    Retracted,
+    /// `valid_until` elapsed (emitted by `voice review`, not `reflect`).
+    Ttl,
+    /// Replaced by a more recent item — see `superseded_by`.
+    Superseded,
+}
+
+/// `item.create` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemCreate {
+    /// Stable identifier minted by the LLM, referenced by later events.
+    pub item_id: ItemId,
+    /// Class of the item.
+    pub class: ItemClass,
+    /// Item text.
+    pub text: String,
+    /// Optional priority; absent means [`Priority::Normal`] at projection.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub priority: Option<Priority>,
+    /// Optional expiry time; absent means "use class default" at projection.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub valid_until: Option<DateTime<Utc>>,
+    /// Optional tags.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tags: Option<Vec<String>>,
+}
+
+/// `item.update` payload. All fields besides `item_id` are optional — any
+/// present field denotes a change.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ItemUpdate {
+    /// Identifier of the existing item to update.
+    pub item_id: ItemId,
+    /// New text (optional).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub text: Option<String>,
+    /// New priority (optional).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub priority: Option<Priority>,
+    /// New expiry (optional; sliding extension on re-mention).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub valid_until: Option<DateTime<Utc>>,
+    /// Replacement tags (optional).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tags: Option<Vec<String>>,
+}
+
+/// `item.expire` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemExpire {
+    /// Identifier of the item to expire.
+    pub item_id: ItemId,
+    /// Why the item is being expired.
+    pub reason: ExpireReason,
+    /// New item replacing this one — present iff `reason == Superseded`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub superseded_by: Option<ItemId>,
+}
+
+/// `item.complete` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ItemComplete {
+    /// Identifier of the completed item.
+    pub item_id: ItemId,
+    /// Optional completion note.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub note: Option<String>,
+}
+
+/// `decision.record` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DecisionRecord {
+    /// Stable identifier for this decision.
+    pub decision_id: DecisionId,
+    /// Decision text.
+    pub text: String,
+    /// Optional list of alternatives that were considered.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub alternatives: Option<Vec<String>>,
+}
+
+/// `research.note` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResearchNote {
+    /// Stable identifier for this note.
+    pub note_id: NoteId,
+    /// Note text.
+    pub text: String,
+    /// Optional supporting links.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub links: Option<Vec<String>>,
+    /// Optional expiry (default P30D at projection).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub valid_until: Option<DateTime<Utc>>,
+}
+
+/// `reflection.error` payload — captured for audit when the LLM output
+/// fails schema validation. Skipped by projection.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReflectionError {
+    /// Raw LLM output that failed validation.
+    pub raw_output: String,
+    /// Human-readable error description.
+    pub error: String,
+}
+
+/// Tagged union of event payloads, paired with the `event_type`
+/// discriminator in the on-wire envelope.
+///
+/// The serde representation is *adjacently tagged* so the envelope ends
+/// up with sibling `event_type` and `payload` fields — matching #799's
+/// example shape. Flattening this enum into [`Event`] then puts those
+/// fields at the same level as the envelope fields (`event_id`, `ts`, …).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event_type", content = "payload")]
+pub enum EventKind {
+    /// Mint a new todo / research note / question.
+    #[serde(rename = "item.create")]
+    ItemCreate(ItemCreate),
+    /// Refine an existing item.
+    #[serde(rename = "item.update")]
+    ItemUpdate(ItemUpdate),
+    /// Item no longer applies.
+    #[serde(rename = "item.expire")]
+    ItemExpire(ItemExpire),
+    /// User completed the item.
+    #[serde(rename = "item.complete")]
+    ItemComplete(ItemComplete),
+    /// A decision was made.
+    #[serde(rename = "decision.record")]
+    DecisionRecord(DecisionRecord),
+    /// Standalone research note.
+    #[serde(rename = "research.note")]
+    ResearchNote(ResearchNote),
+    /// Schema-invalid LLM output captured for audit.
+    #[serde(rename = "reflection.error")]
+    ReflectionError(ReflectionError),
+}
+
+/// One event in the `events.jsonl` log.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Event {
+    /// Sortable, monotonic, no collisions. Used as the canonical
+    /// ordering key by reconciliation.
+    pub event_id: EventId,
+    /// Emission time (UTC RFC3339).
+    pub ts: DateTime<Utc>,
+    /// Identifies the reflection invocation that produced this event.
+    pub reflection_id: ReflectionId,
+    /// What motivated the event.
+    pub provenance: Provenance,
+    /// Discriminated payload + type tag (flattened into the envelope so
+    /// `event_type` and `payload` are top-level keys, per #799).
+    #[serde(flatten)]
+    pub kind: EventKind,
+}
+
+// ─── Projection ────────────────────────────────────────────────────────
+
+/// Materialised item, as projected from the event log.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectedItem {
+    /// Identifier of the item.
+    pub id: ItemId,
+    /// Class (todo / research / question).
+    pub class: ItemClass,
+    /// Current text.
+    pub text: String,
+    /// Current priority (defaults to [`Priority::Normal`] when unspecified).
+    pub priority: Priority,
+    /// Current expiry, if explicitly set.
+    pub valid_until: Option<DateTime<Utc>>,
+    /// Current tags.
+    pub tags: Vec<String>,
+    /// `true` when an `item.complete` has been seen.
+    pub completed: bool,
+    /// `Some(reason)` when an `item.expire` has been seen.
+    pub expired: Option<ExpireReason>,
+}
+
+/// Materialised decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectedDecision {
+    /// Identifier of the decision.
+    pub id: DecisionId,
+    /// Decision text.
+    pub text: String,
+    /// Alternatives that were considered.
+    pub alternatives: Vec<String>,
+}
+
+/// Materialised research note.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectedNote {
+    /// Identifier of the note.
+    pub id: NoteId,
+    /// Note text.
+    pub text: String,
+    /// Supporting links.
+    pub links: Vec<String>,
+    /// Expiry, if set.
+    pub valid_until: Option<DateTime<Utc>>,
+}
+
+/// Materialised state after applying an event log.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProjectedState {
+    /// Items keyed by id. Includes completed and expired items so callers
+    /// can filter as they see fit (`voice reflect` excludes them from
+    /// `<current_state>`; `voice review` may render them under a separate
+    /// heading).
+    pub items: BTreeMap<ItemId, ProjectedItem>,
+    /// Decisions in insertion order.
+    pub decisions: Vec<ProjectedDecision>,
+    /// Notes in insertion order.
+    pub notes: Vec<ProjectedNote>,
+}
+
+/// Projects a sequence of [`Event`]s into a [`ProjectedState`] per #799's
+/// reconciliation invariants:
+///
+/// - Sort by `event_id` (ULIDs are sortable).
+/// - Last-write-wins per item field on `item.update`.
+/// - Idempotent expiry.
+/// - Unknown `item_id` in `item.update` / `item.expire` / `item.complete`
+///   → drop the operation, log a warning.
+/// - `reflection.error` skipped entirely.
+///
+/// **Not** implemented here (deferred to `voice review` / #804):
+/// - TTL eviction (synthesising `item.expire { reason: ttl }`).
+pub fn project<I: IntoIterator<Item = Event>>(events: I) -> ProjectedState {
+    let mut sorted: Vec<Event> = events.into_iter().collect();
+    sorted.sort_by_key(|e| e.event_id);
+    let mut state = ProjectedState::default();
+    for event in sorted {
+        apply_event(&mut state, event);
+    }
+    state
+}
+
+fn apply_event(state: &mut ProjectedState, event: Event) {
+    match event.kind {
+        EventKind::ItemCreate(c) => {
+            state.items.insert(
+                c.item_id,
+                ProjectedItem {
+                    id: c.item_id,
+                    class: c.class,
+                    text: c.text,
+                    priority: c.priority.unwrap_or(Priority::Normal),
+                    valid_until: c.valid_until,
+                    tags: c.tags.unwrap_or_default(),
+                    completed: false,
+                    expired: None,
+                },
+            );
+        }
+        EventKind::ItemUpdate(u) => {
+            let Some(item) = state.items.get_mut(&u.item_id) else {
+                warn!(
+                    item_id = %u.item_id,
+                    "item.update references unknown item; dropping per #799 invariant"
+                );
+                return;
+            };
+            if let Some(text) = u.text {
+                item.text = text;
+            }
+            if let Some(priority) = u.priority {
+                item.priority = priority;
+            }
+            if u.valid_until.is_some() {
+                item.valid_until = u.valid_until;
+            }
+            if let Some(tags) = u.tags {
+                item.tags = tags;
+            }
+        }
+        EventKind::ItemExpire(e) => {
+            let Some(item) = state.items.get_mut(&e.item_id) else {
+                warn!(
+                    item_id = %e.item_id,
+                    "item.expire references unknown item; dropping per #799 invariant"
+                );
+                return;
+            };
+            // Idempotent: ignore if already expired.
+            if item.expired.is_none() {
+                item.expired = Some(e.reason);
+            }
+        }
+        EventKind::ItemComplete(c) => {
+            let Some(item) = state.items.get_mut(&c.item_id) else {
+                warn!(
+                    item_id = %c.item_id,
+                    "item.complete references unknown item; dropping per #799 invariant"
+                );
+                return;
+            };
+            item.completed = true;
+        }
+        EventKind::DecisionRecord(d) => {
+            state.decisions.push(ProjectedDecision {
+                id: d.decision_id,
+                text: d.text,
+                alternatives: d.alternatives.unwrap_or_default(),
+            });
+        }
+        EventKind::ResearchNote(n) => {
+            state.notes.push(ProjectedNote {
+                id: n.note_id,
+                text: n.text,
+                links: n.links.unwrap_or_default(),
+                valid_until: n.valid_until,
+            });
+        }
+        EventKind::ReflectionError(_) => {
+            // Skipped by projection — captured in the log for audit only.
+        }
+    }
+}
+
+/// Default TTLs per item class (per #799). Used when an `item.create`
+/// omits `valid_until`. Callers compute the effective expiry as
+/// `event.ts + class_default_ttl(item.class)`.
+#[must_use]
+pub fn class_default_ttl(class: &ItemClass) -> Duration {
+    match class {
+        ItemClass::Todo => Duration::from_secs(7 * 24 * 60 * 60),
+        ItemClass::Research => Duration::from_secs(30 * 24 * 60 * 60),
+        ItemClass::Question => Duration::from_secs(14 * 24 * 60 * 60),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    fn span() -> TranscriptSpan {
+        TranscriptSpan {
+            start_event_id: ulid::Ulid::from_parts(0, 1),
+            end_event_id: ulid::Ulid::from_parts(0, 2),
+        }
+    }
+
+    fn provenance() -> Provenance {
+        Provenance {
+            transcript_span: span(),
+            model: Some("claude-sonnet-4-6".to_string()),
+            prompt_version: Some("abcd1234".to_string()),
+        }
+    }
+
+    fn event(event_id: u128, kind: EventKind) -> Event {
+        Event {
+            event_id: ulid::Ulid::from_parts(0, event_id),
+            ts: ts(),
+            reflection_id: ReflectionId::Ulid(ulid::Ulid::from_parts(0, 100)),
+            provenance: provenance(),
+            kind,
+        }
+    }
+
+    fn id(n: u128) -> ItemId {
+        ulid::Ulid::from_parts(0, n)
+    }
+
+    #[test]
+    fn item_create_serialises_with_adjacent_tag() {
+        let e = event(
+            10,
+            EventKind::ItemCreate(ItemCreate {
+                item_id: id(200),
+                class: ItemClass::Todo,
+                text: "wire it up".to_string(),
+                priority: None,
+                valid_until: None,
+                tags: None,
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(
+            json.contains(r#""event_type":"item.create""#),
+            "missing event_type discriminator: {json}"
+        );
+        assert!(
+            json.contains(r#""payload":{"#),
+            "missing payload object: {json}"
+        );
+        assert!(
+            json.contains(r#""class":"todo""#),
+            "missing class enum rename: {json}"
+        );
+    }
+
+    #[test]
+    fn event_round_trips_through_serde_json() {
+        let original = event(
+            10,
+            EventKind::ItemCreate(ItemCreate {
+                item_id: id(200),
+                class: ItemClass::Research,
+                text: "look into LocalAgreement-2".to_string(),
+                priority: Some(Priority::High),
+                valid_until: Some(ts()),
+                tags: Some(vec!["asr".to_string(), "whisper".to_string()]),
+            }),
+        );
+        let s = serde_json::to_string(&original).unwrap();
+        let back: Event = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn reflection_id_review_serialises_as_string_literal() {
+        let id = ReflectionId::Review;
+        let s = serde_json::to_string(&id).unwrap();
+        assert_eq!(s, r#""review""#);
+        let back: ReflectionId = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ReflectionId::Review);
+    }
+
+    #[test]
+    fn reflection_id_ulid_round_trips() {
+        let u = ulid::Ulid::from_parts(0, 42);
+        let id = ReflectionId::Ulid(u);
+        let s = serde_json::to_string(&id).unwrap();
+        let back: ReflectionId = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ReflectionId::Ulid(u));
+    }
+
+    #[test]
+    fn project_orders_by_event_id_not_insertion_order() {
+        // Insert items out of order; projection should sort them.
+        let item_a = id(1);
+        let events = vec![
+            event(
+                20,
+                EventKind::ItemUpdate(ItemUpdate {
+                    item_id: item_a,
+                    text: Some("third write".to_string()),
+                    ..Default::default()
+                }),
+            ),
+            event(
+                10,
+                EventKind::ItemCreate(ItemCreate {
+                    item_id: item_a,
+                    class: ItemClass::Todo,
+                    text: "first write".to_string(),
+                    priority: None,
+                    valid_until: None,
+                    tags: None,
+                }),
+            ),
+            event(
+                15,
+                EventKind::ItemUpdate(ItemUpdate {
+                    item_id: item_a,
+                    text: Some("second write".to_string()),
+                    ..Default::default()
+                }),
+            ),
+        ];
+        let state = project(events);
+        assert_eq!(state.items.get(&item_a).unwrap().text, "third write");
+    }
+
+    #[test]
+    fn project_drops_update_for_unknown_item() {
+        let state = project(vec![event(
+            10,
+            EventKind::ItemUpdate(ItemUpdate {
+                item_id: id(999),
+                text: Some("no such item".to_string()),
+                ..Default::default()
+            }),
+        )]);
+        assert!(state.items.is_empty());
+    }
+
+    #[test]
+    fn project_applies_all_item_update_fields() {
+        let i = id(1);
+        let state = project(vec![
+            event(
+                10,
+                EventKind::ItemCreate(ItemCreate {
+                    item_id: i,
+                    class: ItemClass::Todo,
+                    text: "original".into(),
+                    priority: None,
+                    valid_until: None,
+                    tags: None,
+                }),
+            ),
+            event(
+                11,
+                EventKind::ItemUpdate(ItemUpdate {
+                    item_id: i,
+                    text: Some("updated".into()),
+                    priority: Some(Priority::High),
+                    valid_until: Some(ts()),
+                    tags: Some(vec!["urgent".into()]),
+                }),
+            ),
+        ]);
+        let item = state.items.get(&i).unwrap();
+        assert_eq!(item.text, "updated");
+        assert_eq!(item.priority, Priority::High);
+        assert_eq!(item.valid_until, Some(ts()));
+        assert_eq!(item.tags, vec!["urgent".to_string()]);
+    }
+
+    #[test]
+    fn project_drops_expire_and_complete_for_unknown_items() {
+        let state = project(vec![
+            event(
+                10,
+                EventKind::ItemExpire(ItemExpire {
+                    item_id: id(99),
+                    reason: ExpireReason::Retracted,
+                    superseded_by: None,
+                }),
+            ),
+            event(
+                11,
+                EventKind::ItemComplete(ItemComplete {
+                    item_id: id(99),
+                    note: None,
+                }),
+            ),
+        ]);
+        assert!(state.items.is_empty());
+    }
+
+    #[test]
+    fn project_marks_completed_and_expired() {
+        let i = id(1);
+        let state = project(vec![
+            event(
+                10,
+                EventKind::ItemCreate(ItemCreate {
+                    item_id: i,
+                    class: ItemClass::Todo,
+                    text: "x".into(),
+                    priority: None,
+                    valid_until: None,
+                    tags: None,
+                }),
+            ),
+            event(
+                11,
+                EventKind::ItemComplete(ItemComplete {
+                    item_id: i,
+                    note: Some("done".into()),
+                }),
+            ),
+            event(
+                12,
+                EventKind::ItemExpire(ItemExpire {
+                    item_id: i,
+                    reason: ExpireReason::Superseded,
+                    superseded_by: Some(id(2)),
+                }),
+            ),
+        ]);
+        let item = state.items.get(&i).unwrap();
+        assert!(item.completed);
+        assert_eq!(item.expired, Some(ExpireReason::Superseded));
+    }
+
+    #[test]
+    fn project_expire_is_idempotent() {
+        let i = id(1);
+        let state = project(vec![
+            event(
+                10,
+                EventKind::ItemCreate(ItemCreate {
+                    item_id: i,
+                    class: ItemClass::Todo,
+                    text: "x".into(),
+                    priority: None,
+                    valid_until: None,
+                    tags: None,
+                }),
+            ),
+            event(
+                11,
+                EventKind::ItemExpire(ItemExpire {
+                    item_id: i,
+                    reason: ExpireReason::Retracted,
+                    superseded_by: None,
+                }),
+            ),
+            event(
+                12,
+                EventKind::ItemExpire(ItemExpire {
+                    item_id: i,
+                    reason: ExpireReason::Superseded,
+                    superseded_by: Some(id(2)),
+                }),
+            ),
+        ]);
+        // First expire wins; second is a no-op.
+        assert_eq!(
+            state.items.get(&i).unwrap().expired,
+            Some(ExpireReason::Retracted)
+        );
+    }
+
+    #[test]
+    fn project_skips_reflection_errors() {
+        let state = project(vec![event(
+            10,
+            EventKind::ReflectionError(ReflectionError {
+                raw_output: "garbage".into(),
+                error: "missing item_id".into(),
+            }),
+        )]);
+        assert!(state.items.is_empty());
+        assert!(state.decisions.is_empty());
+        assert!(state.notes.is_empty());
+    }
+
+    #[test]
+    fn project_appends_decisions_and_notes() {
+        let state = project(vec![
+            event(
+                10,
+                EventKind::DecisionRecord(DecisionRecord {
+                    decision_id: id(1),
+                    text: "use ULIDs".into(),
+                    alternatives: Some(vec!["UUIDv7".into()]),
+                }),
+            ),
+            event(
+                11,
+                EventKind::ResearchNote(ResearchNote {
+                    note_id: id(2),
+                    text: "AssemblyAI is immutable-finals".into(),
+                    links: None,
+                    valid_until: None,
+                }),
+            ),
+        ]);
+        assert_eq!(state.decisions.len(), 1);
+        assert_eq!(state.notes.len(), 1);
+    }
+
+    #[test]
+    fn class_default_ttls_match_799() {
+        assert_eq!(
+            class_default_ttl(&ItemClass::Todo),
+            Duration::from_secs(7 * 86_400)
+        );
+        assert_eq!(
+            class_default_ttl(&ItemClass::Research),
+            Duration::from_secs(30 * 86_400)
+        );
+        assert_eq!(
+            class_default_ttl(&ItemClass::Question),
+            Duration::from_secs(14 * 86_400)
+        );
+    }
+}

--- a/src/voice/prompts/reflect.md
+++ b/src/voice/prompts/reflect.md
@@ -1,0 +1,102 @@
+You are reflecting on a voice transcript. The user is dictating thoughts,
+todos, decisions, and research notes as they work. Your job is to extract
+actionable changes to the user's working set and emit them as a YAML
+document matching the schema below.
+
+# Output format
+
+Emit a single YAML document with a top-level `events:` list. Each item
+in the list is one event matching `<event_schema>`. Do not emit any
+text outside the YAML document — no preamble, no commentary, no code
+fences.
+
+If the transcript contains nothing actionable, emit `events: []`.
+
+# Schema
+
+<event_schema>
+Each event is one of seven types, identified by `event_type`. The
+`payload` shape depends on the type. All `*_id` fields are ULIDs
+(26-character Crockford base32 strings like `01HZX1G2K3M4N5P6Q7R8S9TBV0`).
+
+# Mint a new todo / research note / question.
+- event_type: item.create
+  payload:
+    item_id: <new ULID>
+    class: todo | research | question
+    text: "..."
+    priority: high | normal | low      # optional; default normal
+    valid_until: "<RFC3339>"           # optional; class defaults apply when absent
+    tags: ["..."]                      # optional
+
+# Refine an existing item (text / priority / TTL / tags).
+- event_type: item.update
+  payload:
+    item_id: <existing ULID from <current_state>>
+    text: "..."                        # optional; any field present = a change
+    priority: high | normal | low      # optional
+    valid_until: "<RFC3339>"           # optional
+    tags: ["..."]                      # optional
+
+# Item no longer applies.
+- event_type: item.expire
+  payload:
+    item_id: <existing ULID>
+    reason: retracted | superseded     # 'retracted' when user dismisses; 'superseded' when replaced
+    superseded_by: <ULID>              # required iff reason == superseded
+
+# User completed the item.
+- event_type: item.complete
+  payload:
+    item_id: <existing ULID>
+    note: "..."                        # optional
+
+# A decision was made (historical record, never expires).
+- event_type: decision.record
+  payload:
+    decision_id: <new ULID>
+    text: "..."
+    alternatives: ["...", "..."]       # optional
+
+# Standalone context worth keeping.
+- event_type: research.note
+  payload:
+    note_id: <new ULID>
+    text: "..."
+    links: ["...", "..."]              # optional
+    valid_until: "<RFC3339>"           # optional; defaults to ~30 days
+</event_schema>
+
+# Current state
+
+The user's working set so far. Reference existing items by `item_id` when
+updating, expiring, or completing them. Do NOT mint new IDs for items
+already listed here.
+
+<current_state>
+{{current_state}}
+</current_state>
+
+# New transcript
+
+Reflect on the following transcript segment. Each line is
+`[<transcript_event_id>] <text>`.
+
+<new_transcript>
+{{new_transcript}}
+</new_transcript>
+
+# Rules
+
+- Emit ONLY the YAML document, with a top-level `events:` list. No
+  surrounding markdown, no code fences.
+- If the user retracts something, emit `item.expire` with
+  `reason: retracted`.
+- If the user replaces an item with a new version, emit `item.expire`
+  with `reason: superseded` and `superseded_by: <new ULID>`, followed by
+  `item.create` for the new item.
+- If the user re-mentions an existing item with the same intent, emit
+  `item.update` to refresh `valid_until` — do not mint a duplicate
+  `item.create`.
+- Mint fresh ULIDs for new items; do not reuse IDs from
+  `<current_state>` when creating.

--- a/src/voice/reflect/mod.rs
+++ b/src/voice/reflect/mod.rs
@@ -1,0 +1,704 @@
+//! `voice reflect` — transcript-to-events Claude consumer.
+//!
+//! Consumes `TranscriptEvent::Final` events from a `transcript.jsonl`
+//! source (file path, stdin, or session directory), calls Claude via the
+//! existing [`AiClient`], parses the YAML response into [`Event`]s, and
+//! appends them to `events.jsonl` (or stdout, for one-shot mode).
+//!
+//! Per #799: this is step 1 of the build order — text-in / events-out,
+//! no audio code. See [the umbrella issue](https://github.com/rust-works/omni-dev/issues/799)
+//! for the load-bearing event schema and the rationale for event-sourced
+//! reflection.
+
+pub mod prompt;
+pub mod validate;
+
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use tracing::warn;
+
+use crate::claude::ai::AiClient;
+use crate::voice::clock::Clock;
+use crate::voice::det::UlidRng;
+use crate::voice::events::{
+    Event, EventKind, ItemId, Provenance, ReflectionError, ReflectionId, TranscriptSpan,
+};
+use crate::voice::session::{self, Session};
+use crate::voice::{EventId, TranscriptEvent};
+
+/// Where to read the transcript from.
+#[derive(Debug, Clone)]
+pub enum TranscriptSource {
+    /// Read from a JSONL file at this path.
+    Path(PathBuf),
+    /// Read from standard input.
+    Stdin,
+    /// Open or create the named session and read its `transcript.jsonl`
+    /// (incrementally, after `meta.last_reflected_event_id`).
+    Session(String),
+}
+
+/// Driver options. The trait fields ([`UlidRng`], [`Clock`], [`AiClient`])
+/// are injected so tests can pin them with deterministic implementations.
+pub struct ReflectOptions {
+    /// Where to read the input transcript from.
+    pub source: TranscriptSource,
+    /// ULID source for `event_id` / `reflection_id` generation.
+    pub ulid_rng: Box<dyn UlidRng>,
+    /// Wall-clock source for `ts` fields.
+    pub clock: Box<dyn Clock>,
+    /// AI client to invoke for the reflection prompt.
+    pub ai: Box<dyn AiClient>,
+    /// Override the session root directory (test hook). When `None` and
+    /// `source = Session(_)`, the standard `~/.omni-dev/voice/` root
+    /// (or `OMNI_DEV_VOICE_ROOT`) is used.
+    pub session_root_override: Option<PathBuf>,
+}
+
+/// System prompt — short, fixed. All schema and behaviour rules live in
+/// the user prompt (`src/voice/prompts/reflect.md`) so the
+/// `prompt_version` hash captures the full contract.
+const SYSTEM_PROMPT: &str = "You convert a voice transcript into structured reflection \
+                              events. Follow the format and rules in the user prompt \
+                              exactly. Emit ONLY the YAML document — no commentary, no \
+                              code fences.";
+
+/// Drives one reflection invocation end-to-end.
+///
+/// Writes resulting JSONL events to `stdout` for non-session sources,
+/// or appends them to the session's `events.jsonl` and updates
+/// `meta.last_reflected_event_id` for session-backed runs.
+pub async fn run_reflect<W: Write>(opts: ReflectOptions, stdout: &mut W) -> Result<()> {
+    let ReflectOptions {
+        source,
+        mut ulid_rng,
+        clock,
+        ai,
+        session_root_override,
+    } = opts;
+
+    // Resolve transcript and existing state.
+    let (finals, session, existing_ids) = resolve_input(&source, session_root_override.as_deref())?;
+
+    let Some(span) = compute_span(&finals) else {
+        // No Finals consumed — nothing to reflect on. Quiet exit.
+        return Ok(());
+    };
+
+    // Build the prompt.
+    let current_state_body = match &session {
+        Some(sess) => {
+            let prior = sess.read_events()?;
+            let projected = crate::voice::events::project(prior);
+            prompt::format_current_state(&projected)
+        }
+        None => prompt::format_current_state(&crate::voice::events::ProjectedState::default()),
+    };
+    let new_transcript_body = prompt::format_new_transcript(&finals);
+    let user_prompt = prompt::render(&current_state_body, &new_transcript_body);
+
+    // Invoke the AI and time it.
+    let reflection_id = ReflectionId::Ulid(ulid_rng.next_ulid());
+    let started = Instant::now();
+    let ai_response = ai.send_request(SYSTEM_PROMPT, &user_prompt).await;
+    let latency_ms = started.elapsed().as_millis();
+    let model = ai.get_metadata().model;
+    let prompt_version = prompt::prompt_version().to_string();
+
+    let raw_response = match ai_response {
+        Ok(s) => s,
+        Err(e) => {
+            // The AI call itself failed (subprocess crash, timeout, …).
+            // Surface it as a reflection.error so the operator can audit.
+            let err_event = mint_error_event(
+                ulid_rng.as_mut(),
+                clock.as_ref(),
+                &reflection_id,
+                &span,
+                &model,
+                &prompt_version,
+                ReflectionError {
+                    raw_output: String::new(),
+                    error: format!("AI invocation failed: {e}"),
+                },
+            );
+            return emit_events(
+                &session,
+                stdout,
+                &[err_event],
+                /*new_marker*/ Some(span.end_event_id),
+                /*reflection_id*/ &reflection_id,
+                &model,
+                latency_ms,
+                /*status*/ "error",
+            );
+        }
+    };
+
+    // Validate; on failure, emit a single reflection.error event.
+    let events = match validate::parse_and_validate(&raw_response, &existing_ids) {
+        Ok(kinds) => kinds
+            .into_iter()
+            .map(|kind| {
+                build_event(
+                    ulid_rng.as_mut(),
+                    clock.as_ref(),
+                    &reflection_id,
+                    &span,
+                    &model,
+                    &prompt_version,
+                    kind,
+                )
+            })
+            .collect::<Vec<_>>(),
+        Err(verr) => vec![mint_error_event(
+            ulid_rng.as_mut(),
+            clock.as_ref(),
+            &reflection_id,
+            &span,
+            &model,
+            &prompt_version,
+            ReflectionError {
+                raw_output: verr.raw_output,
+                error: verr.error,
+            },
+        )],
+    };
+
+    let status = if events
+        .iter()
+        .any(|e| matches!(e.kind, EventKind::ReflectionError(_)))
+    {
+        "error"
+    } else {
+        "ok"
+    };
+
+    emit_events(
+        &session,
+        stdout,
+        &events,
+        Some(span.end_event_id),
+        &reflection_id,
+        &model,
+        latency_ms,
+        status,
+    )
+}
+
+fn resolve_input(
+    source: &TranscriptSource,
+    session_root_override: Option<&Path>,
+) -> Result<(Vec<TranscriptEvent>, Option<Session>, HashSet<ItemId>)> {
+    match source {
+        TranscriptSource::Path(p) if p.as_os_str() == "-" => {
+            let finals = read_finals_from_stdin()?;
+            Ok((finals, None, HashSet::new()))
+        }
+        TranscriptSource::Path(p) => {
+            let finals = session::read_transcript_finals_after(p, None)?;
+            Ok((finals, None, HashSet::new()))
+        }
+        TranscriptSource::Stdin => {
+            let finals = read_finals_from_stdin()?;
+            Ok((finals, None, HashSet::new()))
+        }
+        TranscriptSource::Session(id) => {
+            let sess = match session_root_override {
+                Some(root) => session::open_or_create_under(root, id)?,
+                None => session::open_or_create(id)?,
+            };
+            let finals = sess.read_transcript_finals_after()?;
+            let existing_state = crate::voice::events::project(sess.read_events()?);
+            let existing_ids: HashSet<ItemId> = existing_state.items.keys().copied().collect();
+            Ok((finals, Some(sess), existing_ids))
+        }
+    }
+}
+
+fn read_finals_from_stdin() -> Result<Vec<TranscriptEvent>> {
+    parse_finals_from_reader(&mut std::io::stdin(), "stdin")
+}
+
+/// Reads all `TranscriptEvent`s from `reader`, returning only the `Final`
+/// variants. Split out from [`read_finals_from_stdin`] so unit tests can
+/// drive it with a `&[u8]` rather than needing a real stdin pipe.
+fn parse_finals_from_reader<R: Read>(
+    reader: &mut R,
+    source_label: &str,
+) -> Result<Vec<TranscriptEvent>> {
+    let mut body = String::new();
+    reader
+        .read_to_string(&mut body)
+        .with_context(|| format!("reading transcript from {source_label}"))?;
+    let mut events = Vec::new();
+    for (idx, line) in body.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: TranscriptEvent = serde_json::from_str(line)
+            .with_context(|| format!("parsing {source_label} transcript line {}", idx + 1))?;
+        if matches!(event, TranscriptEvent::Final { .. }) {
+            events.push(event);
+        }
+    }
+    Ok(events)
+}
+
+fn compute_span(finals: &[TranscriptEvent]) -> Option<TranscriptSpan> {
+    let first = finals.iter().find_map(|e| match e {
+        TranscriptEvent::Final { event_id, .. } => Some(*event_id),
+        _ => None,
+    })?;
+    let last = finals.iter().rev().find_map(|e| match e {
+        TranscriptEvent::Final { event_id, .. } => Some(*event_id),
+        _ => None,
+    })?;
+    Some(TranscriptSpan {
+        start_event_id: first,
+        end_event_id: last,
+    })
+}
+
+fn build_event(
+    rng: &mut dyn UlidRng,
+    clock: &dyn Clock,
+    reflection_id: &ReflectionId,
+    span: &TranscriptSpan,
+    model: &str,
+    prompt_version: &str,
+    kind: EventKind,
+) -> Event {
+    Event {
+        event_id: rng.next_ulid(),
+        ts: clock.now(),
+        reflection_id: reflection_id.clone(),
+        provenance: Provenance {
+            transcript_span: span.clone(),
+            model: Some(model.to_string()),
+            prompt_version: Some(prompt_version.to_string()),
+        },
+        kind: rewrite_kind_with_omitted_optionals(kind),
+    }
+}
+
+fn mint_error_event(
+    rng: &mut dyn UlidRng,
+    clock: &dyn Clock,
+    reflection_id: &ReflectionId,
+    span: &TranscriptSpan,
+    model: &str,
+    prompt_version: &str,
+    err: ReflectionError,
+) -> Event {
+    build_event(
+        rng,
+        clock,
+        reflection_id,
+        span,
+        model,
+        prompt_version,
+        EventKind::ReflectionError(err),
+    )
+}
+
+/// No-op pass-through today.
+///
+/// Hook point for future normalisation (e.g. trimming whitespace in
+/// user-supplied text). Kept centralised so any later sanitisation
+/// lives in one place.
+fn rewrite_kind_with_omitted_optionals(kind: EventKind) -> EventKind {
+    kind
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_events<W: Write>(
+    session: &Option<Session>,
+    stdout: &mut W,
+    events: &[Event],
+    new_marker: Option<EventId>,
+    reflection_id: &ReflectionId,
+    model: &str,
+    latency_ms: u128,
+    status: &str,
+) -> Result<()> {
+    if let Some(sess) = session {
+        sess.append_events(events)?;
+        if let Some(marker) = new_marker {
+            // Clone is cheap; we need a mutable session to update meta.
+            let mut sess_mut = sess.clone();
+            sess_mut.set_last_reflected(marker)?;
+        }
+        let refl_id_str = match reflection_id {
+            ReflectionId::Ulid(u) => u.to_string(),
+            ReflectionId::Review => "review".to_string(),
+        };
+        let line = format!(
+            "{ts} {refl_id_str} model={model} cost_usd=unknown latency_ms={latency_ms} events={n} status={status}",
+            ts = chrono::Utc::now().to_rfc3339(),
+            n = events.len(),
+        );
+        sess.append_log(&line)?;
+    } else {
+        for event in events {
+            serde_json::to_writer(&mut *stdout, event)
+                .context("serialising reflection event to stdout")?;
+            stdout
+                .write_all(b"\n")
+                .context("writing newline to stdout")?;
+        }
+        stdout
+            .flush()
+            .context("flushing reflection events to stdout")?;
+        // No log line for non-session mode — the events.jsonl on stdout
+        // is the audit trail.
+        if status == "error" {
+            warn!(
+                model = %model,
+                latency_ms,
+                "reflect completed with errors (see emitted reflection.error event)"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::claude::test_utils::ConfigurableMockAiClient;
+    use crate::voice::clock::FixedClock;
+    use crate::voice::det::CountingUlidRng;
+    use crate::voice::events::ItemClass;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn make_final(event_id: u128, text: &str) -> TranscriptEvent {
+        TranscriptEvent::Final {
+            event_id: ulid::Ulid::from_parts(0, event_id),
+            text: text.to_string(),
+            start: Duration::ZERO,
+            end: Duration::from_millis(500),
+            confidence: 0.95,
+            words: None,
+            speaker: None,
+            revisable: false,
+        }
+    }
+
+    fn write_transcript(tmp: &TempDir, finals: &[TranscriptEvent]) -> PathBuf {
+        let path = tmp.path().join("transcript.jsonl");
+        let mut body = String::new();
+        for e in finals {
+            body.push_str(&serde_json::to_string(e).unwrap());
+            body.push('\n');
+        }
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn fixed_opts(source: TranscriptSource, ai_responses: Vec<Result<String>>) -> ReflectOptions {
+        ReflectOptions {
+            source,
+            ulid_rng: Box::new(CountingUlidRng::new()),
+            clock: Box::new(FixedClock::from_rfc3339("2026-01-01T00:00:00Z")),
+            ai: Box::new(ConfigurableMockAiClient::new(ai_responses)),
+            session_root_override: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn path_source_emits_events_to_stdout() {
+        let tmp = TempDir::new().unwrap();
+        let transcript = write_transcript(&tmp, &[make_final(1, "wire it up")]);
+        let canned = r"events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000007
+      class: todo
+      text: wire it up
+";
+        let opts = fixed_opts(
+            TranscriptSource::Path(transcript),
+            vec![Ok(canned.to_string())],
+        );
+        let mut out: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut out).await.unwrap();
+        let body = String::from_utf8(out).unwrap();
+        assert_eq!(body.lines().count(), 1, "expected exactly one event line");
+        let event: Event = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        assert!(matches!(event.kind, EventKind::ItemCreate(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_transcript_exits_quietly() {
+        let tmp = TempDir::new().unwrap();
+        let transcript = write_transcript(&tmp, &[]);
+        let opts = fixed_opts(
+            TranscriptSource::Path(transcript),
+            vec![/* AI never called */],
+        );
+        let mut out: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut out).await.unwrap();
+        assert!(out.is_empty(), "no events expected when no Finals consumed");
+    }
+
+    #[tokio::test]
+    async fn malformed_response_yields_reflection_error_event() {
+        let tmp = TempDir::new().unwrap();
+        let transcript = write_transcript(&tmp, &[make_final(1, "talk")]);
+        let canned = "this is not yaml: - definitely not";
+        let opts = fixed_opts(
+            TranscriptSource::Path(transcript),
+            vec![Ok(canned.to_string())],
+        );
+        let mut out: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut out).await.unwrap();
+        let body = String::from_utf8(out).unwrap();
+        assert_eq!(body.lines().count(), 1);
+        let event: Event = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        match &event.kind {
+            EventKind::ReflectionError(e) => {
+                assert!(e.raw_output.contains("not yaml"));
+                assert!(e.error.contains("YAML parse failure"));
+            }
+            other => panic!("expected ReflectionError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ai_invocation_failure_yields_reflection_error_event() {
+        let tmp = TempDir::new().unwrap();
+        let transcript = write_transcript(&tmp, &[make_final(1, "talk")]);
+        let opts = fixed_opts(
+            TranscriptSource::Path(transcript),
+            vec![Err(anyhow::anyhow!("simulated subprocess crash"))],
+        );
+        let mut out: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut out).await.unwrap();
+        let body = String::from_utf8(out).unwrap();
+        assert_eq!(body.lines().count(), 1);
+        let event: Event = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        match &event.kind {
+            EventKind::ReflectionError(e) => {
+                assert!(e.error.contains("simulated subprocess crash"));
+            }
+            other => panic!("expected ReflectionError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_source_appends_to_events_jsonl_and_advances_marker() {
+        let tmp = TempDir::new().unwrap();
+        let voice_root = tmp.path().join("voice-root");
+        std::fs::create_dir_all(&voice_root).unwrap();
+
+        // Pre-populate the session with a transcript.
+        let sess = session::open_or_create_under(&voice_root, "s1").unwrap();
+        std::fs::write(
+            &sess.paths.transcript,
+            serde_json::to_string(&make_final(1, "first")).unwrap() + "\n",
+        )
+        .unwrap();
+
+        let canned = r"events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000007
+      class: todo
+      text: first
+";
+        let mut opts = fixed_opts(
+            TranscriptSource::Session("s1".to_string()),
+            vec![Ok(canned.to_string())],
+        );
+        opts.session_root_override = Some(voice_root.clone());
+        let mut out: Vec<u8> = Vec::new();
+        run_reflect(opts, &mut out).await.unwrap();
+
+        assert!(out.is_empty(), "session writes go to disk, not stdout");
+        let appended = std::fs::read_to_string(&sess.paths.events).unwrap();
+        assert_eq!(appended.lines().count(), 1);
+        let reopened = session::open_or_create_under(&voice_root, "s1").unwrap();
+        assert_eq!(
+            reopened.meta.last_reflected_event_id,
+            Some(ulid::Ulid::from_parts(0, 1))
+        );
+        let log = std::fs::read_to_string(&sess.paths.log).unwrap();
+        assert!(log.contains("status=ok"), "log line missing: {log}");
+        assert!(log.contains("events=1"));
+    }
+
+    #[tokio::test]
+    async fn session_second_reflection_skips_already_consumed_finals() {
+        let tmp = TempDir::new().unwrap();
+        let voice_root = tmp.path().join("voice-root");
+        let sess = session::open_or_create_under(&voice_root, "s1").unwrap();
+
+        // First reflection consumes one final.
+        std::fs::write(
+            &sess.paths.transcript,
+            serde_json::to_string(&make_final(1, "first")).unwrap() + "\n",
+        )
+        .unwrap();
+        let canned1 = r"events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000007
+      class: todo
+      text: first
+";
+        let mut opts1 = fixed_opts(
+            TranscriptSource::Session("s1".to_string()),
+            vec![Ok(canned1.to_string())],
+        );
+        opts1.session_root_override = Some(voice_root.clone());
+        let mut sink: Vec<u8> = Vec::new();
+        run_reflect(opts1, &mut sink).await.unwrap();
+
+        // A second final is appended (as if the user dictated more).
+        use std::io::Write as _;
+        let mut transcript_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&sess.paths.transcript)
+            .unwrap();
+        writeln!(
+            transcript_file,
+            "{}",
+            serde_json::to_string(&make_final(2, "second")).unwrap()
+        )
+        .unwrap();
+        drop(transcript_file);
+
+        // Second reflection should see only the "second" final because
+        // meta.last_reflected_event_id now points at ulid 1.
+        let canned2 = r"events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000008
+      class: todo
+      text: second
+";
+        let ai = ConfigurableMockAiClient::new(vec![Ok(canned2.to_string())]);
+        let prompts = ai.prompt_handle();
+        let opts2 = ReflectOptions {
+            source: TranscriptSource::Session("s1".to_string()),
+            ulid_rng: Box::new(CountingUlidRng::new()),
+            clock: Box::new(FixedClock::from_rfc3339("2026-01-01T00:00:00Z")),
+            ai: Box::new(ai),
+            session_root_override: Some(voice_root.clone()),
+        };
+        run_reflect(opts2, &mut sink).await.unwrap();
+
+        let prompts = prompts.prompts();
+        assert_eq!(prompts.len(), 1);
+        let (_sys, user) = &prompts[0];
+        assert!(
+            user.contains("second"),
+            "second prompt should include 'second'"
+        );
+        assert!(
+            !user.contains("] first"),
+            "second prompt should NOT include the already-consumed 'first' transcript line, got: {user}"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_seed_twice_produces_byte_equal_output() {
+        let tmp = TempDir::new().unwrap();
+        let transcript_path = write_transcript(&tmp, &[make_final(1, "wire it up")]);
+        let canned = r"events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000007
+      class: todo
+      text: wire it up
+";
+
+        let mut out1: Vec<u8> = Vec::new();
+        let opts1 = fixed_opts(
+            TranscriptSource::Path(transcript_path.clone()),
+            vec![Ok(canned.to_string())],
+        );
+        run_reflect(opts1, &mut out1).await.unwrap();
+
+        let mut out2: Vec<u8> = Vec::new();
+        let opts2 = fixed_opts(
+            TranscriptSource::Path(transcript_path),
+            vec![Ok(canned.to_string())],
+        );
+        run_reflect(opts2, &mut out2).await.unwrap();
+
+        assert_eq!(
+            out1, out2,
+            "deterministic seeds should produce identical output"
+        );
+    }
+
+    #[test]
+    fn item_class_is_used_in_test() {
+        // Pin imports so the compiler doesn't warn about ItemClass being
+        // imported but unused — it's used in `format_current_state`'s
+        // pattern matching, which we don't otherwise exercise here.
+        let _ = ItemClass::Todo;
+    }
+
+    #[test]
+    fn parse_finals_from_reader_filters_partials_and_endpoints() {
+        let body = format!(
+            "{}\n{}\n{}\n\n",
+            serde_json::to_string(&TranscriptEvent::Partial {
+                text: "ignored".into(),
+                start: Duration::ZERO,
+                end: Duration::from_millis(50),
+                words: None,
+                speaker: None,
+            })
+            .unwrap(),
+            serde_json::to_string(&make_final(1, "kept")).unwrap(),
+            serde_json::to_string(&TranscriptEvent::Endpoint {
+                at: Duration::from_secs(1),
+                kind: crate::voice::EndpointKind::StreamEnd,
+            })
+            .unwrap(),
+        );
+        let mut bytes = body.as_bytes();
+        let finals = super::parse_finals_from_reader(&mut bytes, "test-source").unwrap();
+        assert_eq!(finals.len(), 1, "only the Final should be kept");
+        match &finals[0] {
+            TranscriptEvent::Final { text, .. } => assert_eq!(text, "kept"),
+            other => panic!("expected Final, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_finals_from_reader_skips_blank_lines() {
+        let body = format!(
+            "\n  \n{}\n\n",
+            serde_json::to_string(&make_final(1, "only")).unwrap()
+        );
+        let mut bytes = body.as_bytes();
+        let finals = super::parse_finals_from_reader(&mut bytes, "test-source").unwrap();
+        assert_eq!(finals.len(), 1);
+    }
+
+    #[test]
+    fn parse_finals_from_reader_reports_parse_failure_with_line_number() {
+        let body = format!(
+            "{}\nnot json\n",
+            serde_json::to_string(&make_final(1, "ok")).unwrap()
+        );
+        let mut bytes = body.as_bytes();
+        let err = super::parse_finals_from_reader(&mut bytes, "test-source").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("test-source") && msg.contains("line 2"),
+            "error should point at line 2: {msg}"
+        );
+    }
+}

--- a/src/voice/reflect/prompt.rs
+++ b/src/voice/reflect/prompt.rs
@@ -1,0 +1,302 @@
+//! Prompt template loading and rendering.
+//!
+//! The template lives at `src/voice/prompts/reflect.md` and is loaded via
+//! `include_str!` so its sha256 fingerprint is stable per build —
+//! `prompt_version` returns the first 8 hex chars of that hash and is
+//! recorded on every emitted event's `provenance.prompt_version` field,
+//! letting reconciliation tell which prompt revision produced which
+//! events.
+
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+
+use sha2::{Digest, Sha256};
+
+use crate::voice::events::{ProjectedItem, ProjectedState};
+use crate::voice::TranscriptEvent;
+
+/// The reflection prompt template, bundled at compile time.
+pub const TEMPLATE: &str = include_str!("../prompts/reflect.md");
+
+/// First eight hex characters of the SHA-256 of [`TEMPLATE`].
+///
+/// Used as the `prompt_version` field on emitted events.
+#[must_use]
+pub fn prompt_version() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION.get_or_init(|| {
+        let hash = Sha256::digest(TEMPLATE.as_bytes());
+        let mut out = String::with_capacity(8);
+        for b in &hash[..4] {
+            let _ = write!(out, "{b:02x}");
+        }
+        out
+    })
+}
+
+/// Renders the prompt with `{{current_state}}` and `{{new_transcript}}` substituted in.
+///
+/// No escaping — the substitution targets live inside fenced blocks in
+/// the template, where YAML cannot prematurely terminate the surrounding
+/// document.
+#[must_use]
+pub fn render(current_state: &str, new_transcript: &str) -> String {
+    TEMPLATE
+        .replace("{{current_state}}", current_state)
+        .replace("{{new_transcript}}", new_transcript)
+}
+
+/// Renders a [`ProjectedState`] as the `<current_state>` block body. Skips
+/// completed and expired items — the LLM only needs to see the
+/// still-actionable working set.
+#[must_use]
+pub fn format_current_state(state: &ProjectedState) -> String {
+    let mut out = String::new();
+    let active: Vec<&ProjectedItem> = state
+        .items
+        .values()
+        .filter(|i| !i.completed && i.expired.is_none())
+        .collect();
+
+    if !active.is_empty() {
+        out.push_str("## Items\n\n");
+        for item in &active {
+            let class = match item.class {
+                crate::voice::events::ItemClass::Todo => "todo",
+                crate::voice::events::ItemClass::Research => "research",
+                crate::voice::events::ItemClass::Question => "question",
+            };
+            let _ = writeln!(out, "- [{}] {}: {}", item.id, class, item.text);
+        }
+        out.push('\n');
+    }
+
+    if !state.decisions.is_empty() {
+        out.push_str("## Decisions\n\n");
+        for d in &state.decisions {
+            let _ = writeln!(out, "- [{}] {}", d.id, d.text);
+        }
+        out.push('\n');
+    }
+
+    if !state.notes.is_empty() {
+        out.push_str("## Notes\n\n");
+        for n in &state.notes {
+            let _ = writeln!(out, "- [{}] {}", n.id, n.text);
+        }
+    }
+
+    if out.is_empty() {
+        "(empty)\n".to_string()
+    } else {
+        out
+    }
+}
+
+/// Renders the consumed `Final` transcript events as the `<new_transcript>`
+/// block body, one event per line in the form `[<event_id>] <text>`.
+#[must_use]
+pub fn format_new_transcript(finals: &[TranscriptEvent]) -> String {
+    let mut out = String::new();
+    for event in finals {
+        if let TranscriptEvent::Final { event_id, text, .. } = event {
+            let _ = writeln!(out, "[{event_id}] {text}");
+        }
+    }
+    if out.is_empty() {
+        "(no new transcript)\n".to_string()
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::voice::events::{
+        ItemClass, Priority, ProjectedDecision, ProjectedItem, ProjectedNote,
+    };
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    fn ulid(n: u128) -> ulid::Ulid {
+        ulid::Ulid::from_parts(0, n)
+    }
+
+    #[test]
+    fn prompt_version_is_eight_hex_chars() {
+        let v = prompt_version();
+        assert_eq!(v.len(), 8);
+        assert!(v.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn prompt_version_is_stable_across_calls() {
+        assert_eq!(prompt_version(), prompt_version());
+    }
+
+    #[test]
+    fn render_substitutes_both_placeholders() {
+        let out = render("STATE_BODY", "TRANSCRIPT_BODY");
+        assert!(out.contains("STATE_BODY"), "current_state not substituted");
+        assert!(
+            out.contains("TRANSCRIPT_BODY"),
+            "new_transcript not substituted"
+        );
+        assert!(!out.contains("{{current_state}}"));
+        assert!(!out.contains("{{new_transcript}}"));
+    }
+
+    #[test]
+    fn format_current_state_empty_returns_placeholder() {
+        let state = ProjectedState::default();
+        let s = format_current_state(&state);
+        assert_eq!(s, "(empty)\n");
+    }
+
+    #[test]
+    fn format_current_state_skips_completed_and_expired() {
+        let mut items = BTreeMap::new();
+        items.insert(
+            ulid(1),
+            ProjectedItem {
+                id: ulid(1),
+                class: ItemClass::Todo,
+                text: "active".into(),
+                priority: Priority::Normal,
+                valid_until: None,
+                tags: vec![],
+                completed: false,
+                expired: None,
+            },
+        );
+        items.insert(
+            ulid(2),
+            ProjectedItem {
+                id: ulid(2),
+                class: ItemClass::Todo,
+                text: "done".into(),
+                priority: Priority::Normal,
+                valid_until: None,
+                tags: vec![],
+                completed: true,
+                expired: None,
+            },
+        );
+        items.insert(
+            ulid(3),
+            ProjectedItem {
+                id: ulid(3),
+                class: ItemClass::Todo,
+                text: "expired".into(),
+                priority: Priority::Normal,
+                valid_until: None,
+                tags: vec![],
+                completed: false,
+                expired: Some(crate::voice::events::ExpireReason::Retracted),
+            },
+        );
+        let state = ProjectedState {
+            items,
+            decisions: vec![],
+            notes: vec![],
+        };
+        let s = format_current_state(&state);
+        assert!(s.contains("active"));
+        assert!(!s.contains("done"));
+        assert!(!s.contains("expired"));
+    }
+
+    #[test]
+    fn format_current_state_renders_all_three_classes() {
+        let mut items = BTreeMap::new();
+        for (n, class) in [
+            (1u128, ItemClass::Todo),
+            (2, ItemClass::Research),
+            (3, ItemClass::Question),
+        ] {
+            items.insert(
+                ulid(n),
+                ProjectedItem {
+                    id: ulid(n),
+                    class,
+                    text: format!("text-{n}"),
+                    priority: Priority::Normal,
+                    valid_until: None,
+                    tags: vec![],
+                    completed: false,
+                    expired: None,
+                },
+            );
+        }
+        let state = ProjectedState {
+            items,
+            decisions: vec![],
+            notes: vec![],
+        };
+        let s = format_current_state(&state);
+        assert!(s.contains("todo: text-1"), "missing todo: {s}");
+        assert!(s.contains("research: text-2"), "missing research: {s}");
+        assert!(s.contains("question: text-3"), "missing question: {s}");
+    }
+
+    #[test]
+    fn format_current_state_includes_decisions_and_notes() {
+        let state = ProjectedState {
+            items: BTreeMap::new(),
+            decisions: vec![ProjectedDecision {
+                id: ulid(1),
+                text: "decided X".into(),
+                alternatives: vec![],
+            }],
+            notes: vec![ProjectedNote {
+                id: ulid(2),
+                text: "noted Y".into(),
+                links: vec![],
+                valid_until: None,
+            }],
+        };
+        let s = format_current_state(&state);
+        assert!(s.contains("decided X"));
+        assert!(s.contains("noted Y"));
+        assert!(s.contains("Decisions"));
+        assert!(s.contains("Notes"));
+    }
+
+    #[test]
+    fn format_new_transcript_skips_partials_and_endpoints() {
+        let finals = vec![
+            TranscriptEvent::Partial {
+                text: "ignored".into(),
+                start: Duration::ZERO,
+                end: Duration::from_millis(50),
+                words: None,
+                speaker: None,
+            },
+            TranscriptEvent::Final {
+                event_id: ulid(1),
+                text: "kept".into(),
+                start: Duration::ZERO,
+                end: Duration::from_millis(50),
+                confidence: 0.9,
+                words: None,
+                speaker: None,
+                revisable: false,
+            },
+            TranscriptEvent::Endpoint {
+                at: Duration::from_secs(1),
+                kind: crate::voice::EndpointKind::StreamEnd,
+            },
+        ];
+        let s = format_new_transcript(&finals);
+        assert!(s.contains("kept"));
+        assert!(!s.contains("ignored"));
+        // Endpoint variant has no text body in our format.
+    }
+
+    #[test]
+    fn format_new_transcript_empty_returns_placeholder() {
+        assert_eq!(format_new_transcript(&[]), "(no new transcript)\n");
+    }
+}

--- a/src/voice/reflect/validate.rs
+++ b/src/voice/reflect/validate.rs
@@ -1,0 +1,354 @@
+//! Parses and validates the LLM's YAML reflection response.
+//!
+//! Two-stage: (1) `serde_yaml::from_str` into an `LlmEnvelope` of
+//! [`EventKind`]s, then (2) per-variant semantic checks against the
+//! existing item IDs in the current session state. Failure returns a
+//! [`ValidationError`] that carries the raw output for the caller to
+//! attach to a `reflection.error` event.
+
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+
+use serde::Deserialize;
+
+use crate::voice::events::{EventKind, ExpireReason, ItemId};
+
+/// What the LLM is expected to emit at the top level — a single YAML
+/// document with one key, `events:`, holding the discriminated event
+/// list.
+#[derive(Debug, Deserialize)]
+struct LlmEnvelope {
+    events: Vec<EventKind>,
+}
+
+/// A parse failure or a semantic check failure.
+#[derive(Debug, Clone)]
+pub struct ValidationError {
+    /// One-line human-readable description of what failed.
+    pub error: String,
+    /// The original LLM output, included in the resulting
+    /// `reflection.error` event so an operator can debug.
+    pub raw_output: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Parses `raw_yaml` and validates each event against the v1 rules.
+///
+/// `existing_ids` is the set of item IDs already known from the session's
+/// projected state. Items minted earlier in the same batch are also
+/// allowed as references (the LLM may create-then-update / create-then-
+/// complete inside one response).
+///
+/// On success: returns the validated list of [`EventKind`]s in document
+/// order. On failure: returns a [`ValidationError`] carrying `raw_yaml`
+/// in its `raw_output` field.
+pub fn parse_and_validate<S: BuildHasher>(
+    raw_yaml: &str,
+    existing_ids: &HashSet<ItemId, S>,
+) -> Result<Vec<EventKind>, ValidationError> {
+    let envelope: LlmEnvelope = serde_yaml::from_str(raw_yaml).map_err(|e| ValidationError {
+        error: format!("YAML parse failure: {e}"),
+        raw_output: raw_yaml.to_string(),
+    })?;
+
+    let mut known: HashSet<ItemId> = existing_ids.iter().copied().collect();
+    let mut seen_new_ids: HashSet<ItemId> = HashSet::new();
+
+    for (idx, kind) in envelope.events.iter().enumerate() {
+        if let Err(error) = check_event(kind, &known, &mut seen_new_ids) {
+            return Err(ValidationError {
+                error: format!("event[{idx}] ({}): {error}", event_name(kind)),
+                raw_output: raw_yaml.to_string(),
+            });
+        }
+        // After a successful create, the newly-minted ID becomes
+        // referenceable by later events in the same batch.
+        if let EventKind::ItemCreate(c) = kind {
+            known.insert(c.item_id);
+        }
+    }
+
+    Ok(envelope.events)
+}
+
+fn event_name(kind: &EventKind) -> &'static str {
+    match kind {
+        EventKind::ItemCreate(_) => "item.create",
+        EventKind::ItemUpdate(_) => "item.update",
+        EventKind::ItemExpire(_) => "item.expire",
+        EventKind::ItemComplete(_) => "item.complete",
+        EventKind::DecisionRecord(_) => "decision.record",
+        EventKind::ResearchNote(_) => "research.note",
+        EventKind::ReflectionError(_) => "reflection.error",
+    }
+}
+
+fn check_event(
+    kind: &EventKind,
+    known: &HashSet<ItemId>,
+    seen_new: &mut HashSet<ItemId>,
+) -> Result<(), String> {
+    match kind {
+        EventKind::ItemCreate(c) => {
+            if !seen_new.insert(c.item_id) {
+                return Err(format!(
+                    "duplicate item_id {} minted in this batch",
+                    c.item_id
+                ));
+            }
+            if known.contains(&c.item_id) {
+                return Err(format!(
+                    "item_id {} collides with an existing item from current_state",
+                    c.item_id
+                ));
+            }
+            Ok(())
+        }
+        EventKind::ItemUpdate(u) => require_known(known, u.item_id, "item.update"),
+        EventKind::ItemExpire(e) => {
+            require_known(known, e.item_id, "item.expire")?;
+            if matches!(e.reason, ExpireReason::Ttl) {
+                return Err("reason: ttl is reserved for `voice review`; \
+                            reflect must use `retracted` or `superseded`"
+                    .to_string());
+            }
+            let is_superseded = matches!(e.reason, ExpireReason::Superseded);
+            if is_superseded && e.superseded_by.is_none() {
+                return Err("reason: superseded requires superseded_by".to_string());
+            }
+            if !is_superseded && e.superseded_by.is_some() {
+                return Err(format!(
+                    "superseded_by is only valid when reason == superseded \
+                     (got reason: {:?})",
+                    e.reason
+                ));
+            }
+            Ok(())
+        }
+        EventKind::ItemComplete(c) => require_known(known, c.item_id, "item.complete"),
+        EventKind::DecisionRecord(_)
+        | EventKind::ResearchNote(_)
+        | EventKind::ReflectionError(_) => Ok(()),
+    }
+}
+
+fn require_known(known: &HashSet<ItemId>, id: ItemId, what: &str) -> Result<(), String> {
+    if known.contains(&id) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{what} references unknown item_id {id} (not in current_state and not minted earlier in this batch)"
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn ulid(n: u128) -> ItemId {
+        ulid::Ulid::from_parts(0, n)
+    }
+
+    fn no_existing() -> HashSet<ItemId> {
+        HashSet::new()
+    }
+
+    #[test]
+    fn empty_events_list_is_valid() {
+        let yaml = "events: []";
+        let events = parse_and_validate(yaml, &no_existing()).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn item_create_is_accepted_and_minted_id_is_referenceable() {
+        let new_id = ulid(1);
+        let yaml = format!(
+            "events:\n  - event_type: item.create\n    payload:\n      item_id: {new_id}\n      class: todo\n      text: alpha\n  - event_type: item.update\n    payload:\n      item_id: {new_id}\n      priority: high\n"
+        );
+        let events = parse_and_validate(&yaml, &no_existing()).unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn item_update_unknown_id_errors() {
+        let yaml = format!(
+            "events:\n  - event_type: item.update\n    payload:\n      item_id: {}\n      text: changed\n",
+            ulid(99)
+        );
+        let err = parse_and_validate(&yaml, &no_existing()).unwrap_err();
+        assert!(err.error.contains("unknown item_id"), "got: {}", err.error);
+    }
+
+    #[test]
+    fn item_complete_unknown_id_errors() {
+        let yaml = format!(
+            "events:\n  - event_type: item.complete\n    payload:\n      item_id: {}\n",
+            ulid(99)
+        );
+        let err = parse_and_validate(&yaml, &no_existing()).unwrap_err();
+        assert!(
+            err.error.contains("item.complete") && err.error.contains("unknown item_id"),
+            "expected item.complete error: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn item_expire_unknown_id_errors() {
+        let yaml = format!(
+            "events:\n  - event_type: item.expire\n    payload:\n      item_id: {}\n      reason: retracted\n",
+            ulid(99)
+        );
+        let err = parse_and_validate(&yaml, &no_existing()).unwrap_err();
+        assert!(
+            err.error.contains("item.expire") && err.error.contains("unknown item_id"),
+            "expected item.expire error: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn validation_error_display_returns_inner_message() {
+        let err = ValidationError {
+            error: "schema mismatch".into(),
+            raw_output: "raw bytes".into(),
+        };
+        assert_eq!(err.to_string(), "schema mismatch");
+    }
+
+    #[test]
+    fn item_complete_with_existing_id_is_accepted() {
+        let existing_id = ulid(7);
+        let mut existing = HashSet::new();
+        existing.insert(existing_id);
+        let yaml = format!(
+            "events:\n  - event_type: item.complete\n    payload:\n      item_id: {existing_id}\n      note: shipped\n"
+        );
+        let events = parse_and_validate(&yaml, &existing).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn item_expire_with_reason_ttl_is_rejected() {
+        let existing_id = ulid(7);
+        let mut existing = HashSet::new();
+        existing.insert(existing_id);
+        let yaml = format!(
+            "events:\n  - event_type: item.expire\n    payload:\n      item_id: {existing_id}\n      reason: ttl\n"
+        );
+        let err = parse_and_validate(&yaml, &existing).unwrap_err();
+        assert!(
+            err.error.contains("reason: ttl is reserved"),
+            "got: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn item_expire_superseded_requires_superseded_by() {
+        let existing_id = ulid(7);
+        let mut existing = HashSet::new();
+        existing.insert(existing_id);
+        let yaml = format!(
+            "events:\n  - event_type: item.expire\n    payload:\n      item_id: {existing_id}\n      reason: superseded\n"
+        );
+        let err = parse_and_validate(&yaml, &existing).unwrap_err();
+        assert!(err.error.contains("superseded_by"), "got: {}", err.error);
+    }
+
+    #[test]
+    fn item_expire_retracted_with_superseded_by_is_rejected() {
+        let existing_id = ulid(7);
+        let mut existing = HashSet::new();
+        existing.insert(existing_id);
+        let yaml = format!(
+            "events:\n  - event_type: item.expire\n    payload:\n      item_id: {existing_id}\n      reason: retracted\n      superseded_by: {}\n",
+            ulid(8)
+        );
+        let err = parse_and_validate(&yaml, &existing).unwrap_err();
+        assert!(
+            err.error.contains("superseded_by is only valid"),
+            "got: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn duplicate_item_create_id_is_rejected() {
+        let new_id = ulid(1);
+        let yaml = format!(
+            "events:\n  - event_type: item.create\n    payload:\n      item_id: {new_id}\n      class: todo\n      text: a\n  - event_type: item.create\n    payload:\n      item_id: {new_id}\n      class: todo\n      text: b\n"
+        );
+        let err = parse_and_validate(&yaml, &no_existing()).unwrap_err();
+        assert!(
+            err.error.contains("duplicate item_id"),
+            "got: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn item_create_id_colliding_with_existing_state_is_rejected() {
+        let id = ulid(1);
+        let mut existing = HashSet::new();
+        existing.insert(id);
+        let yaml = format!(
+            "events:\n  - event_type: item.create\n    payload:\n      item_id: {id}\n      class: todo\n      text: a\n"
+        );
+        let err = parse_and_validate(&yaml, &existing).unwrap_err();
+        assert!(err.error.contains("collides"), "got: {}", err.error);
+    }
+
+    #[test]
+    fn malformed_yaml_returns_validation_error_carrying_raw_output() {
+        let yaml = "this is not: valid yaml\n  - unbalanced";
+        let err = parse_and_validate(yaml, &no_existing()).unwrap_err();
+        assert!(
+            err.error.contains("YAML parse failure"),
+            "got: {}",
+            err.error
+        );
+        assert_eq!(err.raw_output, yaml);
+    }
+
+    #[test]
+    fn unknown_event_type_errors_via_serde() {
+        let yaml = "events:\n  - event_type: item.invent\n    payload:\n      item_id: nonsense\n";
+        let err = parse_and_validate(yaml, &no_existing()).unwrap_err();
+        assert!(
+            err.error.contains("YAML parse failure"),
+            "got: {}",
+            err.error
+        );
+    }
+
+    #[test]
+    fn decision_record_does_not_need_existing_ids() {
+        let yaml = format!(
+            "events:\n  - event_type: decision.record\n    payload:\n      decision_id: {}\n      text: choose ULIDs\n",
+            ulid(1)
+        );
+        let events = parse_and_validate(&yaml, &no_existing()).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn research_note_does_not_need_existing_ids() {
+        let yaml = format!(
+            "events:\n  - event_type: research.note\n    payload:\n      note_id: {}\n      text: assemblyai is immutable-finals\n",
+            ulid(1)
+        );
+        let events = parse_and_validate(&yaml, &no_existing()).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+}

--- a/src/voice/session.rs
+++ b/src/voice/session.rs
@@ -1,0 +1,643 @@
+//! `~/.omni-dev/voice/<id>/` session directory I/O.
+//!
+//! Lays out and reads the session directory format from #799:
+//!
+//! ```text
+//! ~/.omni-dev/voice/<session-id>/
+//!   meta.yaml          # session config (this issue: last_reflected_event_id + ttl defaults)
+//!   transcript.jsonl   # append-only TranscriptEvent stream from `voice transcribe`
+//!   events.jsonl       # append-only Event stream from `voice reflect` (and later `voice review`)
+//!   reflections.log    # per-reflection summary line (cost, latency, status)
+//! ```
+//!
+//! Shared with #804 (`voice review`), which reads the same `events.jsonl`
+//! to produce materialised markdown projections. The session root path is
+//! derived from `dirs::home_dir()` by default; the `OMNI_DEV_VOICE_ROOT`
+//! environment variable overrides it (intended for tests, not a stable
+//! user-facing knob).
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::voice::events::Event;
+use crate::voice::{EventId, TranscriptEvent};
+
+/// Filesystem paths under a single session directory.
+#[derive(Debug, Clone)]
+pub struct SessionPaths {
+    /// Session root (`<voice-root>/<id>`).
+    pub root: PathBuf,
+    /// `meta.yaml` — session config (parsed into [`SessionMeta`]).
+    pub meta: PathBuf,
+    /// `transcript.jsonl` — `TranscriptEvent` log.
+    pub transcript: PathBuf,
+    /// `events.jsonl` — reflection [`Event`] log.
+    pub events: PathBuf,
+    /// `reflections.log` — per-reflection summary lines.
+    pub log: PathBuf,
+}
+
+impl SessionPaths {
+    /// Builds [`SessionPaths`] under `voice_root/<id>` without touching disk.
+    #[must_use]
+    pub fn under(voice_root: &Path, id: &str) -> Self {
+        let root = voice_root.join(id);
+        Self {
+            meta: root.join("meta.yaml"),
+            transcript: root.join("transcript.jsonl"),
+            events: root.join("events.jsonl"),
+            log: root.join("reflections.log"),
+            root,
+        }
+    }
+}
+
+/// Default TTLs per item class (per #799), stored in `meta.yaml` so a
+/// session can override them. Serialised as integer seconds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TtlDefaults {
+    /// TTL for `class: todo` items.
+    #[serde(with = "ttl_secs")]
+    pub todo: Duration,
+    /// TTL for `class: research` items.
+    #[serde(with = "ttl_secs")]
+    pub research: Duration,
+    /// TTL for `class: question` items.
+    #[serde(with = "ttl_secs")]
+    pub question: Duration,
+}
+
+impl Default for TtlDefaults {
+    fn default() -> Self {
+        Self {
+            todo: Duration::from_secs(7 * 86_400),
+            research: Duration::from_secs(30 * 86_400),
+            question: Duration::from_secs(14 * 86_400),
+        }
+    }
+}
+
+mod ttl_secs {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_u64(d.as_secs())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+        let secs = u64::deserialize(d)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+/// Parsed contents of `meta.yaml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SessionMeta {
+    /// `event_id` of the last `TranscriptEvent::Final` consumed by a
+    /// previous `voice reflect` invocation. `None` until the first
+    /// reflection completes.
+    #[serde(default)]
+    pub last_reflected_event_id: Option<EventId>,
+    /// TTL defaults applied at projection time (consumed by #804).
+    #[serde(default)]
+    pub ttl_defaults: TtlDefaults,
+}
+
+/// Combination of paths and the parsed meta document.
+#[derive(Debug, Clone)]
+pub struct Session {
+    /// On-disk paths under the session root.
+    pub paths: SessionPaths,
+    /// Parsed `meta.yaml` contents.
+    pub meta: SessionMeta,
+}
+
+impl Session {
+    /// Reads all `Final` transcript events from `transcript.jsonl` after
+    /// `meta.last_reflected_event_id`. Non-`Final` events are skipped —
+    /// reflection is driven by committed text only.
+    pub fn read_transcript_finals_after(&self) -> Result<Vec<TranscriptEvent>> {
+        read_transcript_finals_after(&self.paths.transcript, self.meta.last_reflected_event_id)
+    }
+
+    /// Reads `events.jsonl` into a [`Vec<Event>`]. Empty when the file
+    /// doesn't exist or contains no events.
+    pub fn read_events(&self) -> Result<Vec<Event>> {
+        read_events(&self.paths.events)
+    }
+
+    /// Appends events to `events.jsonl`.
+    pub fn append_events(&self, events: &[Event]) -> Result<()> {
+        append_events(&self.paths.events, events)
+    }
+
+    /// Updates `meta.last_reflected_event_id` in memory and on disk.
+    pub fn set_last_reflected(&mut self, id: EventId) -> Result<()> {
+        self.meta.last_reflected_event_id = Some(id);
+        write_meta(&self.paths.meta, &self.meta)
+    }
+
+    /// Appends a single line to `reflections.log` (no implicit newline).
+    pub fn append_log(&self, line: &str) -> Result<()> {
+        append_log_line(&self.paths.log, line)
+    }
+}
+
+/// Resolves the session root: `$OMNI_DEV_VOICE_ROOT` if set, else
+/// `~/.omni-dev/voice`.
+pub fn voice_root() -> Result<PathBuf> {
+    if let Ok(override_root) = std::env::var("OMNI_DEV_VOICE_ROOT") {
+        return Ok(PathBuf::from(override_root));
+    }
+    let home = dirs::home_dir().context(
+        "could not determine HOME directory for ~/.omni-dev/voice; \
+         set OMNI_DEV_VOICE_ROOT to override",
+    )?;
+    Ok(home.join(".omni-dev").join("voice"))
+}
+
+/// Opens an existing session, or creates an empty one if the directory
+/// doesn't exist. Bootstrap is idempotent: re-running against an
+/// already-populated session reads the existing `meta.yaml`.
+pub fn open_or_create(id: &str) -> Result<Session> {
+    let root = voice_root()?;
+    open_or_create_under(&root, id)
+}
+
+/// Variant of [`open_or_create`] that takes an explicit voice root —
+/// useful for tests that drive several sessions under a `tempfile`
+/// directory.
+pub fn open_or_create_under(voice_root: &Path, id: &str) -> Result<Session> {
+    if id.is_empty() {
+        bail!("session id cannot be empty");
+    }
+    if id.contains('/') || id.contains('\\') || id == "." || id == ".." {
+        bail!("session id must not contain path separators: {id:?}");
+    }
+    let paths = SessionPaths::under(voice_root, id);
+    std::fs::create_dir_all(&paths.root)
+        .with_context(|| format!("creating session directory at {}", paths.root.display()))?;
+
+    // Bootstrap empty files (touch only — don't truncate existing ones).
+    for p in [&paths.transcript, &paths.events, &paths.log] {
+        if !p.exists() {
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+                .with_context(|| format!("creating {}", p.display()))?;
+        }
+    }
+
+    let meta = if paths.meta.exists() {
+        read_meta(&paths.meta)?
+    } else {
+        let m = SessionMeta::default();
+        write_meta(&paths.meta, &m)?;
+        m
+    };
+
+    Ok(Session { paths, meta })
+}
+
+/// Reads and parses `meta.yaml`.
+pub fn read_meta(path: &Path) -> Result<SessionMeta> {
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("reading session meta at {}", path.display()))?;
+    serde_yaml::from_str(&body)
+        .with_context(|| format!("parsing session meta at {}", path.display()))
+}
+
+/// Writes `meta.yaml` atomically (write-temp-then-rename).
+pub fn write_meta(path: &Path, meta: &SessionMeta) -> Result<()> {
+    let body = serde_yaml::to_string(meta).context("serialising session meta to YAML")?;
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, body.as_bytes())
+        .with_context(|| format!("writing temp meta at {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming temp meta to {}", path.display()))?;
+    Ok(())
+}
+
+/// Reads all `TranscriptEvent`s from a JSONL file. Blank lines are
+/// skipped; parse errors include the line number.
+pub fn read_transcript(path: &Path) -> Result<Vec<TranscriptEvent>> {
+    let file =
+        File::open(path).with_context(|| format!("opening transcript at {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading {}:{}", path.display(), idx + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: TranscriptEvent = serde_json::from_str(&line)
+            .with_context(|| format!("parsing {}:{}", path.display(), idx + 1))?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+/// Reads only `Final` transcript events after the optional marker.
+///
+/// Uses stream position (not ULID comparison) — finds the marker line
+/// and returns Finals strictly after it. Errors if the marker is set
+/// but not present in the file.
+pub fn read_transcript_finals_after(
+    path: &Path,
+    after: Option<EventId>,
+) -> Result<Vec<TranscriptEvent>> {
+    let all = read_transcript(path)?;
+    let finals: Vec<TranscriptEvent> = all
+        .into_iter()
+        .filter(|e| matches!(e, TranscriptEvent::Final { .. }))
+        .collect();
+    match after {
+        None => Ok(finals),
+        Some(target) => {
+            let pos = finals.iter().position(|e| match e {
+                TranscriptEvent::Final { event_id, .. } => *event_id == target,
+                _ => false,
+            });
+            match pos {
+                Some(idx) => Ok(finals.into_iter().skip(idx + 1).collect()),
+                None => bail!(
+                    "last_reflected_event_id {target} not found in transcript at {}; \
+                     meta.yaml may be inconsistent with transcript.jsonl",
+                    path.display()
+                ),
+            }
+        }
+    }
+}
+
+/// Reads all reflection [`Event`]s from `events.jsonl`. Returns an empty
+/// vec if the file doesn't exist (greenfield session).
+pub fn read_events(path: &Path) -> Result<Vec<Event>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file =
+        File::open(path).with_context(|| format!("opening events log at {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading {}:{}", path.display(), idx + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: Event = serde_json::from_str(&line)
+            .with_context(|| format!("parsing {}:{}", path.display(), idx + 1))?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+/// Appends events as JSONL to `path`. Each event is one line, flushed
+/// after the batch. Skips silently when `events` is empty.
+pub fn append_events(path: &Path, events: &[Event]) -> Result<()> {
+    if events.is_empty() {
+        return Ok(());
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening events log for append at {}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    for e in events {
+        serde_json::to_writer(&mut writer, e)
+            .with_context(|| format!("serialising event to {}", path.display()))?;
+        writer
+            .write_all(b"\n")
+            .with_context(|| format!("appending newline to {}", path.display()))?;
+    }
+    writer
+        .flush()
+        .with_context(|| format!("flushing events log at {}", path.display()))?;
+    Ok(())
+}
+
+/// Appends a single line (with newline) to `reflections.log`. Creates
+/// the file if it does not exist.
+pub fn append_log_line(path: &Path, line: &str) -> Result<()> {
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening reflections log at {}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(line.as_bytes())
+        .with_context(|| format!("writing log line to {}", path.display()))?;
+    if !line.ends_with('\n') {
+        writer
+            .write_all(b"\n")
+            .with_context(|| format!("appending newline to {}", path.display()))?;
+    }
+    writer
+        .flush()
+        .with_context(|| format!("flushing reflections log at {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::voice::events::{
+        EventKind, ItemClass, ItemCreate, Provenance, ReflectionId, TranscriptSpan,
+    };
+    use crate::voice::transcriber::EndpointKind;
+    use chrono::TimeZone;
+    use tempfile::TempDir;
+
+    fn fixed_ts() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    fn provenance() -> Provenance {
+        Provenance {
+            transcript_span: TranscriptSpan {
+                start_event_id: ulid::Ulid::from_parts(0, 1),
+                end_event_id: ulid::Ulid::from_parts(0, 2),
+            },
+            model: Some("m".into()),
+            prompt_version: Some("p".into()),
+        }
+    }
+
+    fn make_event(event_id: u128) -> Event {
+        Event {
+            event_id: ulid::Ulid::from_parts(0, event_id),
+            ts: fixed_ts(),
+            reflection_id: ReflectionId::Ulid(ulid::Ulid::from_parts(0, 100)),
+            provenance: provenance(),
+            kind: EventKind::ItemCreate(ItemCreate {
+                item_id: ulid::Ulid::from_parts(0, 500),
+                class: ItemClass::Todo,
+                text: format!("event {event_id}"),
+                priority: None,
+                valid_until: None,
+                tags: None,
+            }),
+        }
+    }
+
+    fn make_final(event_id: u128, text: &str) -> TranscriptEvent {
+        TranscriptEvent::Final {
+            event_id: ulid::Ulid::from_parts(0, event_id),
+            text: text.to_string(),
+            start: Duration::from_millis(0),
+            end: Duration::from_millis(100),
+            confidence: 0.9,
+            words: None,
+            speaker: None,
+            revisable: false,
+        }
+    }
+
+    #[test]
+    fn open_or_create_bootstraps_an_empty_session() {
+        let tmp = TempDir::new().unwrap();
+        let session = open_or_create_under(tmp.path(), "s1").unwrap();
+        assert!(session.paths.meta.exists());
+        assert!(session.paths.transcript.exists());
+        assert!(session.paths.events.exists());
+        assert!(session.paths.log.exists());
+        assert_eq!(session.meta, SessionMeta::default());
+    }
+
+    #[test]
+    fn open_or_create_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let s1 = open_or_create_under(tmp.path(), "s1").unwrap();
+        let s2 = open_or_create_under(tmp.path(), "s1").unwrap();
+        assert_eq!(s1.meta, s2.meta);
+    }
+
+    #[test]
+    fn open_or_create_preserves_existing_meta() {
+        let tmp = TempDir::new().unwrap();
+        let mut s = open_or_create_under(tmp.path(), "s1").unwrap();
+        s.set_last_reflected(ulid::Ulid::from_parts(0, 42)).unwrap();
+        let reopened = open_or_create_under(tmp.path(), "s1").unwrap();
+        assert_eq!(
+            reopened.meta.last_reflected_event_id,
+            Some(ulid::Ulid::from_parts(0, 42))
+        );
+    }
+
+    #[test]
+    fn rejects_session_id_with_path_separator() {
+        let tmp = TempDir::new().unwrap();
+        assert!(open_or_create_under(tmp.path(), "a/b").is_err());
+        assert!(open_or_create_under(tmp.path(), "a\\b").is_err());
+        assert!(open_or_create_under(tmp.path(), "..").is_err());
+        assert!(open_or_create_under(tmp.path(), ".").is_err());
+        assert!(open_or_create_under(tmp.path(), "").is_err());
+    }
+
+    #[test]
+    fn ttl_defaults_match_799_defaults() {
+        let t = TtlDefaults::default();
+        assert_eq!(t.todo, Duration::from_secs(7 * 86_400));
+        assert_eq!(t.research, Duration::from_secs(30 * 86_400));
+        assert_eq!(t.question, Duration::from_secs(14 * 86_400));
+    }
+
+    #[test]
+    fn meta_yaml_round_trip_preserves_optional_marker() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("meta.yaml");
+        let meta = SessionMeta {
+            last_reflected_event_id: Some(ulid::Ulid::from_parts(0, 7)),
+            ttl_defaults: TtlDefaults::default(),
+        };
+        write_meta(&path, &meta).unwrap();
+        let back = read_meta(&path).unwrap();
+        assert_eq!(meta, back);
+    }
+
+    #[test]
+    fn append_then_read_events_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        append_events(&path, &[make_event(1), make_event(2)]).unwrap();
+        let back = read_events(&path).unwrap();
+        assert_eq!(back.len(), 2);
+        assert_eq!(back[0], make_event(1));
+        assert_eq!(back[1], make_event(2));
+    }
+
+    #[test]
+    fn append_events_with_empty_slice_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        append_events(&path, &[]).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn read_events_on_missing_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let result = read_events(&tmp.path().join("nothing.jsonl")).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn read_transcript_finals_after_filters_partials_and_endpoints() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::to_string(&TranscriptEvent::Partial {
+                    text: "ignored".into(),
+                    start: Duration::ZERO,
+                    end: Duration::from_millis(50),
+                    words: None,
+                    speaker: None,
+                })
+                .unwrap(),
+                serde_json::to_string(&make_final(1, "first")).unwrap(),
+                serde_json::to_string(&TranscriptEvent::Endpoint {
+                    at: Duration::from_secs(1),
+                    kind: EndpointKind::StreamEnd,
+                })
+                .unwrap(),
+            ),
+        )
+        .unwrap();
+        let finals = read_transcript_finals_after(&path, None).unwrap();
+        assert_eq!(finals.len(), 1);
+    }
+
+    #[test]
+    fn read_transcript_finals_after_skips_through_marker() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("transcript.jsonl");
+        let lines = [
+            serde_json::to_string(&make_final(1, "a")).unwrap(),
+            serde_json::to_string(&make_final(2, "b")).unwrap(),
+            serde_json::to_string(&make_final(3, "c")).unwrap(),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+        let after_id = ulid::Ulid::from_parts(0, 2);
+        let finals = read_transcript_finals_after(&path, Some(after_id)).unwrap();
+        assert_eq!(finals.len(), 1);
+        match &finals[0] {
+            TranscriptEvent::Final { text, .. } => assert_eq!(text, "c"),
+            other => panic!("expected Final, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_transcript_finals_after_errors_when_marker_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            serde_json::to_string(&make_final(1, "a")).unwrap() + "\n",
+        )
+        .unwrap();
+        let err =
+            read_transcript_finals_after(&path, Some(ulid::Ulid::from_parts(0, 99))).unwrap_err();
+        assert!(
+            err.to_string().contains("not found in transcript"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn append_log_line_creates_file_and_adds_newline() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("reflections.log");
+        append_log_line(&path, "first entry").unwrap();
+        append_log_line(&path, "second entry\n").unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "first entry\nsecond entry\n");
+    }
+
+    #[test]
+    fn read_transcript_skips_blank_lines() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("transcript.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                "\n{}\n\n   \n{}\n",
+                serde_json::to_string(&make_final(1, "a")).unwrap(),
+                serde_json::to_string(&make_final(2, "b")).unwrap(),
+            ),
+        )
+        .unwrap();
+        let events = read_transcript(&path).unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn read_transcript_reports_parse_failure_with_line_number() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("transcript.jsonl");
+        let good = serde_json::to_string(&make_final(1, "ok")).unwrap();
+        std::fs::write(&path, format!("{good}\nnot valid json\n")).unwrap();
+        let err = read_transcript(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parsing") && msg.contains(":2"),
+            "error should point at line 2: {msg}"
+        );
+    }
+
+    #[test]
+    fn read_events_skips_blank_lines() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        append_events(&path, &[make_event(1)]).unwrap();
+        // Add a blank line after the existing content.
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(f, "\n  ").unwrap();
+        drop(f);
+        let events = read_events(&path).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn read_events_reports_parse_failure_with_line_number() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        std::fs::write(&path, "not valid json at all\n").unwrap();
+        let err = read_events(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parsing") && msg.contains(":1"),
+            "error should point at line 1: {msg}"
+        );
+    }
+
+    #[test]
+    fn voice_root_respects_override_env_var() {
+        // Env mutation is process-wide; restore on exit. No serial guard
+        // here because no other test in this module reads/writes the var.
+        let original = std::env::var("OMNI_DEV_VOICE_ROOT").ok();
+        std::env::set_var("OMNI_DEV_VOICE_ROOT", "/tmp/overridden");
+        let root = voice_root().unwrap();
+        assert_eq!(root, PathBuf::from("/tmp/overridden"));
+        match original {
+            Some(v) => std::env::set_var("OMNI_DEV_VOICE_ROOT", v),
+            None => std::env::remove_var("OMNI_DEV_VOICE_ROOT"),
+        }
+    }
+}

--- a/tests/fixtures/voice/malformed_reflection_response.yaml
+++ b/tests/fixtures/voice/malformed_reflection_response.yaml
@@ -1,0 +1,4 @@
+events:
+  - event_type: item.update
+    payload:
+      text: "deliberately missing item_id — should produce a single reflection.error event"

--- a/tests/fixtures/voice/short_en_reflection_response.yaml
+++ b/tests/fixtures/voice/short_en_reflection_response.yaml
@@ -1,0 +1,18 @@
+events:
+  - event_type: item.create
+    payload:
+      item_id: 00000000000000000000000007
+      class: todo
+      text: "Wire up real ASR backend to replace mock segments"
+      priority: high
+  - event_type: research.note
+    payload:
+      note_id: 00000000000000000000000008
+      text: "Mock transcriber emits stable placeholder segments suitable for snapshot tests"
+  - event_type: decision.record
+    payload:
+      decision_id: 00000000000000000000000009
+      text: "Use mock backend as default until candle whisper integration lands"
+      alternatives:
+        - "whisper-rs"
+        - "wait for real backend before shipping reflect"

--- a/tests/fixtures/voice/short_en_transcript.jsonl
+++ b/tests/fixtures/voice/short_en_transcript.jsonl
@@ -1,0 +1,3 @@
+{"type":"final","event_id":"01KRGW7MQB272K94WV3XNQXRJ6","text":"[mock transcriber] segment 1","start":0.0,"end":2.0,"confidence":1.0,"revisable":false}
+{"type":"final","event_id":"01KRGW7MQBCCRKH3EWSXZ4T2TV","text":"[mock transcriber] segment 2","start":2.0,"end":5.0,"confidence":1.0,"revisable":false}
+{"type":"endpoint","at":11.6879375,"kind":"stream_end"}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2696,6 +2696,7 @@ Usage: voice <COMMAND>
 Commands:
   capture     Captures audio from a microphone to a 16 kHz mono WAV file
   transcribe  Transcribes a 16 kHz mono WAV file to JSONL or markdown
+  reflect     Reflects on a transcript and emits reflection events
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2715,6 +2716,22 @@ Options:
       --output <OUTPUT>          Destination WAV path. Defaults to `~/.omni-dev/voice/captures/<UTC-timestamp>.wav`
       --device <DEVICE>          Audio input device name. Defaults to the system default input. Matching is exact against the platform-reported device name; an unknown name errors with a list of detected devices
   -h, --help                     Print help
+
+
+================================================================================
+
+omni-dev voice reflect - Reflects on a transcript and emits reflection events
+
+Reflects on a transcript and emits reflection events
+
+Usage: reflect [OPTIONS] [TRANSCRIPT]
+
+Arguments:
+  [TRANSCRIPT]  Path to a `transcript.jsonl` file. Pass `-` for stdin. Omit to fall back to `--session` or stdin
+
+Options:
+      --session <SESSION>  Reflect against a named voice session under `~/.omni-dev/voice/<id>/`. Mutually exclusive with a positional transcript path
+  -h, --help               Print help
 
 
 ================================================================================

--- a/tests/snapshots/voice_reflect_test__voice_reflect_short_en_events.snap
+++ b/tests/snapshots/voice_reflect_test__voice_reflect_short_en_events.snap
@@ -1,0 +1,8 @@
+---
+source: tests/voice_reflect_test.rs
+assertion_line: 102
+expression: body
+---
+{"event_id":"<ULID>","ts":"2026-01-01T00:00:00Z","reflection_id":"<ULID>","provenance":{"transcript_span":{"start_event_id":"<ULID>","end_event_id":"<ULID>"},"model":"mock-model","prompt_version":"f497959d"},"event_type":"item.create","payload":{"item_id":"<ULID>","class":"todo","text":"Wire up real ASR backend to replace mock segments","priority":"high"}}
+{"event_id":"<ULID>","ts":"2026-01-01T00:00:00Z","reflection_id":"<ULID>","provenance":{"transcript_span":{"start_event_id":"<ULID>","end_event_id":"<ULID>"},"model":"mock-model","prompt_version":"f497959d"},"event_type":"research.note","payload":{"note_id":"<ULID>","text":"Mock transcriber emits stable placeholder segments suitable for snapshot tests"}}
+{"event_id":"<ULID>","ts":"2026-01-01T00:00:00Z","reflection_id":"<ULID>","provenance":{"transcript_span":{"start_event_id":"<ULID>","end_event_id":"<ULID>"},"model":"mock-model","prompt_version":"f497959d"},"event_type":"decision.record","payload":{"decision_id":"<ULID>","text":"Use mock backend as default until candle whisper integration lands","alternatives":["whisper-rs","wait for real backend before shipping reflect"]}}

--- a/tests/snapshots/voice_reflect_test__voice_reflect_short_en_malformed.snap
+++ b/tests/snapshots/voice_reflect_test__voice_reflect_short_en_malformed.snap
@@ -1,0 +1,6 @@
+---
+source: tests/voice_reflect_test.rs
+assertion_line: 122
+expression: body
+---
+{"event_id":"<ULID>","ts":"2026-01-01T00:00:00Z","reflection_id":"<ULID>","provenance":{"transcript_span":{"start_event_id":"<ULID>","end_event_id":"<ULID>"},"model":"mock-model","prompt_version":"f497959d"},"event_type":"reflection.error","payload":{"raw_output":"events:\n  - event_type: item.update\n    payload:\n      text: \"deliberately missing item_id — should produce a single reflection.error event\"\n","error":"YAML parse failure: events[0].payload: missing field `item_id` at line 4 column 7"}}

--- a/tests/voice_reflect_cli_test.rs
+++ b/tests/voice_reflect_cli_test.rs
@@ -1,0 +1,79 @@
+//! CLI smoke tests for `voice reflect`.
+//!
+//! Limited to subprocess-observable concerns: argument parsing, `--help`
+//! shape, and error surface. The full reflect pipeline (transcript →
+//! mocked AI → events.jsonl) is covered library-level by
+//! [`tests/voice_reflect_test.rs`], which avoids needing a test backdoor
+//! into the production AI dispatch.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+}
+
+#[test]
+fn voice_reflect_help_renders() {
+    let out = bin().args(["voice", "reflect", "--help"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("Reflects on a transcript"),
+        "help text missing summary line: {stdout}"
+    );
+    assert!(
+        stdout.contains("--session"),
+        "help text missing --session flag: {stdout}"
+    );
+    assert!(
+        stdout.contains("TRANSCRIPT"),
+        "help text missing TRANSCRIPT positional: {stdout}"
+    );
+}
+
+#[test]
+fn voice_reflect_rejects_both_transcript_and_session() {
+    let out = bin()
+        .args([
+            "voice",
+            "reflect",
+            "/tmp/does-not-need-to-exist.jsonl",
+            "--session",
+            "x",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should fail when both are passed");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("either a transcript path or --session"),
+        "expected resolve_source error, got: {stderr}"
+    );
+}
+
+#[test]
+fn voice_reflect_with_nonexistent_path_errors() {
+    let out = bin()
+        .args([
+            "voice",
+            "reflect",
+            "/definitely/does/not/exist/transcript.jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("opening transcript")
+            || stderr.contains("No such file")
+            || stderr.contains("does not exist")
+            || stderr.contains("transcript"),
+        "stderr should reference the missing transcript, got: {stderr}"
+    );
+}

--- a/tests/voice_reflect_test.rs
+++ b/tests/voice_reflect_test.rs
@@ -1,0 +1,147 @@
+//! Library-level integration tests for `voice reflect`.
+//!
+//! Exercises the end-to-end reflection pipeline (transcript → prompt →
+//! mocked AI call → schema validation → events.jsonl) via the public
+//! [`run_reflect`] entry point. The AI client is mocked in-process so
+//! the test is deterministic and cheap; the CLI smoke test
+//! ([`tests/voice_reflect_cli_test.rs`]) covers the subprocess /
+//! argument-parsing layer separately.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use omni_dev::claude::ai::{AiClient, AiClientMetadata};
+use omni_dev::voice::clock::FixedClock;
+use omni_dev::voice::det::CountingUlidRng;
+use omni_dev::voice::reflect::{run_reflect, ReflectOptions, TranscriptSource};
+
+/// Minimal `AiClient` that returns a single canned response. Defined
+/// inline rather than reusing `src/claude/test_utils.rs` because that
+/// module is `pub(crate)` — integration tests can't see it.
+struct CannedAiClient {
+    response: Mutex<Option<String>>,
+    metadata: AiClientMetadata,
+}
+
+impl CannedAiClient {
+    fn new(response: String) -> Self {
+        Self {
+            response: Mutex::new(Some(response)),
+            metadata: AiClientMetadata {
+                provider: "Mock".to_string(),
+                model: "mock-model".to_string(),
+                max_context_length: 200_000,
+                max_response_length: 8_192,
+                active_beta: None,
+            },
+        }
+    }
+}
+
+impl AiClient for CannedAiClient {
+    fn send_request<'a>(
+        &'a self,
+        _system: &'a str,
+        _user: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+        let body = self
+            .response
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or_else(|| String::from("events: []"));
+        Box::pin(async move { Ok(body) })
+    }
+
+    fn get_metadata(&self) -> AiClientMetadata {
+        self.metadata.clone()
+    }
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.join("tests/fixtures/voice").join(name)
+}
+
+fn redact_filters() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // Any 26-char Crockford base32 ULID inside quotes (covers
+        // event_id, reflection_id, transcript_span endpoints, item_id,
+        // decision_id, note_id, superseded_by). Liberal — `[0-9A-Z]`
+        // because that's already established in the transcribe snapshot.
+        (r#""[0-9A-Z]{26}""#, r#""<ULID>""#),
+        // The fixed-clock RFC3339 timestamp varies in `+00:00` vs `Z`
+        // suffix between chrono versions; normalise either way.
+        (r"\+00:00", "Z"),
+    ]
+}
+
+fn build_opts(transcript: PathBuf, canned_response: String) -> ReflectOptions {
+    ReflectOptions {
+        source: TranscriptSource::Path(transcript),
+        ulid_rng: Box::new(CountingUlidRng::new()),
+        clock: Box::new(FixedClock::from_rfc3339("2026-01-01T00:00:00Z")),
+        ai: Box::new(CannedAiClient::new(canned_response)),
+        session_root_override: None,
+    }
+}
+
+#[tokio::test]
+async fn reflect_short_en_transcript_against_canned_response() {
+    let transcript = fixture("short_en_transcript.jsonl");
+    let canned = std::fs::read_to_string(fixture("short_en_reflection_response.yaml")).unwrap();
+    let opts = build_opts(transcript, canned);
+    let mut out: Vec<u8> = Vec::new();
+    run_reflect(opts, &mut out).await.unwrap();
+    let body = String::from_utf8(out).unwrap();
+
+    insta::with_settings!({ filters => redact_filters() }, {
+        insta::assert_snapshot!("voice_reflect_short_en_events", body);
+    });
+}
+
+#[tokio::test]
+async fn malformed_response_yields_one_reflection_error() {
+    let transcript = fixture("short_en_transcript.jsonl");
+    let canned = std::fs::read_to_string(fixture("malformed_reflection_response.yaml")).unwrap();
+    let opts = build_opts(transcript, canned);
+    let mut out: Vec<u8> = Vec::new();
+    run_reflect(opts, &mut out).await.unwrap();
+    let body = String::from_utf8(out).unwrap();
+
+    // Exactly one event line.
+    assert_eq!(body.lines().count(), 1, "got: {body}");
+    // It is a reflection.error.
+    let parsed: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+    assert_eq!(parsed["event_type"], "reflection.error");
+
+    insta::with_settings!({ filters => redact_filters() }, {
+        insta::assert_snapshot!("voice_reflect_short_en_malformed", body);
+    });
+}
+
+#[tokio::test]
+async fn two_runs_with_same_seed_produce_byte_equal_output() {
+    let transcript = fixture("short_en_transcript.jsonl");
+    let canned = std::fs::read_to_string(fixture("short_en_reflection_response.yaml")).unwrap();
+
+    let mut out1: Vec<u8> = Vec::new();
+    run_reflect(build_opts(transcript.clone(), canned.clone()), &mut out1)
+        .await
+        .unwrap();
+
+    let mut out2: Vec<u8> = Vec::new();
+    run_reflect(build_opts(transcript, canned), &mut out2)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        out1, out2,
+        "FixedClock + CountingUlidRng + canned AI response should yield byte-stable output"
+    );
+}


### PR DESCRIPTION
## Description

This PR implements `omni-dev voice reflect`, the first step of the event-sourced voice workflow described in #799. The command reads a `transcript.jsonl` file (from a file path, named session, or stdin), sends the transcript through the configured Claude AI client along with a bundled prompt template, validates the YAML response against the reflection event schema, and emits structured reflection events to `events.jsonl` or stdout.

This establishes the core text-in / events-out pipeline that subsequent commands (`voice review`, #804) will consume to produce materialised markdown projections of the user's working set.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue

Relates to #799 (voice event-sourced reflection pipeline)
Relates to #803 (voice reflect command)

## Changes Made

**Core Library — New Modules:**
- `src/voice/reflect/mod.rs` — end-to-end `run_reflect` driver: resolves transcript source, builds the Claude prompt, invokes the AI, validates the YAML response, and serialises resulting events to the session's `events.jsonl` or stdout
- `src/voice/reflect/prompt.rs` — prompt template loading and rendering; `prompt_version()` returns the first 8 hex chars of the SHA-256 of the bundled template, recorded on every emitted event's `provenance.prompt_version` for audit and reconciliation
- `src/voice/reflect/validate.rs` — two-stage YAML validation: serde parse into `LlmEnvelope` then per-variant semantic checks (unknown `item_id` references, duplicate mints, reserved `reason: ttl`, missing `superseded_by`); failures produce a `reflection.error` event
- `src/voice/events.rs` — full reflection event schema (`item.create`, `item.update`, `item.expire`, `item.complete`, `decision.record`, `research.note`, `reflection.error`) plus `project()` that materialises an event log into `ProjectedState` (last-write-wins, idempotent expiry, unknown-id drop)
- `src/voice/session.rs` — `~/.omni-dev/voice/<id>/` session directory I/O: `meta.yaml` (including `last_reflected_event_id`), `transcript.jsonl`, `events.jsonl`, `reflections.log`; `open_or_create` bootstraps an empty session idempotently
- `src/voice/clock.rs` — pluggable `Clock` trait with `SystemClock` (production) and `FixedClock` (test determinism)
- `src/voice/det.rs` — `UlidRng` trait with `SystemUlidRng` and `CountingUlidRng` extracted from `backends/mock.rs` so reflect can share them for deterministic snapshot tests
- `src/voice/prompts/reflect.md` — bundled prompt template defining the seven event types, `{{current_state}}` / `{{new_transcript}}` substitution slots, and the LLM rules

**CLI Wiring:**
- `src/cli/voice/reflect.rs` — `ReflectCommand` (clap Parser): resolves positional `<TRANSCRIPT>` path vs `--session <id>` vs stdin; rejects both simultaneously; buffers events in memory before writing to stdout to avoid holding a `!Send` `StdoutLock` across an async AI call
- `src/cli/voice.rs` — adds `Reflect` variant to `VoiceSubcommands` and makes `VoiceCommand::execute` async (previously sync)
- `src/cli.rs` — propagates `.await` to the `Voice` dispatch arm
- `src/claude/client.rs` — adds `ClaudeClient::into_ai_client()` so `voice reflect` can extract the underlying `Box<dyn AiClient>` without reimplementing backend-dispatch logic

**Refactoring:**
- `src/voice/backends/mock.rs` — `UlidRng`, `SystemUlidRng`, and `CountingUlidRng` moved to `src/voice/det.rs`; re-exported from `mock.rs` for backwards compatibility

**Testing:**
- `tests/voice_reflect_test.rs` — library-level integration tests using `FixedClock` + `CountingUlidRng` + canned AI responses for byte-stable snapshot output; covers happy path, malformed response → `reflection.error`, and deterministic reproducibility
- `tests/voice_reflect_cli_test.rs` — subprocess smoke tests for `--help` rendering, mutual-exclusion of `<TRANSCRIPT>` and `--session`, and non-existent path error surface
- Insta snapshot fixtures in `tests/fixtures/voice/` and `tests/snapshots/`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (file path source → events to stdout)
- [x] Tested error/edge cases (malformed AI response → `reflection.error` event, AI invocation failure → `reflection.error` event, empty transcript → quiet exit)
- [x] Backward compatibility verified (existing `voice capture` and `voice transcribe` commands unaffected)

**Key Test Scenarios:**
- Happy path: `short_en_transcript.jsonl` + canned AI response → 3 structured events (snapshot-verified)
- Malformed response: missing required `item_id` field → exactly one `reflection.error` event (snapshot-verified)
- Deterministic reproducibility: same `FixedClock` + `CountingUlidRng` + canned response → byte-equal output across two runs
- Session mode: events appended to `events.jsonl`; `meta.last_reflected_event_id` advances; second reflection skips already-consumed Finals
- CLI mutual exclusion: `<TRANSCRIPT>` + `--session` together → non-zero exit with clear error message

### Test Commands

```bash
# Full test suite
cargo test

# Reflect-specific tests
cargo test voice_reflect

# CLI smoke tests
cargo test --test voice_reflect_cli_test

# Code quality
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `VoiceCommand::execute` is now async; the `StdoutLock` buffering workaround in `ReflectCommand::execute` deserves scrutiny (the `!Send` guard cannot be held across an async boundary in a multi-thread Tokio runtime)
- [x] Error handling — all AI invocation failures and schema validation failures are captured as `reflection.error` events rather than surfacing as hard errors, ensuring the event log always has an audit trail
- [x] Session incremental reflection — `read_transcript_finals_after` uses stream position (not ULID comparison) to find the marker; verify the behaviour when `last_reflected_event_id` is set but the transcript has been truncated
- [x] Validation rules in `validate.rs` — particularly the `reason: ttl` rejection, the `superseded_by` requirement for `reason: superseded`, and the cross-event create-then-reference semantics within a single batch

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] Potential performance impact — each `voice reflect` invocation makes one synchronous AI API call (Claude via the existing `AiClient`). Latency is recorded in `reflections.log` (as `latency_ms=`) for monitoring. No impact on existing commands.

## Security Considerations

- [x] No security implications — the command reads local files and calls the existing Claude backend. No new credentials, network endpoints, or data-handling paths are introduced.

## Breaking Changes

`VoiceCommand::execute` is now `async`. Any external callers that drove `VoiceCommand` synchronously will need to `.await` the result. Within this codebase the only call site is `src/cli.rs`, which has been updated.

## Deployment Notes

- [x] No special deployment requirements — the session root defaults to `~/.omni-dev/voice/` and is created on first use. The `OMNI_DEV_VOICE_ROOT` environment variable overrides the root (intended for tests).

## Additional Notes

**Future Enhancements:**
- `voice review` (#804) will consume `events.jsonl` to produce materialised markdown projections and synthesise `item.expire { reason: ttl }` events
- Additional OAuth2/SSO voice provider backends can be wired in without changing the reflect pipeline
- The `rewrite_kind_with_omitted_optionals` hook in `reflect/mod.rs` is a centralised normalisation point for future sanitisation (e.g. text trimming)

**Known Limitations:**
- TTL eviction (`item.expire { reason: ttl }`) is intentionally deferred to `voice review` (#804) and is not implemented in this PR
- `reflections.log` records `cost_usd=unknown` — cost tracking requires provider-specific response metadata not yet exposed by `AiClient`