### PR TITLE
feat(atlassian): add jira remote issue link listing

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -555,6 +555,56 @@ pub struct JiraIssueLink {
     pub linked_issue_summary: String,
 }
 
+/// A remote (external URL) issue link on a JIRA issue.
+///
+/// Returned by `GET /rest/api/3/issue/{issueIdOrKey}/remotelink`. These
+/// point out to non-JIRA resources (Confluence pages, Bitbucket PRs,
+/// external trackers).
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraRemoteIssueLink {
+    /// Remote link ID assigned by JIRA.
+    pub id: String,
+    /// Application-defined global identifier, when the linking application
+    /// supplied one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub global_id: Option<String>,
+    /// Free-form description of how the issue relates to the remote object
+    /// (e.g., "mentioned in", "causes").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship: Option<String>,
+    /// The remote object the link points at.
+    pub object: JiraRemoteIssueLinkObject,
+}
+
+/// The remote object an entry of [`JiraRemoteIssueLink`] points at.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraRemoteIssueLinkObject {
+    /// Remote URL.
+    pub url: String,
+    /// Display title for the remote object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Short summary text for the remote object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Icon associated with the remote object (often labels the kind of
+    /// external target, e.g. "Confluence Page").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<JiraRemoteIssueLinkIcon>,
+}
+
+/// Icon metadata for a [`JiraRemoteIssueLinkObject`]. Mirrors the upstream
+/// `object.icon` shape, with JIRA's `url16x16` flattened to `url`.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraRemoteIssueLinkIcon {
+    /// Icon URL (from JIRA's `url16x16`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Icon title — typically the label of the external target kind.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
 /// A JIRA issue attachment, embedded in the `attachment` field of
 /// `GET /rest/api/3/issue/{key}`.
 ///
