### PR TITLE
test(atlassian): add coverage for jira remote issue link list operations

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -4832,6 +4832,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_remote_issue_links_rejects_unexpected_id_type() {
+        // Exercise the defensive `other =>` arm of the id-normalisation
+        // match. JIRA's wire contract is number-or-string; anything else
+        // should be surfaced as a clear error rather than silently
+        // accepted.
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {
+                        "id": null,
+                        "object": {"url": "https://example.com/x"}
+                    }
+                ])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let err = client.get_remote_issue_links("PROJ-1").await.unwrap_err();
+        assert!(err.to_string().contains("unexpected remote link id type"));
+    }
+
+    #[tokio::test]
     async fn get_remote_issue_links_api_error() {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))

--- a/src/cli/atlassian/jira/link.rs
+++ b/src/cli/atlassian/jira/link.rs
@@ -1040,6 +1040,35 @@ mod tests {
         );
     }
 
+    /// End-to-end exercise of the nested public `execute()` chain for the
+    /// remote-link `list` subcommand: outer `LinkCommand::execute` →
+    /// `RemoteLinkCommand::execute` → `ListRemoteLinksCommand::execute` →
+    /// `create_client` → API.
+    #[tokio::test]
+    async fn link_command_remote_list_execute_drives_create_client_and_calls_api() {
+        use crate::test_support::atlassian_env::AtlassianEnvGuard;
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/rest/api/3/issue/PROJ-1/remotelink",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _env = AtlassianEnvGuard::new(&server.uri(), "u@t.com", "tok");
+        let cmd = LinkCommand {
+            command: LinkSubcommands::Remote(RemoteLinkCommand {
+                command: RemoteLinkSubcommands::List(ListRemoteLinksCommand {
+                    key: "PROJ-1".to_string(),
+                    output: OutputFormat::Yaml,
+                }),
+            }),
+        };
+        cmd.execute().await.unwrap();
+    }
+
     #[tokio::test]
     async fn run_list_remote_links_propagates_error() {
         let server = wiremock::MockServer::start().await;

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -2385,6 +2385,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_jira_link_remote_list_propagates_api_errors() {
+        // Covers the `?` error branch on `client.get_remote_issue_links(k)`
+        // — Codecov flags this as a partial without an explicit failing
+        // path.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/NOPE-1/remotelink"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let err = run_jira_link(&client, "remote_list", Some("NOPE-1"), None, None, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
     async fn run_jira_link_create_posts_link() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))

