### PR TITLE
feat(browser)!: implement multi-tab routing with X-Omni-Bridge-Target

### DIFF
--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -64,8 +64,9 @@ constant-time (`auth::constant_time_eq`) to avoid timing leaks.
 - **WebSocket plane**: the browser presents the token via the WS subprotocol
   (`new WebSocket(url, [token])` → `Sec-WebSocket-Protocol`); the upgrade is
   rejected without it (`auth::ws_subprotocol_token`). An unauthenticated peer can
-  neither connect nor evict the authenticated browser — the hub only clears on a
-  disconnect whose `conn_id` matches the live connection.
+  neither connect nor evict an authenticated browser — connections live in a
+  `conn_id`-keyed registry, so each is cleared only by its own disconnect and a
+  new connection never displaces an existing one (see the #908 note below).
 
 ### Control-plane anti-CSRF / anti-DNS-rebinding
 
@@ -152,7 +153,18 @@ prefix.
   (or a control-plane consumer disconnecting) sends the browser a `cancel` frame
   so it stops its in-page reader. There is **no** socket-level backpressure to
   the browser's reader — memory is bounded by the cumulative cap rather than
-  flow control, an accepted limitation. The remaining limits (single tab,
-  stdin piping) can still be added without revisiting this decision.
+  flow control, an accepted limitation.
+- Multiple concurrent browser tabs with request routing have since been added
+  (#908) without revisiting the trust boundary. The single `Option<WsConn>`
+  becomes a `conn_id`-keyed registry; each connection still authenticates
+  independently via the token subprotocol, and because every connection lives
+  under its own key, a new authenticated tab can never displace an existing one —
+  the non-eviction guarantee now holds **per connection**. A request selects its
+  target tab with an `X-Omni-Bridge-Target` header (or `target` body field) by
+  connection id or unique origin; with several tabs connected and no target the
+  request is rejected rather than routed ambiguously. Routing is strictly to one
+  tab (no fan-out), and `--allow-origin` stays a single global value; a per-origin
+  allowlist remains possible future work. The remaining limit (stdin piping) can
+  still be added without revisiting this decision.
 
 See [docs/browser-bridge.md](../browser-bridge.md) for the operator-facing guide.

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -20,12 +20,13 @@ add-on — both planes are authenticated and default-closed. See
 2. [Quick start](#quick-start)
 3. [Talking to the control plane](#talking-to-the-control-plane)
 4. [The `request` thin client](#the-request-thin-client)
-5. [Security model](#security-model)
-6. [Flags](#flags)
-7. [Random ports](#random-ports)
-8. [Worked example: downloading Grafana / Loki logs](#worked-example-downloading-grafana--loki-logs)
-9. [WebSocket wire protocol](#websocket-wire-protocol)
-10. [Caveats](#caveats)
+5. [Routing to a specific tab](#routing-to-a-specific-tab)
+6. [Security model](#security-model)
+7. [Flags](#flags)
+8. [Random ports](#random-ports)
+9. [Worked example: downloading Grafana / Loki logs](#worked-example-downloading-grafana--loki-logs)
+10. [WebSocket wire protocol](#websocket-wire-protocol)
+11. [Caveats](#caveats)
 
 ## How it works
 
@@ -92,8 +93,8 @@ curl -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
 
 | Method & path            | Purpose                                                                 |
 |--------------------------|-------------------------------------------------------------------------|
-| `GET  /__bridge/status`  | `{ "connected": bool, "browser_origin": str?, "pending": int }`         |
-| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Cross-origin `url` rejected unless `--allow-origin` permits it. |
+| `GET  /__bridge/status`  | `{ "connected": bool, "browser_origin": str?, "tabs": [{id, origin?}], "pending": int }`. `tabs` lists every connected tab; `browser_origin` is the lone tab's origin (present only when exactly one is connected, for back-compat). |
+| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?, target?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Cross-origin `url` rejected unless `--allow-origin` permits it. See [Routing to a tab](#routing-to-a-specific-tab) for `target`. |
 
 ```bash
 curl -s -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
@@ -131,6 +132,56 @@ written to stdout as they arrive, and the head status is printed to stderr.
 ```bash
 omni-dev browser request --stream --url /events | your-consumer   # SSE / chunked
 ```
+
+## Routing to a specific tab
+
+Several authenticated tabs can be connected at once — paste the snippet into each
+(e.g. a Grafana tab *and* an internal admin tab). Each connection is independent:
+a new tab never evicts an existing one, and each authenticates on its own via the
+token subprotocol.
+
+`GET /__bridge/status` lists them, each with a server-assigned **connection id**
+and its `Origin`:
+
+```bash
+curl -s "${H[@]}" http://localhost:9998/__bridge/status
+# → {"connected":true,
+#    "tabs":[{"id":1,"origin":"https://grafana.internal"},
+#            {"id":2,"origin":"https://admin.internal"}],
+#    "pending":0}
+```
+
+Select which tab a request targets with either:
+
+- the **`X-Omni-Bridge-Target`** header (works on the transparent proxy *and*
+  `POST /__bridge/request`), or
+- a **`target`** field in the `POST /__bridge/request` body (or `--target` on the
+  thin client).
+
+The header takes precedence over the body field. A target is either a **connection
+id** (canonical, always unambiguous) or an **`Origin`** that uniquely matches one
+tab:
+
+```bash
+omni-dev browser request --target 2 --url /api/foo                # by id
+omni-dev browser request --target https://admin.internal --url /x # by origin
+curl "${H[@]}" -H "X-Omni-Bridge-Target: 1" http://localhost:9998/api/foo
+```
+
+Resolution rules:
+
+| Situation | Result |
+|-----------|--------|
+| No tab connected | `503` |
+| Exactly one tab, no target | Routes to it (v1 back-compat) |
+| Several tabs, no target | `409` — specify a target (the error lists the tabs) |
+| Target id / origin matches one tab | Routes to it |
+| Target id / origin matches none | `404` |
+| Target origin matches several tabs | `409` — target by connection id instead |
+
+> Requests are routed to **exactly one** tab; there is no fan-out to multiple
+> tabs. `--allow-origin` remains a single global value applied to every
+> connection (a per-origin allowlist is possible future work).
 
 ## Security model
 
@@ -196,7 +247,9 @@ bridge runs.
 
 The `request` subcommand takes `--url`, `--method` (default `GET`),
 `--header` (repeatable), `--body` (`@file` supported), `--stream` (chunk the
-response to stdout), `--control-port` (default `9998`), and `--token-file`.
+response to stdout), `--target` (route to a connection id / origin — see
+[Routing to a specific tab](#routing-to-a-specific-tab)), `--control-port`
+(default `9998`), and `--token-file`.
 
 ## Random ports
 
@@ -303,8 +356,11 @@ Rules:
 - Multiple commands may be in flight concurrently over one socket (id-keyed).
 - A command with no reply within `--request-timeout` resolves the control-plane
   request with `504 Gateway Timeout` and is dropped from `pending`.
-- Only **one authenticated** browser connection is held; an unauthenticated peer
-  cannot connect or evict it.
+- **Several authenticated** tabs may be connected at once, keyed by connection
+  id; a request routes to one of them (see
+  [Routing to a specific tab](#routing-to-a-specific-tab)). A new connection
+  never evicts an existing one, and an unauthenticated peer can neither connect
+  nor evict any of them.
 
 ## Caveats
 
@@ -319,5 +375,6 @@ Rules:
   `--max-body-bytes` (cumulative), but there is no socket-level backpressure to
   the browser's `getReader()` — a fast producer with a slow consumer is capped,
   not throttled.
-- Remaining limitations: a single browser tab and no stdin piping. Binary bodies
-  *and* streaming/chunked responses are supported (see the wire protocol above).
+- Remaining limitations: no stdin piping, and a request fans out to at most one
+  tab. Multiple concurrent tabs (with routing), binary bodies, *and*
+  streaming/chunked responses are all supported (see the wire protocol above).

--- a/src/browser/auth.rs
+++ b/src/browser/auth.rs
@@ -28,6 +28,12 @@ pub const BRIDGE_HEADER: &str = "x-omni-bridge";
 /// Required value of [`BRIDGE_HEADER`].
 pub const BRIDGE_HEADER_VALUE: &str = "1";
 
+/// Optional header selecting which connected tab a control-plane request targets.
+///
+/// The value is a connection id, or an `Origin` that uniquely matches one tab. It
+/// takes precedence over a `target` body field, and is stripped before forwarding.
+pub const BRIDGE_TARGET_HEADER: &str = "x-omni-bridge-target";
+
 /// Number of random bytes behind a generated token (URL-safe base64, no pad).
 const TOKEN_BYTES: usize = 32;
 

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -1229,6 +1229,83 @@ mod tests {
     }
 
     #[test]
+    fn tab_list_renders_id_with_and_without_origin() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        tabs.insert(2, tab(None));
+        // Id-sorted; a tab that sent no `Origin` renders as the bare id.
+        assert_eq!(tab_list(&tabs), "id 1: https://a.test, id 2");
+    }
+
+    /// A minimal [`AppState`] for exercising `dispatch` / `start_stream` without
+    /// a real WebSocket peer.
+    fn test_state() -> AppState {
+        AppState {
+            token: Arc::new("t".to_string()),
+            config: Arc::new(BridgeConfig {
+                ws_port: 0,
+                control_port: 0,
+                request_timeout: Duration::from_secs(5),
+                allow_origin: None,
+                max_body_bytes: 1024,
+                max_concurrent: 8,
+            }),
+            correlator: Correlator::new(),
+            tabs: Arc::new(Mutex::new(HashMap::new())),
+            in_flight: Arc::new(Semaphore::new(8)),
+            conn_counter: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    /// Inserts a tab whose writer receiver is already dropped, so any send to it
+    /// fails — modelling a tab that vanished between routing and dispatch.
+    async fn insert_dead_tab(state: &AppState, id: u64) {
+        let (sender, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        state.tabs.lock().await.insert(
+            id,
+            WsConn {
+                sender,
+                origin: None,
+            },
+        );
+    }
+
+    fn plain_request() -> ControlRequest {
+        ControlRequest {
+            url: "/x".to_string(),
+            method: "GET".to_string(),
+            headers: BTreeMap::new(),
+            body: None,
+            stream: false,
+            target: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_returns_503_when_send_fails() {
+        let state = test_state();
+        insert_dead_tab(&state, 1).await;
+        let err = dispatch(&state, plain_request()).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+        // The failed dispatch leaves no dangling waiter behind.
+        assert_eq!(state.correlator.pending_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn start_stream_returns_503_when_send_fails() {
+        let state = test_state();
+        insert_dead_tab(&state, 1).await;
+        let req = ControlRequest {
+            stream: true,
+            ..plain_request()
+        };
+        let err = start_stream(&state, req).await.err().map(|e| e.0);
+        assert_eq!(err, Some(StatusCode::SERVICE_UNAVAILABLE));
+        assert_eq!(state.correlator.pending_count(), 0);
+    }
+
+    #[test]
     fn correlator_register_resolve_round_trip() {
         let c = Correlator::new();
         let (id, rx) = c.register();

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -34,7 +34,7 @@ use tokio_tungstenite::tungstenite::Message;
 use crate::browser::auth;
 use crate::browser::protocol::{
     BrowserFrame, BrowserReply, CancelCommand, Command, ControlRequest, ReplyOutcome,
-    ResponseEnvelope, StatusResponse, StreamItem, StreamLine,
+    ResponseEnvelope, StatusResponse, StreamItem, StreamLine, TabInfo,
 };
 use crate::browser::snippet;
 
@@ -144,10 +144,8 @@ impl Correlator {
     }
 }
 
-/// The single authenticated browser connection currently held.
+/// One authenticated browser connection in the registry.
 struct WsConn {
-    /// Unique id so a stale disconnect doesn't clear a newer connection.
-    conn_id: u64,
     /// Outbound message channel to this connection's writer task.
     sender: mpsc::UnboundedSender<Message>,
     /// The connecting tab's `Origin`, if it sent one.
@@ -160,7 +158,10 @@ struct AppState {
     token: Arc<String>,
     config: Arc<BridgeConfig>,
     correlator: Correlator,
-    ws: Arc<Mutex<Option<WsConn>>>,
+    /// Connected tabs keyed by connection id (the public routing selector). A
+    /// new authenticated connection never displaces an existing one — each lives
+    /// under its own key — so the non-eviction guarantee holds per-connection.
+    tabs: Arc<Mutex<HashMap<u64, WsConn>>>,
     in_flight: Arc<Semaphore>,
     conn_counter: Arc<AtomicU64>,
 }
@@ -196,7 +197,7 @@ pub async fn run(mut config: BridgeConfig, token: String) -> Result<()> {
         token: token.clone(),
         config: Arc::new(config.clone()),
         correlator: Correlator::new(),
-        ws: Arc::new(Mutex::new(None)),
+        tabs: Arc::new(Mutex::new(HashMap::new())),
         in_flight: Arc::new(Semaphore::new(config.max_concurrent)),
         conn_counter: Arc::new(AtomicU64::new(1)),
     };
@@ -324,12 +325,8 @@ async fn handle_ws_conn(stream: TcpStream, state: AppState) {
 
     let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
     {
-        let mut guard = state.ws.lock().await;
-        *guard = Some(WsConn {
-            conn_id,
-            sender: tx,
-            origin,
-        });
+        let mut guard = state.tabs.lock().await;
+        guard.insert(conn_id, WsConn { sender: tx, origin });
     }
 
     let (mut sink, mut read) = ws_stream.split();
@@ -346,9 +343,10 @@ async fn handle_ws_conn(stream: TcpStream, state: AppState) {
             Message::Text(txt) => match serde_json::from_str::<BrowserFrame>(&txt) {
                 Ok(frame) => {
                     // If a streamed response's control-plane consumer has gone,
-                    // tell the browser to cancel its reader so it stops fetching.
+                    // tell *this* browser (the one fetching it) to cancel its
+                    // reader so it stops fetching.
                     if let Some(cancel_id) = state.correlator.deliver(frame) {
-                        send_cancel(&state, cancel_id).await;
+                        send_cancel(&state, conn_id, cancel_id).await;
                     }
                 }
                 Err(e) => tracing::debug!("Unparseable browser frame: {e}"),
@@ -359,10 +357,9 @@ async fn handle_ws_conn(stream: TcpStream, state: AppState) {
     }
 
     writer.abort();
-    // Only clear the hub if it still points at *this* connection.
-    let mut guard = state.ws.lock().await;
-    if guard.as_ref().is_some_and(|c| c.conn_id == conn_id) {
-        *guard = None;
+    // Drop only this connection's registry entry (keyed by its unique id, so a
+    // reconnect under a new id is never clobbered).
+    if state.tabs.lock().await.remove(&conn_id).is_some() {
         tracing::info!("Browser disconnected (conn {conn_id})");
     }
 }
@@ -428,16 +425,27 @@ async fn guard(State(state): State<AppState>, request: Request, next: Next) -> R
 }
 
 async fn status_handler(State(state): State<AppState>) -> Json<StatusResponse> {
-    let (connected, browser_origin) = {
-        let guard = state.ws.lock().await;
-        match guard.as_ref() {
-            Some(conn) => (true, conn.origin.clone()),
-            None => (false, None),
-        }
+    let mut tabs: Vec<TabInfo> = {
+        let guard = state.tabs.lock().await;
+        guard
+            .iter()
+            .map(|(id, conn)| TabInfo {
+                id: *id,
+                origin: conn.origin.clone(),
+            })
+            .collect()
+    };
+    tabs.sort_by_key(|t| t.id);
+    // `browser_origin` is v1 back-compat: meaningful only when exactly one tab
+    // is connected; ambiguous (so `None`) for zero or several.
+    let browser_origin = match tabs.as_slice() {
+        [only] => only.origin.clone(),
+        _ => None,
     };
     Json(StatusResponse {
-        connected,
+        connected: !tabs.is_empty(),
         browser_origin,
+        tabs,
         pending: state.correlator.pending_count(),
     })
 }
@@ -445,13 +453,21 @@ async fn status_handler(State(state): State<AppState>) -> Json<StatusResponse> {
 /// `POST /__bridge/request` — full-fidelity control endpoint. A `stream: true`
 /// body returns an NDJSON stream (head line, `{seq,chunk}` lines, `{done}`);
 /// otherwise a single JSON response envelope.
-async fn request_handler(State(state): State<AppState>, body: Bytes) -> Response {
-    let req: ControlRequest = match serde_json::from_slice(&body) {
+async fn request_handler(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    body: Bytes,
+) -> Response {
+    let mut req: ControlRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
             return (StatusCode::BAD_REQUEST, format!("invalid JSON body: {e}")).into_response()
         }
     };
+    // The header, when present, overrides a `target` body field.
+    if let Some(target) = target_header(&headers) {
+        req.target = Some(target);
+    }
     if req.stream {
         return match start_stream(&state, req).await {
             Ok((status, headers, driver)) => ndjson_stream_response(status, headers, driver),
@@ -497,6 +513,7 @@ async fn proxy_handler(State(state): State<AppState>, request: Request) -> Respo
         headers,
         body,
         stream,
+        target: target_header(&parts.headers),
     };
 
     if stream {
@@ -548,6 +565,7 @@ fn forwardable_headers(headers: &axum::http::HeaderMap) -> BTreeMap<String, Stri
         "host",
         "authorization",
         auth::BRIDGE_HEADER,
+        auth::BRIDGE_TARGET_HEADER,
         "content-length",
         "connection",
         "accept-encoding",
@@ -568,6 +586,104 @@ fn forwardable_headers(headers: &axum::http::HeaderMap) -> BTreeMap<String, Stri
                 .map(|val| (name.to_string(), val.to_string()))
         })
         .collect()
+}
+
+/// Extracts the `X-Omni-Bridge-Target` selector from request headers, if present
+/// and non-empty.
+fn target_header(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get(auth::BRIDGE_TARGET_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Resolves which connected tab a request targets, returning its connection id
+/// and a clone of its outbound sender.
+///
+/// An explicit `target` is a connection id (canonical) or an `Origin` that
+/// uniquely matches one tab. With no target, routing succeeds only when exactly
+/// one tab is connected — otherwise the request is ambiguous and rejected.
+fn resolve_target(
+    tabs: &HashMap<u64, WsConn>,
+    target: Option<&str>,
+) -> Result<(u64, mpsc::UnboundedSender<Message>), (StatusCode, String)> {
+    if tabs.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no browser connected".to_string(),
+        ));
+    }
+    let Some(sel) = target else {
+        // No target: route only when exactly one tab is connected.
+        let mut it = tabs.iter();
+        return match (it.next(), it.next()) {
+            (Some((id, conn)), None) => Ok((*id, conn.sender.clone())),
+            _ => Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "multiple tabs connected; select one with the X-Omni-Bridge-Target \
+                     header or a `target` field ({})",
+                    tab_list(tabs)
+                ),
+            )),
+        };
+    };
+
+    // A bare integer selects by connection id (canonical, unambiguous).
+    if let Ok(id) = sel.parse::<u64>() {
+        return match tabs.get(&id) {
+            Some(conn) => Ok((id, conn.sender.clone())),
+            None => Err((
+                StatusCode::NOT_FOUND,
+                format!(
+                    "no connected tab with id {id}; connected: {}",
+                    tab_list(tabs)
+                ),
+            )),
+        };
+    }
+
+    // Otherwise match the selector against tab origins.
+    let mut hits = tabs
+        .iter()
+        .filter(|(_, c)| c.origin.as_deref() == Some(sel));
+    match (hits.next(), hits.next()) {
+        (Some((id, conn)), None) => Ok((*id, conn.sender.clone())),
+        (None, _) => Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "no connected tab with origin {sel}; connected: {}",
+                tab_list(tabs)
+            ),
+        )),
+        (Some(_), Some(_)) => Err((
+            StatusCode::CONFLICT,
+            format!(
+                "origin {sel} matches multiple tabs; target by connection id ({})",
+                tab_list(tabs)
+            ),
+        )),
+    }
+}
+
+/// Renders the connected tabs as `id N: origin, …` (id-sorted) for error
+/// messages. Carries no authenticated data beyond the origin already in status.
+fn tab_list(tabs: &HashMap<u64, WsConn>) -> String {
+    let mut items: Vec<(u64, Option<&str>)> = tabs
+        .iter()
+        .map(|(id, c)| (*id, c.origin.as_deref()))
+        .collect();
+    items.sort_by_key(|(id, _)| *id);
+    items
+        .iter()
+        .map(|(id, origin)| match origin {
+            Some(o) => format!("id {id}: {o}"),
+            None => format!("id {id}"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// The shared request path: scope-check, register a waiter, send the command,
@@ -620,16 +736,20 @@ async fn dispatch(
     };
 
     {
-        let guard = state.ws.lock().await;
-        match guard.as_ref() {
-            Some(conn) if conn.sender.send(Message::Text(frame)).is_ok() => {}
-            _ => {
+        let tabs = state.tabs.lock().await;
+        let (_conn_id, sender) = match resolve_target(&tabs, req.target.as_deref()) {
+            Ok(t) => t,
+            Err(e) => {
                 state.correlator.remove(id);
-                return Err((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "no browser connected".to_string(),
-                ));
+                return Err(e);
             }
+        };
+        if sender.send(Message::Text(frame)).is_err() {
+            state.correlator.remove(id);
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no browser connected".to_string(),
+            ));
         }
     }
 
@@ -695,15 +815,16 @@ async fn dispatch(
     }
 }
 
-/// Sends a best-effort cancellation frame to the connected browser and drops the
-/// pending stream, so a stream whose consumer is gone (or which tripped a limit)
-/// stops the in-page reader rather than fetching to completion.
-async fn send_cancel(state: &AppState, id: u64) {
+/// Sends a best-effort cancellation frame to the tab handling stream `id` and
+/// drops the pending stream, so a stream whose consumer is gone (or which
+/// tripped a limit) stops the in-page reader rather than fetching to completion.
+/// A no-op if that tab has since disconnected.
+async fn send_cancel(state: &AppState, conn_id: u64, id: u64) {
     state.correlator.remove(id);
     let Ok(frame) = serde_json::to_string(&CancelCommand::new(id)) else {
         return;
     };
-    if let Some(conn) = state.ws.lock().await.as_ref() {
+    if let Some(conn) = state.tabs.lock().await.get(&conn_id) {
         let _ = conn.sender.send(Message::Text(frame));
     }
 }
@@ -760,19 +881,24 @@ async fn start_stream(
         }
     };
 
-    {
-        let guard = state.ws.lock().await;
-        match guard.as_ref() {
-            Some(conn) if conn.sender.send(Message::Text(frame)).is_ok() => {}
-            _ => {
+    let conn_id = {
+        let tabs = state.tabs.lock().await;
+        let (conn_id, sender) = match resolve_target(&tabs, req.target.as_deref()) {
+            Ok(t) => t,
+            Err(e) => {
                 state.correlator.remove(id);
-                return Err((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "no browser connected".to_string(),
-                ));
+                return Err(e);
             }
+        };
+        if sender.send(Message::Text(frame)).is_err() {
+            state.correlator.remove(id);
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no browser connected".to_string(),
+            ));
         }
-    }
+        conn_id
+    };
 
     let idle = state.config.request_timeout;
     let (status, headers) = match tokio::time::timeout(idle, rx.recv()).await {
@@ -798,7 +924,7 @@ async fn start_stream(
             ));
         }
         Err(_) => {
-            send_cancel(state, id).await;
+            send_cancel(state, conn_id, id).await;
             return Err((
                 StatusCode::GATEWAY_TIMEOUT,
                 "browser did not start streaming in time".to_string(),
@@ -809,6 +935,7 @@ async fn start_stream(
     let driver = StreamDriver {
         state: state.clone(),
         id,
+        conn_id,
         rx,
         idle,
         max_body: state.config.max_body_bytes,
@@ -826,6 +953,8 @@ async fn start_stream(
 struct StreamDriver {
     state: AppState,
     id: u64,
+    /// Connection id of the tab serving this stream; cancels route back to it.
+    conn_id: u64,
     rx: mpsc::UnboundedReceiver<StreamItem>,
     idle: Duration,
     max_body: usize,
@@ -889,7 +1018,7 @@ impl StreamDriver {
     /// timeout, cap exceeded, or an undecodable chunk).
     async fn abort(&mut self) -> NextChunk {
         self.done = true;
-        send_cancel(&self.state, self.id).await;
+        send_cancel(&self.state, self.conn_id, self.id).await;
         NextChunk::End
     }
 }
@@ -1010,6 +1139,93 @@ mod tests {
             seq: None,
             done: None,
         }
+    }
+
+    /// Builds a `tabs` map entry with a detached sender (the receiver is dropped;
+    /// routing tests only assert *which* connection is chosen, not delivery).
+    fn tab(origin: Option<&str>) -> WsConn {
+        let (sender, _rx) = mpsc::unbounded_channel();
+        WsConn {
+            sender,
+            origin: origin.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resolve_target_no_tabs_is_503() {
+        let tabs = HashMap::new();
+        let err = resolve_target(&tabs, None).unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn resolve_target_single_tab_routes_without_target() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        let (id, _s) = resolve_target(&tabs, None).unwrap();
+        assert_eq!(id, 1);
+    }
+
+    #[test]
+    fn resolve_target_multiple_tabs_no_target_is_409() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        tabs.insert(2, tab(Some("https://b.test")));
+        let err = resolve_target(&tabs, None).unwrap_err();
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        // The message lists both connected tabs to disambiguate.
+        assert!(err.1.contains("id 1") && err.1.contains("id 2"));
+    }
+
+    #[test]
+    fn resolve_target_by_connection_id() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        tabs.insert(2, tab(Some("https://b.test")));
+        let (id, _s) = resolve_target(&tabs, Some("2")).unwrap();
+        assert_eq!(id, 2);
+        // Unknown id is a 404.
+        assert_eq!(
+            resolve_target(&tabs, Some("9")).unwrap_err().0,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn resolve_target_by_unique_origin() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        tabs.insert(2, tab(Some("https://b.test")));
+        let (id, _s) = resolve_target(&tabs, Some("https://b.test")).unwrap();
+        assert_eq!(id, 2);
+        // Unknown origin is a 404.
+        assert_eq!(
+            resolve_target(&tabs, Some("https://nope.test"))
+                .unwrap_err()
+                .0,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn resolve_target_ambiguous_origin_is_409() {
+        let mut tabs = HashMap::new();
+        tabs.insert(1, tab(Some("https://a.test")));
+        tabs.insert(2, tab(Some("https://a.test")));
+        let err = resolve_target(&tabs, Some("https://a.test")).unwrap_err();
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        // Two tabs share the origin → caller is told to target by id.
+        assert!(err.1.contains("connection id"));
+    }
+
+    #[test]
+    fn target_header_trims_and_drops_empty() {
+        let mut h = axum::http::HeaderMap::new();
+        assert_eq!(target_header(&h), None);
+        h.insert(auth::BRIDGE_TARGET_HEADER, "  2  ".parse().unwrap());
+        assert_eq!(target_header(&h).as_deref(), Some("2"));
+        h.insert(auth::BRIDGE_TARGET_HEADER, "   ".parse().unwrap());
+        assert_eq!(target_header(&h), None);
     }
 
     #[test]

--- a/src/browser/protocol.rs
+++ b/src/browser/protocol.rs
@@ -35,6 +35,13 @@ pub struct ControlRequest {
     /// (`response.body.getReader()`) rather than buffered into one reply.
     #[serde(default)]
     pub stream: bool,
+    /// Which connected tab to route this request to: a connection id (the
+    /// canonical, always-unambiguous selector) or an `Origin` string that
+    /// uniquely matches one tab. Omitted is allowed only when exactly one tab is
+    /// connected. The `X-Omni-Bridge-Target` header takes precedence over this
+    /// field. Server-side routing only — never sent to the browser.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
 }
 
 fn default_method() -> String {
@@ -310,14 +317,28 @@ pub struct ResponseEnvelope {
     pub encoding: Option<String>,
 }
 
+/// One connected tab, as reported by `GET /__bridge/status`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TabInfo {
+    /// Server-assigned connection id; the canonical routing selector.
+    pub id: u64,
+    /// The connecting tab's `Origin`, if it sent one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
+}
+
 /// `GET /__bridge/status` response body.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StatusResponse {
-    /// Whether an authenticated browser is currently connected.
+    /// Whether at least one authenticated browser tab is currently connected.
     pub connected: bool,
-    /// The connected browser's `Origin`, if it sent one.
+    /// The connected tab's `Origin` when exactly one tab is connected; `None`
+    /// when zero or several are (ambiguous). Retained for v1 back-compat — use
+    /// [`Self::tabs`] for the full picture.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub browser_origin: Option<String>,
+    /// Every connected tab (id + origin), for routing with a `target`.
+    pub tabs: Vec<TabInfo>,
     /// Number of in-flight requests awaiting a browser reply.
     pub pending: usize,
 }
@@ -522,6 +543,7 @@ mod tests {
         let s = StatusResponse {
             connected: false,
             browser_origin: None,
+            tabs: Vec::new(),
             pending: 0,
         };
         let json = serde_json::to_string(&s).unwrap();

--- a/src/cli/browser/request.rs
+++ b/src/cli/browser/request.rs
@@ -53,6 +53,12 @@ pub struct RequestCommand {
     /// long-lived endpoints.
     #[arg(long)]
     pub stream: bool,
+
+    /// Route to a specific connected tab: a connection id (from
+    /// `/__bridge/status`) or an `Origin` that uniquely matches one tab.
+    /// Required when more than one tab is connected.
+    #[arg(long, value_name = "ID|ORIGIN")]
+    pub target: Option<String>,
 }
 
 impl RequestCommand {
@@ -68,6 +74,7 @@ impl RequestCommand {
             headers,
             body,
             stream: self.stream,
+            target: self.target,
         };
 
         let endpoint = format!("http://127.0.0.1:{}/__bridge/request", self.control_port);

--- a/tests/browser_bridge_test.rs
+++ b/tests/browser_bridge_test.rs
@@ -1397,3 +1397,45 @@ async fn single_tab_back_compat() {
     let env: Value = resp.json().await.unwrap();
     assert_eq!(env["body"], "tab:A:/x");
 }
+
+/// A malformed JSON body to `POST /__bridge/request` is rejected with 400.
+#[tokio::test]
+async fn request_invalid_json_body_is_400() {
+    let (control_port, _ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let (http, base, tok) = client(control_port, &token);
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .header("content-type", "application/json")
+        .body("not valid json {")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+/// On `POST /__bridge/request`, the `X-Omni-Bridge-Target` header selects the
+/// tab and overrides a conflicting `target` body field.
+#[tokio::test]
+async fn request_target_header_overrides_body_field() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _b = FakeBrowser::connect_tagged(ws_port, &token, "https://b.test", "B").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    // Body targets A, header targets B; the header wins.
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .header("x-omni-bridge-target", "https://b.test")
+        .json(&serde_json::json!({"url": "/p", "method": "GET", "target": "https://a.test"}))
+        .send()
+        .await
+        .unwrap();
+    let env: Value = resp.json().await.unwrap();
+    assert_eq!(env["body"], "tab:B:/p");
+}

--- a/tests/browser_bridge_test.rs
+++ b/tests/browser_bridge_test.rs
@@ -135,6 +135,35 @@ impl FakeBrowser {
         });
         Self { handle }
     }
+
+    /// Connects presenting an `Origin` header and echoes `tab:<tag>:<url>` for
+    /// each command, so multi-tab routing tests can assert *which* tab replied.
+    async fn connect_tagged(ws_port: u16, token: &str, origin: &str, tag: &str) -> Self {
+        let uri = format!("ws://127.0.0.1:{ws_port}/").parse().unwrap();
+        let request = ClientRequestBuilder::new(uri)
+            .with_sub_protocol(token)
+            .with_header("Origin", origin);
+        let (ws, _resp) = tokio_tungstenite::connect_async(request).await.unwrap();
+        let (mut sink, mut stream) = ws.split();
+        let tag = tag.to_string();
+        let handle = tokio::spawn(async move {
+            while let Some(Ok(msg)) = stream.next().await {
+                if let Message::Text(txt) = msg {
+                    let cmd: Value = serde_json::from_str(&txt).unwrap();
+                    let id = cmd["id"].as_u64().unwrap();
+                    let body = format!("tab:{tag}:{}", cmd["url"].as_str().unwrap_or(""));
+                    let resp = serde_json::json!({
+                        "id": id,
+                        "status": 200,
+                        "headers": {"content-type": "text/plain"},
+                        "body": body,
+                    });
+                    sink.send(Message::Text(resp.to_string())).await.unwrap();
+                }
+            }
+        });
+        Self { handle }
+    }
 }
 
 impl Drop for FakeBrowser {
@@ -1208,4 +1237,163 @@ async fn cli_request_client_reports_bridge_error() {
         .await
         .unwrap();
     assert!(!out.status.success());
+}
+
+// ── Multi-tab connection routing (#908) ──────────────────────────────
+
+/// Fetches `/__bridge/status` and returns the parsed JSON body.
+async fn fetch_status(http: &reqwest::Client, base: &str, tok: &str) -> Value {
+    http.get(format!("{base}/__bridge/status"))
+        .bearer_auth(tok)
+        .header("x-omni-bridge", "1")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+/// Two authenticated tabs connect and both appear in status; neither evicts the
+/// other (the per-connection non-eviction guarantee).
+#[tokio::test]
+async fn two_tabs_coexist_in_status() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _b = FakeBrowser::connect_tagged(ws_port, &token, "https://b.test", "B").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    let body = fetch_status(&http, &base, &tok).await;
+    assert_eq!(body["connected"], Value::Bool(true));
+    let tabs = body["tabs"].as_array().unwrap();
+    assert_eq!(tabs.len(), 2);
+    let origins: Vec<&str> = tabs.iter().map(|t| t["origin"].as_str().unwrap()).collect();
+    assert!(origins.contains(&"https://a.test") && origins.contains(&"https://b.test"));
+    // `browser_origin` is ambiguous with two tabs, so it is omitted.
+    assert!(body.get("browser_origin").is_none() || body["browser_origin"].is_null());
+}
+
+/// With two tabs connected and no target, the request is rejected (409) and the
+/// message lists the connected tabs.
+#[tokio::test]
+async fn two_tabs_no_target_is_409() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _b = FakeBrowser::connect_tagged(ws_port, &token, "https://b.test", "B").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .json(&serde_json::json!({"url": "/x", "method": "GET"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 409);
+}
+
+/// A request targeted by `Origin` routes to the matching tab.
+#[tokio::test]
+async fn route_by_origin_selects_the_right_tab() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _b = FakeBrowser::connect_tagged(ws_port, &token, "https://b.test", "B").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    // Via the `target` body field.
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .json(&serde_json::json!({"url": "/p", "method": "GET", "target": "https://b.test"}))
+        .send()
+        .await
+        .unwrap();
+    let env: Value = resp.json().await.unwrap();
+    assert_eq!(env["body"], "tab:B:/p");
+}
+
+/// A request targeted by connection id (read from status) routes to that tab,
+/// supplied via the `X-Omni-Bridge-Target` header and the transparent proxy.
+#[tokio::test]
+async fn route_by_id_header_via_proxy() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _b = FakeBrowser::connect_tagged(ws_port, &token, "https://b.test", "B").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    // Learn which id maps to origin a.test from status.
+    let status = fetch_status(&http, &base, &tok).await;
+    let id_a = status["tabs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["origin"] == "https://a.test")
+        .unwrap()["id"]
+        .as_u64()
+        .unwrap();
+
+    let resp = http
+        .get(format!("{base}/proxied"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .header("x-omni-bridge-target", id_a.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "tab:A:/proxied");
+}
+
+/// An unknown connection id is a 404.
+#[tokio::test]
+async fn unknown_target_id_is_404() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://a.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .json(&serde_json::json!({"url": "/x", "method": "GET", "target": "999"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+/// A single connected tab still routes without a target (v1 back-compat), and
+/// status reports it via the legacy `browser_origin` field.
+#[tokio::test]
+async fn single_tab_back_compat() {
+    let (control_port, ws_port, token) = start_bridge(None, Duration::from_secs(5)).await;
+    let _a = FakeBrowser::connect_tagged(ws_port, &token, "https://only.test", "A").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (http, base, tok) = client(control_port, &token);
+
+    let status = fetch_status(&http, &base, &tok).await;
+    assert_eq!(status["browser_origin"], "https://only.test");
+    assert_eq!(status["tabs"].as_array().unwrap().len(), 1);
+
+    let resp = http
+        .post(format!("{base}/__bridge/request"))
+        .bearer_auth(&tok)
+        .header("x-omni-bridge", "1")
+        .json(&serde_json::json!({"url": "/x", "method": "GET"}))
+        .send()
+        .await
+        .unwrap();
+    let env: Value = resp.json().await.unwrap();
+    assert_eq!(env["body"], "tab:A:/x");
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1927,6 +1927,7 @@ Options:
       --control-port <CONTROL_PORT>  Control-plane port of the running bridge [default: 9998]
       --token-file <PATH>            Read the session token from this `0600` file instead of the environment
       --stream                       Stream the response: print body chunks to stdout as they arrive instead of buffering the whole response into one envelope. Use for SSE / chunked / long-lived endpoints
+      --target <ID|ORIGIN>           Route to a specific connected tab: a connection id (from `/__bridge/status`) or an `Origin` that uniquely matches one tab. Required when more than one tab is connected
   -h, --help                         Print help
 
 


### PR DESCRIPTION
## Description

This PR implements concurrent multi-tab routing for the browser bridge, replacing the single `Option<WsConn>` connection slot with a `conn_id`-keyed `HashMap<u64, WsConn>` registry. Multiple authenticated browser tabs can now connect simultaneously — each authenticates independently via the token subprotocol, and a new connection never evicts an existing one.

Requests are routed to a specific tab using the new `X-Omni-Bridge-Target` header (or `target` body field / `--target` CLI flag), selecting by connection id or unique `Origin`. With a single tab connected, routing works without a target (v1 back-compat). With multiple tabs and no target, the request is rejected with `409 Conflict` and the error lists the connected tabs to help callers disambiguate.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Fixes #908

## Changes Made

**Core Changes (`src/browser/`):**
- Replaced `Arc<Mutex<Option<WsConn>>>` with `Arc<Mutex<HashMap<u64, WsConn>>>` in `AppState` (`bridge.rs`); connection id removed from `WsConn` struct since it is now the map key
- Added `resolve_target()` function in `bridge.rs` to select a tab by connection id or unique `Origin` string; rejects ambiguous requests (`409`) or unknown targets (`404`); routes implicitly to the sole tab when only one is connected
- Added `target_header()` helper in `bridge.rs` to extract and trim the `X-Omni-Bridge-Target` header value, stripping it from headers forwarded to the browser
- Updated `status_handler` to return sorted `Vec<TabInfo>` in `StatusResponse`; `browser_origin` is retained for back-compat (meaningful only when exactly one tab is connected)
- Updated `request_handler` to accept `axum::http::HeaderMap` and override `req.target` from the header when present
- Updated `proxy_handler` to populate `req.target` from `target_header()`
- Updated `dispatch` and `start_stream` to call `resolve_target()` instead of directly locking `state.ws`
- Updated `send_cancel` to take `conn_id` so cancellations route back to the correct tab; `StreamDriver` now carries `conn_id` for stream aborts
- Added `BRIDGE_TARGET_HEADER` constant (`"x-omni-bridge-target"`) to `auth.rs`
- Added `TabInfo { id, origin }` struct and `target: Option<String>` field to `ControlRequest` in `protocol.rs`; added `tabs: Vec<TabInfo>` field to `StatusResponse`

**CLI Changes (`src/cli/browser/request.rs`):**
- Added `--target <ID|ORIGIN>` argument to `RequestCommand`; wired through to `ControlRequest.target`

**Documentation (`docs/`):**
- Added "Routing to a specific tab" section to `docs/browser-bridge.md` with resolution-rules table, status endpoint example, and CLI/curl usage examples
- Updated status endpoint table and `/__bridge/request` body docs in `docs/browser-bridge.md` to document `tabs` array and `target` field
- Updated Flags section in `docs/browser-bridge.md` to document `--target`
- Updated Caveats and WebSocket wire protocol rules sections to reflect multiple concurrent tabs
- Updated `docs/adrs/adr-0036.md` to document the non-eviction guarantee now holding per-connection and the `X-Omni-Bridge-Target` routing mechanism

**Testing (`tests/`):**
- Added `FakeBrowser::connect_tagged()` to support multi-tab tests where each tab echoes `tab:<tag>:<url>` so tests can assert which tab replied
- Added integration tests: `two_tabs_coexist_in_status`, `two_tabs_no_target_is_409`, `route_by_origin_selects_the_right_tab`, `route_by_id_header_via_proxy`, `unknown_target_id_is_404`, `single_tab_back_compat`
- Added unit tests for `resolve_target` (no tabs → 503, single tab routes without target, multiple tabs no target → 409, by id, by unique origin, ambiguous origin → 409) and `target_header` (trims whitespace, drops empty string)
- Updated `tests/snapshots/integration_test__help_all_output.snap` for new `--target` flag

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (7 new integration tests, 6 new unit tests)
- [x] Integration tests updated/added for all routing scenarios

**Manual Testing:**
- [x] Tested happy path scenarios (single tab back-compat, two-tab routing by id and origin)
- [x] Tested error/edge cases (no tabs → 503, ambiguous → 409, unknown id/origin → 404)
- [x] Backward compatibility verified (single-tab path unchanged)

### Test Commands
```bash
# Core test suite
cargo test

# Browser bridge tests specifically
cargo test --test browser_bridge_test

# Multi-tab routing unit tests
cargo test resolve_target
cargo test target_header

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — `BRIDGE_TARGET_HEADER` is stripped from forwarded headers; target resolution carries no data beyond what the status endpoint already exposes
- [x] Architecture changes — `AppState.ws` replaced by `AppState.tabs`; `send_cancel` and `StreamDriver` now carry `conn_id`
- [x] Error handling — `resolve_target` returns typed `(StatusCode, String)` errors; all callers propagate them correctly
- [x] Backward compatibility — single-tab implicit routing and `browser_origin` in status preserved

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Potential performance impact (describe below)

The connection registry is a `HashMap` protected by a `Mutex`; lock contention is negligible given the expected number of concurrent tabs (typically 1–5). Status responses now sort the `tabs` vec by id, which is O(n log n) but trivially fast at these scales. No benchmark regressions expected.

## Security Considerations

- [x] Security improvement (describe below)

The non-eviction guarantee previously held for the single slot; it now holds **per connection** — a new authenticated tab can never displace an existing one. `BRIDGE_TARGET_HEADER` is explicitly added to the `forwardable_headers` strip-list so the routing selector is never forwarded to the browser. `resolve_target` error messages expose only connection ids and origins, which are already visible via `GET /__bridge/status`. The `--allow-origin` allowlist remains a single global value applied to every connection; per-origin allowlists are noted as future work.

## Breaking Changes

**`StatusResponse` gains a mandatory `tabs: Vec<TabInfo>` field** (no `#[serde(default)]`). Callers that construct `StatusResponse` literals or deserialize the status endpoint without tolerating unknown fields must add the `tabs` field.

**Requests to `POST /__bridge/request` (or the transparent proxy) when more than one browser tab is connected now require a `target` field or `X-Omni-Bridge-Target` header.** Requests without a target in this situation receive `409 Conflict` and must be updated to pass `"target": "<id|origin>"` or the corresponding header.

**Migration Required:**
1. If constructing `StatusResponse` directly (e.g., in tests), add `tabs: Vec::new()` or an appropriate value.
2. If deserializing status responses with strict unknown-field rejection, update your schema to include the `tabs` array.
3. If routing requests when multiple tabs may be connected, add a `target` field to `POST /__bridge/request` bodies or pass the `X-Omni-Bridge-Target` header; use `GET /__bridge/status` to enumerate available connection ids and origins.

**Backward Compatibility:**
- Single-tab implicit routing is fully preserved — no change required for callers that only ever connect one tab.
- The `browser_origin` field in `StatusResponse` is retained and continues to be populated when exactly one tab is connected.

## Deployment Notes

- [x] No special deployment requirements

No environment variable changes, database migrations, or configuration file updates are required. The change is backward-compatible for single-tab deployments.

## Additional Notes

**Future Enhancements:**
- Per-origin `--allow-origin` allowlist (currently a single global value applied to every connection)
- Stdin piping support (noted as a remaining limitation)

**Known Limitations:**
- Requests route to exactly one tab; there is no fan-out to multiple tabs simultaneously.
- `--allow-origin` is a single global value; a per-origin allowlist requires a future extension.