### PR TITLE
docs(docs): reorganize README to lead with demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,30 @@ An intelligent Git commit message toolkit with AI-powered contextual
 intelligence. Transform messy commit histories into professional,
 conventional commit formats with project-aware suggestions.
 
+## 🎬 See It In Action
+
+[![asciicast](https://asciinema.org/a/eJJf5Aj8N26JoCaUsAFVH8dqz.svg)](https://asciinema.org/a/eJJf5Aj8N26JoCaUsAFVH8dqz)
+
+*Watch omni-dev transform messy commits into professional ones with AI-powered analysis*
+
+## 30-Second Demo
+
+Transform your commit messages and create professional PRs with AI intelligence:
+
+```bash
+# Analyze and improve commit messages in your current branch
+omni-dev git commit message twiddle 'origin/main..HEAD' --use-context
+
+# Before: "fix stuff", "wip", "update files"
+# After:  "feat(auth): implement OAuth2 authentication system"
+#         "docs(api): add comprehensive endpoint documentation"
+#         "fix(ui): resolve mobile responsive layout issues"
+
+# Create a professional PR with AI-generated description
+omni-dev git branch create pr
+# 🎉 Generates comprehensive PR with detailed description, testing info, and more
+```
+
 ## ✨ Key Features
 
 - 🤖 **AI-Powered Intelligence**: Claude AI analyzes your code changes to
@@ -60,30 +84,6 @@ eval "$(omni-dev completions bash)"
 
 See [docs/shell-completion.md](docs/shell-completion.md) for per-shell install
 recipes, the `$fpath`/`compinit` setup zsh requires, and troubleshooting.
-
-### 🎬 See It In Action
-
-[![asciicast](https://asciinema.org/a/eJJf5Aj8N26JoCaUsAFVH8dqz.svg)](https://asciinema.org/a/eJJf5Aj8N26JoCaUsAFVH8dqz)
-
-*Watch omni-dev transform messy commits into professional ones with AI-powered analysis*
-
-### 30-Second Demo
-
-Transform your commit messages and create professional PRs with AI intelligence:
-
-```bash
-# Analyze and improve commit messages in your current branch
-omni-dev git commit message twiddle 'origin/main..HEAD' --use-context
-
-# Before: "fix stuff", "wip", "update files"
-# After:  "feat(auth): implement OAuth2 authentication system"
-#         "docs(api): add comprehensive endpoint documentation"
-#         "fix(ui): resolve mobile responsive layout issues"
-
-# Create a professional PR with AI-generated description
-omni-dev git branch create pr
-# 🎉 Generates comprehensive PR with detailed description, testing info, and more
-```
 
 ## 📋 Core Commands
 


### PR DESCRIPTION
## Description

Reorganizes `README.md` to lead with the "See It In Action" asciinema demo and the "30-Second Demo" bash example, placing them immediately after the introductory paragraph. Previously, these sections were buried after the installation instructions — new visitors would have to scroll past feature lists and install commands before seeing what the tool actually does.

By surfacing the demo content early, users get an immediate, concrete understanding of omni-dev's value proposition before committing to reading further. The demo shows real command syntax and before/after commit message transformations, helping users quickly evaluate whether the tool solves their needs.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Fixes #833

## Changes Made

**Documentation:**
- Moved the `## 🎬 See It In Action` asciinema embed section from after the installation instructions to immediately after the introductory paragraph in `README.md`
- Moved the `## 30-Second Demo` bash code block to follow directly after the demo section, maintaining logical flow
- Removed the original placement of both sections from their prior location (previously under the shell completion documentation)
- Promoted both sections from `###` subheadings to `##` top-level headings to reflect their elevated position in the document hierarchy

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no tests required)

**Manual Testing:**
- [x] Verified README renders correctly in Markdown preview
- [x] Confirmed all links and the asciinema embed remain intact after the move
- [x] Backward compatibility verified — no content was removed, only reordered

### Test Commands
```bash
# Code quality checks (no Rust code changed)
cargo fmt --check

# Render the README locally to verify formatting
# Use a Markdown viewer such as `glow` or GitHub preview
glow README.md
```

## Review Focus Areas

**Please pay special attention to:**
- [x] User experience — does the new ordering improve first impressions for new visitors?
- [x] Backward compatibility — confirm no content was dropped, only repositioned

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the demo in its original location and adding a "Quick Start" link at the top — rejected in favour of actually moving the content, since a direct link still requires the user to scroll past feature descriptions before seeing real examples.