### PR TITLE
ci(workflows): add claude-haiku-4-5 model to commit-check workflow

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -25,4 +25,5 @@ jobs:
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           guidelines: .omni-dev/commit-guidelines.md
+          model: claude-haiku-4-5
           verbose: true


### PR DESCRIPTION
## Description

This PR explicitly specifies `claude-haiku-4-5` as the AI model for the commit-check GitHub Actions workflow. Previously, the workflow relied on the default model selection of the underlying action. By pinning to `claude-haiku-4-5`, we ensure faster and more cost-effective commit message validation while maintaining consistency across runs.

## Type of Change

- [x] CI/CD changes

## Related Issue

Relates to #939

## Changes Made

**CI/CD Changes:**
- Added `model: claude-haiku-4-5` parameter to the commit-check workflow step in `.github/workflows/commit-check.yml`

**Documentation:**
- No documentation changes required for this CI-only update

**Testing:**
- No additional tests required; the change takes effect on the next CI run

## Testing

**Automated Testing:**
- [x] All existing tests pass
- No new tests needed for a CI workflow model parameter change

**Manual Testing:**
- [x] Verified the workflow YAML is syntactically valid after the change
- [x] Confirmed `claude-haiku-4-5` is a valid model identifier for the Anthropic API

### Test Commands

```bash
# Validate GitHub Actions workflow syntax (if act is available)
act --dry-run

# Or simply push to trigger the workflow in CI
git push origin issue-939-haiku-commit-check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The only file changed is `.github/workflows/commit-check.yml`. Reviewers should confirm that `claude-haiku-4-5` is the intended model and that the action accepts a `model` input parameter.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement (describe below)

`claude-haiku-4-5` is a faster and more cost-efficient model compared to larger Claude variants. Explicitly specifying it for the commit-check workflow reduces latency and API costs for every CI run that validates commit messages.

## Security Considerations

- [x] No security implications

The model name is a static string referencing a publicly available Anthropic model. No secrets or sensitive data are introduced by this change. The existing `ANTHROPIC_API_KEY` secret handling is unchanged.

## Breaking Changes

None. This is a non-breaking CI configuration update. The commit-check workflow continues to function identically, now with an explicit model selection instead of relying on the action default.

## Deployment Notes

- [x] No special deployment requirements

The change takes effect automatically on the next push or pull request that triggers the `commit-check` workflow. No environment variable changes, secrets rotation, or service restarts are required.

## Additional Notes

**Future Enhancements:**
- Consider making the model name a workflow-level input or repository variable to allow easy model switching without code changes.

**Known Limitations:**
- If `claude-haiku-4-5` is deprecated or renamed by Anthropic in the future, this parameter will need to be updated.

**Alternatives Considered:**
- Using a larger model (e.g., `claude-sonnet`) for potentially richer commit analysis, but Haiku is sufficient for commit message linting and is significantly more cost-effective at the volume of CI runs expected.