### PR TITLE
ci(workflows): enhance PR coverage comments with artifact links, commit refs, and line-count deltas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,9 @@ jobs:
       env:
         COVERAGE_ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
         COVERAGE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        COVERAGE_BASE_SHA: ${{ steps.mb.outputs.sha }}
+        COVERAGE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        COVERAGE_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit
       run: ./scripts/coverage-comment.sh baseline/coverage-files.json coverage-files.json > coverage.md
     - name: Comment coverage on PR
       if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,18 @@ jobs:
           cat coverage-summary.txt
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload coverage artifacts
+      # The full summary lives here (not in the PR comment); codecov.json kept for
+      # when the upload below is re-enabled. Runs before the comment so the comment
+      # can link to this artifact via the step's `artifact-url` output.
+      id: upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-summary
+        path: |
+          coverage-summary.txt
+          codecov.json
+          coverage-files.json
     - name: Determine merge-base
       # The PR's fork point on main. Pinning the baseline to this immutable commit
       # (rather than "latest main") makes per-file deltas attributable to THIS PR
@@ -186,6 +198,9 @@ jobs:
         }' ../base/llvm-cov.json > baseline/coverage-files.json
     - name: Build PR coverage comment
       if: github.event_name == 'pull_request'
+      env:
+        COVERAGE_ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        COVERAGE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: ./scripts/coverage-comment.sh baseline/coverage-files.json coverage-files.json > coverage.md
     - name: Comment coverage on PR
       if: github.event_name == 'pull_request'
@@ -193,16 +208,6 @@ jobs:
       with:
         header: coverage          # sticky key: updates the same comment each run
         path: coverage.md
-    - name: Upload coverage artifacts
-      # The full summary lives here (not in the PR comment); codecov.json kept for
-      # when the upload below is re-enabled.
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-summary
-        path: |
-          coverage-summary.txt
-          codecov.json
-          coverage-files.json
     - name: Publish coverage baseline
       # On main only: this run's per-file coverage becomes the baseline that
       # subsequent PRs download above to compute deltas.

--- a/scripts/coverage-comment.sh
+++ b/scripts/coverage-comment.sh
@@ -22,8 +22,13 @@ HEAD="${2:?usage: coverage-comment.sh <baseline.json> <current.json>}"
 # floating-point noise from re-runs that touch nothing.
 EPS=0.05
 
+# Optional links rendered in the footer (set by CI). Empty when run locally.
+ARTIFACT_URL="${COVERAGE_ARTIFACT_URL:-}"
+RUN_URL="${COVERAGE_RUN_URL:-}"
+
 if [[ -n "$BASE" && -f "$BASE" ]]; then
-  jq -rn --slurpfile b "$BASE" --slurpfile h "$HEAD" --argjson eps "$EPS" '
+  jq -rn --slurpfile b "$BASE" --slurpfile h "$HEAD" --argjson eps "$EPS" \
+    --arg artifactUrl "$ARTIFACT_URL" --arg runUrl "$RUN_URL" '
     ($b[0]) as $base | ($h[0]) as $head |
     def rnd(x): (x * 100 | round) / 100;
     def pct(x): if x == null then "—" else "\(rnd(x))%" end;
@@ -62,10 +67,17 @@ if [[ -n "$BASE" && -f "$BASE" ]]; then
         )
       end ),
     "",
-    "<sub>Full per-file summary is attached as the **coverage-summary** build artifact.</sub>"
+    ( if $artifactUrl != "" then
+        "<sub>📦 [Full per-file coverage summary](\($artifactUrl))"
+        + (if $runUrl != "" then " · [run summary](\($runUrl))" else "" end)
+        + "</sub>"
+      else
+        "<sub>Full per-file summary is attached as the **coverage-summary** build artifact.</sub>"
+      end )
   '
 else
-  jq -rn --slurpfile h "$HEAD" '
+  jq -rn --slurpfile h "$HEAD" \
+    --arg artifactUrl "$ARTIFACT_URL" --arg runUrl "$RUN_URL" '
     ($h[0]) as $head |
     def rnd(x): (x * 100 | round) / 100;
     "## Coverage",
@@ -74,6 +86,12 @@ else
     "",
     "_No baseline available yet (first run, or the `main` baseline artifact was missing). Per-file deltas will appear on PRs once a baseline has been published from `main`._",
     "",
-    "<sub>Full per-file summary is attached as the **coverage-summary** build artifact.</sub>"
+    ( if $artifactUrl != "" then
+        "<sub>📦 [Full per-file coverage summary](\($artifactUrl))"
+        + (if $runUrl != "" then " · [run summary](\($runUrl))" else "" end)
+        + "</sub>"
+      else
+        "<sub>Full per-file summary is attached as the **coverage-summary** build artifact.</sub>"
+      end )
   '
 fi

