### PR TITLE
docs(website): add YouTube transcript and Claude history demos

### DIFF
--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -299,5 +299,9 @@ p code, li code {
     .c-dim    { color: #9aa0a6; }
     .c-ok     { color: #4ec9b0; }
     .c-200    { color: #b5cea8; }
+    .c-num    { color: #ce9178; }
+    .c-time   { color: #569cd6; }
+    .c-path   { color: #4ec9b0; }
+    .c-head   { color: #dcdcaa; }
   }
 }

--- a/website/static/demo-history.cast
+++ b/website/static/demo-history.cast
@@ -1,0 +1,11 @@
+{"version": 2, "width": 104, "height": 32, "timestamp": 1779550960, "idle_time_limit": 1.5, "command": "bash history/demo.sh", "env": {"SHELL": "/bin/zsh"}}
+[0.025, "o", "\u001b[1;36m$\u001b[0m omni-dev ai claude history sync --target ~/hist --output-format jsonl,markdown\r\n"]
+[0.9, "o", "\u001b[32mcreated\u001b[0m  jsonl     -Users-me-omni-dev/0f1a…2b -> ~/hist/…/0f1a…2b.jsonl (48213 bytes)\r\n"]
+[1.05, "o", "\u001b[32mcreated\u001b[0m  markdown  -Users-me-omni-dev/0f1a…2b -> ~/hist/…/0f1a…2b.md (21044 bytes)\r\n"]
+[1.2, "o", "\u001b[32mcreated\u001b[0m  jsonl     -Users-me-spike/a1b2…d4    -> ~/hist/…/a1b2…d4.jsonl (15002 bytes)\r\n"]
+[1.35, "o", "\u001b[32mcreated\u001b[0m  markdown  -Users-me-spike/a1b2…d4    -> ~/hist/…/a1b2…d4.md (8771 bytes)\r\n\r\n"]
+[3.1, "o", "\u001b[1;36m$\u001b[0m omni-dev ai claude history sync --target ~/hist --since 1d --output-format markdown --dry-run\r\n"]
+[4.0, "o", "\u001b[90m[dry-run]\u001b[0m \u001b[32mcreated\u001b[0m  markdown  -Users-me-omni-dev/7b2e…c9 -> ~/hist/…/7b2e…c9.md (9210 bytes)\r\n"]
+[4.15, "o", "\u001b[90m[dry-run]\u001b[0m \u001b[33mskipped\u001b[0m  markdown  -Users-me-spike/a1b2…d4    (filtered-by-since)\r\n\r\n"]
+[5.9, "o", "\u001b[90m# re-runs skip unchanged sessions by mtime; --prune deletes targets whose source is gone\u001b[0m\r\n"]
+[7.8, "o", ""]

--- a/website/static/demo-youtube.cast
+++ b/website/static/demo-youtube.cast
@@ -1,0 +1,9 @@
+{"version": 2, "width": 100, "height": 34, "timestamp": 1779550950, "idle_time_limit": 1.5, "command": "bash youtube/demo.sh", "env": {"SHELL": "/bin/zsh"}}
+[0.025, "o", "\u001b[1;36m$\u001b[0m omni-dev transcript youtube info jNQXAC9IVRw\r\n"]
+[0.8, "o", "Source:    youtube\r\nID:        jNQXAC9IVRw\r\nTitle:     Me at the zoo\r\nChannel:   jawed\r\nDuration:  00:19\r\nLanguages:\r\n  - en       [manual] English\r\n  - en       [auto]   English (auto-generated)\r\n\r\n"]
+[2.6, "o", "\u001b[1;36m$\u001b[0m omni-dev transcript youtube list-langs jNQXAC9IVRw\r\n"]
+[3.4, "o", "code  kind    name\r\n----  ------  ----\r\nen    manual  English\r\nen    auto    English (auto-generated)\r\n\r\n"]
+[5.0, "o", "\u001b[1;36m$\u001b[0m omni-dev transcript youtube fetch jNQXAC9IVRw --format txt\r\n"]
+[6.1, "o", "All right, so here we are in front of the elephants.\r\nThe cool thing about these guys is that they have really,\r\nreally, really long trunks.\r\nAnd that's cool. And that's pretty much all there is to say.\r\n\r\n"]
+[7.8, "o", "\u001b[90m# add -o me-at-the-zoo.srt to write a subtitle file; --auto / --translate for ASR tracks\u001b[0m\r\n"]
+[9.6, "o", ""]

--- a/website/static/tutorial.html
+++ b/website/static/tutorial.html
@@ -67,7 +67,9 @@
     #tab-confluence:checked ~ .tab-bar label[for="tab-confluence"],
     #tab-pr:checked         ~ .tab-bar label[for="tab-pr"],
     #tab-twiddle:checked    ~ .tab-bar label[for="tab-twiddle"],
-    #tab-browser:checked    ~ .tab-bar label[for="tab-browser"] {
+    #tab-browser:checked    ~ .tab-bar label[for="tab-browser"],
+    #tab-youtube:checked    ~ .tab-bar label[for="tab-youtube"],
+    #tab-history:checked    ~ .tab-bar label[for="tab-history"] {
       background: white;
       color: var(--accent);
       border-color: var(--border);
@@ -77,7 +79,9 @@
     #tab-confluence:checked ~ #content-confluence,
     #tab-pr:checked         ~ #content-pr,
     #tab-twiddle:checked    ~ #content-twiddle,
-    #tab-browser:checked    ~ #content-browser { display: block; }
+    #tab-browser:checked    ~ #content-browser,
+    #tab-youtube:checked    ~ #content-youtube,
+    #tab-history:checked    ~ #content-history { display: block; }
 
     h2 { margin-top: 32px; font-size: 20px; border-bottom: 1px solid var(--border); padding-bottom: 6px; }
     h3 { margin-top: 24px; font-size: 16px; }
@@ -272,8 +276,8 @@
 <body>
 
 <header>
-  <h1>omni-dev — Atlassian, PRs, commits, and the browser bridge in five tabs</h1>
-  <p>A tutorial covering the five primary omni-dev workflows. Switch tabs to navigate.</p>
+  <h1>omni-dev — Atlassian, PRs, commits, the browser bridge, and more in seven tabs</h1>
+  <p>A tutorial covering seven omni-dev workflows. Switch tabs to navigate.</p>
 </header>
 
 <div class="container">
@@ -283,6 +287,8 @@
     <input type="radio" name="tab" id="tab-pr">
     <input type="radio" name="tab" id="tab-twiddle">
     <input type="radio" name="tab" id="tab-browser">
+    <input type="radio" name="tab" id="tab-youtube">
+    <input type="radio" name="tab" id="tab-history">
 
     <div class="tab-bar">
       <label for="tab-jira">JIRA</label>
@@ -290,6 +296,8 @@
       <label for="tab-pr">Create PRs</label>
       <label for="tab-twiddle">Twiddle commit messages</label>
       <label for="tab-browser">Browser bridge</label>
+      <label for="tab-youtube">YouTube transcript</label>
+      <label for="tab-history">Claude history</label>
     </div>
 
     <!-- ====================== JIRA TAB ====================== -->
@@ -1451,6 +1459,199 @@ done</pre>
         (relative URLs) is unaffected; cross-origin targets depend on their
         <code>Access-Control-Allow-Origin</code>. The bridge works only while the
         tab is open and the snippet is running.
+      </div>
+    </section>
+
+    <!-- ====================== YOUTUBE TRANSCRIPT TAB ====================== -->
+    <section class="tab-content" id="content-youtube">
+      <h2>YouTube transcript — captions as SRT, VTT, TXT, or JSON</h2>
+
+      <p>
+        <code>omni-dev transcript youtube</code> fetches captions and transcripts
+        from YouTube. The provider is the first positional argument, so the
+        namespace stays clean as more sources (Vimeo, podcast RSS, generic
+        VTT/SRT URLs) are added later. Three subcommands: <code>info</code> and
+        <code>list-langs</code> inspect a video; <code>fetch</code> renders a track.
+      </p>
+
+      <h3>The three subcommands</h3>
+
+      <div class="step">
+        <span class="step-num">1</span><strong>Inspect</strong> the video&apos;s
+        metadata and available tracks.
+        <pre>omni-dev transcript youtube info jNQXAC9IVRw
+omni-dev transcript youtube list-langs jNQXAC9IVRw</pre>
+        <p class="muted">Both default to a human table; pass
+          <code>--output json</code> for machine-readable output.</p>
+      </div>
+
+      <div class="step">
+        <span class="step-num">2</span><strong>Fetch</strong> a track and render it.
+        Writes to stdout unless <code>-o</code> is given.
+        <pre>omni-dev transcript youtube fetch jNQXAC9IVRw --format srt -o me-at-the-zoo.srt</pre>
+      </div>
+
+      <h3>Locator forms</h3>
+      <p><code>&lt;url&gt;</code> accepts any of these — extra query params are ignored:</p>
+      <pre>https://www.youtube.com/watch?v=jNQXAC9IVRw
+https://youtu.be/jNQXAC9IVRw
+https://www.youtube.com/shorts/&lt;id&gt;
+https://www.youtube.com/embed/&lt;id&gt;
+jNQXAC9IVRw                         # bare 11-character video ID</pre>
+
+      <h3><code>fetch</code> flags</h3>
+      <table>
+        <thead><tr><th>Flag</th><th>Default</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td><code>--lang &lt;code&gt;</code></td><td><code>en</code></td><td>Preferred language. Prefix fallback applies — <code>en</code> matches <code>en-US</code>.</td></tr>
+          <tr><td><code>--format &lt;fmt&gt;</code></td><td><code>srt</code></td><td>One of <code>srt</code>, <code>vtt</code>, <code>txt</code>, <code>json</code>.</td></tr>
+          <tr><td><code>--auto</code></td><td>off</td><td>Allow falling through to auto-generated (ASR) captions when no manual track matches.</td></tr>
+          <tr><td><code>--translate &lt;lang&gt;</code></td><td>—</td><td>Synthesise a translated track in <code>&lt;lang&gt;</code> when no native track matches.</td></tr>
+          <tr><td><code>-o</code>, <code>--output</code></td><td>stdout</td><td>Write the rendered transcript to a file.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="panel panel-info">
+        <div class="panel-title">ℹ️ Manual vs. auto-generated</div>
+        <code>list-langs</code> tags each track with a <code>kind</code>:
+        <code>manual</code> (human-authored), <code>auto</code> (ASR), or
+        <code>translated</code>. <code>fetch</code> only uses an <code>auto</code>
+        track when you pass <code>--auto</code> — otherwise it fails with
+        <code>AutoCaptionsRequireOptIn</code> rather than silently handing back a
+        lower-quality transcript.
+      </div>
+
+      <h3>Typed errors, not raw HTTP</h3>
+      <p>Failures surface as named variants, so a script can branch on them:</p>
+      <table>
+        <thead><tr><th>Variant</th><th>When</th></tr></thead>
+        <tbody>
+          <tr><td><code>InvalidLocator</code></td><td>URL did not parse, or bare ID failed validation.</td></tr>
+          <tr><td><code>LanguageNotFound</code></td><td>No track matched <code>--lang</code> (manual or, with <code>--auto</code>, ASR).</td></tr>
+          <tr><td><code>AutoCaptionsRequireOptIn</code></td><td>Only ASR matched, but <code>--auto</code> was not passed.</td></tr>
+          <tr><td><code>PlayabilityRefused</code></td><td>Age-gated, region-locked, removed, or login-required.</td></tr>
+          <tr><td><code>ParseError</code> / <code>Http</code></td><td>Response did not match the expected shape, or a non-2xx response.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Worked example</h3>
+      <span class="lang-tag">terminal</span>
+<pre>$ omni-dev transcript youtube info jNQXAC9IVRw
+Source:    youtube
+ID:        jNQXAC9IVRw
+Title:     Me at the zoo
+Channel:   jawed
+Duration:  00:19
+Languages:
+  - en       [manual] English
+  - en       [auto]   English (auto-generated)
+
+$ omni-dev transcript youtube fetch jNQXAC9IVRw --format txt
+All right, so here we are in front of the elephants.
+The cool thing about these guys is that they have really,
+really, really long trunks. And that's cool. And that's
+pretty much all there is to say.</pre>
+
+      <div class="panel panel-note">
+        <div class="panel-title">📝 Library-first design</div>
+        The fetching logic lives in <code>src/transcript/</code> with no
+        <code>clap</code> dependency; the CLI is a thin bridge. Format converters
+        consume <code>&amp;[Cue]</code> and never reach back into a source, so all
+        four output formats work for any future provider. See
+        <a href="https://github.com/rust-works/omni-dev/blob/main/docs/transcript.md">docs/transcript.md</a>
+        for the recipe to add one.
+      </div>
+    </section>
+
+    <!-- ====================== CLAUDE HISTORY TAB ====================== -->
+    <section class="tab-content" id="content-history">
+      <h2>Claude history — export your Claude Code sessions</h2>
+
+      <p>
+        <code>omni-dev ai claude history sync</code> exports your Claude Code
+        conversation history to a target directory as one <code>.jsonl</code>
+        (and/or rendered <code>.md</code>) per chat. The corpus is a
+        <strong>behavioural transcript</strong> — prompts, responses, thinking,
+        tool calls, and tool-result metadata — sized for analyst use cases like
+        work-log generation and behavioural review.
+      </p>
+
+      <div class="panel panel-info">
+        <div class="panel-title">ℹ️ What is and isn&apos;t exported</div>
+        <strong>Included:</strong> user prompts, assistant responses, thinking,
+        tool calls and tool-result metadata. <strong>Deliberately excluded:</strong>
+        sub-agent internals, tool-result <code>*.txt</code> sidecars, PDF rasters,
+        and auto-memory.
+      </div>
+
+      <h3>The basic command</h3>
+      <div class="step">
+        <span class="step-num">1</span><strong>Sync</strong> every session to a
+        target directory. Both file shapes side by side:
+        <pre>omni-dev ai claude history sync --target ~/claude-history \
+  --output-format jsonl,markdown</pre>
+      </div>
+
+      <h3>On-disk layout</h3>
+      <p>
+        One folder per project (the encoded working-directory slug), one file per
+        session UUID:
+      </p>
+      <pre>~/claude-history/
+  -Users-me-wrk-omni-dev/
+    0f1a…2b.jsonl       # append-only event log, byte-identical across runs
+    0f1a…2b.md          # rendered, human-readable transcript
+  -Users-me-tmp-spike/
+    a1b2…d4.jsonl
+    a1b2…d4.md</pre>
+
+      <h3>Flags</h3>
+      <table>
+        <thead><tr><th>Flag</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td><code>--target &lt;PATH&gt;</code></td><td>Target directory for the export (required). Created if absent.</td></tr>
+          <tr><td><code>--source &lt;PATH&gt;</code></td><td>Override the source root. Defaults to <code>~/.claude/projects</code>.</td></tr>
+          <tr><td><code>--project &lt;NAME&gt;</code></td><td>Restrict to one project — the encoded slug (<code>-Users-me-tmp</code>) or a decoded cwd path.</td></tr>
+          <tr><td><code>--since &lt;DUR|DATE&gt;</code></td><td>Only sessions at/after this point. Relative (<code>30s</code>, <code>2h</code>, <code>7d</code>, <code>4w</code>) or RFC 3339.</td></tr>
+          <tr><td><code>--output-format &lt;LIST&gt;</code></td><td>On-disk shapes: <code>jsonl</code> (default), <code>markdown</code>, or both comma-separated.</td></tr>
+          <tr><td><code>--exclude-system</code></td><td>Hide system-side events from Markdown (JSONL is unaffected).</td></tr>
+          <tr><td><code>--prune</code></td><td>Delete targets for sessions no longer in the source (scoped to managed extensions).</td></tr>
+          <tr><td><code>--dry-run</code></td><td>Preview changes without touching the target.</td></tr>
+          <tr><td><code>--format &lt;text|yaml&gt;</code></td><td>Shape of the run <em>report</em> printed to stdout.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Idempotent re-runs</h3>
+      <p>
+        Each run reports <code>created</code> / <code>updated</code> /
+        <code>skipped</code> / <code>pruned</code> per file. A session is skipped
+        when its source mtime is unchanged, so re-running is cheap and safe to put
+        on a schedule:
+      </p>
+      <span class="lang-tag">terminal</span>
+<pre>$ omni-dev ai claude history sync --target ~/hist --output-format jsonl,markdown
+created  jsonl     -Users-me-omni-dev/0f1a…2b -> ~/hist/…/0f1a…2b.jsonl (48213 bytes)
+created  markdown  -Users-me-omni-dev/0f1a…2b -> ~/hist/…/0f1a…2b.md (21044 bytes)
+
+$ omni-dev ai claude history sync --target ~/hist --output-format jsonl,markdown
+skipped  jsonl     -Users-me-omni-dev/0f1a…2b (unchanged) -> ~/hist/…/0f1a…2b.jsonl
+skipped  markdown  -Users-me-omni-dev/0f1a…2b (unchanged) -> ~/hist/…/0f1a…2b.md</pre>
+
+      <div class="panel panel-warn">
+        <div class="panel-title">⚠️ <code>--prune</code> is scoped, not a blunt delete</div>
+        Only files matching <code>&lt;slug&gt;/&lt;uuid&gt;.&lt;ext&gt;</code> are
+        eligible for deletion, and <code>&lt;ext&gt;</code> is restricted to the
+        formats in <code>--output-format</code> — so artefacts the run was not asked
+        to manage are preserved regardless. Pair with <code>--dry-run</code> the
+        first time to preview what would go.
+      </div>
+
+      <div class="panel panel-success">
+        <div class="panel-title">✅ Versionable by design</div>
+        The JSONL is append-only and byte-identical across runs (mtime alone
+        decides freshness), so committing <code>~/claude-history</code> to a git
+        repo produces clean, meaningful diffs — a durable, greppable record of how
+        the work actually happened.
       </div>
     </section>
   </div>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -22,6 +22,8 @@
     <li><strong>PR creation</strong> &mdash; generate complete pull request descriptions in one command.</li>
     <li><strong>Atlassian integration</strong> &mdash; read and write Jira issues and Confluence pages, with JFM &harr; ADF conversion.</li>
     <li><strong>Browser bridge</strong> &mdash; drive authenticated HTTP requests through a logged-in browser tab without exfiltrating its cookies or tokens.</li>
+    <li><strong>Media transcripts</strong> &mdash; fetch YouTube captions as SRT, VTT, TXT, or JSON, with language fallback and optional ASR/translation.</li>
+    <li><strong>Conversation history</strong> &mdash; export your Claude Code sessions to versionable JSONL and Markdown for work-logs and review.</li>
     <li><strong>MCP server</strong> &mdash; drop omni-dev's capabilities into Claude Code via the bundled MCP binary.</li>
   </ul>
 </section>
@@ -41,7 +43,7 @@
 <section id="demo" class="demo-wide">
   <h2>Demo</h2>
   <p class="demo-caption">
-    Five short asciicasts &mdash; each paired with the artefact it produces.
+    Seven short asciicasts &mdash; each paired with the artefact it produces.
     The source for every cast lives at
     <a href="https://github.com/rust-works/omni-dev-demo">rust-works/omni-dev-demo</a>.
   </p>
@@ -52,6 +54,8 @@
     <button class="tab"           role="tab" id="tab-pr"         aria-selected="false" aria-controls="panel-pr"         data-tab="pr"         tabindex="-1">Create PR</button>
     <button class="tab"           role="tab" id="tab-twiddle"    aria-selected="false" aria-controls="panel-twiddle"    data-tab="twiddle"    tabindex="-1">Twiddle commits</button>
     <button class="tab"           role="tab" id="tab-browser"    aria-selected="false" aria-controls="panel-browser"    data-tab="browser"    tabindex="-1">Browser bridge</button>
+    <button class="tab"           role="tab" id="tab-youtube"    aria-selected="false" aria-controls="panel-youtube"    data-tab="youtube"    tabindex="-1">YouTube transcript</button>
+    <button class="tab"           role="tab" id="tab-history"    aria-selected="false" aria-controls="panel-history"    data-tab="history"    tabindex="-1">Claude history</button>
   </div>
 
   <div class="tab-panel is-active" role="tabpanel" id="panel-jira" aria-labelledby="tab-jira" data-panel="jira">
@@ -169,6 +173,90 @@
       </div>
     </div>
   </div>
+
+  <div class="tab-panel" role="tabpanel" id="panel-youtube" aria-labelledby="tab-youtube" data-panel="youtube" hidden>
+    <p class="panel-caption">
+      <code>omni-dev transcript youtube</code> pulls captions straight from a video.
+      <code>info</code> and <code>list-langs</code> inspect what is available;
+      <code>fetch</code> renders a track as <code>srt</code>, <code>vtt</code>,
+      <code>txt</code>, or <code>json</code>. Here it inspects the first video ever
+      uploaded to YouTube and prints its transcript &mdash; <code>--auto</code> falls
+      through to ASR captions, <code>--translate</code> synthesises a missing language.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-cast"><div id="cast-youtube" class="asciinema-player-wrap"></div></div>
+      <div class="demo-renders">
+        <figure>
+          <div class="console-shot" aria-label="The fetched transcript written as an SRT subtitle file">
+            <div class="console-bar">
+              <span class="console-dot dot-red"></span>
+              <span class="console-dot dot-amber"></span>
+              <span class="console-dot dot-green"></span>
+              <span class="console-title">me-at-the-zoo.srt</span>
+            </div>
+<pre class="console-body"><span class="c-num">1</span>
+<span class="c-time">00:00:00,000 --&gt; 00:00:05,800</span>
+All right, so here we are in front of the elephants.
+
+<span class="c-num">2</span>
+<span class="c-time">00:00:05,800 --&gt; 00:00:11,200</span>
+The cool thing about these guys is that they have
+really, really, really long trunks.
+
+<span class="c-num">3</span>
+<span class="c-time">00:00:11,200 --&gt; 00:00:19,000</span>
+And that's cool. And that's pretty much all there is to say.</pre>
+          </div>
+          <figcaption>Same transcript, written to disk as WebVTT/SRT with
+            <code>-o me-at-the-zoo.srt</code> &mdash; ready to attach to a video or
+            feed to a search index. Drop <code>--format json</code> for cue objects
+            with millisecond timing.</figcaption>
+        </figure>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab-panel" role="tabpanel" id="panel-history" aria-labelledby="tab-history" data-panel="history" hidden>
+    <p class="panel-caption">
+      <code>omni-dev ai claude history sync</code> exports your Claude Code sessions
+      &mdash; prompts, responses, thinking, and tool calls &mdash; to a target
+      directory as one <code>.jsonl</code> (and/or rendered <code>.md</code>) per chat.
+      Re-runs skip unchanged sessions by mtime, so it is safe to schedule;
+      <code>--since</code>, <code>--project</code>, and <code>--dry-run</code> scope
+      the run, and <code>--prune</code> removes exports whose source is gone.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-cast"><div id="cast-history" class="asciinema-player-wrap"></div></div>
+      <div class="demo-renders">
+        <figure>
+          <div class="console-shot" aria-label="The exported history directory tree and a rendered Markdown transcript">
+            <div class="console-bar">
+              <span class="console-dot dot-red"></span>
+              <span class="console-dot dot-amber"></span>
+              <span class="console-dot dot-green"></span>
+              <span class="console-title">~/hist &mdash; after sync</span>
+            </div>
+<pre class="console-body"><span class="c-path">-Users-me-omni-dev/</span>
+  0f1a…2b.jsonl   <span class="c-dim"># append-only event log</span>
+  0f1a…2b.md      <span class="c-dim"># rendered transcript</span>
+<span class="c-path">-Users-me-spike/</span>
+  a1b2…d4.jsonl
+  a1b2…d4.md
+
+<span class="c-dim">── 0f1a…2b.md ──────────────────</span>
+<span class="c-head">## 👤 User</span>
+Refactor the transcript fetcher to support VTT.
+
+<span class="c-head">## 🤖 Assistant</span>
+Here's the plan: extract a Format enum…</pre>
+          </div>
+          <figcaption>One folder per project (the encoded cwd slug), one file per
+            session UUID. The JSONL is append-only and byte-identical across runs;
+            the Markdown is a readable transcript for work-logs and review.</figcaption>
+        </figure>
+      </div>
+    </div>
+  </div>
 </section>
 {% endblock %}
 
@@ -180,7 +268,9 @@
       confluence: '{{ get_url(path="demo-confluence.cast") }}',
       pr:         '{{ get_url(path="demo-pr.cast") }}',
       twiddle:    '{{ get_url(path="demo-twiddle.cast") }}',
-      browser:    '{{ get_url(path="demo-browser.cast") }}'
+      browser:    '{{ get_url(path="demo-browser.cast") }}',
+      youtube:    '{{ get_url(path="demo-youtube.cast") }}',
+      history:    '{{ get_url(path="demo-history.cast") }}'
     };
     const players = {};
 


### PR DESCRIPTION
## Description

This PR extends the omni-dev website demo section and tutorial from five workflows to seven by adding dedicated tabs for the YouTube transcript and Claude history features. Each new tab pairs a synthesized asciicast recording with a console-style preview panel, adds feature-list bullets to the landing page, and includes a full tutorial section covering commands, flags, error variants, and idempotency behaviour.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
No linked issue — purely website documentation expansion.

## Changes Made

**Demo page (`website/templates/index.html`):**
- Added two new ARIA-compliant tab buttons: `YouTube transcript` and `Claude history`
- Added `panel-youtube` tab panel with asciicast player and console-shot preview of a fetched SRT subtitle file (`me-at-the-zoo.srt`) with syntax-coloured cue numbers and timestamps
- Added `panel-history` tab panel with asciicast player and console-shot preview showing the on-disk directory tree and a Markdown transcript excerpt
- Added two feature-list bullets to the landing page for Media transcripts and Conversation history
- Updated demo caption from "Five short asciicasts" to "Seven short asciicasts"
- Wired `demo-youtube.cast` and `demo-history.cast` into the cast URL map

**Asciicast recordings (`website/static/`):**
- Added `demo-youtube.cast`: placeholder recording showing `transcript youtube info`, `list-langs`, and `fetch --format txt` for `jNQXAC9IVRw`
- Added `demo-history.cast`: placeholder recording showing `ai claude history sync` (full run then idempotent dry-run with `--since 1d`)

**Tutorial (`website/static/tutorial.html`):**
- Updated header to "seven tabs" and extended the CSS radio-button selectors to include `tab-youtube` and `tab-history`
- Added full `content-youtube` section covering the three subcommands (`info`, `list-langs`, `fetch`), all locator forms (full URL, short URL, shorts, embed, bare 11-char ID), all `fetch` flags (`--lang`, `--format`, `--auto`, `--translate`, `-o`), a typed-error reference table (`InvalidLocator`, `LanguageNotFound`, `AutoCaptionsRequireOptIn`, `PlayabilityRefused`, `ParseError`/`Http`), a worked terminal example, and a library-first design note
- Added full `content-history` section covering the basic `sync` command, on-disk layout (one folder per project slug, one file per session UUID), all flags (`--target`, `--source`, `--project`, `--since`, `--output-format`, `--exclude-system`, `--prune`, `--dry-run`, `--format`), idempotent re-run behaviour with a terminal example, a scoped-prune warning panel, and a versionable-by-design note

**Styles (`website/sass/style.scss`):**
- Added four syntax colour classes used in the new console-shot previews: `.c-num` (cue numbers, `#ce9178`), `.c-time` (SRT timestamps, `#569cd6`), `.c-path` (directory paths, `#4ec9b0`), `.c-head` (Markdown headings, `#dcdcaa`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- New code coverage: N/A (documentation/HTML/SCSS only)
- Overall project coverage: unchanged

### Test Commands
```bash
# Build the website with Zola to verify templates compile
cd website && zola build

# Optionally serve locally and verify both new tabs render correctly
cd website && zola serve
# then open http://127.0.0.1:1111 and click the YouTube transcript and Claude history tabs
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — tab navigation, console-shot readability, asciicast timing feel correct
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] Backward compatibility — existing five tabs are unaffected; new radio inputs are purely additive

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Replace placeholder asciicasts (`demo-youtube.cast`, `demo-history.cast`) with real terminal recordings once the underlying commands are stable
- Add Vimeo, podcast RSS, and generic VTT/SRT URL provider tabs to the transcript section as those providers land

**Known Limitations:**
- The asciicast files are synthesized placeholders; real recordings should be swapped in before the release that ships the transcript and history commands to end users

**Alternatives Considered:**
- Embedding the new content inline in the existing tabs was rejected in favour of the established tab pattern to keep each workflow self-contained and discoverable