### PR TITLE
docs(docs): add ADR-0036 for omni-dev daemon framework deployment and lifecycle

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -59,3 +59,4 @@ by Michael Nygard.
 | [ADR-0033](adr-0033.md)  | ✅ Accepted                              | 2026-05-14 | `candle` as the Production ASR Runtime                                                 |
 | [ADR-0034](adr-0034.md)  | ✅ Accepted                              | 2026-05-14 | `tract-onnx` as the Speaker-Embedding Runtime                                          |
 | [ADR-0035](adr-0035.md)  | ✅ Accepted                              | 2026-05-25 | OS-Gated ASR Backends with Auto-Upgrading Defaults                                     |
+| [ADR-0036](adr-0036.md)  | 🟡 Proposed                              | 2026-05-25 | omni-dev Daemon Framework — Deployment and Lifecycle                                   |

--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -1,0 +1,512 @@
+# ADR-0036: omni-dev Daemon Framework — Deployment and Lifecycle
+
+## Status
+
+🟡 Proposed (2026-05-25)
+
+## Context
+
+omni-dev has been a per-invocation CLI. [ADR-0021](adr-0021.md) established
+the existing MCP server pattern: a separate stdio binary invoked by Claude
+Code, no persistent state, no inter-invocation coordination. Every feature
+shipped to date fits that shape — git analysis, JIRA, Confluence, Datadog,
+ADF conversion — because each is a stateless wrapper over an external API
+or a one-shot read of the local git tree.
+
+[Issue #876](https://github.com/rust-works/omni-dev/issues/876) proposes a
+Claude Code chat-history MCP server. The proposed feature set —
+keyword + semantic + hybrid search over JSONL session files, a knowledge
+graph of extracted memories, hook-driven auto-capture — requires three
+things the existing per-process MCP pattern cannot cheaply provide:
+
+1. A persistent on-disk index (Tantivy + SQLite + vectors) that survives
+   between Claude Code invocations and must not be concurrently *written* by
+   multiple stdio MCP servers.
+2. A loaded embedding model that costs ~80 ms wall-clock to invoke once
+   loaded, plus ~500 MB resident — too expensive to pay per Claude Code
+   instance.
+3. Coordination across multiple concurrent Claude Code instances on the same
+   machine.
+
+The third is the architecture-defining constraint.
+[anthropics/claude-code#28860](https://github.com/anthropics/claude-code/issues/28860)
+documents what happens without coordination: 4 concurrent Claude Code
+sessions × 6 MCP servers = 42 spawned processes, ~1.9 GB RAM, OOM-killing
+the user. Anthropic has acknowledged the problem but has not shipped a
+protocol-level fix. Projects in the same class — `claude-peers-mcp`,
+`zilliztech/claude-context` — work around it by introducing a shared local
+daemon that per-session MCP servers connect to as thin clients.
+
+omni-dev is likely to grow more than one feature with this shape (the
+history module first, plausibly background MCP aggregators, scheduled-task
+runners, cache prewarmers, multi-session presence). Each addressed in
+isolation would multiply the per-session-spawn problem and duplicate the
+work on supervisor integration, IPC, lifecycle, and packaging. A shared
+daemon framework — generic enough to host multiple modules — solves the
+problem once.
+
+The deployment half of the question is the second half. Per-user
+long-running background processes are a well-trodden problem with distinct
+idioms per OS. Linux has systemd user units with socket activation. macOS
+has launchd with the `Sockets` key. Windows has neither: scheduled tasks,
+startup folder, or no auto-start at all are the only options. omni-dev's
+existing user base spans all three, and the project's distribution channels
+(`cargo install`, Homebrew, future `.deb`/`.rpm`, Scoop) install only the
+binary — they never wire up supervisor units.
+
+Three forces shape the design:
+
+- **Per-OS supervisor integration is the best-practice deployment for this
+  class of process.** Skipping it means losing crash-restart, lazy startup,
+  and predictable log capture. Treating supervisor integration as an
+  afterthought leaves the project shipping a daemon that users have to
+  babysit.
+- **Stub-launches-daemon is the proven fallback** when no supervisor is
+  available. `claude-peers-mcp` does exactly this. The fallback path must
+  work on systems without systemd/launchd (NixOS user mode, some container
+  CI environments, WSL1) and on Windows.
+- **The daemon must be generic from day one**, not retrofitted later.
+  Treating it as a history-specific server now would force a painful module
+  extraction when the second feature ships. The cost of generality up front
+  is one trait and a routing layer; the cost of retrofitting it is a wire
+  protocol break.
+
+The unit of decision in this ADR is the daemon framework, its IPC, its
+supervisor integration, and its per-OS deployment, taken together. The
+supervisor choices, IPC choice, fallback launcher, and path conventions
+are mutually dependent and would be misleading if split across Proposed
+records that forward-reference each other. Per-module concerns (the
+history module's storage map, schema, MCP tool surface) are scoped to
+issue #876 and follow-up ADRs.
+
+## Decision
+
+Twelve policies, taken together.
+
+### 1. Single binary; daemon, stub, and CLI are subcommands
+
+The same `omni-dev` binary serves three roles, selected by subcommand:
+
+- `omni-dev daemon serve` — runs the long-lived daemon process.
+- `omni-dev mcp stub` — runs the per-Claude-Code-instance stdio MCP proxy,
+  which forwards MCP protocol bytes to the daemon over IPC. The stub also
+  auto-launches the daemon when no supervisor is managing it (§2).
+- `omni-dev …` — every existing CLI subcommand continues to work without
+  the daemon. Daemon-backed features expose convenience subcommands
+  (e.g. `omni-dev history search`) that talk to the daemon under the hood.
+
+One artifact ships, one version number governs all three roles, and there
+is no stub↔daemon binary-version skew at the artifact level. The handshake
+in §10 catches the case where two installs of omni-dev coexist on the same
+machine (e.g. user `cargo install`ed over a Homebrew-installed copy).
+
+This extends [ADR-0021](adr-0021.md)'s "MCP via second binary" pattern: the
+binary is the same, but the MCP server is now a thin transport proxy
+rather than the full implementation.
+
+### 2. Stub + daemon split, with socket-activated supervisor as the primary path
+
+The stub is intentionally trivial: stdin/stdout ↔ IPC byte forwarding,
+no MCP-protocol awareness. ~50 LoC of bridge code plus an auto-launch
+fallback. The daemon implements the MCP protocol semantically once.
+
+The daemon's startup path has two modes:
+
+- **Primary path** — a supervisor (systemd on Linux, launchd on macOS) owns
+  the IPC socket and starts the daemon on first connect via socket
+  activation (§4, §5). Crash restart, lazy startup, and consistent log
+  capture come from the supervisor.
+- **Fallback path** — when the stub connects to the well-known socket path
+  and the connection fails, the stub `fork+setsid`s a detached
+  `omni-dev daemon serve` and reconnects. Used on systems without a
+  supervisor unit installed (Windows, non-systemd Linux, fresh installs
+  before `omni-dev daemon install` has run). Less robust — no auto-restart
+  on crash — but functional.
+
+This bias toward supervisor-managed primary with stub-spawn fallback comes
+directly from the `claude-peers-mcp` precedent. Reversing it (stub-spawn
+primary, supervisor optional) would push users toward the less reliable
+path by default; the install command in §9 makes the supervisor path the
+default install state on Linux and macOS.
+
+### 3. IPC: Unix domain socket on Unix; named pipe on Windows; CBOR framing
+
+A single abstraction (`interprocess::local_socket` or equivalent) covers
+both Unix domain sockets and Windows named pipes. The wire format is the
+MCP protocol itself when the connection is a stub↔daemon MCP forward, and
+length-prefixed CBOR (`ciborium`) for the small non-MCP control surface
+(hook events, health probes, internal RPC between subcommands like
+`omni-dev daemon status` and the daemon).
+
+Two transports were rejected:
+
+- **Localhost TCP.** Requires port allocation, opens an attack surface that
+  network firewalls cannot trivially close on multi-user hosts, and offers
+  no advantage on a single-machine deployment. UDS / named pipes carry
+  peer credentials (§11) that TCP does not.
+- **HTTP from the start.** Compatible with the MCP HTTP transport, but
+  forces a launcher dance (daemon must be running before Claude Code starts)
+  for which no clean cross-platform solution exists. Deferred to a future
+  optional `omni-dev daemon serve --http` mode for multi-machine team
+  scenarios; out of scope for v1.
+
+### 4. Linux deployment: systemd user units with socket activation
+
+Two units, written by `omni-dev daemon install` to
+`~/.config/systemd/user/`:
+
+| Unit | Purpose |
+| ---- | ------- |
+| `omni-dev-daemon.socket` | Owns the UDS at `$XDG_RUNTIME_DIR/omni-dev/daemon.sock`. systemd creates the socket, listens on it before the daemon starts, and starts the daemon on first connect. |
+| `omni-dev-daemon.service` | The daemon itself. `Type=notify`, signals readiness via `sd_notify("READY=1")` after Tantivy mmap and SQLite open complete. `Restart=on-failure` with `RestartSec=5s`. `RuntimeDirectory=omni-dev`, `StateDirectory=omni-dev` so systemd manages the per-user runtime and state directories. |
+
+Socket activation makes the daemon process truly lazy: it does not exist
+until the stub first connects, and a crash is restarted by systemd
+without dropping the next connection. The `sd-notify` and `sd-listen-fds`
+crates handle the systemd-side conventions.
+
+Linux installs without systemd (NixOS user-mode setups, some container
+environments, WSL1) fall through to the stub-spawn path from §2. The
+install command detects the absence of `systemctl --user` and skips unit
+installation with a warning.
+
+### 5. macOS deployment: launchd LaunchAgent with `Sockets` key
+
+Plist written by `omni-dev daemon install` to
+`~/Library/LaunchAgents/dev.omni.daemon.plist`. Key fields:
+
+- `Label = dev.omni.daemon`
+- `ProgramArguments` invokes `omni-dev daemon serve`
+- `Sockets.Listener.SockPathName` points at the UDS path at
+  `~/Library/Caches/dev.omni.daemon/daemon.sock` (macOS has no
+  `$XDG_RUNTIME_DIR`; `Caches` is the closest semantic match for
+  ephemeral runtime data)
+- `KeepAlive.Crashed = true` (restart on crash only; clean exits stay
+  exited)
+- `StandardOutPath` and `StandardErrorPath` redirect to
+  `~/Library/Logs/omni-dev/`, making logs visible to Console.app
+
+Loaded via `launchctl bootstrap gui/$(id -u) …` (the modern API;
+deprecated `launchctl load` is intentionally not used). LaunchAgents
+run while the user is logged in; LaunchDaemons (system-wide, root) are
+the wrong scope for per-user data.
+
+### 6. Windows deployment: stub-spawn primary; scheduled task as opt-in
+
+Windows lacks a clean per-user-daemon idiom equivalent to systemd or
+launchd:
+
+- **Windows Services** are system-wide and require admin to install. Wrong
+  scope: per-user data, per-user lifetime, no admin available.
+- **Scheduled Tasks with "At log on" trigger** are the closest match.
+  Standard pattern, but no socket activation and only restart-on-failure
+  via an internal loop in the daemon.
+- **Startup folder** is functional but unsightly (process appears in the
+  user's startup item list, no supervisor semantics).
+
+The default v1 Windows deployment is **stub-spawn only**, no auto-start.
+The stub detects the named pipe is absent and spawns a detached
+`omni-dev daemon serve` via `CreateProcessW` with `DETACHED_PROCESS |
+CREATE_NEW_PROCESS_GROUP`. The daemon runs until reboot or explicit
+`omni-dev daemon stop`. This minimises install-time changes to the user's
+system and matches the experience of Linux users without systemd.
+
+For users who want persistence across logins, `omni-dev daemon
+install-service` registers a Scheduled Task via `schtasks /create`. This
+is opt-in and documented as the longer-lived deployment.
+
+Many Claude Code users on Windows actually work inside WSL2, where the
+Linux deployment from §4 applies. WSL2 with systemd enabled
+(`systemd-genie` or via `/etc/wsl.conf`) gets the full supervisor
+experience; without systemd, the stub-spawn fallback applies.
+
+### 7. XDG-aware filesystem layout via the `directories` crate
+
+Path resolution goes through one cross-platform abstraction (`directories`
+crate). No per-OS path strings appear outside that module.
+
+| Purpose | Linux | macOS | Windows |
+| ------- | ----- | ----- | ------- |
+| Data | `$XDG_DATA_HOME/omni-dev/` (≈ `~/.local/share/omni-dev/`) | `~/Library/Application Support/omni-dev/` | `%LOCALAPPDATA%\omni-dev\` |
+| Config | `$XDG_CONFIG_HOME/omni-dev/` (≈ `~/.config/omni-dev/`) | `~/Library/Preferences/omni-dev/` | `%LOCALAPPDATA%\omni-dev\config\` |
+| State / logs | `$XDG_STATE_HOME/omni-dev/` (≈ `~/.local/state/omni-dev/`) | `~/Library/Logs/omni-dev/` | `%LOCALAPPDATA%\omni-dev\logs\` |
+| IPC socket | `$XDG_RUNTIME_DIR/omni-dev/daemon.sock` | `~/Library/Caches/dev.omni.daemon/daemon.sock` | `\\.\pipe\omni-dev-daemon-<USER>` |
+
+Module-owned data lives under a `modules/<name>/` subdirectory of the
+data root, scoped per module (e.g. `…/omni-dev/modules/history/tantivy/`).
+This isolates module state and makes per-module backup, reset, and
+uninstall straightforward.
+
+### 8. Daemon hosts modules; the framework is generic from day one
+
+The daemon is not a history-specific server. It is a process that loads
+zero or more **modules**, each implementing a small trait that declares:
+
+- A unique name (used in data-dir scoping, MCP tool prefixes, config keys).
+- Module-owned MCP tools (with prefixed names — see below).
+- Optional hook handlers (responding to `SessionStart`, `UserPromptSubmit`,
+  `PostToolUse`, `PreCompact`, `Stop` events forwarded from a per-event CLI).
+- Optional long-lived ingest tasks (file watchers, embedding workers, etc.).
+- A `data_dir()` rooted under `…/omni-dev/modules/<name>/`.
+
+Shared services live on the daemon: the tokio runtime, the IPC layer,
+lifecycle management, and a single embedding-model pool (if any module
+asks for embeddings, the model is loaded once and reused). The
+[`OMNI_DEV_AI_BACKEND` dispatch already in place](../../src/claude/client.rs)
+is exposed to modules so a future LLM-using module reuses the existing
+backend abstraction instead of inventing a parallel one.
+
+**MCP tool namespacing.** Daemon-hosted MCP tools are surfaced through a
+single `omni-dev-daemon` MCP server (separate from the existing
+`mcp__omni-dev__*` server established by ADR-0021), with tool names
+prefixed by module: `mcp__omni-dev-daemon__history_search`,
+`mcp__omni-dev-daemon__history_list_sessions`, and so on. The existing
+non-daemon `omni-dev` MCP server is unchanged. Two registrations in
+Claude Code's MCP config (existing + daemon), each scoped to its own
+dependency profile — non-daemon users see no change.
+
+Modules are compiled into the binary, not loaded dynamically. Adding a
+module is a Rust PR by construction. This is the same asymmetry
+[ADR-0035](adr-0035.md) §1 chose for ASR backends, for the same reason: a
+runtime-overlayable module set would be a contract the implementation
+could not honour, and the cost of a Rust PR per module is bounded.
+
+### 9. Installation flow via `omni-dev daemon setup` and component commands
+
+The single user-facing installation command is:
+
+```text
+omni-dev daemon setup       # = install + install-mcp + install-hooks
+```
+
+Decomposed into three independently-runnable component commands:
+
+| Command | Effect |
+| ------- | ------ |
+| `omni-dev daemon install` | OS-specific supervisor integration. Linux: writes systemd user units, runs `systemctl --user daemon-reload && systemctl --user enable --now omni-dev-daemon.socket`. macOS: writes the LaunchAgent plist, runs `launchctl bootstrap`. Windows: no-op (or registers a Scheduled Task if `--with-service` is passed). Falls through to a no-op + warning where the supervisor is unavailable, leaving the stub-spawn fallback in place. |
+| `omni-dev daemon install-mcp` | Registers the daemon's MCP server with Claude Code. Prefers the `claude` CLI (`claude mcp add omni-dev-daemon -- omni-dev mcp stub`) if present; falls back to editing `~/.claude.json` directly. |
+| `omni-dev daemon install-hooks` | Adds the five Claude Code hook entries (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`, `Stop`) to `~/.claude/settings.json`, each invoking a small `omni-dev daemon hook <event>` CLI that POSTs the hook payload to the daemon. |
+
+Every install step is idempotent — re-running it on an already-installed
+host is a no-op. Every install step has a matching `uninstall` that
+reverses it cleanly. `omni-dev daemon teardown` runs all three uninstalls
+and removes module data after confirmation (per
+[ADR-0027](adr-0027.md)'s destructive-command convention: requires
+explicit `--force` to skip the confirmation prompt).
+
+The umbrella `setup` command is the documented happy path; the component
+commands exist for users who want partial installs (e.g. enable the
+daemon but not auto-hook). All three are exposed at the `omni-dev
+daemon` namespace, not as top-level subcommands, to keep
+[ADR-0016](adr-0016.md)'s hierarchical subcommand structure consistent.
+
+### 10. Upgrade protocol via version handshake
+
+On every stub→daemon connection, the stub sends a handshake frame
+containing its `omni-dev` version. The daemon compares against its own
+running version:
+
+| Condition | Daemon behaviour |
+| --------- | ---------------- |
+| Versions equal | Accept connection; proceed. |
+| Stub newer than daemon | Accept connection, log a warning, and schedule a graceful self-restart via the supervisor (or stub-spawn fallback). The next connection lands on the new version. |
+| Stub older than daemon | Accept connection, log a warning surfaced to the user that they have an older omni-dev install on their PATH than the running daemon (another shell with a newer install spawned the daemon). No restart; proceed. |
+| Protocol-incompatible | Refuse with an actionable error pointing at `omni-dev daemon restart`. |
+
+A `RestartRequest` rate limit (at most one self-restart per minute per
+daemon) prevents flapping when several stubs in different terminals all
+notice an upgrade simultaneously.
+
+`omni-dev daemon restart` is the explicit user-driven form. `omni-dev
+daemon status` reports the running version and any handshake mismatches
+seen recently.
+
+The handshake is the analogue of [ADR-0035](adr-0035.md) §2's sidecar
+protocol-version check: an installed-but-incompatible artifact is
+detected at construction time, not mid-operation, and the error points
+at a remediation command.
+
+### 11. Security: peer credentials, restricted permissions, no network listener
+
+| Concern | Mitigation |
+| ------- | ---------- |
+| Other users on shared host reading session data | Socket / pipe mode `0600` on Unix; named-pipe ACL restricted to current user (`PIPE_REJECT_REMOTE_CLIENTS` plus an explicit DACL) on Windows. Data directories `0700`. |
+| Untrusted process on same machine impersonating Claude Code | At accept time, the daemon verifies the connecting peer's UID via `SO_PEERCRED` (Linux) / `LOCAL_PEERCRED` (macOS) / `GetNamedPipeClientProcessId` + token lookup (Windows). Connections from a different UID are refused. |
+| HTTP mode (future, opt-in) | Bind 127.0.0.1 only; require a bearer token in the `Authorization` header rotated on each daemon start; never expose to the network. Out of scope for v1; documented here so the design space is closed. |
+| Daemon launched with elevated privileges | Refuse to run as root / Administrator. Per-user install only. |
+| Module sandbox | Out of scope. Modules are first-party Rust code in the same binary; the trust boundary is the binary, not the module. Re-evaluate if a future third-party-module ecosystem materialises. |
+
+No telemetry. No network listener by default. No automatic upload of
+indices, logs, or session data.
+
+### 12. Out of scope
+
+- **Multi-machine / team mode.** HTTP MCP transport with auth is the
+  future option (see §3); v1 ships UDS / named pipes only.
+- **Windows Services.** v1 is stub-spawn or Scheduled Task only. A
+  service-mode deployment would re-open the elevated-privilege question
+  in §11.
+- **Docker / OCI image.** Not the primary distribution form for this
+  class of feature. Users who want containerised omni-dev install it
+  themselves; the daemon runs as PID 1 in the container, no supervisor
+  integration needed.
+- **Sandbox / seccomp / launchd hardening.** Daemon runs in the user's
+  normal scope. Confinement beyond filesystem permissions is deferred
+  until a concrete threat-model gap appears.
+- **User-overridable data / socket paths.** v1 uses platform defaults
+  only. A `--data-dir` flag is a small future addition; not designing
+  for it now keeps install discovery simple.
+- **Daemon hot-reload of module configuration.** Module set changes
+  require daemon restart. The handshake in §10 makes this cheap; making
+  it free is not worth the per-module state-machine complexity.
+
+## Consequences
+
+### Positive
+
+- **One binary surface per host.** No per-feature binaries to ship; the
+  daemon, stub, and CLI all live in `omni-dev`. Distribution channels
+  (`cargo install`, Homebrew, `.deb`/`.rpm`, Scoop) install one
+  artifact.
+- **Best-practice deployment is the default on Linux and macOS.** Socket
+  activation gives lazy startup, crash restart, and supervisor log
+  capture for free. Users who run `omni-dev daemon setup` get the
+  full experience; users who do not still get the stub-spawn fallback.
+- **The 42-process problem is solved.** N concurrent Claude Code
+  instances share one daemon, one embedding model, one index. Memory
+  scales with feature count, not session count.
+- **The framework is generic from day one.** The second daemon-hosted
+  feature is a module trait implementation and a data-dir allocation,
+  not an architectural fork.
+- **MCP namespacing is clean.** The existing `omni-dev` MCP server is
+  unchanged. The new `omni-dev-daemon` MCP server is dependency-scoped:
+  installed only when the daemon is, with no impact on non-daemon
+  users' per-session context cost.
+- **Failure modes are observable.** `omni-dev daemon status` and
+  `omni-dev daemon logs` are first-class introspection. Version
+  mismatches are reported at handshake time, not mid-operation.
+- **Cross-platform path discipline is enforced by abstraction.** The
+  `directories` crate is the only place per-OS path strings appear.
+  XDG conformance on Linux, Apple convention compliance on macOS, and
+  `%LOCALAPPDATA%` on Windows fall out automatically.
+- **ADR-0021 is extended, not invalidated.** The existing MCP server
+  pattern continues to govern non-daemon features. The daemon's MCP
+  server is a peer of the existing one, not a replacement.
+
+### Negative
+
+- **More moving parts at runtime.** Daemon, supervisor unit, stub, hook
+  CLI, named socket. Mitigated by: a single install command that wires
+  everything up, idempotent component commands, observable status
+  reporting, and a stub-spawn fallback that works without any
+  supervisor configuration.
+- **Per-OS supervisor integration is real complexity.** systemd, launchd,
+  and Windows Scheduled Tasks each have their own quirks; install
+  commands must handle missing supervisors, partial installs, and
+  cleanup-on-uninstall. Mitigated by limiting v1 to the well-trodden
+  paths (user units, LaunchAgents, basic Scheduled Tasks) and
+  deferring exotic deployments (Docker, services, sandboxes).
+- **The stub-spawn fallback is less robust than supervisor-managed.**
+  No automatic crash restart on systems without systemd / launchd.
+  Mitigated by surfacing the missing-supervisor state in
+  `omni-dev daemon status`, and by the daemon's own internal
+  watchdog catching most non-fatal errors before they crash the
+  process.
+- **Version handshake on every connection is per-call overhead.**
+  Tiny (one CBOR frame) but non-zero. Acceptable trade for
+  catching install skew at the moment it appears rather than
+  during the next opaque failure.
+- **Windows deployment is materially weaker than Linux / macOS.** No
+  socket activation, no first-class supervisor, opt-in Scheduled
+  Task as the closest analogue. Documented as a known gap; WSL2
+  with systemd is the recommended Windows path for users who want
+  the full experience.
+
+### Neutral
+
+- **HTTP MCP transport is deferred, not rejected.** A future
+  `omni-dev daemon serve --http` mode reuses the same daemon for
+  multi-machine team scenarios. The MCP routing layer is
+  transport-agnostic by construction.
+- **Module compilation policy mirrors ADR-0035's backend policy.**
+  Both are bounded by code; both reject runtime-overlayable
+  registration for the same reason (the implementation cannot
+  honour a contract that names artifacts it cannot link).
+  Consistency, not coupling.
+- **The daemon's lifetime is bounded by the user session, not the
+  system.** It runs while the user is logged in. No system-level
+  state, no boot-time presence.
+
+## Coverage expectations
+
+Mirrors the by-design gaps in [ADR-0028](adr-0028.md) and
+[ADR-0035](adr-0035.md). The framework's logic must be testable on every
+CI runner; supervisor integration on hosts that lack the supervisor is by
+design out of reach.
+
+| Surface | Why uncovered |
+| ------- | ------------- |
+| Actual systemd unit registration via `systemctl --user` | Requires a logged-in user systemd instance, which CI runners typically don't provide. The unit-file generation, content, and idempotent re-installation *are* covered with golden tests. |
+| Actual `launchctl bootstrap` execution | Requires macOS host with a valid `gui/$UID` domain, which only macOS runners have. The plist generation and content *are* covered everywhere. |
+| Actual `schtasks` registration | Requires Windows host. The arguments and idempotency layer *are* covered cross-platform. |
+| Live socket activation (systemd / launchd handing a socket FD to the daemon) | Requires the supervisor in the loop. The daemon's `LISTEN_FDS=1`-style accept path *is* covered with a synthetic FD inherited from the test harness. |
+| Daemon restart-on-crash under live supervisor | Requires the supervisor. The graceful-shutdown and re-bind paths *are* covered with direct SIGTERM tests. |
+
+Cross-platform coverage that **must** exist:
+
+- Unit / plist / scheduled-task file *generation* (content, idempotency,
+  uninstall reversibility) — golden tests per
+  [ADR-0030](adr-0030.md), one canonical OS per artifact, generation
+  refused on non-canonical hosts so contributors can't inadvertently
+  regenerate with the wrong defaults.
+- IPC protocol round-trips on the host OS — UDS on Linux/macOS CI,
+  named pipe on Windows CI.
+- Handshake version-skew matrix — same / newer-stub / older-stub /
+  protocol-incompatible — fixture-driven, no daemon spawn needed.
+- Stub-spawn fallback path — exercised on the same CI runners as the
+  supervisor path (the fallback works regardless of supervisor
+  availability; it just isn't the *default* when one is present).
+- `omni-dev daemon setup` end-to-end in a temp `$HOME` — verifies that
+  every file the command writes is in the expected location and is
+  idempotent on re-run.
+
+A `omni-dev daemon doctor`-style status output (parallel to
+[ADR-0035](adr-0035.md) §4's `voice doctor`) is the load-bearing
+observability for deployment state: which supervisor is in use, whether
+the unit file is installed, whether the socket exists, whether the
+daemon is running, whether the MCP and hook registrations are in
+Claude Code's config. A golden snapshot test on the canonical OS per
+[ADR-0030](adr-0030.md) enforces that the descriptor remains
+cross-platform.
+
+## References
+
+- Issue [#876](https://github.com/rust-works/omni-dev/issues/876) —
+  proposal: shared-daemon MCP server for Claude Code session history;
+  the proximate driver for the daemon framework.
+- Issue [anthropics/claude-code#28860](https://github.com/anthropics/claude-code/issues/28860)
+  — Share MCP server processes across concurrent Claude Code sessions;
+  documents the 42-process problem the daemon solves.
+- `claude-peers-mcp` ([louislva/claude-peers-mcp](https://github.com/louislva/claude-peers-mcp))
+  — precedent for the stub + auto-launched broker daemon pattern.
+- `claude-context` issue
+  [zilliztech/claude-context#285](https://github.com/zilliztech/claude-context/issues/285)
+  — directly analogous case (codebase indexing MCP wanting shared
+  long-lived process).
+- [ADR-0016](adr-0016.md) — Clap derive macros with hierarchical
+  subcommand structure; the `omni-dev daemon …` namespace continues
+  that pattern.
+- [ADR-0021](adr-0021.md) — MCP Server via Second Binary with `rmcp`;
+  the existing MCP server pattern. The daemon's MCP server is a peer,
+  not a replacement.
+- [ADR-0027](adr-0027.md) — Destructive CLI commands confirm by
+  default; `omni-dev daemon teardown` follows this convention.
+- [ADR-0028](adr-0028.md) — Sandboxed `claude-cli` subprocess AI
+  backend; precedent for opt-in escape hatches with `warn!()` logging
+  and for the lock-step dispatch / preflight rule.
+- [ADR-0030](adr-0030.md) — CLI snapshot golden testing for the help
+  surface; the same pattern enforces deployment-artifact stability and
+  the `daemon doctor` cross-platform contract.
+- [ADR-0035](adr-0035.md) — OS-gated ASR backends with auto-upgrading
+  defaults; precedent for compile-time descriptor registries,
+  observability via `voice doctor`, and bounded installer commands.


### PR DESCRIPTION
## Description

This PR adds ADR-0036, proposing the daemon framework design for omni-dev, covering deployment, IPC, lifecycle management, and per-OS supervisor integration. The ADR addresses the architectural need for a long-lived shared daemon process to support features requiring persistent state, shared resources, or cross-session coordination — most immediately the proposed Claude Code chat-history module from issue #876.

The core problem: per-invocation MCP servers cannot cheaply support features requiring a persistent on-disk index (Tantivy + SQLite + vectors), an always-loaded embedding model (~500 MB resident, ~80 ms cold-start), or coordination across multiple concurrent Claude Code instances. Without a shared daemon, N concurrent Claude Code sessions each spawn their own MCP server processes, leading to the documented 42-process / ~1.9 GB RAM OOM problem ([anthropics/claude-code#28860](https://github.com/anthropics/claude-code/issues/28860)).

ADR-0036 records twelve policies taken together that define the daemon framework:

1. **Single binary** — `omni-dev daemon serve`, `omni-dev mcp stub`, and all existing CLI subcommands coexist in one artifact with one version number.
2. **Stub + daemon split** — supervisor (systemd/launchd) as the primary path; stub-spawn as the automatic fallback.
3. **IPC** — Unix domain sockets on Linux/macOS, named pipes on Windows, CBOR framing for non-MCP control traffic.
4. **Linux deployment** — systemd user units with socket activation (`omni-dev-daemon.socket` + `omni-dev-daemon.service`).
5. **macOS deployment** — launchd LaunchAgent plist with `Sockets` key and `KeepAlive.Crashed = true`.
6. **Windows deployment** — stub-spawn by default; opt-in Scheduled Task via `omni-dev daemon install-service`.
7. **Filesystem layout** — XDG-aware cross-platform paths via the `directories` crate; per-module data under `modules/<name>/`.
8. **Generic module hosting** — daemon is not history-specific; modules implement a small trait; shared embedding-model pool, tokio runtime, and IPC layer.
9. **Installation flow** — `omni-dev daemon setup` (= `install` + `install-mcp` + `install-hooks`); all steps idempotent with matching `uninstall` counterparts.
10. **Version handshake** — every stub→daemon connection carries version info; stub-newer-than-daemon triggers graceful supervisor-assisted self-restart.
11. **Security** — peer-credential verification, `0600` socket/pipe permissions, `0700` data directories, no network listener by default, refuse to run as root.
12. **Out of scope for v1** — multi-machine HTTP transport, Windows Services, Docker/OCI, sandbox/seccomp hardening, user-overridable paths.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #876 — proposal: shared-daemon MCP server for Claude Code session history; the proximate driver for the daemon framework.

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0036.md` — full Architecture Decision Record (512 lines) covering daemon framework deployment and lifecycle with status 🟡 Proposed (2026-05-25)
- Updated `docs/adrs/README.md` — registered ADR-0036 in the ADR index table

**ADR Content Coverage:**
- Context: explains why the per-invocation MCP pattern is insufficient for persistent-state features and the multi-session OOM problem
- Decision: twelve numbered policies covering binary structure, IPC design, per-OS supervisor integration, module hosting, installation flow, version handshake, security, and explicit out-of-scope boundaries
- Consequences: positive (one binary, best-practice deployment, 42-process problem solved, generic framework), negative (more runtime moving parts, per-OS complexity, weaker Windows story), and neutral observations
- Coverage expectations: mirrors ADR-0028/ADR-0035 patterns; specifies which surfaces are uncovered by design (live `systemctl`/`launchctl` execution in CI) and which must be covered cross-platform (file generation golden tests, IPC round-trips, handshake version-skew matrix, stub-spawn fallback, end-to-end `daemon setup` in a temp `$HOME`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality — N/A; this is a documentation-only PR
- [ ] Integration tests updated/added — N/A
- [ ] Performance tests (if applicable) — N/A

**Manual Testing:**
- [x] Reviewed ADR content for accuracy, consistency with referenced ADRs (ADR-0016, ADR-0021, ADR-0027, ADR-0028, ADR-0030, ADR-0035), and correct Markdown formatting
- [x] Verified ADR index entry in `docs/adrs/README.md` matches the new file name and summary

### Test Commands

```bash
# Code quality checks (no code changed, but verify docs build cleanly)
cargo clippy -- -D warnings
cargo fmt --check

# Core test suite
cargo test
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — the proposed daemon architecture is a significant structural decision; reviewers should evaluate whether the twelve policies are complete, consistent, and correctly scoped
- [ ] Security implications — the security policy in §11 (peer credentials, socket permissions, no-root enforcement) is documented but not yet implemented; verify the policy is sufficient before implementation begins
- [ ] Backward compatibility — §1 and §8 assert the existing `omni-dev` MCP server and all existing CLI subcommands are unchanged; confirm the proposed namespacing (`omni-dev-daemon` MCP server alongside `omni-dev`) is acceptable
- [ ] User experience — the `omni-dev daemon setup` / `install` / `install-mcp` / `install-hooks` / `teardown` command hierarchy; verify it fits ADR-0016's hierarchical subcommand conventions

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A; documentation-only PR
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published — implementation PRs will follow
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — this PR adds only documentation; no code is changed

## Security Considerations

- [x] No security implications — this PR contains only an ADR document proposing a security policy; no security-sensitive code is added or modified in this PR

## Breaking Changes

None. This PR adds only documentation. No existing functionality is changed.

## Deployment Notes

- [x] No special deployment requirements — documentation-only change

## Additional Notes

**Future Enhancements:**
- Implementation PRs will follow this ADR to build the actual daemon framework, starting with the IPC layer and module trait, then per-OS supervisor integration
- A follow-up ADR specific to the history module (storage schema, MCP tool surface, embedding strategy) is scoped to issue #876

**Known Limitations:**
- ADR-0036 is currently 🟡 Proposed; it is not yet Accepted. Implementation should not begin until the ADR is accepted after review
- Windows deployment is materially weaker than Linux/macOS in v1 (no socket activation, opt-in Scheduled Task only); WSL2 with systemd is the recommended Windows path for full experience

**Alternatives Considered:**
- **Localhost TCP instead of UDS/named pipes** — rejected due to port allocation complexity and lack of peer-credential support
- **HTTP MCP transport from day one** — deferred to a future opt-in `omni-dev daemon serve --http` mode for multi-machine scenarios; out of scope for v1
- **Windows Services** — rejected as system-wide and requiring admin elevation; wrong scope for a per-user tool
- **Dynamic module loading** — rejected for the same reasons ADR-0035 rejected runtime-overlayable ASR backends; compile-time modules are a bounded contract the implementation can honour