### PR TITLE
feat(claude, cli): add --from-commits mode for PR generation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -315,6 +315,7 @@ omni-dev git branch create pr [BASE_BRANCH] [OPTIONS]
 | `--context-dir PATH` | Custom context directory (defaults to `.omni-dev/`) | `--context-dir ./config` |
 | `--auto-apply` | Create/update PR without confirmation | `--auto-apply` |
 | `--save-only FILE` | Save PR details to YAML file instead of creating | `--save-only pr-details.yaml` |
+| `--from-commits` | Drive PR generation from commit messages instead of the diff (faster, no diff bytes are sent to the AI) | `--from-commits` |
 
 **What it does:**
 
@@ -1514,6 +1515,10 @@ omni-dev git branch create pr --auto-apply
 omni-dev git branch create pr --save-only review-pr.yaml
 # Review and edit the file...
 # Then create manually using GitHub CLI or web interface
+
+# Drive the PR description from commit messages (no diff sent to AI)
+# Useful when the branch's commits are well-crafted and convey the intent
+omni-dev git branch create pr --from-commits
 ```
 
 ### Collaborative PR Workflow

--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -175,9 +175,13 @@ impl ClaudeClient {
     /// Returns `Ok(Ok(user_prompt))` when the full diff fits,
     /// `Ok(Err(BudgetExceeded))` when it does not, or a top-level error
     /// on serialization failure.
-    fn try_full_diff_budget(
+    ///
+    /// Generic over the view type so the diff-driven path
+    /// (`RepositoryViewForAI`) and the commit-driven path
+    /// (`RepositoryViewForAiFromCommits`) can share the same budget check.
+    fn try_full_diff_budget<V: serde::Serialize>(
         &self,
-        ai_view: &RepositoryViewForAI,
+        ai_view: &V,
         system_prompt: &str,
         build_user_prompt: &(impl Fn(&str) -> String + ?Sized),
     ) -> Result<std::result::Result<String, BudgetExceeded>> {
@@ -1264,6 +1268,118 @@ impl ClaudeClient {
                 }
                 self.merge_pr_content_chunks(&per_commit_contents, pr_template)
                     .await
+            }
+        }
+    }
+
+    /// Generates AI-powered PR content from commit messages only (no diff).
+    ///
+    /// Used by `omni-dev git branch create pr --from-commits`. Builds a
+    /// payload that contains commit messages and metadata (hash, author,
+    /// date, detected type/scope) but **no diff content** — the full diff
+    /// files are never read from disk for this path. Falls back to a
+    /// per-commit split dispatch if the commit-message payload exceeds the
+    /// token budget (rare; commit messages are small).
+    pub async fn generate_pr_content_with_context_from_commits(
+        &self,
+        repo_view: &RepositoryView,
+        pr_template: &str,
+        context: &crate::data::context::CommitContext,
+    ) -> Result<crate::cli::git::PrContent> {
+        use crate::data::RepositoryViewForAiFromCommits;
+
+        let commits_view = RepositoryViewForAiFromCommits::from_repository_view(repo_view.clone());
+
+        let prompt_style = self.ai_client.get_metadata().prompt_style();
+        let system_prompt = self.adjusted_system_prompt(
+            prompts::generate_pr_system_prompt_from_commits_with_context_for_provider(
+                context,
+                prompt_style,
+            ),
+        );
+
+        let build_user_prompt = |yaml: &str| {
+            prompts::generate_pr_description_prompt_from_commits_with_context(
+                yaml,
+                pr_template,
+                context,
+            )
+        };
+
+        match self.try_full_diff_budget(&commits_view, &system_prompt, &build_user_prompt)? {
+            Ok(user_prompt) => {
+                let content = self
+                    .send_with_optional_schema(
+                        &system_prompt,
+                        &user_prompt,
+                        self.schema_if_supported(response_schema::pr_content_schema()),
+                    )
+                    .await?;
+
+                debug!(
+                    content_length = content.len(),
+                    "Received AI response for from-commits PR content"
+                );
+
+                self.parse_pr_response(&content)
+            }
+            Err(_exceeded) => {
+                let mut per_commit_contents = Vec::new();
+                for commit in &commits_view.commits {
+                    let pr = self
+                        .generate_pr_content_for_commit_from_commits(
+                            commit,
+                            &commits_view,
+                            &system_prompt,
+                            &build_user_prompt,
+                        )
+                        .await?;
+                    per_commit_contents.push(pr);
+                }
+                if per_commit_contents.len() == 1 {
+                    return per_commit_contents
+                        .into_iter()
+                        .next()
+                        .context("Per-commit PR contents unexpectedly empty");
+                }
+                self.merge_pr_content_chunks(&per_commit_contents, pr_template)
+                    .await
+            }
+        }
+    }
+
+    /// Per-commit dispatch for the `--from-commits` path.
+    ///
+    /// Builds a single-commit view of the commit-message payload and
+    /// sends it. No file-level fallback exists for this path because the
+    /// payload is already a single commit message — if it does not fit
+    /// the budget, the commit message itself is pathologically large and
+    /// we surface a clear error rather than silently truncating.
+    async fn generate_pr_content_for_commit_from_commits(
+        &self,
+        commit: &crate::data::CommitInfoFromCommits,
+        commits_view: &crate::data::RepositoryViewForAiFromCommits,
+        system_prompt: &str,
+        build_user_prompt: &(dyn Fn(&str) -> String + Sync),
+    ) -> Result<crate::cli::git::PrContent> {
+        let single_view = commits_view.single_commit_view_from_commits(commit);
+
+        match self.try_full_diff_budget(&single_view, system_prompt, build_user_prompt)? {
+            Ok(user_prompt) => {
+                let content = self
+                    .send_with_optional_schema(
+                        system_prompt,
+                        &user_prompt,
+                        self.schema_if_supported(response_schema::pr_content_schema()),
+                    )
+                    .await?;
+                self.parse_pr_response(&content)
+            }
+            Err(_exceeded) => {
+                anyhow::bail!(
+                    "Token budget exceeded for commit {} in --from-commits mode; commit message is too large to fit",
+                    &commit.hash[..8.min(commit.hash.len())]
+                )
             }
         }
     }
@@ -3276,6 +3392,394 @@ mod tests {
         let pr = result.unwrap();
         assert!(pr.title.contains("modules"));
         assert_eq!(handle.remaining(), 0, "expected all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_from_commits_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo_view = make_test_repo_view(&dir);
+        let context = crate::data::context::CommitContext::default();
+
+        let response = "title: \"feat: from commits\"\ndescription: \"derived from commit\"\n";
+        let client = make_configurable_client(vec![Ok(response.to_string())]);
+
+        let result = client
+            .generate_pr_content_with_context_from_commits(&repo_view, "", &context)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "PR from-commits generation failed: {:?}",
+            result.err()
+        );
+        let pr = result.unwrap();
+        assert_eq!(pr.title, "feat: from commits");
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_from_commits_omits_diff_in_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        // Write a recognisable diff payload to the diff_file so we can prove it
+        // is NOT being read into the prompt.
+        let diff_path = dir.path().join("recognisable.diff");
+        std::fs::write(
+            &diff_path,
+            "diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+UNIQUE_DIFF_MARKER\n",
+        )
+        .unwrap();
+
+        // Build a repo view whose single commit's diff_file points at the
+        // marker file but whose commit message contains a distinct subject.
+        let repo_view = {
+            use crate::data::{AiInfo, FieldExplanation, WorkingDirectoryInfo};
+            use crate::git::commit::FileChanges;
+            use crate::git::{CommitAnalysis, CommitInfo};
+            crate::data::RepositoryView {
+                versions: None,
+                explanation: FieldExplanation::default(),
+                working_directory: WorkingDirectoryInfo {
+                    clean: true,
+                    untracked_changes: Vec::new(),
+                },
+                remotes: Vec::new(),
+                ai: AiInfo {
+                    scratch: String::new(),
+                },
+                branch_info: None,
+                pr_template: None,
+                pr_template_location: None,
+                branch_prs: None,
+                commits: vec![CommitInfo {
+                    hash: format!("{:0>40}", 0),
+                    author: "Test <test@test.com>".to_string(),
+                    date: chrono::Utc::now().fixed_offset(),
+                    original_message: "feat(test): UNIQUE_COMMIT_SUBJECT_MARKER".to_string(),
+                    in_main_branches: Vec::new(),
+                    analysis: CommitAnalysis {
+                        detected_type: "feat".to_string(),
+                        detected_scope: "test".to_string(),
+                        proposed_message: "feat(test): unique".to_string(),
+                        file_changes: FileChanges {
+                            total_files: 1,
+                            files_added: 1,
+                            files_deleted: 0,
+                            file_list: Vec::new(),
+                        },
+                        diff_summary: "UNIQUE_STAT_MARKER | 1 +".to_string(),
+                        diff_file: diff_path.to_string_lossy().to_string(),
+                        file_diffs: Vec::new(),
+                    },
+                }],
+            }
+        };
+        let context = crate::data::context::CommitContext::default();
+
+        let (client, _resp_handle, prompt_handle) =
+            make_configurable_client_with_prompts(vec![Ok(
+                "title: \"feat: x\"\ndescription: \"y\"\n".to_string(),
+            )]);
+
+        client
+            .generate_pr_content_with_context_from_commits(&repo_view, "", &context)
+            .await
+            .unwrap();
+
+        let prompts = prompt_handle.prompts();
+        assert_eq!(prompts.len(), 1, "expected exactly one AI call");
+        let (system_prompt, user_prompt) = &prompts[0];
+
+        // Commit narrative IS present
+        assert!(
+            user_prompt.contains("UNIQUE_COMMIT_SUBJECT_MARKER"),
+            "user prompt must include the commit subject"
+        );
+        // No diff content
+        assert!(
+            !user_prompt.contains("UNIQUE_DIFF_MARKER"),
+            "user prompt must NOT include diff content: {user_prompt}"
+        );
+        assert!(
+            !user_prompt.contains("diff --git"),
+            "user prompt must NOT include diff hunks"
+        );
+        assert!(
+            !user_prompt.contains("diff_content"),
+            "user prompt must NOT include diff_content YAML field"
+        );
+        assert!(
+            !user_prompt.contains("UNIQUE_STAT_MARKER"),
+            "user prompt must NOT include diff_summary"
+        );
+        // System prompt references commits, not diff files
+        assert!(
+            !system_prompt.contains("diff files"),
+            "system prompt must not mention diff files"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_default_mode_includes_diff_in_prompt() {
+        // Regression test locking in the byte-identical-default guarantee:
+        // when --from-commits is OFF, the prompt MUST still contain diff content.
+        let dir = tempfile::tempdir().unwrap();
+        let repo_view = make_test_repo_view(&dir);
+        let context = crate::data::context::CommitContext::default();
+
+        let (client, _resp_handle, prompt_handle) =
+            make_configurable_client_with_prompts(vec![Ok(
+                "title: \"feat: x\"\ndescription: \"y\"\n".to_string(),
+            )]);
+
+        client
+            .generate_pr_content_with_context(&repo_view, "", &context)
+            .await
+            .unwrap();
+
+        let prompts = prompt_handle.prompts();
+        assert_eq!(prompts.len(), 1);
+        let (_system_prompt, user_prompt) = &prompts[0];
+        assert!(
+            user_prompt.contains("diff_content"),
+            "default mode must still serialise diff_content into the prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_from_commits_multi_commit_per_commit_dispatch() {
+        // Force per-commit fallback by giving each commit a large message
+        // so the combined view busts the small (50K) context window.
+        use crate::data::{AiInfo, FieldExplanation, WorkingDirectoryInfo};
+        use crate::git::commit::FileChanges;
+        use crate::git::{CommitAnalysis, CommitInfo};
+
+        let dir = tempfile::tempdir().unwrap();
+        let make_commit = |hash: String, marker: &str, msg_size: usize| {
+            let diff_path = dir.path().join(format!("{}.diff", &hash[..4]));
+            std::fs::write(&diff_path, "+x\n").unwrap();
+            CommitInfo {
+                hash,
+                author: "Test <test@test.com>".to_string(),
+                date: chrono::Utc::now().fixed_offset(),
+                original_message: format!("feat({marker}): {}", "x".repeat(msg_size)),
+                in_main_branches: Vec::new(),
+                analysis: CommitAnalysis {
+                    detected_type: "feat".to_string(),
+                    detected_scope: marker.to_string(),
+                    proposed_message: format!("feat({marker}): t"),
+                    file_changes: FileChanges {
+                        total_files: 1,
+                        files_added: 1,
+                        files_deleted: 0,
+                        file_list: Vec::new(),
+                    },
+                    diff_summary: String::new(),
+                    diff_file: diff_path.to_string_lossy().to_string(),
+                    file_diffs: Vec::new(),
+                },
+            }
+        };
+
+        // Two commits, each with a ~80KB message → combined ~160KB chars,
+        // exceeds the 50K-context-length mock's ~20K-token input budget.
+        let repo_view = crate::data::RepositoryView {
+            versions: None,
+            explanation: FieldExplanation::default(),
+            working_directory: WorkingDirectoryInfo {
+                clean: true,
+                untracked_changes: Vec::new(),
+            },
+            remotes: Vec::new(),
+            ai: AiInfo {
+                scratch: String::new(),
+            },
+            branch_info: None,
+            pr_template: None,
+            pr_template_location: None,
+            branch_prs: None,
+            commits: vec![
+                make_commit("a".repeat(40), "a", 80_000),
+                make_commit("b".repeat(40), "b", 80_000),
+            ],
+        };
+        let context = crate::data::context::CommitContext::default();
+
+        // Full view exceeds → per-commit fallback (2 calls) → merge (1 call).
+        let (client, handle) = make_small_context_client_tracked(vec![
+            Ok(valid_pr_yaml("feat(a): a", "did a")),
+            Ok(valid_pr_yaml("feat(b): b", "did b")),
+            Ok(valid_pr_yaml("feat: a and b", "did both")),
+        ]);
+
+        let result = client
+            .generate_pr_content_with_context_from_commits(&repo_view, "", &context)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "from-commits per-commit dispatch failed: {:?}",
+            result.err()
+        );
+        let pr = result.unwrap();
+        assert!(
+            pr.title.contains("and"),
+            "unexpected merged title: {}",
+            pr.title
+        );
+        assert_eq!(handle.remaining(), 0, "expected all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_from_commits_single_commit_per_commit_return() {
+        // Force per-commit fallback with a single commit whose message busts
+        // the budget on the full view but fits in the slimmer single-commit
+        // view (no envelope around it). Exercises the
+        // `per_commit_contents.len() == 1` return branch — no merge pass.
+        use crate::data::{AiInfo, FieldExplanation, WorkingDirectoryInfo};
+        use crate::git::commit::FileChanges;
+        use crate::git::{CommitAnalysis, CommitInfo};
+
+        let dir = tempfile::tempdir().unwrap();
+        let diff_path = dir.path().join("0.diff");
+        std::fs::write(&diff_path, "+x\n").unwrap();
+        let commit = CommitInfo {
+            hash: "a".repeat(40),
+            author: "Test <test@test.com>".to_string(),
+            date: chrono::Utc::now().fixed_offset(),
+            // ~80KB message → busts the 50K-context client's input budget
+            // when wrapped in the full envelope, but the slimmer single-commit
+            // view (envelope stripped) still fits with the small context.
+            original_message: format!("feat(only): {}", "x".repeat(80_000)),
+            in_main_branches: Vec::new(),
+            analysis: CommitAnalysis {
+                detected_type: "feat".to_string(),
+                detected_scope: "only".to_string(),
+                proposed_message: "feat(only): m".to_string(),
+                file_changes: FileChanges {
+                    total_files: 1,
+                    files_added: 1,
+                    files_deleted: 0,
+                    file_list: Vec::new(),
+                },
+                diff_summary: String::new(),
+                diff_file: diff_path.to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
+            },
+        };
+        let repo_view = crate::data::RepositoryView {
+            versions: None,
+            explanation: FieldExplanation::default(),
+            working_directory: WorkingDirectoryInfo {
+                clean: true,
+                untracked_changes: Vec::new(),
+            },
+            remotes: Vec::new(),
+            ai: AiInfo {
+                scratch: String::new(),
+            },
+            branch_info: None,
+            pr_template: None,
+            pr_template_location: None,
+            branch_prs: None,
+            commits: vec![commit],
+        };
+        let context = crate::data::context::CommitContext::default();
+
+        // Full envelope view exceeds → per-commit dispatch (1 call) → single
+        // result returned directly, no merge.
+        let (client, handle) = make_small_context_client_tracked(vec![Ok(valid_pr_yaml(
+            "feat(only): direct return",
+            "single commit body",
+        ))]);
+
+        let result = client
+            .generate_pr_content_with_context_from_commits(&repo_view, "", &context)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "from-commits single-commit per-commit dispatch failed: {:?}",
+            result.err()
+        );
+        let pr = result.unwrap();
+        assert_eq!(pr.title, "feat(only): direct return");
+        assert_eq!(
+            handle.remaining(),
+            0,
+            "exactly one response should be consumed (no merge call)"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_pr_content_with_context_from_commits_bails_on_oversized_single_commit() {
+        // A single commit whose own slim view still exceeds the budget triggers
+        // the bail in `generate_pr_content_for_commit_from_commits`.
+        use crate::data::{AiInfo, FieldExplanation, WorkingDirectoryInfo};
+        use crate::git::commit::FileChanges;
+        use crate::git::{CommitAnalysis, CommitInfo};
+
+        let dir = tempfile::tempdir().unwrap();
+        let diff_path = dir.path().join("0.diff");
+        std::fs::write(&diff_path, "+x\n").unwrap();
+        let commit = CommitInfo {
+            hash: "c".repeat(40),
+            author: "Test <test@test.com>".to_string(),
+            date: chrono::Utc::now().fixed_offset(),
+            // Message large enough that even the single-commit slim view
+            // overflows the 50K context window's input budget.
+            original_message: format!("feat: {}", "z".repeat(200_000)),
+            in_main_branches: Vec::new(),
+            analysis: CommitAnalysis {
+                detected_type: "feat".to_string(),
+                detected_scope: String::new(),
+                proposed_message: "feat: oversized".to_string(),
+                file_changes: FileChanges {
+                    total_files: 0,
+                    files_added: 0,
+                    files_deleted: 0,
+                    file_list: Vec::new(),
+                },
+                diff_summary: String::new(),
+                diff_file: diff_path.to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
+            },
+        };
+        let repo_view = crate::data::RepositoryView {
+            versions: None,
+            explanation: FieldExplanation::default(),
+            working_directory: WorkingDirectoryInfo {
+                clean: true,
+                untracked_changes: Vec::new(),
+            },
+            remotes: Vec::new(),
+            ai: AiInfo {
+                scratch: String::new(),
+            },
+            branch_info: None,
+            pr_template: None,
+            pr_template_location: None,
+            branch_prs: None,
+            commits: vec![commit],
+        };
+        let context = crate::data::context::CommitContext::default();
+
+        // No mock responses are needed; the call should bail before making
+        // any AI request.
+        let client = make_small_context_client(Vec::new());
+
+        let result = client
+            .generate_pr_content_with_context_from_commits(&repo_view, "", &context)
+            .await;
+
+        assert!(result.is_err(), "expected bail on oversized single commit");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("Token budget exceeded"),
+            "expected token-budget error message, got: {msg}"
+        );
+        assert!(
+            msg.contains("--from-commits"),
+            "error should reference the from-commits mode"
+        );
     }
 
     #[tokio::test]

--- a/src/claude/prompts.rs
+++ b/src/claude/prompts.rs
@@ -766,6 +766,163 @@ Start immediately with "title:" and provide only YAML content. The title should 
     prompt
 }
 
+/// System prompt for the `--from-commits` PR description generation path.
+///
+/// Tells the AI that the input is *only* commit messages (no diffs). The
+/// commit messages are the curated narrative of intent — the AI must
+/// derive the PR title and description from those messages alone.
+pub const PR_GENERATION_FROM_COMMITS_SYSTEM_PROMPT: &str = r#"You are a software engineer generating pull request descriptions. You will receive git history (commit messages only — no diffs) and a PR template.
+
+Your task:
+1. Analyze the commit messages to understand the intent and narrative of the change
+2. Fill out the PR template with specific information about what was changed
+3. Replace template placeholders with actual details derived from the commit messages
+
+Analysis steps:
+1. Read each commit message (subject and body) to understand the curated narrative the author has already established
+2. Determine if this is a new feature, bug fix, or other type of change from the commit subjects
+3. Fill in the template with accurate information drawn from the commit messages
+
+IMPORTANT: You will NOT receive any diffs or file-level content. The commit messages are the authoritative source of intent — trust them and use them verbatim where possible.
+
+RESPONSE FORMAT: Respond with YAML only. No explanations or markdown blocks.
+
+Structure:
+title: "Short descriptive title"
+description: |
+  Filled-in template content here
+
+Requirements:
+- Replace all template placeholders with real information from the commit messages
+- Check appropriate boxes based on the commit types (feat, fix, docs, etc.)
+- Remove template comments and instructions
+- Provide specific details from the commit messages, not from imagined diffs"#;
+
+/// Generates a `--from-commits` PR system prompt with provider-specific handling.
+///
+/// Counterpart to [`generate_pr_system_prompt_with_context_for_provider`]
+/// for the commit-message-driven path. Same project-guidelines and scopes
+/// treatment, but built on top of [`PR_GENERATION_FROM_COMMITS_SYSTEM_PROMPT`].
+pub fn generate_pr_system_prompt_from_commits_with_context_for_provider(
+    context: &crate::data::context::CommitContext,
+    provider: PromptStyle,
+) -> String {
+    let mut prompt = PR_GENERATION_FROM_COMMITS_SYSTEM_PROMPT.to_string();
+
+    // Add provider-specific template handling instructions
+    if provider == PromptStyle::Claude {
+        prompt.push_str("\n\n=== TEMPLATE HANDLING FOR CLAUDE ===");
+        prompt.push_str(
+            "\nThe PR template provided is a TEMPLATE TO FILL OUT, not literal text to copy.",
+        );
+        prompt.push_str(
+            "\nYou must REPLACE placeholder content with actual information derived from the commit messages.",
+        );
+    } else {
+        prompt.push_str("\n\n=== TEMPLATE FILLING INSTRUCTIONS ===");
+        prompt.push_str("\nThe provided PR template should be filled out with specific information about the changes.");
+        prompt.push_str(
+            "\nReplace placeholder content with actual details drawn from the commit messages:",
+        );
+        prompt.push_str(
+            "\n- Fill in the Description section with what this PR actually does (per the commits)",
+        );
+        prompt.push_str("\n- Mark the correct Type of Change checkboxes based on commit types");
+        prompt.push_str("\n- List the specific changes made in the Changes Made section");
+        prompt.push_str("\n- Remove placeholder text like '(issue_number)' and template comments");
+        prompt.push_str(
+            "\n- Replace empty bullet points with actual information from the commit subjects",
+        );
+    }
+
+    // Add project-specific PR guidelines if available
+    if let Some(pr_guidelines) = &context.project.pr_guidelines {
+        prompt.push_str("\n\n=== PROJECT PR GUIDELINES ===");
+        prompt.push_str("\nThis project has specific guidelines for pull request descriptions:");
+        prompt.push_str(&format!("\n\n{pr_guidelines}"));
+        prompt.push_str("\n\nIMPORTANT: Follow these project-specific guidelines when generating the PR description.");
+        prompt.push_str("\nUse these guidelines to inform the style, level of detail, and specific sections to emphasize.");
+    }
+
+    // Add scope information if available
+    if !context.project.valid_scopes.is_empty() {
+        let scope_names: Vec<&str> = context
+            .project
+            .valid_scopes
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        prompt.push_str(&format!(
+            "\n\nValid scopes for this project: {}",
+            scope_names.join(", ")
+        ));
+    }
+
+    prompt
+}
+
+/// Generates a `--from-commits` PR description user prompt with project context.
+///
+/// Counterpart to [`generate_pr_description_prompt_with_context`] for the
+/// commit-message-driven path. All references to "diffs" are removed; the
+/// AI is instructed to derive its description from the commit history alone.
+pub fn generate_pr_description_prompt_from_commits_with_context(
+    repo_yaml: &str,
+    pr_template: &str,
+    context: &crate::data::context::CommitContext,
+) -> String {
+    let mut prompt = format!(
+        r"Please analyze the following commit history and generate a comprehensive pull request description following the project's specific guidelines:
+
+Commit History (no diffs included — derive the PR description from these commit messages alone):
+{repo_yaml}
+
+PR Template:
+{pr_template}
+
+"
+    );
+
+    // Add project context information
+    if context.project.pr_guidelines.is_some() {
+        prompt
+            .push_str("IMPORTANT: This project has specific PR guidelines that must be followed. ");
+        prompt.push_str("Review the guidelines in the system prompt and apply them to create an appropriate PR description.\n\n");
+    }
+
+    // Add branch context if available
+    if context.branch.is_feature_branch {
+        prompt.push_str(&format!(
+            "BRANCH CONTEXT: This is {} work on '{}'. Use this context to better describe the purpose and scope.\n\n",
+            context.branch.work_type, context.branch.description
+        ));
+    }
+
+    prompt.push_str(r#"INSTRUCTIONS:
+1. **ANALYZE THE COMMIT HISTORY**: Read through every commit message (subject and body) to understand exactly what the author intended
+2. **UNDERSTAND THE OVERALL PURPOSE**: Determine what this branch accomplishes as a whole from the commit narrative
+3. **FOLLOW PROJECT GUIDELINES**: Apply any project-specific PR guidelines provided in the system prompt
+4. **GENERATE COMPREHENSIVE DESCRIPTION**: Create a clear, informative PR description that explains the changes based on the commits
+5. **USE APPROPRIATE DETAIL LEVEL**: Match the level of detail to the significance of the changes
+6. **BE SPECIFIC**: Provide concrete details about what was added, changed, or fixed based on the commit subjects and bodies
+7. **EXPLAIN VALUE**: Describe why these changes are beneficial or necessary
+8. **REPLACE PLACEHOLDERS**: Remove all placeholder text, comments, and generic content
+9. **INCLUDE ACTUAL CHANGES**: List specific bullet points of what was modified based on the commit messages — do NOT speculate about file-level details that the commits do not mention
+
+CRITICAL RESPONSE FORMAT: Respond with ONLY valid YAML content. Do not include explanatory text, markdown wrappers, or code blocks.
+
+Your response must follow this exact YAML structure:
+
+title: "Your concise PR title here"
+description: |
+  Your comprehensive PR description in markdown format here.
+  Follow project guidelines and replace all template placeholders with actual information from the commit messages.
+
+Start immediately with "title:" and provide only YAML content. The title should follow conventional commit format when appropriate and the description should be tailored to this project's standards."#);
+
+    prompt
+}
+
 /// System prompt for commit message check/validation.
 pub const CHECK_SYSTEM_PROMPT: &str = r#"You are a commit message reviewer. Your task is to evaluate commit messages against project guidelines and report violations.
 
@@ -1751,6 +1908,126 @@ mod tests {
         let prompt = generate_pr_description_prompt_with_context("yaml", "template", &context);
         assert!(prompt.contains("BRANCH CONTEXT"));
         assert!(prompt.contains("add feature"));
+    }
+
+    // ── from-commits prompt builders ───────────────────────────────
+
+    #[test]
+    fn from_commits_system_prompt_claude_branch_mentions_template_handling() {
+        let context = make_context();
+        let prompt = generate_pr_system_prompt_from_commits_with_context_for_provider(
+            &context,
+            PromptStyle::Claude,
+        );
+        assert!(prompt.contains("TEMPLATE HANDLING FOR CLAUDE"));
+        assert!(prompt.contains("REPLACE placeholder"));
+        assert!(!prompt.contains("TEMPLATE FILLING INSTRUCTIONS"));
+        // No diff references — flag is "commit-message-only" mode.
+        assert!(!prompt.contains("diff files"));
+    }
+
+    #[test]
+    fn from_commits_system_prompt_openai_branch_mentions_explicit_instructions() {
+        let context = make_context();
+        let prompt = generate_pr_system_prompt_from_commits_with_context_for_provider(
+            &context,
+            PromptStyle::OpenAi,
+        );
+        assert!(prompt.contains("TEMPLATE FILLING INSTRUCTIONS"));
+        assert!(prompt.contains("Fill in the Description section"));
+        assert!(prompt.contains("Mark the correct Type of Change"));
+        assert!(!prompt.contains("TEMPLATE HANDLING FOR CLAUDE"));
+    }
+
+    #[test]
+    fn from_commits_system_prompt_includes_pr_guidelines_when_present() {
+        let mut context = make_context();
+        context.project.pr_guidelines = Some("Always use conventional titles".to_string());
+        let prompt = generate_pr_system_prompt_from_commits_with_context_for_provider(
+            &context,
+            PromptStyle::Claude,
+        );
+        assert!(prompt.contains("PROJECT PR GUIDELINES"));
+        assert!(prompt.contains("Always use conventional titles"));
+    }
+
+    #[test]
+    fn from_commits_system_prompt_omits_guidelines_section_when_absent() {
+        let context = make_context();
+        let prompt = generate_pr_system_prompt_from_commits_with_context_for_provider(
+            &context,
+            PromptStyle::Claude,
+        );
+        assert!(!prompt.contains("PROJECT PR GUIDELINES"));
+    }
+
+    #[test]
+    fn from_commits_system_prompt_includes_scopes_when_present() {
+        let mut context = make_context();
+        context.project.valid_scopes = vec![
+            ScopeDefinition {
+                name: "cli".to_string(),
+                description: String::new(),
+                examples: Vec::new(),
+                file_patterns: Vec::new(),
+            },
+            ScopeDefinition {
+                name: "git".to_string(),
+                description: String::new(),
+                examples: Vec::new(),
+                file_patterns: Vec::new(),
+            },
+        ];
+        let prompt = generate_pr_system_prompt_from_commits_with_context_for_provider(
+            &context,
+            PromptStyle::Claude,
+        );
+        assert!(prompt.contains("Valid scopes for this project: cli, git"));
+    }
+
+    #[test]
+    fn from_commits_user_prompt_includes_yaml_and_template() {
+        let context = make_context();
+        let prompt = generate_pr_description_prompt_from_commits_with_context(
+            "commits:\n  - hash: abc",
+            "# Template",
+            &context,
+        );
+        assert!(prompt.contains("commits:\n  - hash: abc"));
+        assert!(prompt.contains("# Template"));
+        assert!(prompt.contains("Commit History"));
+        assert!(prompt.contains("no diffs included"));
+        // Branch context is populated by make_context()
+        assert!(prompt.contains("BRANCH CONTEXT"));
+        assert!(prompt.contains("add feature"));
+    }
+
+    #[test]
+    fn from_commits_user_prompt_includes_guidelines_reminder_when_present() {
+        let mut context = make_context();
+        context.project.pr_guidelines = Some("Use conventional titles".to_string());
+        let prompt =
+            generate_pr_description_prompt_from_commits_with_context("yaml", "tpl", &context);
+        assert!(prompt.contains("specific PR guidelines that must be followed"));
+    }
+
+    #[test]
+    fn from_commits_user_prompt_omits_branch_context_for_non_feature_branch() {
+        let mut context = make_context();
+        context.branch.is_feature_branch = false;
+        let prompt =
+            generate_pr_description_prompt_from_commits_with_context("yaml", "tpl", &context);
+        assert!(!prompt.contains("BRANCH CONTEXT"));
+    }
+
+    #[test]
+    fn from_commits_user_prompt_never_mentions_diffs() {
+        let context = make_context();
+        let prompt =
+            generate_pr_description_prompt_from_commits_with_context("yaml", "tpl", &context);
+        // The instruction wording must not push the model toward inventing diff details.
+        assert!(!prompt.contains("ANALYZE THE COMMITS AND DIFFS"));
+        assert!(!prompt.contains("their diff files"));
     }
 
     // ── coherence prompts ──────────────────────────────────────────

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -40,6 +40,10 @@ pub struct CreatePrCommand {
     /// Skip pushing the branch to remote before creating the PR.
     #[arg(long)]
     pub no_push: bool,
+
+    /// Use commit messages (not the diff) as the primary input for PR generation.
+    #[arg(long)]
+    pub from_commits: bool,
 }
 
 /// PR action choices.
@@ -694,11 +698,20 @@ impl CreatePrCommand {
         debug!("Context collection completed");
 
         // Generate AI-powered PR content with context
-        debug!("About to call Claude AI for PR content generation");
-        match claude_client
-            .generate_pr_content_with_context(repo_view, &pr_template, &context)
-            .await
-        {
+        debug!(
+            from_commits = self.from_commits,
+            "About to call Claude AI for PR content generation"
+        );
+        let ai_result = if self.from_commits {
+            claude_client
+                .generate_pr_content_with_context_from_commits(repo_view, &pr_template, &context)
+                .await
+        } else {
+            claude_client
+                .generate_pr_content_with_context(repo_view, &pr_template, &context)
+                .await
+        };
+        match ai_result {
             Ok(pr_content) => {
                 debug!(
                     ai_generated_title = %pr_content.title,
@@ -1383,6 +1396,7 @@ pub async fn run_create_pr(
         draft: false,
         context_dir: None,
         no_push: true,
+        from_commits: false,
     };
 
     let repo_view = cmd.generate_repository_view()?;
@@ -1409,10 +1423,16 @@ pub(crate) async fn run_create_pr_with_client(
         None => cmd.get_default_pr_template(),
     };
 
-    let pr_content = match claude_client
-        .generate_pr_content_with_context(repo_view, &pr_template, context)
-        .await
-    {
+    let ai_result = if cmd.from_commits {
+        claude_client
+            .generate_pr_content_with_context_from_commits(repo_view, &pr_template, context)
+            .await
+    } else {
+        claude_client
+            .generate_pr_content_with_context(repo_view, &pr_template, context)
+            .await
+    };
+    let pr_content = match ai_result {
         Ok(content) => content,
         Err(_e) => {
             let mut description = pr_template;
@@ -1472,6 +1492,7 @@ mod run_create_pr_tests {
             draft: false,
             context_dir: None,
             no_push: true,
+            from_commits: false,
         }
     }
 
@@ -1585,6 +1606,70 @@ mod run_create_pr_tests {
             outcome.description.contains("# Custom template"),
             "fallback description should include repo template: {}",
             outcome.description
+        );
+    }
+
+    #[tokio::test]
+    async fn run_create_pr_with_client_from_commits_omits_diff() {
+        // Write a recognisable diff payload so we can prove it never reaches
+        // the AI when from_commits is set.
+        let dir = tempfile::tempdir().unwrap();
+        let diff_path = dir.path().join("recognisable.diff");
+        std::fs::write(
+            &diff_path,
+            "diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+UNIQUE_DIFF_MARKER\n",
+        )
+        .unwrap();
+
+        let commit = CommitInfo {
+            hash: format!("{:0>40}", 0),
+            author: "Test <test@test.com>".to_string(),
+            date: chrono::Utc::now().fixed_offset(),
+            original_message: "feat: UNIQUE_COMMIT_SUBJECT_MARKER".to_string(),
+            in_main_branches: vec![],
+            analysis: CommitAnalysis {
+                detected_type: "feat".to_string(),
+                detected_scope: String::new(),
+                proposed_message: "feat: t".to_string(),
+                file_changes: FileChanges {
+                    total_files: 1,
+                    files_added: 0,
+                    files_deleted: 0,
+                    file_list: vec![],
+                },
+                diff_summary: String::new(),
+                diff_file: diff_path.to_string_lossy().to_string(),
+                file_diffs: Vec::new(),
+            },
+        };
+        let repo_view = sample_repo_view(vec![commit], None);
+        let context = CommitContext::new();
+        let mut cmd = fresh_cmd();
+        cmd.from_commits = true;
+
+        let yaml = "title: feat: x\ndescription: y\n".to_string();
+        let mock = ConfigurableMockAiClient::new(vec![Ok(yaml)]);
+        let prompt_handle = mock.prompt_handle();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        run_create_pr_with_client(&cmd, &repo_view, &context, &client)
+            .await
+            .unwrap();
+
+        let prompts = prompt_handle.prompts();
+        assert_eq!(prompts.len(), 1, "expected one AI call");
+        let (_, user_prompt) = &prompts[0];
+        assert!(
+            user_prompt.contains("UNIQUE_COMMIT_SUBJECT_MARKER"),
+            "commit subject should be in the prompt"
+        );
+        assert!(
+            !user_prompt.contains("UNIQUE_DIFF_MARKER"),
+            "diff content must NOT appear in the prompt when from_commits is set"
+        );
+        assert!(
+            !user_prompt.contains("diff --git"),
+            "diff hunks must NOT appear in the prompt when from_commits is set"
         );
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -56,6 +56,28 @@ pub struct RepositoryView<C = CommitInfo> {
 /// Enhanced repository view for AI processing with full diff content.
 pub type RepositoryViewForAI = RepositoryView<CommitInfoForAI>;
 
+/// Commit analysis stripped of all diff-related content.
+///
+/// Used by the `--from-commits` PR generation path, which drives the AI
+/// from commit messages alone. Carries only pre-computed metadata that
+/// does not require reading any diff content from disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitAnalysisFromCommits {
+    /// Automatically detected conventional commit type (feat, fix, docs, etc.).
+    pub detected_type: String,
+    /// Automatically detected scope based on file paths (cli, git, data, etc.).
+    pub detected_scope: String,
+}
+
+/// Commit information for the commit-message-driven PR path.
+pub type CommitInfoFromCommits = CommitInfo<CommitAnalysisFromCommits>;
+
+/// Repository view used by `--from-commits`.
+///
+/// Never reads diff content from disk. Each commit carries only its
+/// metadata and the curated commit message.
+pub type RepositoryViewForAiFromCommits = RepositoryView<CommitInfoFromCommits>;
+
 /// Self-describing schema metadata embedded under [`RepositoryView::explanation`].
 ///
 /// Always present. Carries prose intro text plus a per-field list so an AI consumer can
@@ -586,6 +608,72 @@ impl RepositoryViewForAI {
     }
 }
 
+impl RepositoryViewForAiFromCommits {
+    /// Converts a `RepositoryView` into the commit-message-only view.
+    ///
+    /// No diff content is read; only pre-computed analysis metadata
+    /// (`detected_type`, `detected_scope`) is retained alongside the
+    /// commit hash, author, date, and message.
+    ///
+    /// The schema-documentation [`FieldExplanation`] is stripped here:
+    /// the default explanation lists diff-related field names (e.g.
+    /// `commits[].analysis.diff_file`) that this view never carries,
+    /// and the user prompt explicitly tells the AI what shape the
+    /// payload has — leaving the documentation in would be misleading.
+    #[must_use]
+    pub fn from_repository_view(repo_view: RepositoryView) -> Self {
+        #[allow(clippy::unwrap_used)] // Conversion is infallible.
+        let mut view: Self = repo_view
+            .map_commits(|c| {
+                Ok(CommitInfo {
+                    hash: c.hash,
+                    author: c.author,
+                    date: c.date,
+                    original_message: c.original_message,
+                    in_main_branches: c.in_main_branches,
+                    analysis: CommitAnalysisFromCommits {
+                        detected_type: c.analysis.detected_type,
+                        detected_scope: c.analysis.detected_scope,
+                    },
+                })
+            })
+            .unwrap();
+        view.explanation = FieldExplanation {
+            text: String::new(),
+            fields: Vec::new(),
+        };
+        view
+    }
+
+    /// Creates a minimal view containing a single commit for split dispatch.
+    ///
+    /// Mirrors [`RepositoryView::single_commit_view`] but for the
+    /// commit-message-only payload used by `--from-commits`.
+    #[must_use]
+    pub(crate) fn single_commit_view_from_commits(&self, commit: &CommitInfoFromCommits) -> Self {
+        Self {
+            versions: None,
+            explanation: FieldExplanation {
+                text: String::new(),
+                fields: Vec::new(),
+            },
+            working_directory: WorkingDirectoryInfo {
+                clean: true,
+                untracked_changes: Vec::new(),
+            },
+            remotes: Vec::new(),
+            ai: AiInfo {
+                scratch: String::new(),
+            },
+            branch_info: self.branch_info.clone(),
+            pr_template: None,
+            pr_template_location: None,
+            branch_prs: None,
+            commits: vec![commit.clone()],
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -893,6 +981,53 @@ mod tests {
         // branch_info IS preserved (for scope context)
         assert!(single.branch_info.is_some());
         assert_eq!(single.branch_info.unwrap().branch, "feature/test");
+    }
+
+    // ── RepositoryViewForAiFromCommits ───────────────────────────────
+
+    #[test]
+    fn from_commits_view_preserves_commit_messages() {
+        let mut view = make_repo_view(vec![make_commit_info("aaa"), make_commit_info("bbb")]);
+        view.commits[0].original_message = "feat: alpha\n\nbody line".to_string();
+        view.commits[1].original_message = "fix: beta".to_string();
+
+        let commits_view = RepositoryViewForAiFromCommits::from_repository_view(view);
+
+        assert_eq!(commits_view.commits.len(), 2);
+        assert_eq!(commits_view.commits[0].hash, "aaa");
+        assert_eq!(
+            commits_view.commits[0].original_message,
+            "feat: alpha\n\nbody line"
+        );
+        assert_eq!(commits_view.commits[1].original_message, "fix: beta");
+        assert_eq!(commits_view.commits[0].analysis.detected_type, "feat");
+        assert_eq!(commits_view.commits[1].analysis.detected_type, "feat"); // make_commit_info hard-codes feat
+    }
+
+    #[test]
+    fn from_commits_view_serialization_contains_no_diff_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let diff_path = dir.path().join("0.diff");
+        std::fs::write(&diff_path, "diff --git a/x b/x\n@@ -1 +1 @@\n-old\n+new\n").unwrap();
+
+        let mut commit = make_commit_info("aaa");
+        commit.original_message = "feat(test): unique-commit-subject-marker".to_string();
+        commit.analysis.diff_file = diff_path.to_string_lossy().to_string();
+        commit.analysis.diff_summary = "x | 1 +".to_string();
+
+        let view = make_repo_view(vec![commit]);
+        let commits_view = RepositoryViewForAiFromCommits::from_repository_view(view);
+        let yaml = yaml::to_yaml(&commits_view).unwrap();
+
+        // Commit narrative IS present
+        assert!(yaml.contains("unique-commit-subject-marker"));
+        // Diff-related fields are NOT
+        assert!(!yaml.contains("diff --git"));
+        assert!(!yaml.contains("diff_content"));
+        assert!(!yaml.contains("diff_file"));
+        assert!(!yaml.contains("diff_summary"));
+        assert!(!yaml.contains("file_changes"));
+        assert!(!yaml.contains("file_diffs"));
     }
 
     // ── FieldExplanation::default ────────────────────────────────────

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2596,6 +2596,7 @@ Options:
       --draft                      Creates PR as draft (overrides default)
       --context-dir <CONTEXT_DIR>  Path to custom context directory (defaults to .omni-dev/)
       --no-push                    Skip pushing the branch to remote before creating the PR
+      --from-commits               Use commit messages (not the diff) as the primary input for PR generation
   -h, --help                       Print help
 
 


### PR DESCRIPTION
## Description

This PR adds a `--from-commits` flag to `omni-dev git branch create pr` that drives AI-powered PR description generation from commit messages alone, without reading or sending any diff content to the AI. This is faster and cheaper for branches whose commits already carry a well-crafted narrative — the AI derives the PR title and description entirely from the curated commit history rather than from file-level diff bytes.

The implementation introduces a parallel data path (`RepositoryViewForAiFromCommits`) and matching Claude client methods and prompts that mirror the existing diff-driven pipeline but deliberately omit all diff fields.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #899

## Changes Made

**Data Layer (`src/data.rs`):**
- Added `CommitAnalysisFromCommits` struct carrying only `detected_type` and `detected_scope` (no diff fields)
- Added `CommitInfoFromCommits` and `RepositoryViewForAiFromCommits` type aliases for the diff-free payload shape
- Implemented `RepositoryViewForAiFromCommits::from_repository_view` to convert a full `RepositoryView` into the stripped form, clearing the `FieldExplanation` so stale diff-field docs are not forwarded to the AI
- Implemented `single_commit_view_from_commits` for per-commit split dispatch when the combined message payload exceeds the token budget

**Claude Client (`src/claude/client.rs`):**
- Generalised `try_full_diff_budget` with a `V: serde::Serialize` bound so it can serve both the diff-driven and commit-driven paths
- Added `generate_pr_content_with_context_from_commits` public method: builds the commit-message-only payload, attempts full-view dispatch, falls back to per-commit split + merge when the budget is exceeded
- Added `generate_pr_content_for_commit_from_commits` private helper for the per-commit split leg; surfaces a clear error if a single commit message is itself too large rather than silently truncating

**Claude Prompts (`src/claude/prompts.rs`):**
- Added `PR_GENERATION_FROM_COMMITS_SYSTEM_PROMPT` constant instructing the AI that no diffs are present and commit messages are the authoritative source of intent
- Added `generate_pr_system_prompt_from_commits_with_context_for_provider` with provider-specific template-filling instructions and project-scope injection
- Added `generate_pr_description_prompt_from_commits_with_context` user prompt builder that explicitly excludes diff references

**CLI (`src/cli/git/create_pr.rs`):**
- Added `--from-commits` boolean flag to `CreatePrCommand`
- Routed `generate_pr_content_with_context_from_commits` vs the default `generate_pr_content_with_context` based on the flag in both `run_create_pr` and `run_create_pr_with_client`

**Documentation (`docs/user-guide.md`):**
- Documented `--from-commits` flag in the options table
- Added usage example showing the commit-driven workflow

**Testing:**
- Added `generate_pr_content_with_context_from_commits_succeeds` — happy path for the new client method
- Added `generate_pr_content_with_context_from_commits_omits_diff_in_prompt` — verifies diff markers never appear in the AI prompt
- Added `generate_pr_content_with_context_default_mode_includes_diff_in_prompt` — regression guard ensuring the default path still serialises diff content
- Added `generate_pr_content_with_context_from_commits_multi_commit_per_commit_dispatch` — exercises the budget-exceeded fallback with two large-message commits
- Added `run_create_pr_with_client_from_commits_omits_diff` — end-to-end CLI-level test confirming diff content is absent when the flag is set
- Updated help-output snapshot to include `--from-commits`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (budget-exceeded fallback, single oversized commit message)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified — default behaviour (without `--from-commits`) is unchanged and regression-guarded by `generate_pr_content_with_context_default_mode_includes_diff_in_prompt`

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh

# Run only the new from-commits tests
cargo test from_commits
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — new parallel data path (`RepositoryViewForAiFromCommits`) alongside existing `RepositoryViewForAI`; confirm the abstraction boundary is clean
- [x] Error handling — per-commit fallback and the "single commit too large" error path in `generate_pr_content_for_commit_from_commits`
- [ ] Security implications
- [x] Performance impact — this path intentionally avoids reading diff files from disk, so it should be measurably faster on large branches
- [ ] User experience
- [x] Backward compatibility

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Performance improvement: the `--from-commits` path never reads diff files from disk and sends significantly fewer bytes to the AI API, reducing both latency and token cost for branches with well-crafted commit messages.

## Security Considerations
- [x] No security implications — the new path sends *less* data to the external AI API than the default path.

## Breaking Changes
None. The `--from-commits` flag is opt-in; all existing behaviour is unchanged.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `--from-commits` path could be made the default when all commits on the branch already have conventional-commit subjects, avoiding the need to pass the flag explicitly.

**Known Limitations:**
- If a single commit message is pathologically large (exceeds the per-commit token budget), the tool surfaces a clear error rather than silently truncating. This is intentional.

**Alternatives Considered:**
- Truncating oversized commit messages instead of erroring: rejected because silent truncation would produce misleading PR descriptions.
- Reusing the existing diff-driven prompt with an empty diff payload: rejected because the system prompt explicitly tells the AI to look for diff files, which would be confusing and produce lower-quality output.