@@ -1188,6 +1238,35 @@ struct JiraIssueLinkIssue {
 #[derive(Deserialize)]
 struct JiraIssueLinkIssueFields {
     summary: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct JiraRemoteIssueLinkEntry {
+    id: serde_json::Value,
+    #[serde(rename = "globalId", default)]
+    global_id: Option<String>,
+    #[serde(default)]
+    relationship: Option<String>,
+    object: JiraRemoteIssueLinkObjectEntry,
+}
+
+#[derive(Deserialize)]
+struct JiraRemoteIssueLinkObjectEntry {
+    url: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    icon: Option<JiraRemoteIssueLinkIconEntry>,
+}
+
+#[derive(Deserialize)]
+struct JiraRemoteIssueLinkIconEntry {
+    #[serde(rename = "url16x16", default)]
+    url: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -4660,6 +4739,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_remote_issue_links_success() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {
+                        "id": 10001,
+                        "globalId": "system=https://example.atlassian.net/wiki&id=12345",
+                        "relationship": "mentioned in",
+                        "object": {
+                            "url": "https://example.atlassian.net/wiki/spaces/X/pages/12345",
+                            "title": "Design doc",
+                            "summary": "Architecture overview",
+                            "icon": {
+                                "url16x16": "https://example.atlassian.net/icons/page.png",
+                                "title": "Confluence Page"
+                            }
+                        }
+                    },
+                    {
+                        "id": "10002",
+                        "object": {
+                            "url": "https://bitbucket.org/acme/repo/pull-requests/42"
+                        }
+                    }
+                ])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let links = client.get_remote_issue_links("PROJ-1").await.unwrap();
+
+        assert_eq!(links.len(), 2);
+
+        // First entry: full payload, numeric id normalized to string.
+        assert_eq!(links[0].id, "10001");
+        assert_eq!(
+            links[0].global_id.as_deref(),
+            Some("system=https://example.atlassian.net/wiki&id=12345")
+        );
+        assert_eq!(links[0].relationship.as_deref(), Some("mentioned in"));
+        assert_eq!(
+            links[0].object.url,
+            "https://example.atlassian.net/wiki/spaces/X/pages/12345"
+        );
+        assert_eq!(links[0].object.title.as_deref(), Some("Design doc"));
+        assert_eq!(
+            links[0].object.summary.as_deref(),
+            Some("Architecture overview")
+        );
+        let icon = links[0].object.icon.as_ref().expect("icon present");
+        assert_eq!(
+            icon.url.as_deref(),
+            Some("https://example.atlassian.net/icons/page.png")
+        );
+        assert_eq!(icon.title.as_deref(), Some("Confluence Page"));
+
+        // Second entry: minimal payload, string id, no optional fields.
+        assert_eq!(links[1].id, "10002");
+        assert!(links[1].global_id.is_none());
+        assert!(links[1].relationship.is_none());
+        assert_eq!(
+            links[1].object.url,
+            "https://bitbucket.org/acme/repo/pull-requests/42"
+        );
+        assert!(links[1].object.title.is_none());
+        assert!(links[1].object.summary.is_none());
+        assert!(links[1].object.icon.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_remote_issue_links_empty() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let links = client.get_remote_issue_links("PROJ-1").await.unwrap();
+        assert!(links.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_remote_issue_links_api_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/NOPE-1/remotelink",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_remote_issue_links("NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
     async fn get_link_types_success() {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -8014,6 +8202,57 @@ impl AtlassianClient {
             }
         }
 
+        Ok(links)
+    }
+
+    /// Lists remote (external URL) issue links on a JIRA issue.
+    ///
+    /// Endpoint: `GET /rest/api/3/issue/{key}/remotelink` — returns a bare
+    /// JSON array (not a wrapped `{ links: [...] }` envelope).
+    pub async fn get_remote_issue_links(&self, key: &str) -> Result<Vec<JiraRemoteIssueLink>> {
+        let url = format!("{}/rest/api/3/issue/{}/remotelink", self.instance_url, key);
+
+        let response = self.get_json(&url).await?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
+        }
+
+        let entries: Vec<JiraRemoteIssueLinkEntry> = response
+            .json()
+            .await
+            .context("Failed to parse remote issue links response")?;
+
+        let mut links = Vec::with_capacity(entries.len());
+        for entry in entries {
+            // JIRA returns the remote link id as a number; normalize to String
+            // so callers don't have to care about the wire shape.
+            let id = match entry.id {
+                serde_json::Value::String(s) => s,
+                serde_json::Value::Number(n) => n.to_string(),
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "unexpected remote link id type in response: {other:?}"
+                    ));
+                }
+            };
+            links.push(JiraRemoteIssueLink {
+                id,
+                global_id: entry.global_id,
+                relationship: entry.relationship,
+                object: JiraRemoteIssueLinkObject {
+                    url: entry.object.url,
+                    title: entry.object.title,
+                    summary: entry.object.summary,
+                    icon: entry.object.icon.map(|i| JiraRemoteIssueLinkIcon {
+                        url: i.url,
+                        title: i.title,
+                    }),
+                },
+            });
+        }
         Ok(links)
     }
 

--- a/src/cli/atlassian/jira/link.rs
+++ b/src/cli/atlassian/jira/link.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 
 use std::io::{self, BufRead, Write};
 
-use crate::atlassian::client::{AtlassianClient, JiraIssueLink, JiraLinkType};
+use crate::atlassian::client::{AtlassianClient, JiraIssueLink, JiraLinkType, JiraRemoteIssueLink};
 use crate::cli::atlassian::confirm::{guard_destructive_with_io, GuardOptions, GuardOutcome};
 use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
@@ -31,6 +31,8 @@ pub enum LinkSubcommands {
     Remove(RemoveLinkCommand),
     /// Links an issue to an epic (sets parent).
     Epic(EpicLinkCommand),
+    /// Manages remote (external URL) issue links.
+    Remote(RemoteLinkCommand),
 }
 
 impl LinkCommand {
@@ -42,6 +44,7 @@ impl LinkCommand {
             LinkSubcommands::Create(cmd) => cmd.execute().await,
             LinkSubcommands::Remove(cmd) => cmd.execute().await,
             LinkSubcommands::Epic(cmd) => cmd.execute().await,
+            LinkSubcommands::Remote(cmd) => cmd.execute().await,
         }
     }
 }
@@ -183,6 +186,49 @@ impl EpicLinkCommand {
     }
 }
 