--- a/src/mcp/jira_tools.rs
+++ b/src/mcp/jira_tools.rs
@@ -2108,6 +2108,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn link_remote_list_yaml_returns_yaml() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/PROJ-1/remotelink"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 10001,
+                    "globalId": "system=https://example.atlassian.net/wiki&id=12345",
+                    "relationship": "mentioned in",
+                    "object": {
+                        "url": "https://example.atlassian.net/wiki/page/1",
+                        "title": "Design doc",
+                        "icon": {"url16x16": "https://example.atlassian.net/icons/page.png"}
+                    }
+                }
+            ])))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let yaml = link_remote_list_yaml(&client, "PROJ-1").await.unwrap();
+        assert!(yaml.contains("10001"));
+        assert!(yaml.contains("mentioned in"));
+        assert!(yaml.contains("Design doc"));
+        assert!(yaml.contains("global_id"));
+    }
+
+    #[tokio::test]
+    async fn link_remote_list_yaml_propagates_api_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/NOPE-1/remotelink"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let err = link_remote_list_yaml(&client, "NOPE-1").await.unwrap_err();
+        assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
     async fn link_types_yaml_returns_yaml() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -619,6 +619,13 @@ async fn jira_tool_handlers_round_trip_through_wiremock() -> Result<()> {
         .mount(&server)
         .await;
 
+    // jira_link_remote_list
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-1/remotelink"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
     // jira_dev
     Mock::given(method("GET"))
         .and(path("/rest/dev-status/1.0/issue/summary"))
@@ -642,7 +649,7 @@ async fn jira_tool_handlers_round_trip_through_wiremock() -> Result<()> {
     let _env = AtlassianEnvGuard::new(&server.uri(), "test@test.com", "token")?;
     let (client, server_handle) = spawn_server().await;
 
-    let calls: [(&str, serde_json::Value); 8] = [
+    let calls: [(&str, serde_json::Value); 9] = [
         ("jira_read", serde_json::json!({"key": "PROJ-1"})),
         ("jira_search", serde_json::json!({"jql": "project = PROJ"})),
         (
@@ -662,6 +669,10 @@ async fn jira_tool_handlers_round_trip_through_wiremock() -> Result<()> {
             serde_json::json!({"key": "PROJ-1", "action": "list"}),
         ),
         ("jira_link", serde_json::json!({"action": "types"})),
+        (
+            "jira_link_remote_list",
+            serde_json::json!({"key": "PROJ-1"}),
+        ),
         ("jira_dev", serde_json::json!({"key": "PROJ-1"})),
     ];
 
@@ -701,6 +712,7 @@ async fn jira_tool_handlers_surface_tool_error_without_credentials() -> Result<(
         "jira_transition",
         "jira_comment",
         "jira_link",
+        "jira_link_remote_list",
         "jira_dev",
         "jira_user_search",
     ] {


### PR DESCRIPTION
## Description

This PR adds unit and integration test coverage for Jira remote issue link listing operations across the full stack: the Atlassian client, CLI execute chain, MCP tool handlers, and the MCP integration test suite.

The motivation is to address Codecov partial-branch flags and defensive code paths that were previously untested in the `jira_link_remote_list` feature. All five modified files receive targeted tests covering both the happy path and error/edge case branches.

## Type of Change

- [x] Test coverage improvement

## Related Issue

Relates to #827

## Changes Made

**Testing — `src/atlassian/client.rs`:**
- Added `get_remote_issue_links_rejects_unexpected_id_type` to exercise the defensive `other =>` arm of the id-normalisation match when a remote link's `id` field is `null` (or another unexpected type), asserting the "unexpected remote link id type" error is surfaced

**Testing — `src/cli/atlassian/jira/link.rs`:**
- Added `link_command_remote_list_execute_drives_create_client_and_calls_api` to drive the complete public `execute()` chain: `LinkCommand → RemoteLinkCommand → ListRemoteLinksCommand → create_client → API`, verified end-to-end via `AtlassianEnvGuard` and wiremock

**Testing — `src/mcp/jira_core_tools.rs`:**
- Added `run_jira_link_remote_list_propagates_api_errors` to cover the `?` error branch on `client.get_remote_issue_links()` previously flagged as a partial branch by Codecov; uses a 404 mock response to assert the error is propagated

**Testing — `src/mcp/jira_tools.rs`:**
- Added `link_remote_list_yaml_returns_yaml` to verify the success path of `link_remote_list_yaml`, asserting the returned YAML contains the expected id, relationship, title, and `global_id` fields
- Added `link_remote_list_yaml_propagates_api_errors` to verify the 404 error path is propagated correctly from `link_remote_list_yaml`

**Testing — `tests/mcp_integration_test.rs`:**
- Extended `jira_tool_handlers_round_trip_through_wiremock` from 8 to 9 tool calls to include a `jira_link_remote_list` round-trip against a wiremock server
- Added `jira_link_remote_list` to the `jira_tool_handlers_surface_tool_error_without_credentials` error-surface test

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run atlassian-specific tests
cargo test atlassian

# Run MCP tool tests
cargo test jira_link_remote_list

# Run integration test
cargo test jira_tool_handlers_round_trip_through_wiremock

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — each test explicitly validates that errors propagate correctly through the `?` operator chain
- [x] Backward compatibility — all changes are additive tests only; no production code was modified

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- Test coverage percentages are not reported here; Codecov will update automatically on CI run.

**Alternatives Considered:**
- Considered mocking at a higher level rather than using wiremock end-to-end; chose wiremock for consistency with the existing test patterns in this module and for greater fidelity to real HTTP interactions.