### PR TITLE
docs(docs): expand adr-0034 with alternatives considered section

### DIFF
--- a/docs/adrs/adr-0034.md
+++ b/docs/adrs/adr-0034.md
@@ -39,10 +39,102 @@ committed fixture [tests/fixtures/voice/two_speakers.wav](../../tests/fixtures/v
 
 `tract-onnx` passed every measured bar with substantial margin. Per the
 Day-1 rule, no fall-back candidate was prototyped; SPIKE.md's candidate
-audit documents the skip rationale for `candle` + HF model (no
-candle-transformers reference impl exists for wespeaker / WavLM-SV; both
-candidate models ship only `pytorch_model.bin`; 2–3 day cost with real
-implementation-bug risk).
+audit documents the skip rationale for `candle` + HF model — see
+**Alternatives considered** below.
+
+## Alternatives considered
+
+The Day-1 stop rule prevented prototyping fall-backs once `tract-onnx`
+cleared every gate. The audit considered the following options and
+recorded skip rationale; none change the decision, but they are
+documented for traceability and so future consolidation work has a
+starting point.
+
+### `candle` + HuggingFace speaker-embedding model (rejected)
+
+- **No first-party reference implementation.**
+  [candle-transformers/src/models](https://github.com/huggingface/candle/tree/main/candle-transformers/src/models)
+  ships ~100+ models (Llama, Mistral, Whisper, Mimi, Encodec, CLIP,
+  …) but none for speaker verification — no wespeaker, WavLM-SV,
+  ECAPA-TDNN, x-vector, or TitaNet. Audio coverage is biased toward
+  ASR and codecs.
+- **Available weights aren't candle-friendly.**
+  [`Wespeaker/wespeaker-voxceleb-resnet34-LM`](https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM/tree/main)
+  ships the ONNX (26.5 MB) plus an `avg_model` raw pickle (45.1 MB) —
+  no safetensors and no Transformers-style `pytorch_model.bin`.
+  [`microsoft/wavlm-base-plus-sv`](https://huggingface.co/microsoft/wavlm-base-plus-sv/tree/main)
+  ships only `pytorch_model.bin` (405 MB) — no safetensors, no ONNX.
+  Either path forces a reimplementation rather than a load.
+- **Hand-port cost is real.** wespeaker ResNet34-TSTP-emb256 is
+  6.63 M params / 4.55 GFLOPs (fbank80 input); the architecture is a
+  standard 2D ResNet-34 trunk + temporal statistics pooling + an FC
+  head, well within candle's expressive range. But re-implementing it
+  (including the fbank80 feature extractor) with bit-equivalence to
+  the reference is a 2–3 day exercise with silent-numerical-drift
+  risk and no golden output to compare against until the ONNX is
+  loaded — circular.
+
+### `candle-onnx` (deferred, not rejected outright)
+
+[`candle-onnx`](https://crates.io/crates/candle-onnx) lets candle load
+ONNX models directly, which would in principle have avoided introducing
+a second runtime. Not pursued in this spike for two reasons:
+
+- **Op coverage is incomplete.** Open issues such as
+  [candle#2876](https://github.com/huggingface/candle/issues/2876)
+  flag commonly-needed ONNX ops (e.g. `Resize`) as unsupported.
+  Verifying every op in the wespeaker ResNet-34 + TSTP graph runs
+  through `candle-onnx` is itself a half-day exercise — outside the
+  Day-1 budget.
+- **Day-1 stop rule.** `tract-onnx` had already cleared every
+  acceptance gate with substantial margin; the spike stopped there.
+
+**Future consolidation.** If `candle-onnx` op coverage closes the gaps
+the wespeaker graph hits, the production code can swap
+`WespeakerEmbedder`'s tract backend for a candle-onnx-backed one with
+no public API change. Worth a follow-up spike if the two-runtime cost
+ever becomes a maintenance burden, or if a candle-transformers
+reference impl for a speaker model lands upstream.
+
+### `native-pyannote-rs` (Burn-based, skipped)
+
+[`native-pyannote-rs`](https://crates.io/crates/native-pyannote-rs) is
+a pure-Rust pipeline using **Burn + ndarray + kaldi-native-fbank**
+that ships a working wespeaker-resnet34 speaker-identification path
+today. Burn was ranked last in #805's preference order ("less mature
+for audio"), but a working production-pipeline-shaped precedent
+already exists in the ecosystem. Not pursued because:
+
+- Adding Burn is a heavier dep-graph change than adding tract — Burn
+  is a much larger framework with its own model-definition surface
+  and a multi-backend abstraction.
+- The Day-1 winner (`tract-onnx`) had already cleared every gate.
+
+Recorded here so future runtime-consolidation reviews have the
+precedent.
+
+### Other ONNX runtimes considered
+
+- **[`rten`](https://github.com/robertknight/rten)** — pure-Rust,
+  actively maintained, runs ResNet-50 in the README. Plausible
+  substitute for tract; skipped at Day-1 in favour of tract's larger
+  production deployment record (Sonos on-device speech).
+- **[`wonnx`](https://github.com/webonnx/wonnx)** — effectively
+  discontinued (no release in 12+ months); correctly excluded.
+- **[`ort`](https://github.com/pykeio/ort)** — Rust bindings to
+  Microsoft's C++ ONNX Runtime; excluded by the no-C++ constraint.
+
+### Alternative speaker models
+
+ECAPA-TDNN
+([`Wespeaker/wespeaker-ecapa-tdnn512-LM`](https://huggingface.co/Wespeaker/wespeaker-ecapa-tdnn512-LM),
+EER 0.728 %) and 3D-Speaker CAM++ / ERes2NetV2
+([modelscope/3D-Speaker](https://github.com/modelscope/3D-Speaker))
+are near-equivalent-accuracy ONNX exports that would load under
+`tract-onnx` without architectural changes. Not evaluated in the
+spike; flagged as the obvious A/B candidates if
+`wespeaker_en_voxceleb_resnet34_LM` ever underperforms on a
+non-English fixture or in field conditions.
 
 ## Decision
 
@@ -233,3 +325,27 @@ exception list.
   runtime, ~85% op coverage in the relevant subset (Conv, BatchNorm,
   statistical pooling); resnet-family models load without
   modification.
+- [candle-transformers models directory](https://github.com/huggingface/candle/tree/main/candle-transformers/src/models)
+  — confirmed absence of any speaker-verification model.
+- [candle-onnx](https://crates.io/crates/candle-onnx) +
+  [candle#2876](https://github.com/huggingface/candle/issues/2876) —
+  candle's ONNX loader plus an example of the op-coverage gap that
+  motivates the deferral.
+- [Wespeaker/wespeaker-voxceleb-resnet34-LM HF files](https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM/tree/main)
+  — actual HuggingFace artefacts (ONNX + `avg_model` pickle; no
+  safetensors).
+- [microsoft/wavlm-base-plus-sv HF files](https://huggingface.co/microsoft/wavlm-base-plus-sv/tree/main)
+  — `pytorch_model.bin` only.
+- [pyannote/wespeaker-voxceleb-resnet34-LM](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM)
+  and [thewh1teagle/pyannote-rs](https://github.com/thewh1teagle/pyannote-rs)
+  — established pyannote precedent for the same ONNX model.
+- [native-pyannote-rs](https://crates.io/crates/native-pyannote-rs) —
+  Burn-based pure-Rust precedent for a wespeaker-resnet34 pipeline;
+  recorded for future consolidation reviews.
+- wespeaker
+  [voxceleb/v2 README](https://github.com/wenet-e2e/wespeaker/blob/master/examples/voxceleb/v2/README.md)
+  — published EER (0.723 % on VoxCeleb1-O-clean) and architecture
+  parameters (6.63 M params, fbank80 input).
+- Alternative speaker models:
+  [Wespeaker/wespeaker-ecapa-tdnn512-LM](https://huggingface.co/Wespeaker/wespeaker-ecapa-tdnn512-LM),
+  [modelscope/3D-Speaker](https://github.com/modelscope/3D-Speaker).


### PR DESCRIPTION
## Description

This PR expands ADR-0034 (tract-onnx speaker embedding) with a detailed "Alternatives considered" section, documenting the evaluation rationale for all candidate approaches that were assessed but not selected during the spike. The additions provide full traceability for the technology decision and give future contributors a documented starting point for any consolidation or re-evaluation work.

## Type of Change

- [x] Documentation update

## Related Issue

Relates to ADR-0034: tract-onnx speaker embedding decision

## Changes Made

**Documentation (`docs/adrs/adr-0034.md`):**
- Added "Alternatives considered" section (~120 lines) replacing a brief inline note
- Documented rejection of `candle` + HuggingFace speaker-embedding models: no first-party reference implementations in candle-transformers, incompatible weight formats (no safetensors or standard `pytorch_model.bin` for wespeaker/WavLM-SV), and 2–3 day hand-port cost with numerical-drift risk
- Documented deferral (not rejection) of `candle-onnx` due to incomplete ONNX op coverage and the Day-1 stop rule once tract-onnx cleared all acceptance gates; noted a clear future consolidation path
- Recorded `native-pyannote-rs` (Burn-based) as a working ecosystem precedent for wespeaker-resnet34, skipped due to heavier dep-graph and Day-1 stop rule
- Enumerated other ONNX runtimes considered: `rten` (deferred), `wonnx` (discontinued), `ort` (excluded by no-C++ constraint)
- Flagged ECAPA-TDNN and 3D-Speaker CAM++/ERes2NetV2 as obvious A/B candidates if the chosen model underperforms on non-English fixtures
- Extended the references section with links to candle-transformers models directory, candle-onnx, HuggingFace artefact listings, pyannote precedents, native-pyannote-rs, and alternative speaker model repos

## Testing

**Automated Testing:**
- [x] All existing tests pass
- Documentation-only change; no code tests required

**Manual Testing:**
- [x] Verified markdown renders correctly and all links are well-formed
- [x] Confirmed section headings are consistent with existing ADR structure

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a documentation-only change with no impact on code or APIs.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- If `candle-onnx` op coverage improves to cover the wespeaker ResNet-34 + TSTP graph, `WespeakerEmbedder`'s tract backend could be swapped for a candle-onnx-backed one with no public API change
- ECAPA-TDNN and 3D-Speaker CAM++/ERes2NetV2 are flagged as ready A/B alternatives requiring no architectural changes to load under `tract-onnx`

**Known Limitations:**
- The "Alternatives considered" section is deliberately bounded by the Day-1 stop rule; deeper prototyping of deferred options (e.g. candle-onnx) is out of scope for this PR