### PR TITLE
chore(workflows): remove nix build job and cachix binary cache references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,29 +121,6 @@ jobs:
         files: codecov.json
         fail_ci_if_error: true
 
-  nix:
-    name: Nix Build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: cachix/install-nix-action@v31
-      with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-    - uses: cachix/cachix-action@v17
-      with:
-        name: omni-dev
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-        extraPullNames: nix-community
-        skipPush: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    - name: Check Nix flake
-      run: nix flake check
-    - name: Build with Nix
-      run: nix build --no-link
-    - name: Test Nix app
-      run: nix run . -- --version
-
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,30 +38,12 @@ nix profile install github:rust-works/omni-dev
 
 # Install with Nix flakes (development)
 nix run github:rust-works/omni-dev
-
-# Enable binary cache for faster builds (optional)
-cachix use omni-dev
 ```
 
 **Next step:** see [Getting Started](docs/getting-started.md) — a
 10-minute walkthrough from authentication to your first AI-improved
 commit. (For just the API-key reference, see
 [Authentication](docs/configuration.md#authentication).)
-
-#### Nix Binary Cache (Optional)
-
-For faster Nix builds, you can use the binary cache:
-
-```bash
-# Install cachix if you don't have it
-nix profile install nixpkgs#cachix
-
-# Enable the omni-dev binary cache
-cachix use omni-dev
-
-# Now Nix installations will use pre-built binaries instead of compiling from source
-nix profile install github:rust-works/omni-dev
-```
 
 #### Shell Completion
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -18,7 +18,6 @@ The release process follows semantic versioning with **automated CI/CD**:
 7. GitHub release creation
 8. Cross-platform binary builds (Linux, macOS, Windows)
 9. crates.io publication
-10. Nix binary cache publication
 
 ## Prerequisites
 
@@ -145,8 +144,6 @@ Pushing a `v*` tag triggers the following automated workflows:
 - Runs clippy linting
 - Builds documentation
 - Generates code coverage
-- Builds and tests Nix package
-- Publishes to `omni-dev` Cachix binary cache
 
 ### Release Workflow (`.github/workflows/release.yml`)
 - **Creates GitHub Release**: Automatically from the tag
@@ -177,13 +174,6 @@ After pushing the tag, monitor the automated release:
    cargo search omni-dev
    # Or test installation
    cargo install omni-dev
-   ```
-
-4. **Verify Nix Binary Cache**:
-   ```bash
-   nix search github:rust-works/omni-dev
-   cachix use omni-dev
-   nix profile install github:rust-works/omni-dev
    ```
 
 ## Post-Release Tasks
@@ -260,11 +250,10 @@ The automated release pipeline requires these GitHub secrets:
 |------------------------|-------------------------------------------------------------|
 | `GITHUB_TOKEN`         | Automatically provided by GitHub Actions for release creation |
 | `CARGO_REGISTRY_TOKEN` | crates.io API token for publishing                          |
-| `CACHIX_AUTH_TOKEN`    | Cachix authentication for Nix binary cache                  |
 
 ### Workflow Files
 
-- `.github/workflows/ci.yml` - Quality checks and Nix builds
+- `.github/workflows/ci.yml` - Quality checks
 - `.github/workflows/release.yml` - Release creation and publishing
 - `.github/workflows/commit-check.yml` - PR commit message validation
 


### PR DESCRIPTION
## Description

This PR removes Nix packaging support from the project's CI pipeline and related documentation. The project is dropping the Nix binary cache (Cachix) support, so the associated CI job, installation instructions, and release documentation have been cleaned up accordingly.

The Nix build CI job previously installed Nix, configured the `omni-dev` Cachix binary cache, and published build artifacts on tagged releases. These steps are no longer needed and have been removed alongside all documentation references to `CACHIX_AUTH_TOKEN` and the `cachix use omni-dev` workflow.

Note: Basic Nix installation via `nix profile install` remains documented; only the binary cache layer is being removed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [x] CI/CD changes
- [ ] Dependency update

## Related Issue

No related issue.

## Changes Made

**CI/CD Changes:**
- Removed the `nix` job (`Nix Build`) from `.github/workflows/ci.yml`, which previously installed Nix using `cachix/install-nix-action@v31`, configured the binary cache using `cachix/cachix-action@v17`, and ran `nix flake check`, `nix build`, and `nix run . -- --version`
- Updated the CI workflow description in `docs/RELEASE.md` from "Quality checks and Nix builds" to "Quality checks"

**Documentation:**
- Removed the "Nix Binary Cache (Optional)" section from `README.md`, including `cachix use omni-dev` setup instructions and the `nix profile install` via cache example
- Removed `cachix use omni-dev` from the short install snippet in `README.md`
- Removed "Nix binary cache publication" from the release process step list in `docs/RELEASE.md`
- Removed "Builds and tests Nix package" and "Publishes to `omni-dev` Cachix binary cache" from the CI workflow description in `docs/RELEASE.md`
- Removed the "Verify Nix Binary Cache" post-release verification step from `docs/RELEASE.md`
- Removed `CACHIX_AUTH_TOKEN` secret entry from the GitHub secrets table in `docs/RELEASE.md`

**Testing:**
- No functional code changes; no new tests required

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable — CI/docs-only change)
- [ ] Integration tests updated/added (not applicable)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Verified CI job removal does not break remaining pipeline jobs (`test`, `audit`, etc.)
- [x] Confirmed documentation reads correctly without the removed sections
- [x] Backward compatibility verified — cargo-based installation is unaffected

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility — users who previously relied on `cachix use omni-dev` for faster Nix builds will no longer have that option; they will need to build from source via Nix

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications — the `CACHIX_AUTH_TOKEN` secret is no longer referenced anywhere in the CI pipeline or documentation, reducing secret surface area

## Deployment Notes
- [x] No special deployment requirements
- The `CACHIX_AUTH_TOKEN` GitHub Actions secret can be safely removed from the repository settings after this PR is merged

## Additional Notes

**Known Limitations:**
- Users who relied on the Cachix binary cache for faster Nix builds will need to build from source. The `nix profile install github:rust-works/omni-dev` command still works but will compile from source rather than pulling a pre-built binary.

**Alternatives Considered:**
- Keeping the Nix cache but disabling publishing: rejected in favour of a clean removal to reduce maintenance overhead and secret management burden.