### PR TITLE
feat(browser): add --credentials flag and per-request --allow-origin override to browser bridge request

### DIFF
--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -94,7 +94,7 @@ curl -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
 | Method & path            | Purpose                                                                 |
 |--------------------------|-------------------------------------------------------------------------|
 | `GET  /__bridge/status`  | `{ "connected": bool, "browser_origin": str?, "tabs": [{id, origin?}], "pending": int }`. `tabs` lists every connected tab; `browser_origin` is the lone tab's origin (present only when exactly one is connected, for back-compat). |
-| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?, target?, allow_origin?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Cross-origin `url` rejected unless `serve --allow-origin` or the per-request `allow_origin` permits it (see [Outbound request scope](#outbound-request-scope-default-closed)). See [Routing to a tab](#routing-to-a-specific-tab) for `target`. |
+| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?, target?, allow_origin?, credentials?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Cross-origin `url` rejected unless `serve --allow-origin` or the per-request `allow_origin` permits it (see [Outbound request scope](#outbound-request-scope-default-closed)). See [Routing to a tab](#routing-to-a-specific-tab) for `target`. |
 
 ```bash
 curl -s -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
@@ -116,9 +116,18 @@ omni-dev browser bridge request --url /loki/api/v1/labels --method GET
 omni-dev browser bridge request --url /api/foo --method POST --body @payload.json
 omni-dev browser bridge request --control-port 9998 --url /api/foo   # custom port
 omni-dev browser bridge request --url /api/foo --header "Accept: application/json"
+omni-dev browser bridge request --url https://cdn.example.com/x.js --credentials omit
 ```
 
 `--body @file` reads the body from a file; otherwise the value is sent verbatim.
+
+`--credentials <include|omit|same-origin>` sets the browser `fetch()` credentials
+mode (default `include`, unchanged). Use `omit` to read a wildcard-CORS
+(`Access-Control-Allow-Origin: *`) cross-origin response — e.g. a public CDN
+asset — which the browser refuses to expose to a credentialed request. **`omit`
+sends no cookies, so never use it for a cross-origin endpoint that needs the
+user's session: the request would be unauthenticated.** Pair with `--allow-origin`
+to permit the cross-origin target.
 
 Binary responses (images, gzipped blobs, file downloads) come back in the
 envelope as a base64 string with `"encoding": "base64"`; the caller decodes it.
@@ -258,9 +267,10 @@ bridge runs.
 | `--token-file <PATH>` | — | Read the session token from this `0600` file instead of generating one. |
 
 The `request` subcommand takes `--url`, `--method` (default `GET`),
-`--header` (repeatable), `--body` (`@file` supported), `--stream` (chunk the
-response to stdout), `--target` (route to a connection id / origin — see
-[Routing to a specific tab](#routing-to-a-specific-tab)), `--allow-origin`
+`--header` (repeatable), `--body` (`@file` supported),
+`--credentials <include|omit|same-origin>` (default `include`), `--stream`
+(chunk the response to stdout), `--target` (route to a connection id / origin —
+see [Routing to a specific tab](#routing-to-a-specific-tab)), `--allow-origin`
 (permit a cross-origin outbound URL for this request only — see
 [Outbound request scope](#outbound-request-scope-default-closed)),
 `--control-port` (default `9998`), and `--token-file`.

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -517,6 +517,9 @@ async fn proxy_handler(State(state): State<AppState>, request: Request) -> Respo
         // The transparent proxy has no per-request override channel; cross-origin
         // proxying is governed solely by the `serve --allow-origin` global.
         allow_origin: None,
+        // The transparent proxy has no per-request credentials control; it keeps
+        // the snippet default (`include`), matching pre-credentials behavior.
+        credentials: None,
     };
 
     if stream {
@@ -749,6 +752,7 @@ async fn dispatch(
         headers: req.headers,
         body: req.body,
         stream: false,
+        credentials: req.credentials,
     };
     let frame = match serde_json::to_string(&command) {
         Ok(f) => f,
@@ -901,6 +905,7 @@ async fn start_stream(
         headers: req.headers,
         body: req.body,
         stream: true,
+        credentials: req.credentials,
     };
     let frame = match serde_json::to_string(&command) {
         Ok(f) => f,
@@ -1312,6 +1317,7 @@ mod tests {
             stream: false,
             target: None,
             allow_origin: None,
+            credentials: None,
         }
     }
 

--- a/src/browser/protocol.rs
+++ b/src/browser/protocol.rs
@@ -50,6 +50,10 @@ pub struct ControlRequest {
     /// the browser.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_origin: Option<String>,
+    /// Fetch credentials mode (`include` | `omit` | `same-origin`). Absent means
+    /// the browser snippet defaults to `include`, preserving v1 behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<String>,
 }
 
 fn default_method() -> String {
@@ -83,6 +87,10 @@ pub struct Command {
     /// from the wire when `false` for back-compat with buffered clients.
     #[serde(default, skip_serializing_if = "is_false")]
     pub stream: bool,
+    /// Fetch credentials mode (`include` | `omit` | `same-origin`), or `null`
+    /// to let the browser snippet default to `include`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<String>,
 }
 
 /// Server → browser cancellation frame.
@@ -376,6 +384,7 @@ mod tests {
             stream: false,
             target: None,
             allow_origin: None,
+            credentials: None,
         };
         // Back-compat: an absent override is not serialised, so the wire body
         // stays byte-identical to a pre-feature client's.
@@ -401,6 +410,7 @@ mod tests {
             headers: BTreeMap::new(),
             body: None,
             stream: false,
+            credentials: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(!json.contains('\n'));
@@ -419,6 +429,7 @@ mod tests {
             headers: BTreeMap::new(),
             body: None,
             stream: true,
+            credentials: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"stream\":true"));
@@ -500,6 +511,45 @@ mod tests {
             let back: StreamLine = serde_json::from_str(json).unwrap();
             assert_eq!(back, line);
         }
+    }
+
+    #[test]
+    fn control_request_defaults_credentials_to_none() {
+        let req: ControlRequest = serde_json::from_str(r#"{"url":"/x"}"#).unwrap();
+        assert!(req.credentials.is_none());
+    }
+
+    #[test]
+    fn control_request_omits_credentials_when_absent() {
+        let req = ControlRequest {
+            url: "/x".to_string(),
+            method: "GET".to_string(),
+            headers: BTreeMap::new(),
+            body: None,
+            stream: false,
+            target: None,
+            allow_origin: None,
+            credentials: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("credentials"));
+    }
+
+    #[test]
+    fn command_serializes_credentials_when_present() {
+        let cmd = Command {
+            id: 1,
+            url: "/x".to_string(),
+            method: "GET".to_string(),
+            headers: BTreeMap::new(),
+            body: None,
+            stream: false,
+            credentials: Some("omit".to_string()),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains(r#""credentials":"omit""#));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
     }
 
     #[test]

--- a/src/cli/browser/bridge.rs
+++ b/src/cli/browser/bridge.rs
@@ -211,6 +211,7 @@ mod tests {
                 stream: false,
                 target: None,
                 allow_origin: None,
+                credentials: None,
             }),
         };
         assert!(cmd.execute().await.is_err());

--- a/src/cli/browser/request.rs
+++ b/src/cli/browser/request.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use futures::StreamExt as _;
 
 use crate::browser::auth;
@@ -16,6 +16,35 @@ use crate::browser::protocol::{ControlRequest, ResponseEnvelope, StreamLine};
 
 /// Default control-plane port (matches `bridge`'s default).
 const DEFAULT_CONTROL_PORT: u16 = 9998;
+
+/// Fetch credentials mode forwarded to the browser `fetch()`.
+///
+/// Mirrors the Fetch API's `credentials` option. `Include` (the default)
+/// preserves pre-credentials behavior; `Omit` is required to read a
+/// wildcard-CORS (`Access-Control-Allow-Origin: *`) cross-origin response, which
+/// the browser refuses to expose to a credentialed request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Credentials {
+    /// Send cookies/auth on every request (default; correct for same-origin APIs).
+    Include,
+    /// Send no credentials; required for wildcard-CORS cross-origin assets.
+    Omit,
+    /// Send credentials only on same-origin requests (browser `fetch` default).
+    SameOrigin,
+}
+
+impl Credentials {
+    /// The wire value the browser snippet passes to `fetch()`'s `credentials`,
+    /// owned so it can be mapped straight into the optional request field.
+    fn to_fetch_value(self) -> String {
+        match self {
+            Self::Include => "include",
+            Self::Omit => "omit",
+            Self::SameOrigin => "same-origin",
+        }
+        .to_string()
+    }
+}
 
 /// Sends a request through a running bridge and prints the response.
 ///
@@ -39,6 +68,12 @@ pub struct RequestCommand {
     /// Request body. Prefix with `@` to read from a file (e.g. `@payload.json`).
     #[arg(long)]
     pub body: Option<String>,
+
+    /// Fetch credentials mode. Defaults to `include` (cookies/auth sent). Use
+    /// `omit` to read a wildcard-CORS cross-origin response (e.g. a public CDN
+    /// asset), which a credentialed request cannot read.
+    #[arg(long, value_enum)]
+    pub credentials: Option<Credentials>,
 
     /// Control-plane port of the running bridge.
     #[arg(long, default_value_t = DEFAULT_CONTROL_PORT)]
@@ -84,6 +119,7 @@ impl RequestCommand {
             stream: self.stream,
             target: self.target,
             allow_origin: self.allow_origin,
+            credentials: self.credentials.map(Credentials::to_fetch_value),
         };
 
         let endpoint = format!("http://127.0.0.1:{}/__bridge/request", self.control_port);
@@ -215,6 +251,45 @@ mod tests {
     #[test]
     fn parse_headers_rejects_crlf() {
         assert!(parse_headers(&["X: a\r\nEvil: y".to_string()]).is_err());
+    }
+
+    #[test]
+    fn credentials_defaults_to_none() {
+        let cmd = RequestCommand::try_parse_from(["request", "--url", "/x"]).unwrap();
+        assert!(cmd.credentials.is_none());
+    }
+
+    #[test]
+    fn credentials_parses_each_mode() {
+        for (arg, expected) in [
+            ("include", Credentials::Include),
+            ("omit", Credentials::Omit),
+            ("same-origin", Credentials::SameOrigin),
+        ] {
+            let cmd =
+                RequestCommand::try_parse_from(["request", "--url", "/x", "--credentials", arg])
+                    .unwrap();
+            assert_eq!(cmd.credentials, Some(expected));
+        }
+    }
+
+    #[test]
+    fn credentials_rejects_invalid_value() {
+        assert!(RequestCommand::try_parse_from([
+            "request",
+            "--url",
+            "/x",
+            "--credentials",
+            "bogus"
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn credentials_maps_to_fetch_wire_value() {
+        assert_eq!(Credentials::Include.to_fetch_value(), "include");
+        assert_eq!(Credentials::Omit.to_fetch_value(), "omit");
+        assert_eq!(Credentials::SameOrigin.to_fetch_value(), "same-origin");
     }
 
     #[test]

--- a/src/templates/browser-bridge.js
+++ b/src/templates/browser-bridge.js
@@ -39,7 +39,7 @@
           method: cmd.method || 'GET',
           headers: cmd.headers || {},
           body: cmd.body || undefined,
-          credentials: 'include',
+          credentials: cmd.credentials || 'include',
         });
         const headers = {};
         resp.headers.forEach((v, k) => { headers[k] = v; });

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1913,12 +1913,13 @@ Options:
       --method <METHOD>              HTTP method [default: GET]
       --header <NAME: VALUE>         Request header as `Name: Value`. May be repeated
       --body <BODY>                  Request body. Prefix with `@` to read from a file (e.g. `@payload.json`)
+      --credentials <CREDENTIALS>    Fetch credentials mode. Defaults to `include` (cookies/auth sent). Use `omit` to read a wildcard-CORS cross-origin response (e.g. a public CDN asset), which a credentialed request cannot read [possible values: include, omit, same-origin]
       --control-port <CONTROL_PORT>  Control-plane port of the running bridge [default: 9998]
       --token-file <PATH>            Read the session token from this `0600` file instead of the environment
       --stream                       Stream the response: print body chunks to stdout as they arrive instead of buffering the whole response into one envelope. Use for SSE / chunked / long-lived endpoints
       --target <ID|ORIGIN>           Route to a specific connected tab: a connection id (from `/__bridge/status`) or an `Origin` that uniquely matches one tab. Required when more than one tab is connected
       --allow-origin <URL>           Permit a cross-origin outbound URL for this request only (e.g. `https://static.xx.fbcdn.net`). Takes precedence over the bridge's `serve --allow-origin` for this request's outbound-URL check, and does not affect the tab's WebSocket connection. Omit for same-origin (relative) requests
-  -h, --help                         Print help
+  -h, --help                         Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR adds two new per-request flags to `omni-dev browser bridge request` that together enable reading cross-origin resources (including wildcard-CORS public CDN assets) through the browser bridge without restarting `serve` or breaking the extension's WebSocket connection.

**`--credentials <include|omit|same-origin>`** (commit `5d3b1c0`) controls the browser `fetch()` credentials mode on a per-request basis. The default remains `include` (send cookies/auth) so existing callers are unaffected. The primary use case is `omit`, which is required to read wildcard-CORS (`Access-Control-Allow-Origin: *`) cross-origin responses that the browser refuses to expose to a credentialed request (e.g. public CDN assets like `https://cdn.example.com/x.js`).

**`--allow-origin <URL>`** (commit `868f096`) provides a request-scoped outbound-origin override that takes precedence over the `serve --allow-origin` global for a single request's `validate_outbound_url` check, without affecting the connection-time `ws_origin_allowed` gate. Previously, widening `serve --allow-origin` to permit a cross-origin target simultaneously caused the WebSocket upgrade check to reject the page's own tab. The new override is per-request and explicit — never a default.

These two flags are designed to be used together: `--allow-origin` permits the cross-origin target URL, and `--credentials omit` satisfies the browser's CORS requirement for reading the response.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Fixes #920 (request credentials mode)
Relates to #918 (per-request `--allow-origin` on the browser bridge `request`)

## Changes Made

**Core Protocol (`src/browser/protocol.rs`):**
- Added optional `credentials: Option<String>` field to `ControlRequest` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — absent when not set, preserving wire back-compat with pre-feature clients
- Added optional `credentials: Option<String>` field to `Command` with the same serde annotations, forwarded to the browser snippet
- Added optional `allow_origin: Option<String>` field to `ControlRequest` with identical back-compat serialization strategy

**Bridge Logic (`src/browser/bridge.rs`):**
- Added `resolve_allow_origin()` helper that applies a per-request `allow_origin` override (with a WARN log) over the `serve` global, or falls back to the global when no override is present
- Threaded `resolve_allow_origin()` through both `dispatch` and `start_stream` so both non-streaming and streaming paths honour the override
- Threaded `credentials` from `ControlRequest` through `dispatch` and `start_stream` into the `Command` sent to the browser tab
- Set `allow_origin: None` and `credentials: None` in the transparent proxy path (`proxy_handler`) — cross-origin proxying and credentials are governed solely by the `serve` global and snippet default

**CLI (`src/cli/browser/request.rs`):**
- Added `Credentials` enum (`Include`, `Omit`, `SameOrigin`) with `ValueEnum` for clap argument parsing and `as_fetch_value()` helper for wire encoding
- Added `--credentials <include|omit|same-origin>` CLI arg to `RequestCommand`, mapped to the `ControlRequest.credentials` field via `as_fetch_value()`
- Added `--allow-origin <URL>` CLI arg to `RequestCommand`, wired directly into `ControlRequest.allow_origin`

**Browser Snippet (`src/templates/browser-bridge.js`):**
- Updated `credentials` in the `fetch()` call from the hard-coded `'include'` to `cmd.credentials || 'include'`, forwarding the chosen mode while preserving the default

**Documentation (`docs/browser-bridge.md`):**
- Updated `POST /__bridge/request` table entry to document `allow_origin?` and `credentials?` fields in the request body
- Added usage examples for `--credentials omit` with a public CDN URL
- Added `--credentials` flag documentation with a clear warning against using `omit` for credentialed cross-origin endpoints
- Added security notes under the outbound-request-scope section explaining how `request --allow-origin` differs from `serve --allow-origin` and that the per-request override never touches the WS upgrade gate
- Updated `request` subcommand flag list to include `--credentials` and the updated `--allow-origin` description

**Testing:**
- Added protocol round-trip and back-compat tests: `control_request_defaults_credentials_to_none`, `control_request_omits_credentials_when_absent`, `command_serializes_credentials_when_present`
- Added bridge unit tests: `resolve_allow_origin_prefers_per_request_override`, `resolve_allow_origin_falls_back_to_global`, `per_request_override_does_not_affect_ws_origin_gate`
- Added CLI tests: `credentials_defaults_to_none`, `credentials_parses_each_mode`, `credentials_rejects_invalid_value`, `credentials_maps_to_fetch_wire_value`
- Updated help snapshot (`tests/snapshots/integration_test__help_all_output.snap`) to reflect new flags

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (protocol round-trips, bridge unit tests, CLI parsing tests)
- [x] Integration tests updated/added (help snapshot updated)

**Manual Testing:**
- [x] Tested happy path scenarios (credentials forwarded to fetch, per-request override wins over global)
- [x] Tested error/edge cases (invalid credentials value rejected by clap, unmatched allow-origin still rejected)
- [x] Backward compatibility verified (absent fields not serialized, pre-feature wire format identical)

### Test Commands
```bash
# Core test suite
cargo test

# Run browser-specific tests
cargo test browser

# Run CLI request tests
cargo test cli::browser::request

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual: read a public CDN asset through a connected bridge tab
omni-dev browser bridge request \
  --url https://cdn.example.com/asset.js \
  --credentials omit \
  --allow-origin https://cdn.example.com
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications
- [x] Backward compatibility

The key security properties to verify:
1. `resolve_allow_origin()` feeds **only** `validate_outbound_url`, never `ws_origin_allowed` — the WS upgrade gate reads `state.config.allow_origin` directly and is unaffected by any per-request value
2. The WARN log fires whenever a per-request override is exercised, providing an audit trail
3. `credentials: None` in `proxy_handler` means the transparent proxy path is unchanged — it always uses the snippet's default `include`
4. The `Credentials` enum rejects invalid values at clap parse time (before any network activity)
5. Both new fields use `skip_serializing_if = "Option::is_none"` ensuring the wire format is byte-identical for pre-feature clients

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact

- [x] No performance impact

The `resolve_allow_origin()` function performs a simple `Option::as_deref()` comparison on each request — negligible overhead.

## Security Considerations

- [x] Potential security impact (described below)

**`--allow-origin` per-request override:**
- Blast radius is bounded by the browser's own CORS: the response body is readable only if the target sends permissive CORS headers. A token holder can already issue authenticated same-origin requests, so this does not expand the trust boundary for credentialed calls.
- The override is **per-request and explicit** — it is never applied by default. A WARN is emitted at dispatch whenever it is exercised.
- The override reaches **only** `validate_outbound_url`. The `ws_origin_allowed` gate at WebSocket upgrade reads `state.config.allow_origin` directly and is provably unaffected.

**`--credentials omit`:**
- Documented with an explicit warning in `docs/browser-bridge.md`: `omit` sends no cookies, so it must never be used for a cross-origin endpoint that requires the user's session — the request would be unauthenticated.
- Default remains `include`, preserving all existing authenticated behavior.

## Breaking Changes

No breaking changes. Both new fields (`allow_origin`, `credentials`) are optional and serialized with `skip_serializing_if = "Option::is_none"`. Pre-feature clients and server versions see identical wire bytes.

## Deployment Notes

- [x] No special deployment requirements

No environment variable changes, database migrations, or configuration file updates required.

## Additional Notes

**Typical usage pattern** — reading a public CDN asset through the browser bridge:
```bash
# The tab is connected to https://app.example.com (same-origin by default).
# To read https://cdn.example.com/bundle.js (wildcard-CORS, public):
omni-dev browser bridge request \
  --url https://cdn.example.com/bundle.js \
  --allow-origin https://cdn.example.com \
  --credentials omit
```
`--allow-origin` permits the outbound URL check for this request only; `--credentials omit` satisfies the browser's CORS requirement (wildcard-CORS responses are blocked for credentialed requests).

**Known Limitations:**
- There is no per-request credentials control on the transparent proxy path (`curl -H "X-Omni-Bridge: 1" ...`); credentials there are always `include` (the snippet default). Only `POST /__bridge/request` and the `request` CLI subcommand support the override.