--- a/scripts/coverage-comment.sh
+++ b/scripts/coverage-comment.sh
@@ -40,7 +40,7 @@ if [[ -n "$BASE" && -f "$BASE" ]]; then
     ($b[0]) as $base | ($h[0]) as $head |
     def rnd(x): (x * 100 | round) / 100;
     def pct(x): if x == null then "—" else "\(rnd(x))%" end;
-    def arrow(d): if d > 0 then "🔺" elif d < 0 then "🔻" else "▪️" end;
+    def arrow(d): if d > 0 then "🟢" elif d < 0 then "🔴" else "⚪" end;
 
     # Per-file rows: new files, or files whose coverage moved by at least EPS.
     ( [ $head.files | to_entries[]

--- a/scripts/coverage-comment.sh
+++ b/scripts/coverage-comment.sh
@@ -22,13 +22,21 @@ HEAD="${2:?usage: coverage-comment.sh <baseline.json> <current.json>}"
 # floating-point noise from re-runs that touch nothing.
 EPS=0.05
 
-# Optional links rendered in the footer (set by CI). Empty when run locally.
+# Optional links/identifiers rendered in the comment (set by CI). Empty locally.
 ARTIFACT_URL="${COVERAGE_ARTIFACT_URL:-}"
 RUN_URL="${COVERAGE_RUN_URL:-}"
+BASE_SHA="${COVERAGE_BASE_SHA:-}"      # merge-base commit the baseline was taken at
+HEAD_SHA="${COVERAGE_HEAD_SHA:-}"      # PR head commit the coverage was measured at
+COMMIT_URL="${COVERAGE_COMMIT_URL:-}"  # prefix for commit links, e.g. https://…/<repo>/commit
 
 if [[ -n "$BASE" && -f "$BASE" ]]; then
   jq -rn --slurpfile b "$BASE" --slurpfile h "$HEAD" --argjson eps "$EPS" \
-    --arg artifactUrl "$ARTIFACT_URL" --arg runUrl "$RUN_URL" '
+    --arg artifactUrl "$ARTIFACT_URL" --arg runUrl "$RUN_URL" \
+    --arg baseSha "$BASE_SHA" --arg headSha "$HEAD_SHA" --arg commitUrl "$COMMIT_URL" '
+    # Render a commit ref as a short, optionally-linked SHA.
+    def shaRef(sha):
+      (sha[0:7]) as $short
+      | if $commitUrl != "" then "[`\($short)`](\($commitUrl)/\(sha))" else "`\($short)`" end;
     ($b[0]) as $base | ($h[0]) as $head |
     def rnd(x): (x * 100 | round) / 100;
     def pct(x): if x == null then "—" else "\(rnd(x))%" end;
@@ -55,6 +63,10 @@ if [[ -n "$BASE" && -f "$BASE" ]]; then
       else "Total: **\(pct($head.total))** \(arrow($totDelta)) \(rnd($totDelta)) pp vs `main`"
       end ),
     "",
+    ( if $baseSha != "" and $headSha != ""
+      then ("Comparing \(shaRef($baseSha))..\(shaRef($headSha)) _(merge-base → PR head)_", "")
+      else empty
+      end ),
     ( if ($rows | length) == 0
       then "_No per-file coverage changes vs `main`._"
       else


### PR DESCRIPTION
## Description

This PR significantly improves the CI coverage reporting workflow to produce richer, more actionable PR comments. Previously, coverage comments showed only percentage changes per file with static artifact references. After this PR, coverage comments include clickable artifact and run links, explicit commit range references (merge-base → PR head), per-file covered-line deltas alongside percentage changes, and a covered-line summary showing newly covered and newly uncovered lines across the entire PR.

The changes maintain full backward compatibility: the `coverage-comment.sh` script degrades gracefully when run locally (no env vars set) and tolerates old baseline artifacts that carry bare percentages rather than the new `{percent, covered, count}` object shape.

## Type of Change

- [x] CI/CD changes
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

No linked issue.

## Changes Made

**CI Workflow (`.github/workflows/ci.yml`):**
- Moved `upload-artifact` step earlier in the coverage job so its `artifact-url` output is available to later steps
- Added `id: upload` to the artifact upload step to expose the `artifact-url` output
- Passed `COVERAGE_ARTIFACT_URL` and `COVERAGE_RUN_URL` environment variables to the "Build PR coverage comment" step
- Added `COVERAGE_BASE_SHA`, `COVERAGE_HEAD_SHA`, and `COVERAGE_COMMIT_URL` environment variables for commit reference rendering
- Updated both `jq` normalization steps (current coverage and baseline) to extract `{percent, covered, count}` line objects instead of bare percentages, enabling per-file line count comparisons

**Coverage Comment Script (`scripts/coverage-comment.sh`):**
- Extracted shared jq helpers into a `$HELPERS` shell variable to avoid duplication across both code paths:
  - `cov(v)` — normalizes bare-number or object coverage values into `{percent, covered, count}` (backward compatible with old baselines)
  - `pct(x)` — formats a percentage with rounding and null-safe fallback
  - `arrow(d)` — renders directional emoji (🟢 / 🔴 / ⚪, replacing the previous 🔺 / 🔻 / ▪️)
  - `signed(n)` — renders signed integers with a leading `+`
  - `shaRef(sha; $commitUrl)` — renders a short 7-char SHA as an optional hyperlink
  - `footer($artifactUrl; $runUrl)` — renders the footer with a clickable artifact link (or static fallback)
- Added `ARTIFACT_URL`, `RUN_URL`, `BASE_SHA`, `HEAD_SHA`, and `COMMIT_URL` shell variables sourced from environment, all empty when run locally
- Conditionally renders a "Comparing `abc1234`..`def5678` _(merge-base → PR head)_" line when commit SHAs are available
- Added per-file `covDelta` computation: covered-line difference between baseline and current for each file; new files count all their covered lines as newly covered
- Added row selection criteria: include a file row if its percentage delta ≥ EPS **or** its `covDelta` is non-zero
- Added "Lines" column to the per-file Markdown table showing `arrow(covDelta) signed(covDelta)`
- Aggregated `$newlyCovered` (sum of positive `covDelta`s) and `$newlyUncovered` (sum of negative `covDelta`s) across all files
- Added "Covered lines: N → M · 🟢 +X newly covered · 🔴 Y newly uncovered · net Z" summary line when both baseline and current carry line counts
- Extended the no-baseline code path to also display `Covered lines: N / M` when counts are available
- Updated script header comment to reflect the merge-base comparison model and new JSON shape

**Documentation:**
- Updated inline comments in `coverage-comment.sh` header to document both the new and legacy JSON shapes
- Added inline comments explaining the `cov()` backward-compatibility shim

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (script logic is validated by CI runs)
- [x] Integration tests updated/added (CI workflow itself serves as the integration test)

**Manual Testing:**
- [x] Tested happy path scenarios (PR coverage comment with both baseline and current artifacts)
- [x] Backward compatibility verified (old-shape baselines with bare percentage values degrade gracefully to `—` in the Lines column)
- [x] Local invocation verified (script runs without env vars, renders static artifact text instead of links)

**Test Coverage:**
- No new application code added; changes are CI workflow and shell/jq scripting.

### Test Commands
```bash
# Validate the coverage-comment script locally (requires two coverage-files.json artifacts)
./scripts/coverage-comment.sh baseline/coverage-files.json coverage-files.json

# With environment variables simulating CI
COVERAGE_ARTIFACT_URL="https://github.com/org/repo/actions/artifacts/123" \
COVERAGE_RUN_URL="https://github.com/org/repo/actions/runs/456" \
COVERAGE_BASE_SHA="abc1234567890" \
COVERAGE_HEAD_SHA="def5678901234" \
COVERAGE_COMMIT_URL="https://github.com/org/repo/commit" \
./scripts/coverage-comment.sh baseline/coverage-files.json coverage-files.json
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `cov()` jq helper must correctly tolerate old baselines that store bare numbers rather than `{percent, covered, count}` objects
- [x] The reordering of the `upload-artifact` step: it now runs before the "Build PR coverage comment" step so the `artifact-url` output is populated in time
- [x] jq correctness for edge cases: new files (no baseline entry), files removed from head, zero `covDelta`, and null covered counts from old baselines

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The coverage JSON shape change (`{percent, covered, count}` instead of bare percentage) is handled transparently by the `cov()` normalization helper, which accepts both forms.

## Deployment Notes

- [x] No special deployment requirements

The CI workflow changes take effect automatically on the next run. No environment variable updates are required beyond what is already injected by GitHub Actions contexts (`github.server_url`, `github.repository`, `github.run_id`, `github.event.pull_request.head.sha`).

## Additional Notes

**Future Enhancements:**
- The `covDelta` aggregation currently sums across all files; a future enhancement could highlight the specific files responsible for the largest line-count movements
- Consider adding a threshold filter so very small covered-line deltas (e.g. ±1 line) don't create table rows when the percentage delta is also below EPS

**Known Limitations:**
- The "Lines" column shows `—` for any file whose baseline was generated before this PR (old shape without `covered`/`count`). This is intentional and will self-resolve once the first post-merge baseline is published from `main`.