### PR TITLE
feat(cli): add youtube channel transcript sync command

### DIFF
--- a/src/cli/transcript/youtube/mod.rs
+++ b/src/cli/transcript/youtube/mod.rs
@@ -3,6 +3,7 @@
 pub mod fetch;
 pub mod info;
 pub mod list_langs;
+pub mod sync;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -24,6 +25,8 @@ pub enum YoutubeSubcommands {
     ListLangs(list_langs::ListLangsCommand),
     /// Shows top-level metadata (title, channel, duration, languages) for a YouTube video.
     Info(info::InfoCommand),
+    /// Syncs transcripts for all videos in one or more channels to the filesystem.
+    Sync(sync::SyncCommand),
 }
 
 impl YoutubeCommand {
@@ -33,6 +36,7 @@ impl YoutubeCommand {
             YoutubeSubcommands::Fetch(cmd) => cmd.execute().await,
             YoutubeSubcommands::ListLangs(cmd) => cmd.execute().await,
             YoutubeSubcommands::Info(cmd) => cmd.execute().await,
+            YoutubeSubcommands::Sync(cmd) => cmd.execute().await,
         }
     }
 }
@@ -66,6 +70,24 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, YoutubeSubcommands::ListLangs(_)));
+    }
+
+    #[test]
+    fn youtube_subcommands_sync_variant() {
+        let cmd = YoutubeCommand {
+            command: YoutubeSubcommands::Sync(sync::SyncCommand {
+                channels: vec!["@handle".to_string()],
+                out: std::path::PathBuf::from("/tmp/yt"),
+                lang: "en".to_string(),
+                format: CliFormat::Srt,
+                auto: false,
+                full: false,
+                since: None,
+                concurrency: 4,
+                dry_run: false,
+            }),
+        };
+        assert!(matches!(cmd.command, YoutubeSubcommands::Sync(_)));
     }
 
     #[test]

