### PR TITLE
docs(browser): surface browser bridge in README, CLAUDE.md, and ADR-0036

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,17 @@ Dev-only notes:
 - `ClaudeCliAiClient::run` is the warn site for both escape hatches, the INFO-level `total_cost_usd` log, and the post-response WARN when reported cost exceeds the configured cap.
 - `--beta-header` is ignored for the `claude-cli` backend (`claude`'s `--betas` flag has different semantics).
 
+### Browser Bridge
+The `omni-dev browser bridge` command tree drives HTTP requests **through an authenticated browser tab** (Grafana/Loki, SSO-gated dashboards) without exfiltrating the browser's cookies/tokens — a *confused deputy by design*. It is a two-plane local server joined by an `id`-keyed correlator:
+
+- `src/cli/browser.rs` + `src/cli/browser/` — the CLI surface: `bridge serve` (`bridge.rs`, the long-lived server) and `bridge request` (`request.rs`, the thin client).
+- `src/browser/bridge.rs` — server core: the HTTP control plane (axum, default `127.0.0.1:9998`), the WebSocket plane the browser connects to (default `127.0.0.1:9999`), the `Correlator` (per-`id` channel), the transparent proxy, and `dispatch`/`start_stream`.
+- `src/browser/protocol.rs` — the wire types (`ControlRequest`, `Command`, `BrowserReply`/`ResponseEnvelope`, the streaming `StreamItem`/`StreamLine`/`CancelCommand`, `StatusResponse`/`TabInfo`). New optional fields use `#[serde(default, skip_serializing_if = ...)]` to keep older clients byte-identical on the wire.
+- `src/browser/auth.rs` — the **load-bearing** security primitives: token generation/resolution, `constant_time_eq`, the `X-Omni-Bridge` / `X-Omni-Bridge-Target` header constants, Host/Origin/Sec-Fetch-Site guards, and `validate_outbound_url` (server-side outbound scope; the in-page snippet is never trusted).
+- `src/templates/browser-bridge.js` — the snippet pasted into the DevTools console (rendered by `src/browser/snippet.rs`); it reads `cmd.stream` / `cmd.credentials` and base64-encodes non-text bodies.
+
+The security model is **core, not an add-on**: both planes are authenticated and default-closed. When touching the trust boundary (auth guards, outbound scope, token handling, the planes), keep [ADR-0036](docs/adrs/adr-0036.md) and the operator guide [docs/browser-bridge.md](docs/browser-bridge.md) in sync. Changes to the CLI surface require the [`update-snapshots`](.claude/skills/update-snapshots/SKILL.md) skill (see Code Changes §5).
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ conventional commit formats with project-aware suggestions.
   descriptions
 - 📦 **Automatic Batching**: Handles large commit ranges intelligently
 - 🎯 **Conventional Commits**: Automatic detection and formatting
+- 🌐 **Browser Bridge**: Drive HTTP requests through an authenticated browser
+  tab without exfiltrating cookies or tokens
 - 🛡️ **Safety First**: Working directory validation and error recovery
 - ⚡ **Fast & Reliable**: Built with Rust for memory safety and performance
 
@@ -239,6 +241,41 @@ omni-dev transcript youtube info <url> --output json
 or a bare 11-character video ID. Age-gated and login-required videos
 surface as a typed `PlayabilityRefused` error carrying YouTube's status
 code rather than a generic HTTP failure.
+
+### 🌐 Browser Bridge
+
+Drive HTTP requests **through an authenticated browser tab**. When you are
+investigating internal services (Grafana/Loki, internal dashboards, SSO-gated
+admin panels), the browser already holds sessions — SSO, OAuth, cookies — that
+are hard to replicate programmatically. The bridge issues requests inside the
+browser's authenticated context **without exfiltrating cookies or tokens** (a
+*confused deputy by design*). Both planes are authenticated and default-closed;
+see [docs/browser-bridge.md](docs/browser-bridge.md) for the full guide and
+[ADR-0036](docs/adrs/adr-0036.md) for the security rationale.
+
+```bash
+# Start the bridge; it prints the bound ports, a session token, and a JS
+# snippet to paste into the DevTools console of the authenticated tab.
+omni-dev browser bridge serve
+
+# Drive requests through the tab (token from the bridge's stdout).
+export OMNI_BRIDGE_TOKEN=<token printed by the bridge>
+omni-dev browser bridge request --url /loki/api/v1/labels
+
+# POST a JSON payload from a file, with a custom header.
+omni-dev browser bridge request --url /api/foo --method POST \
+  --body @payload.json --header "Accept: application/json"
+
+# Stream a long-lived endpoint (SSE / chunked) instead of buffering.
+omni-dev browser bridge request --url /api/events --stream
+
+# Route to a specific tab when several are connected (by id or origin).
+omni-dev browser bridge request --url /api/foo --target https://grafana.internal
+```
+
+Supports binary and streaming response bodies, multi-tab routing via
+`X-Omni-Bridge-Target`, per-request `--credentials` and `--allow-origin`
+overrides, and a transparent proxy for tools that speak plain HTTP.
 
 ### ✏️ Manual Amendment
 

--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -163,8 +163,24 @@ prefix.
   target tab with an `X-Omni-Bridge-Target` header (or `target` body field) by
   connection id or unique origin; with several tabs connected and no target the
   request is rejected rather than routed ambiguously. Routing is strictly to one