+/// Manages JIRA remote (external URL) issue links.
+#[derive(Parser)]
+pub struct RemoteLinkCommand {
+    /// The remote-link subcommand to execute.
+    #[command(subcommand)]
+    pub command: RemoteLinkSubcommands,
+}
+
+/// Remote link subcommands.
+#[derive(Subcommand)]
+pub enum RemoteLinkSubcommands {
+    /// Lists remote (external URL) links on a JIRA issue.
+    List(ListRemoteLinksCommand),
+}
+
+impl RemoteLinkCommand {
+    /// Executes the remote-link command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            RemoteLinkSubcommands::List(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+/// Lists remote (external URL) links on a JIRA issue.
+#[derive(Parser)]
+pub struct ListRemoteLinksCommand {
+    /// JIRA issue key (e.g., PROJ-123).
+    pub key: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ListRemoteLinksCommand {
+    /// Fetches and displays remote issue links.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_list_remote_links(&client, &self.key, &self.output).await
+    }
+}
+
 /// Fetches and displays issue links.
 async fn run_list_links(client: &AtlassianClient, key: &str, output: &OutputFormat) -> Result<()> {
     let links = client.get_issue_links(key).await?;
@@ -314,6 +360,64 @@ fn print_link_types(types: &[JiraLinkType]) {
         println!(
             "{:<id_width$}  {:<name_width$}  {:<inward_width$}  {}",
             t.id, t.name, t.inward, t.outward
+        );
+    }
+}
+
+/// Fetches and displays remote (external URL) issue links.
+async fn run_list_remote_links(
+    client: &AtlassianClient,
+    key: &str,
+    output: &OutputFormat,
+) -> Result<()> {
+    let links = client.get_remote_issue_links(key).await?;
+    if output_as(&links, output)? {
+        return Ok(());
+    }
+    print_remote_links(key, &links);
+    Ok(())
+}
+
+/// Prints remote (external URL) issue links as a formatted table.
+fn print_remote_links(key: &str, links: &[JiraRemoteIssueLink]) {
+    if links.is_empty() {
+        println!("{key}: no remote links.");
+        return;
+    }
+
+    let id_width = links.iter().map(|l| l.id.len()).max().unwrap_or(2).max(2);
+    let rel_width = links
+        .iter()
+        .map(|l| l.relationship.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(12)
+        .max(12); // "RELATIONSHIP"
+    let title_width = links
+        .iter()
+        .map(|l| l.object.title.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(5)
+        .max(5); // "TITLE"
+
+    println!(
+        "{:<id_width$}  {:<rel_width$}  {:<title_width$}  URL",
+        "ID", "RELATIONSHIP", "TITLE"
+    );
+    let url_sep = "-".repeat(3);
+    println!(
+        "{:<id_width$}  {:<rel_width$}  {:<title_width$}  {url_sep}",
+        "-".repeat(id_width),
+        "-".repeat(rel_width),
+        "-".repeat(title_width),
+    );
+
+    for link in links {
+        println!(
+            "{:<id_width$}  {:<rel_width$}  {:<title_width$}  {}",
+            link.id,
+            link.relationship.as_deref().unwrap_or("-"),
+            link.object.title.as_deref().unwrap_or("-"),
+            link.object.url,
         );
     }
 }
@@ -816,5 +920,142 @@ mod tests {
             dry_run: false,
         };
         cmd.execute().await.unwrap();
+    }
+
+    // ── remote links ───────────────────────────────────────────────
+
+    use crate::atlassian::client::{JiraRemoteIssueLinkIcon, JiraRemoteIssueLinkObject};
+
+    fn sample_remote_link(
+        id: &str,
+        relationship: Option<&str>,
+        url: &str,
+        title: Option<&str>,
+        icon_title: Option<&str>,
+    ) -> JiraRemoteIssueLink {
+        JiraRemoteIssueLink {
+            id: id.to_string(),
+            global_id: None,
+            relationship: relationship.map(String::from),
+            object: JiraRemoteIssueLinkObject {
+                url: url.to_string(),
+                title: title.map(String::from),
+                summary: None,
+                icon: icon_title.map(|t| JiraRemoteIssueLinkIcon {
+                    url: None,
+                    title: Some(t.to_string()),
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn print_remote_links_empty() {
+        // Just exercises the empty-print path; no panic.
+        print_remote_links("PROJ-1", &[]);
+    }
+
+    #[test]
+    fn print_remote_links_with_data() {
+        let links = vec![
+            sample_remote_link(
+                "10001",
+                Some("mentioned in"),
+                "https://example.atlassian.net/wiki/page/1",
+                Some("Design doc"),
+                Some("Confluence Page"),
+            ),
+            sample_remote_link(
+                "10002",
+                None,
+                "https://bitbucket.org/acme/repo/pull-requests/42",
+                None,
+                None,
+            ),
+        ];
+        print_remote_links("PROJ-1", &links);
+    }
+
+    #[test]
+    fn link_command_remote_variant() {
+        let cmd = LinkCommand {
+            command: LinkSubcommands::Remote(RemoteLinkCommand {
+                command: RemoteLinkSubcommands::List(ListRemoteLinksCommand {
+                    key: "PROJ-1".to_string(),
+                    output: OutputFormat::Table,
+                }),
+            }),
+        };
+        assert!(matches!(cmd.command, LinkSubcommands::Remote(_)));
+    }
+
+    #[tokio::test]
+    async fn run_list_remote_links_table_ok() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {
+                        "id": 10001,
+                        "relationship": "mentioned in",
+                        "object": {
+                            "url": "https://example.atlassian.net/wiki/page/1",
+                            "title": "Design doc"
+                        }
+                    }
+                ])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(
+            run_list_remote_links(&client, "PROJ-1", &OutputFormat::Table)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_list_remote_links_yaml_ok() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        assert!(
+            run_list_remote_links(&client, "PROJ-1", &OutputFormat::Yaml)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_list_remote_links_propagates_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/NOPE-1/remotelink",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server.uri());
+        let err = run_list_remote_links(&client, "NOPE-1", &OutputFormat::Table)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
     }
 }

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -193,7 +193,8 @@ pub struct JiraCommentEditParams {
 /// Parameters for the `jira_link` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct JiraLinkParams {
-    /// Action: `list`, `types`, `create`, `remove`, or `parent`.
+    /// Action: `list`, `types`, `create`, `remove`, `parent`, or
+    /// `remote_list` (read-only listing of external URL links).
     pub action: String,
     /// Issue key. Required for `list`; for `create`, this is the source
     /// (inward) issue; for `parent`, this is the child issue. Ignored for
@@ -592,8 +593,14 @@ async fn run_jira_link(
             client.set_issue_parent(child, parent_key).await?;
             Ok(format!("Set parent of {child} to {parent_key}.\n"))
         }
+        "remote_list" => {
+            let k = key
+                .ok_or_else(|| anyhow::anyhow!("`key` is required for link remote_list"))?;
+            let links = client.get_remote_issue_links(k).await?;
+            yaml_result(&links)
+        }
         other => anyhow::bail!(
-            "unknown link action {other:?} (expected \"list\", \"types\", \"create\", \"remove\", or \"parent\")"
+            "unknown link action {other:?} (expected \"list\", \"types\", \"create\", \"remove\", \"parent\", or \"remote_list\")"
         ),
     }
 }
@@ -822,7 +829,10 @@ impl OmniDevServer {
                        \"types\", \"create\" (needs `key`, `target`, `link_type`), \
                        \"remove\" (needs `link_id`), \"parent\" (needs `key` = child, \
                        `target` = parent — sets the system parent field for Epic → Story / \
-                       Story → Sub-task hierarchy, distinct from relationship links)."
+                       Story → Sub-task hierarchy, distinct from relationship links), \
+                       \"remote_list\" (needs `key` — read-only listing of external URL \
+                       links pointing out to non-JIRA resources like Confluence or \
+                       Bitbucket PRs)."
     )]
     pub async fn jira_link(
         &self,
@@ -2333,6 +2343,42 @@ mod tests {
     async fn run_jira_link_list_requires_key() {
         let client = mock_client("http://127.0.0.1:1");
         let err = run_jira_link(&client, "list", None, None, None, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("`key` is required"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_link_remote_list_returns_yaml() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/PROJ-1/remotelink"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 10001,
+                    "relationship": "mentioned in",
+                    "object": {
+                        "url": "https://example.atlassian.net/wiki/page/1",
+                        "title": "Design doc"
+                    }
+                }
+            ])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let yaml = run_jira_link(&client, "remote_list", Some("PROJ-1"), None, None, None)
+            .await
+            .unwrap();
+        assert!(yaml.contains("10001"));
+        assert!(yaml.contains("mentioned in"));
+        assert!(yaml.contains("Design doc"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_link_remote_list_requires_key() {
+        let client = mock_client("http://127.0.0.1:1");
+        let err = run_jira_link(&client, "remote_list", None, None, None, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("`key` is required"));

--- a/src/mcp/jira_tools.rs
+++ b/src/mcp/jira_tools.rs
@@ -584,6 +584,18 @@ pub(crate) async fn link_remove_yaml(
     serde_yaml::to_string(&STATUS_OK).context("Failed to serialize status as YAML")
 }
 
+/// Parameters for the `jira_link_remote_list` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct LinkRemoteListParams {
+    /// JIRA issue key (e.g., `PROJ-123`).
+    pub key: String,
+}
+
+pub(crate) async fn link_remote_list_yaml(client: &AtlassianClient, key: &str) -> Result<String> {
+    let links = client.get_remote_issue_links(key).await?;
+    serde_yaml::to_string(&links).context("Failed to serialize remote issue links as YAML")
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Worklog tools
 // ─────────────────────────────────────────────────────────────────────────
@@ -1179,6 +1191,27 @@ impl OmniDevServer {
         let yaml = (async {
             let (client, _) = create_client()?;
             link_remove_yaml(&client, &params.link_id, params.confirm).await
+        })
+        .await
+        .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Tool: list remote (external URL) links on an issue.
+    #[tool(
+        description = "List remote (external URL) links on a JIRA issue — links pointing out \
+                       to non-JIRA resources (Confluence pages, Bitbucket PRs, external \
+                       trackers). Read-only. Returns YAML with one entry per remote link \
+                       (id, optional global_id, optional relationship, object.{url, title, \
+                       summary, icon}). Mirrors `omni-dev atlassian jira link remote list`."
+    )]
+    pub async fn jira_link_remote_list(
+        &self,
+        Parameters(params): Parameters<LinkRemoteListParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let yaml = (async {
+            let (client, _) = create_client()?;
+            link_remote_list_yaml(&client, &params.key).await
         })
         .await
         .map_err(tool_error)?;

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -270,6 +270,10 @@ async fn jira_extension_tools_route_through_mcp() -> Result<()> {
             "jira_link_remove",
             serde_json::json!({"link_id": "1", "confirm": true}),
         ),
+        (
+            "jira_link_remote_list",
+            serde_json::json!({"key": "PROJ-1"}),
+        ),
         ("jira_project_list", serde_json::json!({})),
         ("jira_sprint_list", serde_json::json!({"board_id": 1})),
         ("jira_sprint_issues", serde_json::json!({"sprint_id": 1})),

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1247,6 +1247,7 @@ Commands:
   create  Creates a link between two issues
   remove  Removes an issue link by ID
   epic    Links an issue to an epic (sets parent)
+  remote  Manages remote (external URL) issue links
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1287,6 +1288,38 @@ Options:
 omni-dev atlassian jira link list - Lists links on a JIRA issue
 
 Lists links on a JIRA issue
+
+Usage: list [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>  JIRA issue key (e.g., PROJ-123)
+
+Options:
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian jira link remote - Manages remote (external URL) issue links
+
+Manages remote (external URL) issue links
+
+Usage: remote <COMMAND>
+
+Commands:
+  list  Lists remote (external URL) links on a JIRA issue
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira link remote list - Lists remote (external URL) links on a JIRA issue
+
+Lists remote (external URL) links on a JIRA issue
 
 Usage: list [OPTIONS] <KEY>
 


### PR DESCRIPTION
## Description

This PR implements end-to-end support for reading JIRA remote (external URL) issue links — links that point to non-JIRA resources such as Confluence pages, Bitbucket PRs, and external issue trackers.

JIRA distinguishes between internal issue-to-issue links and "remote links" that reference external systems. Previously, `omni-dev` had no way to read or list these remote links. This change adds full read support across the Atlassian client, CLI, and MCP layers, giving users and AI tools access to external resource references attached to JIRA issues.

A notable implementation detail: JIRA's `/remotelink` endpoint returns the link `id` field as either a JSON number or a JSON string depending on the JIRA instance version. The new `get_remote_issue_links` method normalizes this to a Rust `String` so callers don't need to handle the wire ambiguity.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #827

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `JiraRemoteIssueLink`, `JiraRemoteIssueLinkObject`, and `JiraRemoteIssueLinkIcon` as public serializable data types
- Added private deserialization types (`JiraRemoteIssueLinkEntry`, `JiraRemoteIssueLinkObjectEntry`, `JiraRemoteIssueLinkIconEntry`) that mirror the JIRA API wire shape, including renaming `url16x16` to `url`
- Added `AtlassianClient::get_remote_issue_links(key)` calling `GET /rest/api/3/issue/{key}/remotelink`, with id-type normalization (JSON number or string → Rust `String`)

**CLI (`src/cli/atlassian/jira/link.rs`):**
- Added `Remote(RemoteLinkCommand)` variant to `LinkSubcommands`
- Added `RemoteLinkCommand`, `RemoteLinkSubcommands`, and `ListRemoteLinksCommand` structs with `--output` flag supporting table, JSON, YAML, YAMLs, and JSONL formats
- Added `run_list_remote_links()` async helper and `print_remote_links()` table formatter with dynamic column widths

**MCP Tools (`src/mcp/jira_core_tools.rs`):**
- Added `remote_list` action to the existing `jira_link` MCP tool (requires `key` parameter)
- Updated the `jira_link` tool description and error message to document the new action

**MCP Tools (`src/mcp/jira_tools.rs`):**
- Added `LinkRemoteListParams` parameter struct
- Added `link_remote_list_yaml()` helper function
- Added dedicated `jira_link_remote_list` MCP tool for direct access, mirroring `omni-dev atlassian jira link remote list`

**Testing:**
- Added unit tests in `src/atlassian/client.rs`: `get_remote_issue_links_success`, `get_remote_issue_links_empty`, `get_remote_issue_links_api_error`
- Added unit tests in `src/cli/atlassian/jira/link.rs`: `print_remote_links_empty`, `print_remote_links_with_data`, `link_command_remote_variant`, `run_list_remote_links_table_ok`, `run_list_remote_links_yaml_ok`, `run_list_remote_links_propagates_error`
- Added unit tests in `src/mcp/jira_core_tools.rs`: `run_jira_link_remote_list_returns_yaml`, `run_jira_link_remote_list_requires_key`
- Added `jira_link_remote_list` to MCP integration test routing in `tests/mcp_integration_test.rs`
- Updated help snapshot `tests/snapshots/integration_test__help_all_output.snap` to include new `remote` subcommand and its `list` sub-subcommand

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (success with full payload, success with minimal payload)
- [x] Tested error/edge cases (empty list, 404 API error, missing required `key` parameter)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- All three layers (client, CLI, MCP) have dedicated tests for success, empty, and API-error cases
- The id-normalization edge case (numeric vs. string JSON id) is explicitly covered in `get_remote_issue_links_success`

### Test Commands
```bash
# Core test suite
cargo test

# Run only remote link related tests
cargo test remote

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — particularly the `id` type normalization in `get_remote_issue_links` (handles `serde_json::Value::Number`, `Value::String`, and rejects unexpected variants)
- [x] Architecture changes — the `remote_list` action is wired into the existing `jira_link` MCP tool and also exposed as a dedicated `jira_link_remote_list` tool; both paths are tested
- [ ] Security implications
- [ ] Performance impact
- [ ] User experience
- [x] Backward compatibility

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications — this is a read-only feature that uses the existing authenticated `AtlassianClient`; no new credentials or data storage is introduced

## Breaking Changes
None. All additions are purely additive: new data types, a new API method, a new CLI subcommand, and new MCP tools.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Add `remote_create` and `remote_remove` actions to support creating and deleting remote links via MCP and CLI
- Consider adding filtering options (e.g., by relationship type or URL pattern) to `list remote`

**Known Limitations:**
- The current implementation is read-only; creating or deleting remote links is not yet supported
- The table output does not display `global_id`, `summary`, or icon metadata — these are available in JSON/YAML output formats

**Alternatives Considered:**
- Exposing remote links only through the existing `jira_link` tool's `remote_list` action (without a dedicated `jira_link_remote_list` tool) — decided to add both for consistency with the pattern used by other link-related tools and for direct MCP discoverability