--- a/src/cli/transcript/youtube/sync.rs
+++ b/src/cli/transcript/youtube/sync.rs
@@ -1,0 +1,808 @@
+//! `omni-dev transcript youtube sync` — enumerate a channel's videos and
+//! sync their transcripts to the filesystem, incrementally.
+//!
+//! Builds on the per-video fetcher: enumerate video IDs in each channel
+//! ([`Youtube::recent_channel_videos`] for incremental, [`Youtube::all_channel_video_ids`]
+//! for `--full` backfill), then loop the existing [`Youtube::fetch`], writing
+//! each transcript to a deterministic path `<out>/<channel-id>/<video-id>.<lang>.<format>`.
+//! "Already synced" is filesystem state: the target path existing means skip.
+//!
+//! Videos without a usable transcript (no captions, age-gated, region-locked)
+//! are recorded and skipped — never abort the whole run.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, Utc};
+use clap::Parser;
+use futures::stream::{self, StreamExt};
+
+use crate::cli::transcript::format::CliFormat;
+use crate::transcript::error::TranscriptError;
+use crate::transcript::format::Format;
+use crate::transcript::source::{FetchOpts, TranscriptSource};
+use crate::transcript::sources::youtube::Youtube;
+
+/// Syncs transcripts for all videos in one or more YouTube channels to the
+/// filesystem, incrementally (skips videos already synced).
+#[derive(Parser)]
+pub struct SyncCommand {
+    /// One or more channel references: a `UC…` ID, a channel URL
+    /// (`/channel/UC…`, `/@handle`, `/c/Name`, `/user/Name`), or a bare
+    /// `@handle`.
+    #[arg(required = true, num_args = 1..)]
+    pub channels: Vec<String>,
+
+    /// Output directory. Transcripts are written under
+    /// `<out>/<channel-id>/<video-id>.<lang>.<format>`.
+    #[arg(long)]
+    pub out: PathBuf,
+
+    /// Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is
+    /// applied — `en` matches `en-US`.
+    #[arg(long, default_value = "en")]
+    pub lang: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = CliFormat::Srt)]
+    pub format: CliFormat,
+
+    /// Allow falling through to auto-generated (ASR) captions when no manual
+    /// track matches. Recommended for channel syncs — many uploads only have
+    /// auto captions.
+    #[arg(long)]
+    pub auto: bool,
+
+    /// Backfill the channel's entire upload history via the InnerTube
+    /// `/browse` endpoint. Without this, only the ~15 most recent uploads
+    /// (the RSS feed) are considered.
+    #[arg(long)]
+    pub full: bool,
+
+    /// Only sync videos published on or after this date (`YYYY-MM-DD` or an
+    /// RFC 3339 timestamp). Reliable for the default (RSS) path, which carries
+    /// per-video publish dates; best-effort under `--full` (the browse grid
+    /// has no per-item dates, so this is ignored there).
+    #[arg(long, value_name = "DATE")]
+    pub since: Option<String>,
+
+    /// Maximum number of transcripts to fetch concurrently.
+    #[arg(long, default_value_t = 4)]
+    pub concurrency: usize,
+
+    /// List what would be fetched without downloading or writing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl SyncCommand {
+    /// Runs the sync against the public YouTube origin.
+    pub async fn execute(self) -> Result<()> {
+        let yt = Youtube::new()?;
+        self.sync_with(&yt).await
+    }
+
+    /// Plan, run, and report the sync against `yt`. Split from [`Self::execute`]
+    /// so the whole orchestration is testable with a mock-backed [`Youtube`];
+    /// `execute` only adds construction of the live client.
+    async fn sync_with(self, yt: &Youtube) -> Result<()> {
+        let plan = self.into_plan()?;
+        let report = run(&plan, yt).await;
+        report.print();
+        Ok(())
+    }
+
+    /// Validate and normalise CLI args into a [`SyncPlan`].
+    fn into_plan(self) -> Result<SyncPlan> {
+        let since = self
+            .since
+            .as_deref()
+            .map(parse_since)
+            .transpose()
+            .context("Invalid --since date")?;
+        Ok(SyncPlan {
+            channels: self.channels,
+            out: self.out,
+            lang: self.lang,
+            format: self.format,
+            allow_auto: self.auto,
+            full: self.full,
+            since,
+            concurrency: self.concurrency.max(1),
+            dry_run: self.dry_run,
+        })
+    }
+}
+
+/// Parse a `--since` value as either a bare `YYYY-MM-DD` date (interpreted as
+/// midnight UTC) or a full RFC 3339 timestamp.
+fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    let date = NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .with_context(|| format!("expected YYYY-MM-DD or RFC 3339, got `{s}`"))?;
+    #[allow(clippy::expect_used)]
+    let naive = date
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight is always a valid time");
+    Ok(DateTime::from_naive_utc_and_offset(naive, Utc))
+}
+
+/// Validated, normalised sync parameters (independent of the HTTP source so
+/// the core loop is testable).
+struct SyncPlan {
+    channels: Vec<String>,
+    out: PathBuf,
+    lang: String,
+    format: CliFormat,
+    allow_auto: bool,
+    full: bool,
+    since: Option<DateTime<Utc>>,
+    concurrency: usize,
+    dry_run: bool,
+}
+
+/// Tally of a sync run, accumulated across all channels.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SyncReport {
+    /// Transcripts newly written.
+    synced: usize,
+    /// Skipped because the target file already existed.
+    already_present: usize,
+    /// Skipped because the video has no usable transcript (no captions,
+    /// age-gated, region-locked, …).
+    no_transcript: usize,
+    /// Failed for another reason (HTTP, parse, I/O).
+    failed: usize,
+    /// `--dry-run`: would have been fetched.
+    would_fetch: usize,
+    /// Channels that could not be resolved or enumerated.
+    channel_errors: usize,
+}
+
+impl SyncReport {
+    fn print(&self) {
+        println!("\nSync complete:");
+        if self.would_fetch > 0 {
+            println!("  would fetch:      {}", self.would_fetch);
+        }
+        println!("  synced:           {}", self.synced);
+        println!("  already present:  {}", self.already_present);
+        println!("  no transcript:    {}", self.no_transcript);
+        println!("  failed:           {}", self.failed);
+        if self.channel_errors > 0 {
+            println!("  channel errors:   {}", self.channel_errors);
+        }
+    }
+}
+
+/// Core sync loop. Resolves and enumerates each channel, plans which videos
+/// need fetching (filesystem-as-state), then fetches the missing ones
+/// concurrently. Never aborts on a single video or channel failure.
+async fn run(plan: &SyncPlan, yt: &Youtube) -> SyncReport {
+    let mut report = SyncReport::default();
+    for channel in &plan.channels {
+        if let Err(e) = sync_channel(plan, yt, channel, &mut report).await {
+            eprintln!("channel `{channel}`: {e}");
+            report.channel_errors += 1;
+        }
+    }
+    report
+}
+
+/// Resolve, enumerate, and sync a single channel into `report`. Returns `Err`
+/// only for channel-level failures (resolution / enumeration); per-video
+/// failures are folded into `report`.
+async fn sync_channel(
+    plan: &SyncPlan,
+    yt: &Youtube,
+    channel: &str,
+    report: &mut SyncReport,
+) -> Result<(), TranscriptError> {
+    let channel_id = yt.resolve_channel_id(channel).await?;
+    let dir = plan.out.join(&channel_id);
+    if !plan.dry_run {
+        std::fs::create_dir_all(&dir)?;
+    }
+
+    let ids = enumerate(plan, yt, &channel_id).await?;
+    let ext = Format::from(plan.format).as_str();
+    let plan_result = plan_fetches(&ids, &dir, &plan.lang, ext, plan.full);
+    report.already_present += plan_result.already_present;
+
+    println!(
+        "channel {channel_id}: {} video(s), {} to fetch, {} already present",
+        ids.len(),
+        plan_result.to_fetch.len(),
+        plan_result.already_present,
+    );
+
+    if plan.dry_run {
+        for (id, path) in &plan_result.to_fetch {
+            println!("  would fetch {id} -> {}", path.display());
+        }
+        report.would_fetch += plan_result.to_fetch.len();
+        return Ok(());
+    }
+
+    let opts = FetchOpts {
+        language: plan.lang.clone(),
+        allow_auto: plan.allow_auto,
+        translate_to: None,
+    };
+
+    let outcomes = stream::iter(plan_result.to_fetch)
+        .map(|(id, path)| {
+            let opts = &opts;
+            async move {
+                let outcome = fetch_and_write(yt, &id, opts, plan.format, &path).await;
+                (id, outcome)
+            }
+        })
+        .buffer_unordered(plan.concurrency)
+        .collect::<Vec<_>>()
+        .await;
+
+    for (id, outcome) in outcomes {
+        match outcome {
+            Ok(()) => report.synced += 1,
+            Err(e) if is_no_transcript(&e) => {
+                report.no_transcript += 1;
+                eprintln!("  skip {id}: {e}");
+            }
+            Err(e) => {
+                report.failed += 1;
+                eprintln!("  fail {id}: {e}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Enumerate a channel's video IDs, newest-first. `--full` pages the whole
+/// upload history via browse; otherwise the RSS feed, filtered by `--since`.
+async fn enumerate(
+    plan: &SyncPlan,
+    yt: &Youtube,
+    channel_id: &str,
+) -> Result<Vec<String>, TranscriptError> {
+    if plan.full {
+        yt.all_channel_video_ids(channel_id).await
+    } else {
+        let entries = yt.recent_channel_videos(channel_id).await?;
+        Ok(entries
+            .into_iter()
+            .filter(|e| match (plan.since, e.published) {
+                (Some(since), Some(published)) => published >= since,
+                // No lower bound, or no date to compare against → keep it.
+                _ => true,
+            })
+            .map(|e| e.id)
+            .collect())
+    }
+}
+
+/// Result of partitioning enumerated IDs against on-disk state.
+struct FetchPlan {
+    to_fetch: Vec<(String, PathBuf)>,
+    already_present: usize,
+}
+
+/// Decide which enumerated videos need fetching. IDs are newest-first, so in
+/// incremental mode (`full == false`) scanning stops at the first
+/// already-present file: older uploads are assumed already synced, which
+/// makes routine re-syncs cheap. Under `--full`, every ID is examined so gaps
+/// in the history get filled.
+fn plan_fetches(ids: &[String], dir: &Path, lang: &str, ext: &str, full: bool) -> FetchPlan {
+    let mut to_fetch = Vec::new();
+    let mut already_present = 0;
+    for id in ids {
+        let path = dir.join(format!("{id}.{lang}.{ext}"));
+        if path.exists() {
+            already_present += 1;
+            if !full {
+                break;
+            }
+        } else {
+            to_fetch.push((id.clone(), path));
+        }
+    }
+    FetchPlan {
+        to_fetch,
+        already_present,
+    }
+}
+
+/// Fetch one transcript and write it atomically (temp file + rename) so a
+/// partially written file is never mistaken for a completed sync.
+async fn fetch_and_write(
+    yt: &Youtube,
+    id: &str,
+    opts: &FetchOpts,
+    format: CliFormat,
+    path: &Path,
+) -> Result<(), TranscriptError> {
+    let transcript = yt.fetch(id, opts).await?;
+    let rendered = Format::from(format).render(&transcript)?;
+    write_atomic(path, &rendered)?;
+    Ok(())
+}
+
+/// Write `contents` to `path` via a sibling temp file then rename, so readers
+/// (including the next sync) never observe a half-written transcript.
+fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("out");
+    let tmp = path.with_file_name(format!(".{file_name}.tmp"));
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)
+}
+
+/// Whether `err` means "this video simply has no transcript we can use" — a
+/// skip-and-record condition rather than a run-aborting failure.
+fn is_no_transcript(err: &TranscriptError) -> bool {
+    matches!(
+        err,
+        TranscriptError::PlayabilityRefused { .. }
+            | TranscriptError::LanguageNotFound { .. }
+            | TranscriptError::AutoCaptionsRequireOptIn(_)
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, FromArgMatches};
+
+    fn parse(args: &[&str]) -> SyncCommand {
+        let cmd = SyncCommand::command().no_binary_name(true);
+        let matches = cmd.try_get_matches_from(args).unwrap();
+        SyncCommand::from_arg_matches(&matches).unwrap()
+    }
+
+    #[test]
+    fn sync_command_defaults() {
+        let cmd = parse(&["@handle", "--out", "/tmp/yt"]);
+        assert_eq!(cmd.channels, vec!["@handle".to_string()]);
+        assert_eq!(cmd.out, PathBuf::from("/tmp/yt"));
+        assert_eq!(cmd.lang, "en");
+        assert_eq!(cmd.format, CliFormat::Srt);
+        assert!(!cmd.auto);
+        assert!(!cmd.full);
+        assert_eq!(cmd.since, None);
+        assert_eq!(cmd.concurrency, 4);
+        assert!(!cmd.dry_run);
+    }
+
+    #[test]
+    fn sync_command_all_flags_and_multiple_channels() {
+        let cmd = parse(&[
+            "UC_x5XG1OV2P6uZZ5FSM9Ttw",
+            "@another",
+            "--out",
+            "/tmp/out",
+            "--lang",
+            "fr",
+            "--format",
+            "vtt",
+            "--auto",
+            "--full",
+            "--since",
+            "2024-01-01",
+            "--concurrency",
+            "8",
+            "--dry-run",
+        ]);
+        assert_eq!(cmd.channels.len(), 2);
+        assert_eq!(cmd.lang, "fr");
+        assert_eq!(cmd.format, CliFormat::Vtt);
+        assert!(cmd.auto);
+        assert!(cmd.full);
+        assert_eq!(cmd.since.as_deref(), Some("2024-01-01"));
+        assert_eq!(cmd.concurrency, 8);
+        assert!(cmd.dry_run);
+    }
+
+    #[test]
+    fn sync_command_requires_a_channel() {
+        let cmd = SyncCommand::command().no_binary_name(true);
+        assert!(cmd.try_get_matches_from(["--out", "/tmp"]).is_err());
+    }
+
+    #[test]
+    fn parse_since_accepts_date_and_rfc3339() {
+        let date = parse_since("2024-11-20").unwrap();
+        assert_eq!(date.to_rfc3339(), "2024-11-20T00:00:00+00:00");
+        let ts = parse_since("2024-11-20T12:30:00+00:00").unwrap();
+        assert_eq!(ts.to_rfc3339(), "2024-11-20T12:30:00+00:00");
+    }
+
+    #[test]
+    fn parse_since_rejects_garbage() {
+        assert!(parse_since("not-a-date").is_err());
+    }
+
+    #[test]
+    fn into_plan_clamps_zero_concurrency_to_one() {
+        let cmd = parse(&["@h", "--out", "/tmp", "--concurrency", "0"]);
+        let plan = cmd.into_plan().unwrap();
+        assert_eq!(plan.concurrency, 1);
+    }
+
+    #[test]
+    fn plan_fetches_incremental_stops_at_first_present() {
+        let dir = tempfile::tempdir().unwrap();
+        // Newest-first ids; mark the 2nd as already present.
+        let ids: Vec<String> = vec!["aaa".into(), "bbb".into(), "ccc".into()];
+        std::fs::write(dir.path().join("bbb.en.srt"), "x").unwrap();
+
+        let plan = plan_fetches(ids.as_slice(), dir.path(), "en", "srt", false);
+        // aaa is fetched; bbb is present → stop before ccc.
+        assert_eq!(plan.already_present, 1);
+        assert_eq!(
+            plan.to_fetch
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>(),
+            vec!["aaa".to_string()]
+        );
+    }
+
+    #[test]
+    fn plan_fetches_full_fills_gaps() {
+        let dir = tempfile::tempdir().unwrap();
+        let ids: Vec<String> = vec!["aaa".into(), "bbb".into(), "ccc".into()];
+        std::fs::write(dir.path().join("bbb.en.srt"), "x").unwrap();
+
+        let plan = plan_fetches(ids.as_slice(), dir.path(), "en", "srt", true);
+        // --full examines all: bbb present, aaa+ccc to fetch.
+        assert_eq!(plan.already_present, 1);
+        assert_eq!(
+            plan.to_fetch
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>(),
+            vec!["aaa".to_string(), "ccc".to_string()]
+        );
+    }
+
+    #[test]
+    fn plan_fetches_uses_lang_and_ext_in_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let ids = vec!["zzz".to_string()];
+        let plan = plan_fetches(&ids, dir.path(), "fr", "vtt", false);
+        let (_, path) = &plan.to_fetch[0];
+        assert!(path.ends_with("zzz.fr.vtt"));
+    }
+
+    #[test]
+    fn write_atomic_writes_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vid.en.srt");
+        write_atomic(&path, "hello").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello");
+        assert!(!dir.path().join(".vid.en.srt.tmp").exists());
+    }
+
+    #[test]
+    fn is_no_transcript_classifies_skip_conditions() {
+        assert!(is_no_transcript(&TranscriptError::PlayabilityRefused {
+            status: "LOGIN_REQUIRED".into(),
+            reason: None,
+        }));
+        assert!(is_no_transcript(&TranscriptError::LanguageNotFound {
+            requested: "en".into(),
+            available: vec![],
+        }));
+        assert!(is_no_transcript(
+            &TranscriptError::AutoCaptionsRequireOptIn("en".into())
+        ));
+        assert!(!is_no_transcript(&TranscriptError::ParseError("x".into())));
+    }
+
+    // ── wiremock-driven end-to-end sync ──
+
+    use serde_json::Value;
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const CHANNEL_ID: &str = "UC_x5XG1OV2P6uZZ5FSM9Ttw";
+    const RSS_FEED: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/channel_rss.xml");
+    const PLAYER_RESPONSE: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/player_response_basic.json");
+    const PLAYER_RESPONSE_AGE_GATED: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/player_response_age_gated.json");
+    const TIMEDTEXT: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/timedtext_basic.json");
+    const WATCH_PAGE: &str = include_str!(
+        "../../../transcript/sources/youtube/fixtures/watch_page_with_visitor_data.html"
+    );
+    const BROWSE_PAGE1: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/browse_videos_page1.json");
+    const BROWSE_PAGE2: &str =
+        include_str!("../../../transcript/sources/youtube/fixtures/browse_videos_page2.json");
+
+    /// Point every caption track's `baseUrl` at the mock so `select_track`
+    /// yields a URL the same server answers (mirrors the youtube.rs test
+    /// helper).
+    fn player_response_for(mock_uri: &str) -> String {
+        let mut value: Value = serde_json::from_str(PLAYER_RESPONSE).unwrap();
+        let tracks = value["captions"]["playerCaptionsTracklistRenderer"]["captionTracks"]
+            .as_array_mut()
+            .unwrap();
+        for track in tracks {
+            let lang = track["languageCode"].as_str().unwrap().to_string();
+            track["baseUrl"] = Value::String(format!("{mock_uri}/api/timedtext?lang={lang}"));
+        }
+        serde_json::to_string(&value).unwrap()
+    }
+
+    async fn mount_rss(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/feeds/videos.xml"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(RSS_FEED))
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_watch(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(WATCH_PAGE))
+            .mount(server)
+            .await;
+    }
+
+    /// Mount a `/player` mock returning `body` for every video, plus the
+    /// timedtext endpoint its caption URLs point at.
+    async fn mount_player_body(server: &MockServer, body: String) {
+        Mock::given(method("POST"))
+            .and(path("/youtubei/v1/player"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/timedtext"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(TIMEDTEXT))
+            .mount(server)
+            .await;
+    }
+
+    /// Mount the two-page `/browse` continuation sequence.
+    async fn mount_browse(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/youtubei/v1/browse"))
+            .and(body_partial_json(
+                serde_json::json!({ "browseId": CHANNEL_ID }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(BROWSE_PAGE1))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/youtubei/v1/browse"))
+            .and(body_partial_json(
+                serde_json::json!({ "continuation": "CONT_TOKEN_1" }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(BROWSE_PAGE2))
+            .mount(server)
+            .await;
+    }
+
+    /// Full happy-path server: RSS + watch + basic player + timedtext.
+    async fn mock_youtube() -> (MockServer, Youtube) {
+        let server = MockServer::start().await;
+        mount_rss(&server).await;
+        mount_watch(&server).await;
+        mount_player_body(&server, player_response_for(&server.uri())).await;
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+        (server, yt)
+    }
+
+    fn plan_for(out: PathBuf) -> SyncPlan {
+        SyncPlan {
+            channels: vec![CHANNEL_ID.to_string()],
+            out,
+            lang: "en".to_string(),
+            format: CliFormat::Srt,
+            allow_auto: false,
+            full: false,
+            since: None,
+            concurrency: 2,
+            dry_run: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_writes_transcripts_then_skips_on_resync() {
+        let (_server, yt) = mock_youtube().await;
+        let dir = tempfile::tempdir().unwrap();
+        let plan = plan_for(dir.path().to_path_buf());
+
+        // First run: all 3 RSS entries are new.
+        let report = run(&plan, &yt).await;
+        assert_eq!(report.synced, 3);
+        assert_eq!(report.already_present, 0);
+        assert_eq!(report.failed, 0);
+
+        let channel_dir = dir.path().join(CHANNEL_ID);
+        for id in ["aaaaaaaaaaa", "bbbbbbbbbbb", "ccccccccccc"] {
+            assert!(channel_dir.join(format!("{id}.en.srt")).exists());
+        }
+
+        // Second run: newest is already present → incremental early-stop.
+        let report2 = run(&plan, &yt).await;
+        assert_eq!(report2.synced, 0);
+        assert_eq!(report2.already_present, 1);
+    }
+
+    #[tokio::test]
+    async fn run_dry_run_writes_nothing() {
+        let (_server, yt) = mock_youtube().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut plan = plan_for(dir.path().to_path_buf());
+        plan.dry_run = true;
+
+        let report = run(&plan, &yt).await;
+        assert_eq!(report.would_fetch, 3);
+        assert_eq!(report.synced, 0);
+        // No channel directory is created in dry-run.
+        assert!(!dir.path().join(CHANNEL_ID).exists());
+    }
+
+    #[tokio::test]
+    async fn run_full_enumerates_via_browse() {
+        // --full takes the browse path (not RSS), paging both fixture pages.
+        let server = MockServer::start().await;
+        mount_watch(&server).await;
+        mount_browse(&server).await;
+        mount_player_body(&server, player_response_for(&server.uri())).await;
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut plan = plan_for(dir.path().to_path_buf());
+        plan.full = true;
+
+        let report = run(&plan, &yt).await;
+        assert_eq!(report.synced, 3);
+        let channel_dir = dir.path().join(CHANNEL_ID);
+        for id in ["vid00000001", "vid00000002", "vid00000003"] {
+            assert!(channel_dir.join(format!("{id}.en.srt")).exists());
+        }
+    }
+
+    #[tokio::test]
+    async fn run_since_filters_out_older_entries() {
+        // RSS entries are dated 2024-11-24 / -20 / -15; a 2024-11-21 lower
+        // bound keeps only the newest.
+        let (_server, yt) = mock_youtube().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut plan = plan_for(dir.path().to_path_buf());
+        plan.since = Some(parse_since("2024-11-21").unwrap());
+
+        let report = run(&plan, &yt).await;
+        assert_eq!(report.synced, 1);
+        assert!(dir
+            .path()
+            .join(CHANNEL_ID)
+            .join("aaaaaaaaaaa.en.srt")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn run_records_no_transcript_for_age_gated() {
+        // Age-gated player response → PlayabilityRefused → skip-and-record.
+        let server = MockServer::start().await;
+        mount_rss(&server).await;
+        mount_watch(&server).await;
+        mount_player_body(&server, PLAYER_RESPONSE_AGE_GATED.to_string()).await;
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let report = run(&plan_for(dir.path().to_path_buf()), &yt).await;
+        assert_eq!(report.no_transcript, 3);
+        assert_eq!(report.synced, 0);
+        assert_eq!(report.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn run_records_failures_on_http_error() {
+        // Player 500 → HTTP error → recorded as a failure, run continues.
+        let server = MockServer::start().await;
+        mount_rss(&server).await;
+        mount_watch(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/youtubei/v1/player"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let report = run(&plan_for(dir.path().to_path_buf()), &yt).await;
+        assert_eq!(report.failed, 3);
+        assert_eq!(report.synced, 0);
+    }
+
+    #[tokio::test]
+    async fn run_records_channel_error_when_unresolvable() {
+        // Channel page carries no channelId → ChannelNotFound → run records a
+        // channel-level error and keeps going.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/@ghost"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>no id</html>"))
+            .mount(&server)
+            .await;
+        let yt = Youtube::with_base_url(server.uri()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut plan = plan_for(dir.path().to_path_buf());
+        plan.channels = vec!["@ghost".to_string()];
+
+        let report = run(&plan, &yt).await;
+        assert_eq!(report.channel_errors, 1);
+        assert_eq!(report.synced, 0);
+    }
+
+    #[tokio::test]
+    async fn sync_with_drives_full_orchestration() {
+        // Covers the execute() orchestration (into_plan → run → print) against
+        // a mock-backed client, without constructing a live Youtube.
+        let (_server, yt) = mock_youtube().await;
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = SyncCommand {
+            channels: vec![CHANNEL_ID.to_string()],
+            out: dir.path().to_path_buf(),
+            lang: "en".to_string(),
+            format: CliFormat::Srt,
+            auto: false,
+            full: false,
+            since: None,
+            concurrency: 2,
+            dry_run: false,
+        };
+        cmd.sync_with(&yt).await.unwrap();
+        assert!(dir
+            .path()
+            .join(CHANNEL_ID)
+            .join("aaaaaaaaaaa.en.srt")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn sync_with_surfaces_invalid_since() {
+        // The into_plan() error path inside the orchestration.
+        let (_server, yt) = mock_youtube().await;
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = SyncCommand {
+            channels: vec![CHANNEL_ID.to_string()],
+            out: dir.path().to_path_buf(),
+            lang: "en".to_string(),
+            format: CliFormat::Srt,
+            auto: false,
+            full: false,
+            since: Some("not-a-date".to_string()),
+            concurrency: 2,
+            dry_run: false,
+        };
+        let err = cmd.sync_with(&yt).await.unwrap_err();
+        assert!(err.to_string().contains("Invalid --since date"));
+    }
+
+    #[test]
+    fn report_print_covers_optional_branches() {
+        // Exercises the `would_fetch > 0` and `channel_errors > 0` branches.
+        let report = SyncReport {
+            synced: 1,
+            already_present: 2,
+            no_transcript: 3,
+            failed: 4,
+            would_fetch: 5,
+            channel_errors: 6,
+        };
+        report.print();
+        SyncReport::default().print();
+    }
+}

--- a/src/transcript/error.rs
+++ b/src/transcript/error.rs
@@ -64,6 +64,17 @@ pub enum TranscriptError {
         /// The URL whose response body was scraped.
         url: String,
     },
+
+    /// A channel locator (`@handle`, `/c/Name`, `/user/Name`, …) could not be
+    /// resolved to a `UC…` channel ID. Either the input is not a recognised
+    /// channel reference or the scraped channel page did not carry the
+    /// expected `channelId` token (the page format drifts, like
+    /// [`Self::MissingVisitorData`]).
+    #[error("could not resolve a YouTube channel ID from `{input}`")]
+    ChannelNotFound {
+        /// The channel locator the caller supplied.
+        input: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/transcript/sources/youtube.rs
+++ b/src/transcript/sources/youtube.rs
@@ -14,11 +14,14 @@ use async_trait::async_trait;
 use crate::transcript::error::Result;
 use crate::transcript::source::{FetchOpts, LanguageInfo, MediaInfo, Transcript, TranscriptSource};
 
+pub mod channel;
 pub mod innertube;
 pub mod player_response;
 pub mod timedtext;
 pub mod url;
 pub mod watch_page;
+
+pub use channel::VideoEntry;
 
 pub use player_response::{
     check_playability, extract_media_info, list_languages, parse as parse_player_response,
@@ -127,6 +130,27 @@ impl Youtube {
         let response = parse_player_response(&raw)?;
         check_playability(&response)?;
         Ok(response)
+    }
+
+    /// Resolve a channel locator (`@handle`, `/c/Name`, channel URL, or a raw
+    /// `UC…` ID) to its canonical `UC…` channel ID. See
+    /// [`channel::resolve_channel_id`].
+    pub async fn resolve_channel_id(&self, input: &str) -> Result<String> {
+        channel::resolve_channel_id(&self.http, &self.base_url, input).await
+    }
+
+    /// Enumerate a channel's recent uploads via its RSS feed (newest-first,
+    /// ~15 most recent). See [`channel::fetch_recent_videos`].
+    pub async fn recent_channel_videos(&self, channel_id: &str) -> Result<Vec<VideoEntry>> {
+        channel::fetch_recent_videos(&self.http, &self.base_url, channel_id).await
+    }
+
+    /// Enumerate a channel's full upload history via the InnerTube `/browse`
+    /// endpoint (newest-first). Uses the WEB client; no `visitorData` bootstrap
+    /// is needed (browse is a public endpoint). See
+    /// [`channel::fetch_all_video_ids`].
+    pub async fn all_channel_video_ids(&self, channel_id: &str) -> Result<Vec<String>> {
+        channel::fetch_all_video_ids(&self.http, &self.base_url, channel_id).await
     }
 }
 

--- a/src/transcript/sources/youtube/channel.rs
+++ b/src/transcript/sources/youtube/channel.rs
@@ -1,0 +1,641 @@
+//! Channel video enumeration — the one capability the per-video fetcher
+//! lacks. Two no-auth strategies, both reusing the existing HTTP plumbing:
+//!
+//! - **RSS** ([`fetch_recent_videos`]): GET `feeds/videos.xml?channel_id=…`,
+//!   regex out the ~15 newest `<yt:videoId>`s plus their `<published>` dates.
+//!   Trivial and robust; ideal for incremental "keep up to date" syncs.
+//! - **InnerTube `/browse`** ([`fetch_all_video_ids`]): page through the
+//!   channel's *Videos* tab via continuation tokens for the full upload
+//!   history. Reuses [`super::innertube::fetch_browse`] (same host, same
+//!   client context as `/player`). This depends on YouTube's internal JSON
+//!   shape — the same accepted fragility the `/player` parsing already lives
+//!   with.
+//!
+//! Both return newest-first, which lets a sync stop paging once it hits a
+//! contiguous run of already-synced IDs.
+//!
+//! Channel locators (`@handle`, `/c/Name`, `/user/Name`, channel URLs) are
+//! resolved to a canonical `UC…` ID by [`resolve_channel_id`] — a raw `UC…`
+//! and `/channel/UC…` URLs short-circuit without any HTTP; everything else is
+//! scraped from the channel page (same watch-page-bootstrap pattern as
+//! [`super::watch_page`]).
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use serde_json::{json, Value};
+use url::Url;
+
+use crate::transcript::error::{Result, TranscriptError};
+
+use super::innertube::{fetch_browse, web_client_context};
+use super::watch_page::BROWSER_USER_AGENT;
+
+/// Length of a `UC…` channel ID (the `UC` prefix plus 22 base64-ish chars).
+const CHANNEL_ID_LEN: usize = 24;
+
+/// Opaque, version-stable `params` selecting a channel's *Videos* tab on the
+/// InnerTube `/browse` endpoint. A base64-encoded protobuf; treated as a
+/// constant token (the same way the `/player` request shape is pinned).
+const VIDEOS_TAB_PARAMS: &str = "EgZ2aWRlb3PyBgQKAjoA";
+
+/// A single video enumerated from a channel, newest-first.
+///
+/// `published` is present for the RSS path (which carries `<published>` per
+/// entry) and absent for the browse path (the upload grid has no per-item
+/// dates).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VideoEntry {
+    /// 11-character YouTube video ID.
+    pub id: String,
+    /// Publish timestamp, when the enumeration source provides one.
+    pub published: Option<DateTime<Utc>>,
+}
+
+/// Resolve a channel locator to its canonical `UC…` ID.
+///
+/// Short-circuits (no HTTP) for a bare `UC…` ID and for `/channel/UC…` URLs.
+/// For `@handle`, `/c/Name`, `/user/Name`, a bare handle/name, or any other
+/// channel URL, GETs the page with a browser UA and scrapes the `channelId`
+/// token out of the HTML. Returns [`TranscriptError::ChannelNotFound`] when
+/// the input is unusable or the token is absent.
+pub async fn resolve_channel_id(
+    http: &reqwest::Client,
+    base_url: &str,
+    input: &str,
+) -> Result<String> {
+    if is_channel_id(input) {
+        return Ok(input.to_string());
+    }
+
+    // Decide which page to scrape. A `/channel/UC…` URL is resolved inline.
+    let page_url = match Url::parse(input) {
+        Ok(url) => {
+            if let Some(id) = channel_id_from_path(url.path()) {
+                return Ok(id);
+            }
+            input.to_string()
+        }
+        Err(_) => format!(
+            "{base}/{path}",
+            base = base_url.trim_end_matches('/'),
+            path = input.trim_start_matches('/'),
+        ),
+    };
+
+    let body = http
+        .get(&page_url)
+        .header(reqwest::header::USER_AGENT, BROWSER_USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    extract_channel_id(&body)
+        .map(str::to_string)
+        .ok_or_else(|| TranscriptError::ChannelNotFound {
+            input: input.to_string(),
+        })
+}
+
+/// RSS enumeration: the ~15 most recent uploads, newest-first. One GET, no
+/// continuation logic. Ideal for incremental syncs.
+pub async fn fetch_recent_videos(
+    http: &reqwest::Client,
+    base_url: &str,
+    channel_id: &str,
+) -> Result<Vec<VideoEntry>> {
+    let url = format!(
+        "{base}/feeds/videos.xml?channel_id={id}",
+        base = base_url.trim_end_matches('/'),
+        id = channel_id,
+    );
+    let body = http
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(parse_rss(&body))
+}
+
+/// Browse enumeration: the full upload history, newest-first.
+///
+/// Pages the *Videos* tab through continuation tokens using the WEB client
+/// (see [`super::innertube::fetch_browse`]). No `visitorData` is needed —
+/// browse is a public, non-bot-gated endpoint.
+pub async fn fetch_all_video_ids(
+    http: &reqwest::Client,
+    base_url: &str,
+    channel_id: &str,
+) -> Result<Vec<String>> {
+    let mut ids: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut seen_tokens: HashSet<String> = HashSet::new();
+
+    // First page keys off `browseId` + the Videos-tab `params`; subsequent
+    // pages key off the continuation token returned by the previous page.
+    let mut body = json!({
+        "context": web_client_context(),
+        "browseId": channel_id,
+        "params": VIDEOS_TAB_PARAMS,
+    });
+
+    loop {
+        let raw = fetch_browse(http, base_url, &body).await?;
+        let value: Value = serde_json::from_str(&raw).map_err(|e| {
+            TranscriptError::ParseError(format!("browse response was not valid JSON: {e}"))
+        })?;
+        let (page_ids, token) = parse_browse_page(&value);
+
+        let mut added_any = false;
+        for id in page_ids {
+            if seen.insert(id.clone()) {
+                ids.push(id);
+                added_any = true;
+            }
+        }
+
+        // Stop when the page advances nothing new or the token loops/ends —
+        // each guard alone prevents a runaway pagination loop.
+        match token {
+            Some(t) if added_any && seen_tokens.insert(t.clone()) => {
+                body = json!({
+                    "context": web_client_context(),
+                    "continuation": t,
+                });
+            }
+            _ => break,
+        }
+    }
+
+    Ok(ids)
+}
+
+/// Whether `s` is a bare canonical channel ID (`UC` + 22 ID chars).
+fn is_channel_id(s: &str) -> bool {
+    s.len() == CHANNEL_ID_LEN
+        && s.starts_with("UC")
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// Pull a `UC…` ID out of a URL path like `/channel/UC…/videos`.
+fn channel_id_from_path(path: &str) -> Option<String> {
+    let rest = path.trim_start_matches('/').strip_prefix("channel/")?;
+    let candidate = rest.split('/').next().unwrap_or(rest);
+    is_channel_id(candidate).then(|| candidate.to_string())
+}
+
+/// Lazy-compiled `channelId` / `externalId` extractor. The token is a JSON
+/// string value in an inline script block; anchored on the exact keys so it
+/// doesn't match neighbouring `*Id` fields. Same regex-over-HTML approach as
+/// [`super::watch_page`]'s `visitorData` scrape.
+fn channel_id_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    #[allow(clippy::expect_used)]
+    RE.get_or_init(|| {
+        Regex::new(r#""(?:channelId|externalId)":"(UC[0-9A-Za-z_-]{22})""#)
+            .expect("channel_id regex must compile")
+    })
+}
+
+/// Pure helper: pull the `UC…` channel ID out of a channel-page body.
+fn extract_channel_id(body: &str) -> Option<&str> {
+    channel_id_regex()
+        .captures(body)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str())
+}
+
+/// Lazy-compiled extractor for a single RSS `<entry>` block's video ID.
+fn rss_video_id_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    #[allow(clippy::expect_used)]
+    RE.get_or_init(|| {
+        Regex::new(r"<yt:videoId>([0-9A-Za-z_-]{11})</yt:videoId>")
+            .expect("rss video id regex must compile")
+    })
+}
+
+/// Lazy-compiled extractor for a single RSS `<entry>` block's publish date.
+fn rss_published_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    #[allow(clippy::expect_used)]
+    RE.get_or_init(|| {
+        Regex::new(r"<published>([^<]+)</published>").expect("rss published regex must compile")
+    })
+}
+
+/// Lazy-compiled splitter for RSS `<entry>…</entry>` blocks.
+fn rss_entry_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    #[allow(clippy::expect_used)]
+    RE.get_or_init(|| {
+        Regex::new(r"(?s)<entry>(.*?)</entry>").expect("rss entry regex must compile")
+    })
+}
+
+/// Pure helper: parse a YouTube channel RSS feed into newest-first entries.
+/// Entries without a parseable video ID are skipped; an unparseable
+/// `<published>` degrades to `None` rather than dropping the entry.
+fn parse_rss(xml: &str) -> Vec<VideoEntry> {
+    rss_entry_regex()
+        .captures_iter(xml)
+        .filter_map(|entry| {
+            let block = entry.get(1)?.as_str();
+            let id = rss_video_id_regex()
+                .captures(block)
+                .and_then(|c| c.get(1))?
+                .as_str()
+                .to_string();
+            let published = rss_published_regex()
+                .captures(block)
+                .and_then(|c| c.get(1))
+                .and_then(|m| DateTime::parse_from_rfc3339(m.as_str()).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+            Some(VideoEntry { id, published })
+        })
+        .collect()
+}
+
+/// Pure helper: extract `(video_ids, next_continuation_token)` from one
+/// `/browse` response page.
+///
+/// IDs are collected by a tolerant tree-walk in document order (newest-first
+/// for the Videos tab). Two item shapes are recognised:
+///
+/// - `lockupViewModel` with `contentType == "LOCKUP_CONTENT_TYPE_VIDEO"` →
+///   `contentId` (the current WEB grid shape).
+/// - `videoRenderer.videoId` (the legacy shape, still emitted on some tabs).
+///
+/// The continuation token is taken **only** from the array that also holds the
+/// video items — the grid's "load more". A response carries other
+/// `continuationItemRenderer`s too (e.g. one in the channel header) that page
+/// unrelated content; scoping to the video array avoids paging the wrong list
+/// (which would stop enumeration after the first ~30 uploads).
+///
+/// The `contentType` guard avoids playlist / channel lockups, and keying only
+/// off these wrappers avoids the duplicate IDs that appear under
+/// `watchEndpoint` / `addToPlaylist` link targets.
+fn parse_browse_page(value: &Value) -> (Vec<String>, Option<String>) {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+    collect_video_ids(value, &mut ids, &mut seen);
+    let token = find_grid_continuation(value);
+    (ids, token)
+}
+
+fn collect_video_ids(value: &Value, ids: &mut Vec<String>, seen: &mut HashSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(id) = video_id_from_item(map) {
+                if seen.insert(id.to_string()) {
+                    ids.push(id.to_string());
+                }
+            }
+            for child in map.values() {
+                collect_video_ids(child, ids, seen);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_video_ids(child, ids, seen);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Find the continuation token belonging to the *video grid*: the
+/// `continuationItemRenderer` token that sits in the same array as the video
+/// items. Returns `None` once the grid has no further pages.
+fn find_grid_continuation(value: &Value) -> Option<String> {
+    match value {
+        Value::Array(arr) => {
+            // The video items in this array are wrapped (e.g. in
+            // `richItemRenderer`), so test the subtree, not the item directly.
+            let has_video = arr.iter().any(contains_video);
+            if has_video {
+                if let Some(token) = arr
+                    .iter()
+                    .filter_map(Value::as_object)
+                    .find_map(continuation_token_from_item)
+                {
+                    return Some(token);
+                }
+            }
+            arr.iter().find_map(find_grid_continuation)
+        }
+        Value::Object(map) => map.values().find_map(find_grid_continuation),
+        _ => None,
+    }
+}
+
+/// Whether `value`'s subtree contains at least one video item.
+fn contains_video(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => video_id_from_item(map).is_some() || map.values().any(contains_video),
+        Value::Array(arr) => arr.iter().any(contains_video),
+        _ => false,
+    }
+}
+
+/// Pull a video ID out of a single item renderer if `map` is one. Recognises
+/// the current `lockupViewModel` shape and the legacy `videoRenderer` shape;
+/// returns `None` for any other object.
+fn video_id_from_item(map: &serde_json::Map<String, Value>) -> Option<&str> {
+    if let Some(lockup) = map.get("lockupViewModel") {
+        if lockup.get("contentType").and_then(Value::as_str) == Some("LOCKUP_CONTENT_TYPE_VIDEO") {
+            return lockup.get("contentId").and_then(Value::as_str);
+        }
+    }
+    map.get("videoRenderer")
+        .and_then(|vr| vr.get("videoId"))
+        .and_then(Value::as_str)
+}
+
+/// Pull a continuation token out of a `continuationItemRenderer` item.
+fn continuation_token_from_item(map: &serde_json::Map<String, Value>) -> Option<String> {
+    map.get("continuationItemRenderer")?
+        .get("continuationEndpoint")?
+        .get("continuationCommand")?
+        .get("token")?
+        .as_str()
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_partial_json, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const CHANNEL_PAGE: &str = include_str!("fixtures/channel_page.html");
+    const RSS_FEED: &str = include_str!("fixtures/channel_rss.xml");
+    const BROWSE_PAGE1: &str = include_str!("fixtures/browse_videos_page1.json");
+    const BROWSE_PAGE2: &str = include_str!("fixtures/browse_videos_page2.json");
+
+    const CHANNEL_ID: &str = "UC_x5XG1OV2P6uZZ5FSM9Ttw";
+
+    fn http() -> reqwest::Client {
+        reqwest::Client::builder().build().unwrap()
+    }
+
+    // ── pure helpers ──
+
+    #[test]
+    fn is_channel_id_accepts_canonical() {
+        assert!(is_channel_id(CHANNEL_ID));
+        assert!(!is_channel_id("UCshort"));
+        assert!(!is_channel_id("AB_x5XG1OV2P6uZZ5FSM9Ttw")); // wrong prefix
+    }
+
+    #[test]
+    fn channel_id_from_path_extracts_uc() {
+        assert_eq!(
+            channel_id_from_path(&format!("/channel/{CHANNEL_ID}/videos")).as_deref(),
+            Some(CHANNEL_ID)
+        );
+        assert_eq!(channel_id_from_path("/@handle"), None);
+    }
+
+    #[test]
+    fn extract_channel_id_from_fixture() {
+        assert_eq!(extract_channel_id(CHANNEL_PAGE), Some(CHANNEL_ID));
+    }
+
+    #[test]
+    fn extract_channel_id_ignores_other_id_keys() {
+        let body = r#"{"clientId":"x","sessionId":"y"}"#;
+        assert_eq!(extract_channel_id(body), None);
+    }
+
+    #[test]
+    fn parse_rss_returns_entries_newest_first_with_dates() {
+        let entries = parse_rss(RSS_FEED);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].id, "aaaaaaaaaaa");
+        assert_eq!(entries[2].id, "ccccccccccc");
+        assert!(entries[0].published.unwrap() > entries[2].published.unwrap());
+    }
+
+    #[test]
+    fn parse_browse_page1_yields_ids_and_token() {
+        let value: Value = serde_json::from_str(BROWSE_PAGE1).unwrap();
+        let (ids, token) = parse_browse_page(&value);
+        // The playlist lockup is filtered out by the contentType guard.
+        assert_eq!(ids, vec!["vid00000001", "vid00000002"]);
+        assert_eq!(token.as_deref(), Some("CONT_TOKEN_1"));
+    }
+
+    #[test]
+    fn parse_browse_page_accepts_legacy_video_renderer() {
+        // Older shape: `videoRenderer.videoId` rather than `lockupViewModel`.
+        let value = json!({
+            "contents": {
+                "richGridRenderer": {
+                    "contents": [
+                        { "richItemRenderer": { "content": {
+                            "videoRenderer": { "videoId": "legacyvid01" } } } },
+                        { "continuationItemRenderer": { "continuationEndpoint": {
+                            "continuationCommand": { "token": "LEGACY_TOK" } } } }
+                    ]
+                }
+            }
+        });
+        let (ids, token) = parse_browse_page(&value);
+        assert_eq!(ids, vec!["legacyvid01"]);
+        assert_eq!(token.as_deref(), Some("LEGACY_TOK"));
+    }
+
+    #[test]
+    fn find_grid_continuation_recurses_past_video_less_arrays() {
+        // Arrays without any video → `contains_video` false → recurse → None.
+        let empty = json!({ "a": [{ "x": 1 }], "b": { "c": [] } });
+        assert_eq!(find_grid_continuation(&empty), None);
+
+        // Outer array's items are wrappers (no direct continuation); the grid
+        // token sits deeper, forcing the recursion fall-through branch.
+        let nested = json!({
+            "outer": [
+                { "wrap": { "richGridRenderer": { "contents": [
+                    { "richItemRenderer": { "content": { "lockupViewModel": {
+                        "contentId": "vidxxxxxxx1",
+                        "contentType": "LOCKUP_CONTENT_TYPE_VIDEO" } } } },
+                    { "continuationItemRenderer": { "continuationEndpoint": {
+                        "continuationCommand": { "token": "DEEP_TOK" } } } }
+                ] } } }
+            ]
+        });
+        assert_eq!(find_grid_continuation(&nested).as_deref(), Some("DEEP_TOK"));
+    }
+
+    #[test]
+    fn parse_browse_page2_is_final() {
+        let value: Value = serde_json::from_str(BROWSE_PAGE2).unwrap();
+        let (ids, token) = parse_browse_page(&value);
+        assert_eq!(ids, vec!["vid00000003"]);
+        assert_eq!(token, None);
+    }
+
+    // ── HTTP layer ──
+
+    #[tokio::test]
+    async fn resolve_channel_id_passthrough_skips_http() {
+        // No mock server: a bare UC id must not trigger any request.
+        let id = resolve_channel_id(&http(), "http://127.0.0.1:1", CHANNEL_ID)
+            .await
+            .unwrap();
+        assert_eq!(id, CHANNEL_ID);
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_id_from_channel_url_skips_http() {
+        let id = resolve_channel_id(
+            &http(),
+            "http://127.0.0.1:1",
+            &format!("https://www.youtube.com/channel/{CHANNEL_ID}"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(id, CHANNEL_ID);
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_id_scrapes_handle() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/@google"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(CHANNEL_PAGE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let id = resolve_channel_id(&http(), &server.uri(), "@google")
+            .await
+            .unwrap();
+        assert_eq!(id, CHANNEL_ID);
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_id_scrapes_full_url() {
+        // A full URL whose path isn't `/channel/UC…` is scraped as-is.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/c/SomeName"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(CHANNEL_PAGE))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let input = format!("{}/c/SomeName", server.uri());
+        let id = resolve_channel_id(&http(), &server.uri(), &input)
+            .await
+            .unwrap();
+        assert_eq!(id, CHANNEL_ID);
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_id_surfaces_missing_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/@nobody"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>no id</html>"))
+            .mount(&server)
+            .await;
+
+        let err = resolve_channel_id(&http(), &server.uri(), "@nobody")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TranscriptError::ChannelNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn fetch_recent_videos_parses_feed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/feeds/videos.xml"))
+            .and(query_param("channel_id", CHANNEL_ID))
+            .respond_with(ResponseTemplate::new(200).set_body_string(RSS_FEED))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let entries = fetch_recent_videos(&http(), &server.uri(), CHANNEL_ID)
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].id, "aaaaaaaaaaa");
+    }
+
+    #[tokio::test]
+    async fn fetch_all_video_ids_pages_through_continuation() {
+        let server = MockServer::start().await;
+        // First page: keyed by browseId.
+        Mock::given(method("POST"))
+            .and(path(super::super::innertube::BROWSE_PATH))
+            .and(body_partial_json(json!({ "browseId": CHANNEL_ID })))
+            .respond_with(ResponseTemplate::new(200).set_body_string(BROWSE_PAGE1))
+            .mount(&server)
+            .await;
+        // Continuation page: keyed by the token from page 1.
+        Mock::given(method("POST"))
+            .and(path(super::super::innertube::BROWSE_PATH))
+            .and(body_partial_json(json!({ "continuation": "CONT_TOKEN_1" })))
+            .respond_with(ResponseTemplate::new(200).set_body_string(BROWSE_PAGE2))
+            .mount(&server)
+            .await;
+
+        let ids = fetch_all_video_ids(&http(), &server.uri(), CHANNEL_ID)
+            .await
+            .unwrap();
+        assert_eq!(ids, vec!["vid00000001", "vid00000002", "vid00000003"]);
+    }
+
+    #[tokio::test]
+    async fn fetch_all_video_ids_surfaces_invalid_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(super::super::innertube::BROWSE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{ not json"))
+            .mount(&server)
+            .await;
+
+        let err = fetch_all_video_ids(&http(), &server.uri(), CHANNEL_ID)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TranscriptError::ParseError(_)));
+    }
+
+    // ── Online integration test ──
+    //
+    // Hits real YouTube — gated behind the `online_tests` custom cfg (see the
+    // note in `super`'s tests). Run manually with
+    // `RUSTFLAGS='--cfg online_tests' cargo test online_resolve_and_enumerate`.
+    #[cfg(online_tests)]
+    #[tokio::test]
+    async fn online_resolve_and_enumerate() {
+        const BASE_URL: &str = "https://www.youtube.com";
+        // Google Developers — stable, high-volume, captioned channel.
+        let id = resolve_channel_id(&http(), BASE_URL, "@GoogleDevelopers")
+            .await
+            .unwrap();
+        assert!(is_channel_id(&id));
+
+        let recent = fetch_recent_videos(&http(), BASE_URL, &id).await.unwrap();
+        assert!(!recent.is_empty());
+        assert!(recent.iter().all(|e| e.id.len() == 11));
+
+        // Browse should return at least as many as RSS (full history ≥ recent
+        // 15) and page past the first ~30 via continuation tokens.
+        let all = fetch_all_video_ids(&http(), BASE_URL, &id).await.unwrap();
+        assert!(all.len() >= recent.len());
+        assert!(all.iter().all(|v| v.len() == 11));
+    }
+}

--- a/src/transcript/sources/youtube/fixtures/browse_videos_page1.json
+++ b/src/transcript/sources/youtube/fixtures/browse_videos_page1.json
@@ -1,0 +1,65 @@
+{
+  "contents": {
+    "twoColumnBrowseResultsRenderer": {
+      "tabs": [
+        {
+          "tabRenderer": {
+            "title": "Videos",
+            "selected": true,
+            "content": {
+              "richGridRenderer": {
+                "contents": [
+                  {
+                    "richItemRenderer": {
+                      "content": {
+                        "lockupViewModel": {
+                          "contentId": "vid00000001",
+                          "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+                          "rendererContext": {
+                            "commandContext": {
+                              "watchEndpoint": { "videoId": "vid00000001" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "richItemRenderer": {
+                      "content": {
+                        "lockupViewModel": {
+                          "contentId": "vid00000002",
+                          "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "richItemRenderer": {
+                      "content": {
+                        "lockupViewModel": {
+                          "contentId": "PLnotavideoplaylist",
+                          "contentType": "LOCKUP_CONTENT_TYPE_PLAYLIST"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "continuationItemRenderer": {
+                      "continuationEndpoint": {
+                        "continuationCommand": {
+                          "token": "CONT_TOKEN_1",
+                          "request": "CONTINUATION_REQUEST_TYPE_BROWSE"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/transcript/sources/youtube/fixtures/browse_videos_page2.json
+++ b/src/transcript/sources/youtube/fixtures/browse_videos_page2.json
@@ -1,0 +1,20 @@
+{
+  "onResponseReceivedActions": [
+    {
+      "appendContinuationItemsAction": {
+        "continuationItems": [
+          {
+            "richItemRenderer": {
+              "content": {
+                "lockupViewModel": {
+                  "contentId": "vid00000003",
+                  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/transcript/sources/youtube/fixtures/channel_page.html
+++ b/src/transcript/sources/youtube/fixtures/channel_page.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head><title>Sample Channel - YouTube</title></head>
+<body>
+<script>
+var ytInitialData = {"responseContext":{"serviceTrackingParams":[]},
+"metadata":{"channelMetadataRenderer":{
+"title":"Sample Channel",
+"externalId":"UC_x5XG1OV2P6uZZ5FSM9Ttw",
+"channelUrl":"http://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw"}},
+"microformat":{"microformatDataRenderer":{
+"urlCanonical":"http://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw"}}};
+</script>
+<script>
+ytcfg.set({"CHANNEL_ID":"UC_x5XG1OV2P6uZZ5FSM9Ttw","channelId":"UC_x5XG1OV2P6uZZ5FSM9Ttw"});
+</script>
+</body>
+</html>

--- a/src/transcript/sources/youtube/fixtures/channel_rss.xml
+++ b/src/transcript/sources/youtube/fixtures/channel_rss.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns:media="http://search.yahoo.com/mrss/"
+      xmlns="http://www.w3.org/2005/Atom">
+  <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+  <title>Sample Channel</title>
+  <entry>
+    <id>yt:video:aaaaaaaaaaa</id>
+    <yt:videoId>aaaaaaaaaaa</yt:videoId>
+    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+    <title>Newest video</title>
+    <published>2024-11-24T18:00:00+00:00</published>
+    <updated>2024-11-24T18:30:00+00:00</updated>
+  </entry>
+  <entry>
+    <id>yt:video:bbbbbbbbbbb</id>
+    <yt:videoId>bbbbbbbbbbb</yt:videoId>
+    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+    <title>Middle video</title>
+    <published>2024-11-20T12:00:00+00:00</published>
+    <updated>2024-11-20T12:30:00+00:00</updated>
+  </entry>
+  <entry>
+    <id>yt:video:ccccccccccc</id>
+    <yt:videoId>ccccccccccc</yt:videoId>
+    <yt:channelId>UC_x5XG1OV2P6uZZ5FSM9Ttw</yt:channelId>
+    <title>Oldest video</title>
+    <published>2024-11-15T09:00:00+00:00</published>
+    <updated>2024-11-15T09:30:00+00:00</updated>
+  </entry>
+</feed>

--- a/src/transcript/sources/youtube/innertube.rs
+++ b/src/transcript/sources/youtube/innertube.rs
@@ -19,18 +19,38 @@
 //! Oculus YouTube app, and refresh `INNERTUBE_API_KEY` if the
 //! ANDROID-family key starts being rejected.
 
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::transcript::error::Result;
 
 /// Path appended to the `base_url` for the `/player` POST.
 pub(crate) const PLAYER_PATH: &str = "/youtubei/v1/player";
 
+/// Path appended to the `base_url` for the `/browse` POST. Used to enumerate
+/// a channel's uploads (see [`super::channel`]). Unlike `/player`, browse uses
+/// the **WEB** client (see [`web_client_context`]): only the WEB grid is
+/// paginated (continuation tokens) and carries the `richGridRenderer` /
+/// `lockupViewModel` shape the channel parser reads. The `ANDROID_VR` client
+/// returns an unpaginated `compactVideoRenderer` mobile shape instead.
+pub(crate) const BROWSE_PATH: &str = "/youtubei/v1/browse";
+
 /// Public InnerTube API key for the ANDROID-family clients (including
 /// `ANDROID_VR`). Sent as the `X-Goog-Api-Key` header — YouTube returns
 /// 400 for the legacy `?key=` query form on modern `/player` paths.
 /// Embedded in the public Oculus YouTube app binary; not a credential.
 pub(crate) const INNERTUBE_API_KEY: &str = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
+
+/// Public InnerTube API key for the `WEB` client, used by the channel
+/// [`fetch_browse`] path. Like [`INNERTUBE_API_KEY`], it is embedded in the
+/// public web app and is not a credential.
+pub(crate) const WEB_INNERTUBE_API_KEY: &str = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+
+/// `client.clientName` for the WEB browse client.
+pub(crate) const WEB_CLIENT_NAME: &str = "WEB";
+
+/// `client.clientVersion` for the WEB browse client. Browse is not bot-gated
+/// the way `/player` is, so this need only be recent enough to be accepted.
+pub(crate) const WEB_CLIENT_VERSION: &str = "2.20240101.00.00";
 
 /// `client.clientName`.
 pub(crate) const CLIENT_NAME: &str = "ANDROID_VR";
@@ -58,6 +78,67 @@ pub(crate) const OS_VERSION: &str = "12L";
 /// param; modern YouTube `/player` paths reject the latter with HTTP 400.
 const API_KEY_HEADER: &str = "X-Goog-Api-Key";
 
+/// The `context.client` object pinned to the `ANDROID_VR` fingerprint and
+/// carrying the scraped `visitorData` token. Shared by every InnerTube POST
+/// ([`fetch_player_response`], [`fetch_browse`]) so the device fingerprint
+/// and bot-bypass token stay identical across endpoints.
+pub(crate) fn client_context(visitor_data: &str) -> Value {
+    json!({
+        "client": {
+            "clientName": CLIENT_NAME,
+            "clientVersion": CLIENT_VERSION,
+            "androidSdkVersion": ANDROID_SDK_VERSION,
+            "deviceMake": DEVICE_MAKE,
+            "deviceModel": DEVICE_MODEL,
+            "osName": OS_NAME,
+            "osVersion": OS_VERSION,
+            "hl": "en",
+            "gl": "US",
+            "visitorData": visitor_data,
+        },
+    })
+}
+
+/// The `context.client` object for the **WEB** client used by channel browse.
+/// Carries no device fingerprint or `visitorData` — browse is a public,
+/// non-bot-gated endpoint, unlike `/player`.
+pub(crate) fn web_client_context() -> Value {
+    json!({
+        "client": {
+            "clientName": WEB_CLIENT_NAME,
+            "clientVersion": WEB_CLIENT_VERSION,
+            "hl": "en",
+            "gl": "US",
+        },
+    })
+}
+
+/// POST `body` to the InnerTube `/browse` endpoint and return the raw body.
+///
+/// Callers build `body` with a WEB `context` (see [`web_client_context`]) plus
+/// either a `browseId` (first page) or a `continuation` token (subsequent
+/// pages); [`super::channel`] feeds the result to its `lockupViewModel` /
+/// continuation parser. Sent with the WEB API key — the ANDROID key returns
+/// the unpaginated mobile shape.
+///
+/// `base_url` is normally `https://www.youtube.com`; tests inject a
+/// `wiremock::MockServer::uri()` instead.
+pub async fn fetch_browse(http: &reqwest::Client, base_url: &str, body: &Value) -> Result<String> {
+    let url = format!(
+        "{base}{path}",
+        base = base_url.trim_end_matches('/'),
+        path = BROWSE_PATH,
+    );
+    let response = http
+        .post(&url)
+        .header(API_KEY_HEADER, WEB_INNERTUBE_API_KEY)
+        .json(body)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(response.text().await?)
+}
+
 /// POST `videoId` to the InnerTube `/player` endpoint at `base_url` and
 /// return the raw response body. Callers feed the body to
 /// [`super::player_response::parse`].
@@ -80,20 +161,7 @@ pub async fn fetch_player_response(
         path = PLAYER_PATH,
     );
     let body = json!({
-        "context": {
-            "client": {
-                "clientName": CLIENT_NAME,
-                "clientVersion": CLIENT_VERSION,
-                "androidSdkVersion": ANDROID_SDK_VERSION,
-                "deviceMake": DEVICE_MAKE,
-                "deviceModel": DEVICE_MODEL,
-                "osName": OS_NAME,
-                "osVersion": OS_VERSION,
-                "hl": "en",
-                "gl": "US",
-                "visitorData": visitor_data,
-            },
-        },
+        "context": client_context(visitor_data),
         "videoId": video_id,
         "contentCheckOk": true,
         "racyCheckOk": true,
@@ -257,6 +325,55 @@ mod tests {
         let _ = fetch_player_response(&http(), &server.uri(), VIDEO_ID, VISITOR_DATA)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn browse_posts_to_browse_endpoint_with_web_key_and_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(BROWSE_PATH))
+            .and(header(API_KEY_HEADER, WEB_INNERTUBE_API_KEY))
+            .and(body_partial_json(json!({
+                "browseId": "UC_x5XG1OV2P6uZZ5FSM9Ttw",
+                "context": { "client": { "clientName": WEB_CLIENT_NAME } },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let body = json!({
+            "context": web_client_context(),
+            "browseId": "UC_x5XG1OV2P6uZZ5FSM9Ttw",
+        });
+        let out = fetch_browse(&http(), &server.uri(), &body).await.unwrap();
+        assert_eq!(out, r#"{"ok":true}"#);
+    }
+
+    #[tokio::test]
+    async fn browse_surfaces_non_2xx_as_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(BROWSE_PATH))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let body = json!({ "context": client_context(VISITOR_DATA), "browseId": "UCabc" });
+        let err = fetch_browse(&http(), &server.uri(), &body)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::transcript::TranscriptError::Http(_)));
+    }
+
+    #[test]
+    fn client_context_pins_full_quest_fingerprint() {
+        let ctx = client_context("vd-token");
+        let client = &ctx["client"];
+        assert_eq!(client["clientName"], CLIENT_NAME);
+        assert_eq!(client["clientVersion"], CLIENT_VERSION);
+        assert_eq!(client["osVersion"], OS_VERSION);
+        assert_eq!(client["visitorData"], "vd-token");
     }
 
     #[tokio::test]

--- a/src/transcript/sources/youtube/watch_page.rs
+++ b/src/transcript/sources/youtube/watch_page.rs
@@ -36,7 +36,10 @@ const BOOTSTRAP_VIDEO_ID: &str = "dQw4w9WgXcQ";
 ///
 /// Distinct from [`super::USER_AGENT`], which the InnerTube `/player`
 /// POSTs use — that one must match `clientName: ANDROID_VR`.
-const BROWSER_USER_AGENT: &str =
+///
+/// Also reused by [`super::channel`] when scraping a channel page for its
+/// `channelId` — same browser-vs-bot reasoning applies there.
+pub(crate) const BROWSER_USER_AGENT: &str =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
      (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2910,6 +2910,7 @@ Commands:
   fetch       Fetches the transcript for a YouTube video
   list-langs  Lists the caption tracks available on a YouTube video
   info        Shows top-level metadata (title, channel, duration, languages) for a YouTube video
+  sync        Syncs transcripts for all videos in one or more channels to the filesystem
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2966,6 +2967,29 @@ Arguments:
 Options:
       --output <OUTPUT>  Output format [default: table] [possible values: table, json]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev transcript youtube sync - Syncs transcripts for all videos in one or more channels to the filesystem
+
+Syncs transcripts for all videos in one or more channels to the filesystem
+
+Usage: sync [OPTIONS] --out <OUT> <CHANNELS>...
+
+Arguments:
+  <CHANNELS>...  One or more channel references: a `UC…` ID, a channel URL (`/channel/UC…`, `/@handle`, `/c/Name`, `/user/Name`), or a bare `@handle`
+
+Options:
+      --out <OUT>                  Output directory. Transcripts are written under `<out>/<channel-id>/<video-id>.<lang>.<format>`
+      --lang <LANG>                Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is applied — `en` matches `en-US` [default: en]
+      --format <FORMAT>            Output format [default: srt] [possible values: srt, vtt, txt, json]
+      --auto                       Allow falling through to auto-generated (ASR) captions when no manual track matches. Recommended for channel syncs — many uploads only have auto captions
+      --full                       Backfill the channel's entire upload history via the InnerTube `/browse` endpoint. Without this, only the ~15 most recent uploads (the RSS feed) are considered
+      --since <DATE>               Only sync videos published on or after this date (`YYYY-MM-DD` or an RFC 3339 timestamp). Reliable for the default (RSS) path, which carries per-video publish dates; best-effort under `--full` (the browse grid has no per-item dates, so this is ignored there)
+      --concurrency <CONCURRENCY>  Maximum number of transcripts to fetch concurrently [default: 4]
+      --dry-run                    List what would be fetched without downloading or writing anything
+  -h, --help                       Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR introduces the `omni-dev transcript youtube sync` subcommand for incrementally syncing transcripts from one or more YouTube channels to the filesystem. It builds on the existing per-video fetcher with channel enumeration, filesystem-as-state deduplication, and concurrent fetching.

The command resolves channel locators (`@handle`, `/c/Name`, `/user/Name`, channel URLs, or bare `UC…` IDs) to canonical channel IDs, enumerates their videos via RSS (incremental) or InnerTube `/browse` (full history), and writes transcripts atomically. Videos without usable transcripts (age-gated, region-locked, no captions) are skipped rather than aborting the run.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Fixes #928

## Changes Made

**New CLI Command (`src/cli/transcript/youtube/sync.rs`):**
- Added `SyncCommand` with `--out`, `--lang`, `--format`, `--auto`, `--full`, `--since`, `--concurrency`, and `--dry-run` flags
- Validates and normalises CLI args into a `SyncPlan` before execution
- Parses `--since` as either `YYYY-MM-DD` (midnight UTC) or RFC 3339 timestamp
- Incremental mode stops at the first already-present file (newest-first ordering); `--full` examines every ID to fill gaps
- Fetches transcripts concurrently via `futures::stream::buffer_unordered`
- Writes each transcript atomically via a sibling `.tmp` file + rename
- Records and prints a `SyncReport` (synced / already present / no transcript / failed / would fetch / channel errors)

**Channel Enumeration Library (`src/transcript/sources/youtube/channel.rs`):**
- `resolve_channel_id`: resolves `@handle`, `/c/Name`, `/user/Name`, channel URLs, or bare `UC…` IDs; short-circuits without HTTP for bare IDs and `/channel/UC…` URLs; otherwise scrapes `channelId`/`externalId` from the channel page with a browser UA
- `fetch_recent_videos`: RSS-based enumeration (~15 most recent uploads with publish timestamps, newest-first); single GET, no pagination
- `fetch_all_video_ids`: InnerTube `/browse` full-history enumeration with continuation-token pagination and loop-guard deduplication
- `VideoEntry` struct carrying video ID and optional publish timestamp

**InnerTube Enhancements (`src/transcript/sources/youtube/innertube.rs`):**
- Extracted `client_context(visitor_data)` helper shared by `/player` and new `/browse` POSTs, eliminating duplicated JSON construction
- Added `fetch_browse` function, `BROWSE_PATH` constant, and `web_client_context` helper for the WEB browse client
- Added `WEB_INNERTUBE_API_KEY`, `WEB_CLIENT_NAME`, `WEB_CLIENT_VERSION` constants for the WEB client
- Exported `BROWSER_USER_AGENT` from `watch_page.rs` as `pub(crate)` for reuse by channel-page scraping

**Error Handling (`src/transcript/error.rs`):**
- Added `TranscriptError::ChannelNotFound { input }` variant for when a channel locator cannot be resolved to a `UC…` ID

**CLI Router (`src/cli/transcript/youtube/mod.rs`):**
- Added `Sync(sync::SyncCommand)` variant to `YoutubeSubcommands` enum
- Wired `execute()` dispatch for the new subcommand

**Test Fixtures (new files):**
- `fixtures/channel_page.html` — minimal channel page with `externalId` for scraping tests
- `fixtures/channel_rss.xml` — 3-entry RSS feed with publish dates
- `fixtures/browse_videos_page1.json` — first browse page with continuation token and playlist lockup (filtered out)
- `fixtures/browse_videos_page2.json` — final browse page (no continuation token)

**Snapshot Update:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include the new `sync` subcommand in help output

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

**Key scenarios exercised:**
- `sync_command_defaults`: verifies all default flag values
- `sync_command_all_flags_and_multiple_channels`: verifies multi-channel input and all flags
- `sync_command_requires_a_channel`: verifies CLI rejects missing required positional arg
- `parse_since_accepts_date_and_rfc3339`: both date formats parse correctly
- `parse_since_rejects_garbage`: invalid input returns error
- `into_plan_clamps_zero_concurrency_to_one`: guards against zero concurrency
- `plan_fetches_incremental_stops_at_first_present`: early-stop logic is correct
- `plan_fetches_full_fills_gaps`: `--full` examines all IDs
- `plan_fetches_uses_lang_and_ext_in_path`: output path uses correct lang/ext
- `write_atomic_writes_and_leaves_no_temp`: atomic write leaves no temp file
- `is_no_transcript_classifies_skip_conditions`: skip vs. fail classification is correct
- `run_writes_transcripts_then_skips_on_resync` (wiremock, async): full end-to-end sync and incremental early-stop
- `run_dry_run_writes_nothing` (wiremock, async): dry-run creates no files or directories
- `is_channel_id_accepts_canonical`, `channel_id_from_path_extracts_uc`, `extract_channel_id_from_fixture`: pure channel ID helpers
- `parse_rss_returns_entries_newest_first_with_dates`: RSS parsing order and timestamps
- `parse_browse_page1_yields_ids_and_token`, `parse_browse_page2_is_final`: browse page parsing with/without continuation
- `resolve_channel_id_passthrough_skips_http`, `resolve_channel_id_from_channel_url_skips_http`: no-HTTP short-circuit paths
- `resolve_channel_id_scrapes_handle`, `resolve_channel_id_surfaces_missing_token` (wiremock): HTTP scraping happy/error paths
- `fetch_recent_videos_parses_feed` (wiremock): RSS GET request and parse
- `fetch_all_video_ids_pages_through_continuation` (wiremock): multi-page browse pagination
- `browse_posts_to_browse_endpoint_with_web_key_and_body`, `browse_surfaces_non_2xx_as_http_error`, `client_context_pins_full_quest_fingerprint`: innertube `/browse` plumbing

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new channel sync tests
cargo test sync
cargo test channel

# Run innertube tests
cargo test innertube

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Online integration test (requires network, opt-in)
RUSTFLAGS='--cfg online_tests' cargo test online_resolve_and_enumerate
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — new `channel.rs` module and how it integrates with the existing `Youtube` struct via `resolve_channel_id`, `recent_channel_videos`, and `all_channel_video_ids` methods
- [x] Error handling — `ChannelNotFound` variant and the skip-vs-fail classification for videos without transcripts (`is_no_transcript`)
- [x] Performance impact — concurrent fetching via `buffer_unordered` and the incremental early-stop in `plan_fetches`
- [x] Security implications — browser UA reuse and public API key usage

**Key design decisions to review:**
- **Filesystem-as-state**: presence of `<channel-id>/<video-id>.<lang>.<ext>` is the sole signal for "already synced", keeping the implementation stateless and idempotent
- **Incremental early-stop**: in default (RSS) mode, scanning stops at the first already-present file because IDs are newest-first and channels are append-only; `--full` bypasses this to fill historical gaps
- **Atomic writes**: temp-file + rename avoids a half-written transcript being mistaken for a completed sync on the next run
- **Loop guard**: `fetch_all_video_ids` tracks seen tokens and added IDs to prevent runaway pagination if YouTube ever returns a cycle
- **WEB client for browse**: the ANDROID_VR client returns an unpaginated mobile shape; the WEB client is required for the paginated `richGridRenderer` / `lockupViewModel` shape

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement (describe below)

Concurrent transcript fetching via `futures::stream::buffer_unordered` with a configurable `--concurrency` parameter (default 4) means channel syncs are substantially faster than sequential fetching. The incremental early-stop mechanism makes routine re-syncs O(1) HTTP requests for up-to-date channels — only the RSS feed is fetched, and scanning stops immediately at the first already-present file.

## Security Considerations

- [x] Potential security impact (describe below)

Channel-page scraping uses a browser `User-Agent` header to avoid bot detection (reusing the same `BROWSER_USER_AGENT` already used for watch-page bootstrapping). No credentials or authentication tokens are introduced. The InnerTube API keys (`WEB_INNERTUBE_API_KEY`, `INNERTUBE_API_KEY`) are both public keys embedded in the YouTube web/app binaries, not credentials. Atomic file writes (temp + rename) prevent partial writes from corrupting the on-disk state.

## Breaking Changes

None. This is a purely additive feature. The new `sync` subcommand is added to `YoutubeSubcommands`; all existing subcommands (`fetch`, `list-langs`, `info`) are unchanged.

## Deployment Notes

- [x] No special deployment requirements

No new environment variables, database migrations, or configuration changes are required. The command uses the same HTTP client and InnerTube infrastructure already in place.

## Additional Notes

**Future Enhancements:**
- `--since` filtering under `--full` is currently ignored (browse grid carries no per-item dates); a future enhancement could infer dates from other signals or support a separate date-indexed lookup
- Additional output formats or per-channel configuration could be layered on top of `SyncPlan`
- An optional manifest/state file could replace filesystem-as-state for remote or cloud storage backends

**Known Limitations:**
- `--full` (InnerTube `/browse`) depends on YouTube's internal JSON shape, which can drift; the same accepted fragility already present in the `/player` path
- `--since` under `--full` is best-effort and currently a no-op since the browse grid provides no per-item publish dates
- The RSS feed only covers ~15 most recent uploads; `--full` is required for complete historical backfill

**Alternatives Considered:**
- Using the official YouTube Data API v3 (requires OAuth credentials and quota management; deliberately avoided to keep the tool credential-free)
- XML parsing library instead of regex for RSS (regex is sufficient and already the established pattern in this codebase for watch-page scraping)