-  tab (no fan-out), and `--allow-origin` stays a single global value; a per-origin
-  allowlist remains possible future work. The remaining limit (stdin piping) can
-  still be added without revisiting this decision.
+  tab (no fan-out). The remaining limit (stdin piping) can still be added without
+  revisiting this decision.
+- A per-request `--allow-origin` override has since been added (#918) without
+  loosening the trust boundary. The `serve --allow-origin` global feeds **two**
+  checks at different times — `ws_origin_allowed` at the WebSocket upgrade (the
+  tab's `Origin`) and `validate_outbound_url` per request (the target URL's
+  origin) — so widening the global to permit a cross-origin target would also
+  relax the connection-time gate and could reject the page's own tab. The new
+  `request --allow-origin` (and `allow_origin` on `POST /__bridge/request`)
+  reaches **only** `validate_outbound_url` for that one request and never
+  `ws_origin_allowed`; it is explicit and per-request, never a default. Blast
+  radius stays bounded by the browser's own CORS (the response body is readable
+  only if the target sends permissive CORS).
+- A per-request `--credentials <include|omit|same-origin>` override has since
+  been added (#920), threaded through `ControlRequest`/`Command` to the snippet's
+  `fetch(..., {credentials})`. The default stays `include` (the v1 behaviour), so
+  it neither widens nor narrows the trust boundary by default; `omit` exists to
+  read wildcard-CORS cross-origin assets the browser refuses to expose to a
+  credentialed request, and is paired with `--allow-origin`.
 
 See [docs/browser-bridge.md](../browser-bridge.md) for the operator-facing guide.


### PR DESCRIPTION
## Description

The browser bridge had a comprehensive operator guide (`docs/browser-bridge.md`) and a docs index entry, but was undiscoverable from the main entry points. Additionally, ADR-0036 had drifted from the shipped feature set — specifically, it incorrectly described `--allow-origin` as a single global value, when a per-request override had already shipped in #918.

This PR makes the browser bridge visible at every natural discovery point:
- **README.md**: New "Browser Bridge" section under Core Commands with runnable examples, plus a Key Features bullet
- **CLAUDE.md**: New architecture section mapping the full code surface so AI assistants (and contributors) can orient quickly and know where the trust boundary lives
- **docs/adrs/adr-0036.md**: Corrected stale claim about `--allow-origin`, added explicit later-extension notes for #918 (per-request `--allow-origin`) and #920 (`--credentials`)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #918 (per-request `--allow-origin`)
Relates to #920 (`--credentials` override)

## Changes Made

**README.md:**
- Added `🌐 Browser Bridge` bullet to the Key Features list
- Added a full "Browser Bridge" section under Core Commands with an explanatory paragraph and five runnable `omni-dev browser bridge` examples covering `serve`, `request`, `--body @file`, `--stream`, and `--target`

**CLAUDE.md:**
- Added a "Browser Bridge" subsection in the architecture reference, mapping `src/cli/browser.rs`, `src/cli/browser/`, `src/browser/bridge.rs`, `src/browser/protocol.rs`, `src/browser/auth.rs`, and `src/templates/browser-bridge.js`
- Flagged `auth.rs` as the load-bearing security/trust-boundary module
- Called out that CLI surface changes require the `update-snapshots` skill

**docs/adrs/adr-0036.md:**
- Removed the stale claim that `--allow-origin` is a single global value
- Added a detailed later-extension note for #918 explaining how `serve --allow-origin` feeds two distinct checks (`ws_origin_allowed` at WebSocket upgrade and `validate_outbound_url` per request) and how `request --allow-origin` safely reaches only the per-request outbound scope check
- Added a later-extension note for #920 documenting the `--credentials <include|omit|same-origin>` override, its default (`include` = v1 behaviour), and the intended `omit` + `--allow-origin` pairing

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no new tests required)

**Manual Testing:**
- [x] Verified all code surface paths mentioned in CLAUDE.md exist in the repository
- [x] Verified README examples match the actual `omni-dev browser bridge` CLI flags
- [x] Verified ADR corrections align with the code in `src/browser/auth.rs` and `src/browser/bridge.rs`
- [x] Confirmed no broken internal links (all `docs/browser-bridge.md` and `docs/adrs/adr-0036.md` references are valid)

### Test Commands
```bash
# Code quality checks (no Rust changes in this PR)
cargo clippy -- -D warnings
cargo fmt --check

# Verify CLI help text still matches documented flags
omni-dev browser bridge serve --help
omni-dev browser bridge request --help
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — the ADR corrections describe the trust-boundary subtlety of the two-check `--allow-origin` design; reviewers should verify the prose accurately reflects `auth.rs`
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility — the ADR note confirms that per-request `--allow-origin` (#918) and `--credentials` (#920) do not widen the default trust boundary

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications — this is a documentation-only change. The ADR corrections document the existing security model more accurately; no security primitives are modified.

## Breaking Changes
None. This is a purely documentation change with no impact on runtime behaviour.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Consider adding the browser bridge to the top-level `omni-dev --help` summary if it grows further adoption

**Known Limitations:**
- The README examples assume the reader has already completed the bridge setup described in `docs/browser-bridge.md`; cross-links are provided for discoverability

**Alternatives Considered:**
- Keeping the README section minimal (just a one-liner and a link) — rejected in favour of the same depth used for the Atlassian and Datadog sections, which give enough concrete examples for a user to evaluate the feature without leaving the README