### PR TITLE
docs(website): add browser bridge demo and tutorial tab

### DIFF
--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -250,3 +250,54 @@ p code, li code {
     }
   }
 }
+
+// Mock DevTools console used in place of a screenshot for the browser-bridge
+// demo tab (there is no static artefact to photograph for that workflow).
+.console-shot {
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e5e5;
+
+  .console-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    background: #ebebeb;
+    border-bottom: 1px solid #dcdcdc;
+  }
+
+  .console-dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+
+    &.dot-red { background: #ff5f56; }
+    &.dot-amber { background: #ffbd2e; }
+    &.dot-green { background: #27c93f; }
+  }
+
+  .console-title {
+    margin-left: 0.4rem;
+    font-size: 0.78rem;
+    color: #555;
+  }
+
+  .console-body {
+    margin: 0;
+    padding: 0.9rem 1rem;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    border-radius: 0;
+
+    .c-prompt { color: #6a9955; }
+    .c-reply  { color: #808080; }
+    .c-dim    { color: #9aa0a6; }
+    .c-ok     { color: #4ec9b0; }
+    .c-200    { color: #b5cea8; }
+  }
+}

--- a/website/static/demo-browser.cast
+++ b/website/static/demo-browser.cast
@@ -1,0 +1,11 @@
+{"version": 2, "width": 100, "height": 32, "timestamp": 1779550900, "idle_time_limit": 1.5, "command": "bash browser/demo.sh", "env": {"SHELL": "/bin/zsh"}}
+[0.025, "o", "\u001b[1;36m$\u001b[0m omni-dev browser bridge serve &\r\n"]
+[0.55, "o", "omni-dev browser bridge  ·  control \u001b[33m127.0.0.1:9998\u001b[0m  ·  ws \u001b[33m127.0.0.1:9999\u001b[0m\r\n"]
+[0.7, "o", "   session token exported to \u001b[33mOMNI_BRIDGE_TOKEN\u001b[0m\r\n   → paste the printed snippet into the DevTools console on your authenticated tab\r\n"]
+[2.1, "o", "\u001b[32m✓\u001b[0m tab connected  (id 1, https://grafana.internal)\r\n\r\n"]
+[2.4, "o", "\u001b[1;36m$\u001b[0m omni-dev browser bridge request --url /api/datasources | jq '.status, (.body|fromjson)'\r\n"]
+[3.6, "o", "200\r\n[\r\n  {\r\n    \"type\": \"loki\",\r\n    \"uid\": \"P8E80F9AEF\"\r\n  }\r\n]\r\n\r\n"]
+[4.2, "o", "\u001b[1;36m$\u001b[0m omni-dev browser bridge request \\\r\n    --url '/api/datasources/proxy/uid/P8E80F9AEF/loki/api/v1/labels' | jq '.body|fromjson|.data'\r\n"]
+[5.6, "o", "[\r\n  \"app\",\r\n  \"level\",\r\n  \"namespace\",\r\n  \"pod\"\r\n]\r\n\r\n"]
+[6.2, "o", "\u001b[90m# same-origin, fully authenticated — the bridge never saw the session cookie\u001b[0m\r\n"]
+[8.2, "o", ""]

--- a/website/static/tutorial.html
+++ b/website/static/tutorial.html
@@ -66,7 +66,8 @@
     #tab-jira:checked       ~ .tab-bar label[for="tab-jira"],
     #tab-confluence:checked ~ .tab-bar label[for="tab-confluence"],
     #tab-pr:checked         ~ .tab-bar label[for="tab-pr"],
-    #tab-twiddle:checked    ~ .tab-bar label[for="tab-twiddle"] {
+    #tab-twiddle:checked    ~ .tab-bar label[for="tab-twiddle"],
+    #tab-browser:checked    ~ .tab-bar label[for="tab-browser"] {
       background: white;
       color: var(--accent);
       border-color: var(--border);
@@ -75,7 +76,8 @@
     #tab-jira:checked       ~ #content-jira,
     #tab-confluence:checked ~ #content-confluence,
     #tab-pr:checked         ~ #content-pr,
-    #tab-twiddle:checked    ~ #content-twiddle { display: block; }
+    #tab-twiddle:checked    ~ #content-twiddle,
+    #tab-browser:checked    ~ #content-browser { display: block; }
 
     h2 { margin-top: 32px; font-size: 20px; border-bottom: 1px solid var(--border); padding-bottom: 6px; }
     h3 { margin-top: 24px; font-size: 16px; }
@@ -270,8 +272,8 @@
 <body>
 
 <header>
-  <h1>omni-dev — Atlassian, PRs, and commits in four tabs</h1>
-  <p>A tutorial covering the four primary omni-dev workflows. Switch tabs to navigate.</p>
+  <h1>omni-dev — Atlassian, PRs, commits, and the browser bridge in five tabs</h1>
+  <p>A tutorial covering the five primary omni-dev workflows. Switch tabs to navigate.</p>
 </header>
 
 <div class="container">
@@ -280,12 +282,14 @@
     <input type="radio" name="tab" id="tab-confluence">
     <input type="radio" name="tab" id="tab-pr">
     <input type="radio" name="tab" id="tab-twiddle">
+    <input type="radio" name="tab" id="tab-browser">
 
     <div class="tab-bar">
       <label for="tab-jira">JIRA</label>
       <label for="tab-confluence">Confluence</label>
       <label for="tab-pr">Create PRs</label>
       <label for="tab-twiddle">Twiddle commit messages</label>
+      <label for="tab-browser">Browser bridge</label>
     </div>
 
     <!-- ====================== JIRA TAB ====================== -->
@@ -1209,6 +1213,245 @@ Apply rewrite? [y/N] y
 omni-dev git commit message twiddle --range HEAD~5..HEAD \
   &amp;&amp; git push --force-with-lease \
   &amp;&amp; omni-dev git branch create pr --draft</pre>
+    </section>
+
+    <!-- ====================== BROWSER BRIDGE TAB ====================== -->
+    <section class="tab-content" id="content-browser">
+      <h2>Browser bridge — drive authenticated requests through a logged-in tab</h2>
+
+      <p>
+        <code>omni-dev browser bridge serve</code> runs a long-lived local
+        process that lets you issue HTTP requests <strong>through an
+        authenticated browser tab</strong>. When you are poking at internal
+        services — Grafana/Loki, SSO-gated dashboards, admin panels — the
+        browser already holds sessions (SSO, OAuth, session cookies) that are
+        painful to replicate from a script. The bridge borrows that authority
+        <em>without exfiltrating the cookies or tokens</em>: the <code>fetch()</code>
+        runs in-page, so the credentials never leave the browser.
+      </p>
+
+      <div class="panel panel-warn">
+        <div class="panel-title">⚠️ Confused deputy by design</div>
+        The bridge lends the browser&apos;s authority to whoever can talk to it.
+        That makes the <strong>security model the load-bearing part of the
+        design</strong>, not an add-on — both planes are authenticated and
+        default-closed. The rationale lives in
+        <a href="https://github.com/rust-works/omni-dev/blob/main/docs/adrs/adr-0036.md">ADR-0036</a>;
+        the operator guide is
+        <a href="https://github.com/rust-works/omni-dev/blob/main/docs/browser-bridge.md">docs/browser-bridge.md</a>.
+      </div>
+
+      <h3>How it works</h3>
+
+      <p>
+        Two local planes joined by an <code>id</code>-keyed correlator: an HTTP
+        control plane you drive from the shell, and a WebSocket plane the browser
+        tab connects to.
+      </p>
+
+      <span class="lang-tag">request flow</span>
+<pre>   operator CLI / authorized script             browser tab (DevTools console)
+              │                                          │
+   HTTP + bearer token + X-Omni-Bridge      WebSocket + token subprotocol
+              │                                          │
+              ▼                                          ▼
+  ┌──────────────────────── omni-dev browser bridge ────────────────────────┐
+  │   HTTP control plane            id-correlator           WebSocket plane  │
+  │   127.0.0.1:9998      ──►   pending: id → oneshot   ──►   127.0.0.1:9999 │
+  │   (axum)              ◄──   resolve on WS reply     ◄──   (tungstenite)  │
+  └─────────────────────────────────────────────────────────────────────────┘</pre>
+
+      <p>
+        A request flows: <strong>control plane (authenticated) → assign
+        <code>id</code> + register a waiter → serialize a command frame →
+        WebSocket → browser <code>fetch()</code> → response frame → correlator
+        resolves the waiter by <code>id</code> → control plane returns the HTTP
+        response.</strong>
+      </p>
+
+      <h3>The basic loop</h3>
+
+      <div class="step">
+        <span class="step-num">1</span><strong>Start the bridge.</strong> It prints
+        the bound ports, a generated session token, and a ready-to-paste JS snippet.
+        <pre>omni-dev browser bridge serve</pre>
+      </div>
+
+      <div class="step">
+        <span class="step-num">2</span><strong>Paste the snippet</strong> into the
+        DevTools console on the authenticated tab (e.g.
+        <code>https://grafana.internal/…</code>). It connects over the WebSocket,
+        presenting the token via the subprotocol, and reconnects with backoff.
+      </div>
+
+      <div class="step">
+        <span class="step-num">3</span><strong>Drive requests</strong> from your
+        shell. The token is in the bridge&apos;s stdout.
+        <pre>export OMNI_BRIDGE_TOKEN=&lt;token printed by the bridge&gt;
+omni-dev browser bridge request --url /loki/api/v1/labels</pre>
+      </div>
+
+      <p class="muted">
+        The bridge works only while the tab is open and the snippet is running.
+      </p>
+
+      <h3>Two ways to issue a request</h3>
+
+      <h4>The <code>request</code> thin client</h4>
+      <p>
+        Reads the token (from <code>OMNI_BRIDGE_TOKEN</code> or
+        <code>--token-file</code>), adds the required headers, POSTs to a
+        <em>running</em> bridge, and prints the response envelope:
+      </p>
+<pre>omni-dev browser bridge request --url /loki/api/v1/labels --method GET
+omni-dev browser bridge request --url /api/foo --method POST --body @payload.json
+omni-dev browser bridge request --url /api/foo --header "Accept: application/json"
+omni-dev browser bridge request --stream --url /events | your-consumer   # SSE / chunked</pre>
+
+      <h4>The transparent proxy</h4>
+      <p>
+        Any control-plane path <em>not</em> under <code>/__bridge/</code> is
+        forwarded verbatim to the browser, resolved against the page&apos;s origin.
+        Handy with <code>curl</code> — binary bodies are decoded automatically:
+      </p>
+<pre>T="$OMNI_BRIDGE_TOKEN"
+curl -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
+  http://localhost:9998/loki/api/v1/labels</pre>
+
+      <div class="panel panel-info">
+        <div class="panel-title">ℹ️ The two mandatory headers</div>
+        Every control-plane request must carry
+        <code>Authorization: Bearer &lt;token&gt;</code> <strong>and</strong>
+        <code>X-Omni-Bridge: 1</code>. The custom header forces a CORS preflight
+        that the server refuses to answer — which is exactly what blocks
+        simple-request CSRF from a random web page.
+      </div>
+
+      <h3>Routing to a specific tab</h3>
+
+      <p>
+        Paste the snippet into several authenticated tabs (e.g. a Grafana tab
+        <em>and</em> an admin tab) and each connects independently.
+        <code>GET /__bridge/status</code> lists them by connection <strong>id</strong>
+        and <code>Origin</code>; select one with <code>--target</code> (or the
+        <code>X-Omni-Bridge-Target</code> header):
+      </p>
+<pre>omni-dev browser bridge request --target 2 --url /api/foo                 # by id
+omni-dev browser bridge request --target https://admin.internal --url /x  # by origin</pre>
+
+      <table>
+        <thead><tr><th>Situation</th><th>Result</th></tr></thead>
+        <tbody>
+          <tr><td>No tab connected</td><td><code>503</code></td></tr>
+          <tr><td>Exactly one tab, no target</td><td>Routes to it (v1 back-compat)</td></tr>
+          <tr><td>Several tabs, no target</td><td><code>409</code> — specify a target (the error lists the tabs)</td></tr>
+          <tr><td>Target id / origin matches one tab</td><td>Routes to it</td></tr>
+          <tr><td>Target matches none</td><td><code>404</code></td></tr>
+          <tr><td>Target origin matches several tabs</td><td><code>409</code> — target by connection id instead</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Security model</h3>
+
+      <p>
+        The trust boundary, stated once: <strong>a request is trusted only if it
+        presents the session token AND is not a cross-origin browser request;
+        everything else is denied.</strong> A localhost bind is necessary but not
+        sufficient — it stops off-host access, not other local processes or the web
+        pages you visit while the bridge runs.
+      </p>
+
+      <div class="panel panel-success">
+        <div class="panel-title">✅ Session token — mandatory on both planes</div>
+        Generated at startup and printed with the snippet; <strong>never</strong>
+        accepted as a CLI argument (argv is world-readable via <code>ps</code>).
+        The control plane requires <code>Authorization: Bearer</code>; the WebSocket
+        upgrade is rejected without the token in its subprotocol. An
+        unauthenticated peer can never connect or evict the browser connection.
+      </div>
+
+      <div class="panel panel-info">
+        <div class="panel-title">ℹ️ Anti-CSRF / anti-DNS-rebinding (all enforced)</div>
+        <strong>Host allowlist</strong> — only <code>localhost</code>/<code>127.0.0.1</code>/<code>[::1]</code>
+        accepted (blocks DNS rebinding). <strong>Reject browser-originated
+        requests</strong> — any <code>Origin</code> header or
+        <code>Sec-Fetch-Site: cross-site</code>/<code>same-site</code> is denied.
+        <strong>Require <code>X-Omni-Bridge: 1</code></strong> on every request.
+        No CORS allow headers; <code>OPTIONS</code> is never answered.
+      </div>
+
+      <div class="panel panel-warn">
+        <div class="panel-title">⚠️ Outbound scope — default-closed</div>
+        The in-page snippet is <strong>not trusted</strong> to scope requests; the
+        server enforces scope before sending the command. <strong>Relative URLs
+        only by default</strong> (resolved against the page origin). Absolute /
+        cross-origin URLs are rejected unless explicitly enabled with
+        <code>serve --allow-origin &lt;url&gt;</code>, or per-request with
+        <code>request --allow-origin &lt;url&gt;</code> (logged with a WARN, and
+        still bounded by the browser&apos;s own CORS).
+      </div>
+
+      <h3>Worked example: draining Grafana / Loki logs</h3>
+
+      <p>
+        The bridge issues the same same-origin requests the Grafana UI makes,
+        carrying the <code>grafana_session</code> cookie; CSRF passes because the
+        <code>fetch()</code> runs in-page. Pagination is client-side — walk the
+        window backward until a page comes back empty:
+      </p>
+
+      <span class="lang-tag">bash — drain loop</span>
+<pre>DS_UID=&lt;loki-datasource-uid&gt;
+QUERY='{app="foo"}|="error"'
+END=$(date +%s)000000000   # now, in nanoseconds
+LIMIT=5000
+
+while :; do
+  page=$(omni-dev browser bridge request \
+    --url "/api/datasources/proxy/uid/${DS_UID}/loki/api/v1/query_range?query=${QUERY}&amp;end=${END}&amp;limit=${LIMIT}&amp;direction=backward")
+
+  # The upstream JSON is the envelope's `body` string; parse it once.
+  body=$(printf '%s' "$page" | jq -r '.body')
+
+  rows=$(printf '%s' "$body" | jq '[.data.result[].values[]] | length')
+  [ "$rows" -eq 0 ] &amp;&amp; break
+
+  printf '%s\n' "$body"   # collect / process this page
+
+  # Oldest timestamp on this page (ns) becomes the next `end`, minus 1ns.
+  oldest=$(printf '%s' "$body" | jq -r '[.data.result[].values[][0] | tonumber] | min')
+  END=$((oldest - 1))
+done</pre>
+
+      <p class="muted">
+        Each page must still fit under <code>--max-body-bytes</code>. For genuinely
+        streaming endpoints (Grafana Live, SSE, chunked APIs), opt into
+        <code>--stream</code> instead of paginating.
+      </p>
+
+      <h3>Flags worth knowing</h3>
+
+      <table>
+        <thead><tr><th>Flag (on <code>serve</code>)</th><th>Default</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td><code>--control-port &lt;PORT&gt;</code></td><td><code>9998</code></td><td>HTTP control-plane port. <code>0</code> binds a random free port.</td></tr>
+          <tr><td><code>--ws-port &lt;PORT&gt;</code></td><td><code>9999</code></td><td>WebSocket-plane port. <code>0</code> binds a random free port.</td></tr>
+          <tr><td><code>--allow-origin &lt;URL&gt;</code></td><td>—</td><td>Permit this exact cross-origin for the WS upgrade and outbound URLs.</td></tr>
+          <tr><td><code>--request-timeout &lt;SECS&gt;</code></td><td><code>30</code></td><td>Per-request timeout before the control plane returns <code>504</code>.</td></tr>
+          <tr><td><code>--max-body-bytes &lt;N&gt;</code></td><td><code>8388608</code></td><td>Maximum browser response body size accepted.</td></tr>
+          <tr><td><code>--max-concurrent &lt;N&gt;</code></td><td><code>64</code></td><td>Maximum concurrent in-flight requests.</td></tr>
+          <tr><td><code>--token-file &lt;PATH&gt;</code></td><td>—</td><td>Read the token from a <code>0600</code> file instead of generating one.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="panel panel-note">
+        <div class="panel-title">📝 Caveats</div>
+        A strict CSP <code>connect-src</code> can block the WebSocket. CORS
+        constrains the in-page <code>fetch()</code>, not the bridge: same-origin
+        (relative URLs) is unaffected; cross-origin targets depend on their
+        <code>Access-Control-Allow-Origin</code>. The bridge works only while the
+        tab is open and the snippet is running.
+      </div>
     </section>
   </div>
 </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -21,6 +21,7 @@
     <li><strong>Safe amendments</strong> &mdash; improve single or batched commit messages with working-directory validation.</li>
     <li><strong>PR creation</strong> &mdash; generate complete pull request descriptions in one command.</li>
     <li><strong>Atlassian integration</strong> &mdash; read and write Jira issues and Confluence pages, with JFM &harr; ADF conversion.</li>
+    <li><strong>Browser bridge</strong> &mdash; drive authenticated HTTP requests through a logged-in browser tab without exfiltrating its cookies or tokens.</li>
     <li><strong>MCP server</strong> &mdash; drop omni-dev's capabilities into Claude Code via the bundled MCP binary.</li>
   </ul>
 </section>
@@ -40,7 +41,7 @@
 <section id="demo" class="demo-wide">
   <h2>Demo</h2>
   <p class="demo-caption">
-    Four short asciicasts &mdash; each paired with the artefact it produces.
+    Five short asciicasts &mdash; each paired with the artefact it produces.
     The source for every cast lives at
     <a href="https://github.com/rust-works/omni-dev-demo">rust-works/omni-dev-demo</a>.
   </p>
@@ -50,6 +51,7 @@
     <button class="tab"           role="tab" id="tab-confluence" aria-selected="false" aria-controls="panel-confluence" data-tab="confluence" tabindex="-1">Confluence</button>
     <button class="tab"           role="tab" id="tab-pr"         aria-selected="false" aria-controls="panel-pr"         data-tab="pr"         tabindex="-1">Create PR</button>
     <button class="tab"           role="tab" id="tab-twiddle"    aria-selected="false" aria-controls="panel-twiddle"    data-tab="twiddle"    tabindex="-1">Twiddle commits</button>
+    <button class="tab"           role="tab" id="tab-browser"    aria-selected="false" aria-controls="panel-browser"    data-tab="browser"    tabindex="-1">Browser bridge</button>
   </div>
 
   <div class="tab-panel is-active" role="tabpanel" id="panel-jira" aria-labelledby="tab-jira" data-panel="jira">
@@ -131,6 +133,42 @@
       </div>
     </div>
   </div>
+
+  <div class="tab-panel" role="tabpanel" id="panel-browser" aria-labelledby="tab-browser" data-panel="browser" hidden>
+    <p class="panel-caption">
+      <code>omni-dev browser bridge serve</code> runs a local server that drives
+      <code>fetch()</code> calls <em>inside</em> an authenticated browser tab &mdash;
+      so requests carry the tab&apos;s SSO session, but the cookies and tokens never
+      leave the browser. Here it pulls a Loki datasource and its labels straight out
+      of a logged-in Grafana, with no API keys to manage. A <em>confused deputy by
+      design</em>; the <a href="https://github.com/rust-works/omni-dev/blob/main/docs/browser-bridge.md">security model</a>
+      is the load-bearing part.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-cast"><div id="cast-browser" class="asciinema-player-wrap"></div></div>
+      <div class="demo-renders">
+        <figure>
+          <div class="console-shot" aria-label="DevTools console on the authenticated Grafana tab">
+            <div class="console-bar">
+              <span class="console-dot dot-red"></span>
+              <span class="console-dot dot-amber"></span>
+              <span class="console-dot dot-green"></span>
+              <span class="console-title">grafana.internal &mdash; DevTools &rsaquo; Console</span>
+            </div>
+<pre class="console-body"><span class="c-prompt">&gt;</span> <span class="c-dim">(async () =&gt; { /* omni-dev bridge snippet */ })()</span>
+<span class="c-reply">&lt; Promise {&lt;pending&gt;}</span>
+<span class="c-ok">[omni-bridge]</span> connected to ws://127.0.0.1:9999
+<span class="c-ok">[omni-bridge]</span> authenticated &middot; origin https://grafana.internal
+<span class="c-dim">[omni-bridge]</span> GET /api/datasources &rarr; <span class="c-200">200</span> (1 datasource)
+<span class="c-dim">[omni-bridge]</span> GET &hellip;/loki/api/v1/labels &rarr; <span class="c-200">200</span> (4 labels)</pre>
+          </div>
+          <figcaption>The pasted snippet runs in-page, so every request inherits the tab&apos;s
+            <code>grafana_session</code> cookie and passes CSRF &mdash; while the bridge
+            process only ever sees the response bodies, never the credentials.</figcaption>
+        </figure>
+      </div>
+    </div>
+  </div>
 </section>
 {% endblock %}
 
@@ -141,7 +179,8 @@
       jira:       '{{ get_url(path="demo-jira.cast") }}',
       confluence: '{{ get_url(path="demo-confluence.cast") }}',
       pr:         '{{ get_url(path="demo-pr.cast") }}',
-      twiddle:    '{{ get_url(path="demo-twiddle.cast") }}'
+      twiddle:    '{{ get_url(path="demo-twiddle.cast") }}',
+      browser:    '{{ get_url(path="demo-browser.cast") }}'
     };
     const players = {};
 


### PR DESCRIPTION
## Description

This PR surfaces the browser bridge feature on the omni-dev.john-ky.io website by adding a fifth demo tab and a comprehensive tutorial section. The browser bridge allows developers to issue authenticated HTTP requests through a logged-in browser tab without exfiltrating session cookies or tokens — the `fetch()` runs in-page, so credentials never leave the browser. This change brings the website in line with the existing browser-bridge documentation in `docs/browser-bridge.md` and ADR-0036.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Implements content from [docs/browser-bridge.md](https://github.com/rust-works/omni-dev/blob/main/docs/browser-bridge.md) and [ADR-0036](https://github.com/rust-works/omni-dev/blob/main/docs/adrs/adr-0036.md).

## Changes Made

**Website Demo Page (`website/templates/index.html`):**
- Added a fifth "Browser bridge" tab button to the demo tab-bar
- Added `panel-browser` tab panel with a descriptive caption explaining the confused-deputy model and security approach
- Added mock DevTools console figure (`console-shot`) showing the bridge connecting and executing two authenticated Loki requests — used in place of a static screenshot, since no artifact exists for this workflow
- Registered `demo-browser.cast` in the asciinema player map
- Updated the feature-list bullet with a "Browser bridge" entry
- Updated the demo caption from "Four short asciicasts" to "Five short asciicasts"

**Tutorial Page (`website/static/tutorial.html`):**
- Added `tab-browser` radio input and tab-bar label
- Updated CSS selectors to include `#tab-browser:checked` for active-tab styling and content visibility
- Updated page `<h1>` and subtitle to reference five workflows
- Added a full "Browser bridge" `<section id="content-browser">` covering:
  - Overview of the confused-deputy design and why credentials never leave the browser
  - Architecture diagram showing the HTTP control plane, id-correlator, and WebSocket plane
  - Step-by-step basic loop (start bridge → paste snippet → drive requests)
  - Both request mechanisms: the `request` thin client and the transparent proxy
  - Tab routing semantics and a routing-result table (503 / 409 / 404 / 200 cases)
  - Security model summary panel (session token, anti-CSRF, anti-DNS-rebinding, outbound scope)
  - Worked Grafana/Loki drain-loop example with paginated bash script
  - `serve` flags reference table (`--control-port`, `--ws-port`, `--allow-origin`, `--request-timeout`, `--max-body-bytes`, `--max-concurrent`, `--token-file`)
  - Caveats panel (CSP, CORS, tab lifecycle)

**Placeholder Asciicast (`website/static/demo-browser.cast`):**
- New asciinema v2 cast file simulating: bridge startup → tab connect → two authenticated Loki requests (`/api/datasources` and `/loki/api/v1/labels`)
- Styled in the same format as the existing casts; intended to be swapped for a real recording later

**Styles (`website/sass/style.scss`):**
- Added `.console-shot` component styles for the mock DevTools console preview used in the browser-bridge demo panel
- Includes `.console-bar`, `.console-dot` (red/amber/green), `.console-title`, and `.console-body` with VS Code Dark+ colour tokens (`.c-prompt`, `.c-reply`, `.c-dim`, `.c-ok`, `.c-200`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation/HTML changes — no automated tests applicable)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios — browser bridge tab renders correctly alongside the four existing tabs
- [x] Tested error/edge cases — tab switching CSS selectors verified to not break existing tabs
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified — all four existing demo and tutorial tabs unaffected

### Test Commands
```bash
# Build the website (Zola)
cd website && zola build

# Serve locally and verify all five tabs
cd website && zola serve
# Then open http://localhost:1111 and check:
#   - "Browser bridge" tab appears in both the Demo and Tutorial sections
#   - Asciicast plays in the demo panel
#   - Mock DevTools console renders correctly
#   - Existing tabs (JIRA, Confluence, Create PR, Twiddle commits) are unaffected
```

## Screenshots/Recordings

The mock DevTools console in the browser-bridge demo panel renders as a styled `<pre>` block with macOS-style traffic-light dots, simulating the output of the in-page snippet connecting to `grafana.internal` and executing two authenticated GET requests.

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications — the tutorial accurately describes the security model (token auth, anti-CSRF headers, DNS-rebinding protection, outbound scope enforcement)
- [ ] User experience — the mock DevTools console (`console-shot`) is the only non-asciicast artefact among the five demo panels; reviewers should assess whether it reads clearly enough as a placeholder
- [x] Backward compatibility — CSS selector changes in `tutorial.html` extend existing selectors rather than replacing them

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — documentation only)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications — this PR only adds website documentation; the browser bridge implementation itself is unchanged. The tutorial accurately documents the existing security model.

## Breaking Changes

None. This is a purely additive documentation change with no effect on existing functionality.

## Deployment Notes
- [x] No special deployment requirements — static site rebuild only.

## Additional Notes

**Future Enhancements:**
- Replace `demo-browser.cast` with a real recording once a suitable environment is available.
- Consider adding a screenshot of a real DevTools console in place of the styled mock once a recording exists.

**Known Limitations:**
- `demo-browser.cast` is a synthesized/placeholder recording. The cast timestamps and output are representative but not captured from a live session.
- The mock DevTools console (`console-shot`) diverges slightly from the asciicast format used for the other four demo panels; a real recording would unify the presentation.

**Alternatives Considered:**
- Omitting a demo artefact entirely for the browser-bridge panel and showing only the asciicast — rejected because all other tabs pair a cast with a rendered output artefact, so the panel would look incomplete.