### PR TITLE
docs(website): lead install snippet with --features mcp

### DIFF
--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -26,6 +26,10 @@
 
 <section id="install">
   <h2>Install</h2>
+  <p>Both the CLI and the MCP server &mdash; the latter ships behind the <code>mcp</code> feature so it picks up its <code>rmcp</code> dependencies:</p>
+  <pre><code>cargo install omni-dev --features mcp</code></pre>
+
+  <p>This installs both <code>omni-dev</code> and <code>omni-dev-mcp</code>. If you only want the CLI, drop the feature flag:</p>
   <pre><code>cargo install omni-dev</code></pre>
 
   <p>Or with Nix:</p>


### PR DESCRIPTION
## Summary

\`cargo install omni-dev\` only builds the CLI — the \`omni-dev-mcp\` binary has \`required-features = [\"mcp\"]\` in [Cargo.toml](Cargo.toml), so users following the landing-page snippet end up without the MCP server. The landing page already advertises the MCP server in the features list, so the install command was misleading.

Switches the primary install snippet in [website/templates/index.html](website/templates/index.html) to \`cargo install omni-dev --features mcp\` (installs both binaries) and keeps the bare form as a secondary option for CLI-only installs.

## Test plan

- [ ] CI \`Deploy website\` workflow goes green.
- [ ] https://omni-dev.john-ky.io#install shows the \`--features mcp\` snippet first, followed by the CLI-only form.