### PR TITLE
ci(workflows): simplify coverage workflow by removing redundant binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,16 +161,11 @@ jobs:
           cat coverage-summary.txt
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
-    - name: Build omni-dev binary
-      # Renders the PR comment below via `omni-dev coverage diff`. Under the same
-      # coverage env, this reuses the dependency artifacts already compiled for
-      # the tests — only omni-dev's own crate is rebuilt, not the whole tree. The
-      # resulting binary is coverage-instrumented, which is harmless to run.
-      if: github.event_name == 'pull_request'
-      run: |
-        # shellcheck disable=SC1090
-        source <(cargo llvm-cov show-env --sh)
-        cargo build --all-features --bin omni-dev
+    # No separate binary build: `cargo test` above already compiled the
+    # `omni-dev` executable (target/debug/omni-dev, part of the test build graph)
+    # with the same instrumentation env. The PR-comment step below runs it
+    # directly. Building it separately with `cargo build --bin` would recompile a
+    # dozen crates whose features differ once dev-dependencies drop out.
     - name: Upload coverage artifacts
       # The full summary lives here (not in the PR comment); codecov.json kept for
       # when the upload below is re-enabled. Runs before the comment so the comment


### PR DESCRIPTION
## Description

This PR simplifies the CI coverage workflow by removing a redundant `cargo build --bin omni-dev` step that was unnecessarily recompiling the binary after `cargo test` had already built it.

The removed step built the `omni-dev` binary under the coverage instrumentation environment for use in the PR-comment step (`omni-dev coverage diff`). However, `cargo test` already compiles `target/debug/omni-dev` as part of the test build graph with identical instrumentation settings. Running a separate `cargo build --bin omni-dev` caused Cargo to recompile a dozen crates whose feature sets differ once dev-dependencies are excluded from the build, resulting in wasted CI time with no benefit.

A comment has been added in place of the removed step to document why no explicit binary build is needed, preventing future confusion and accidental re-introduction of the redundant step.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement
- [x] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #949

## Changes Made

**CI/CD Changes:**
- Removed the "Build omni-dev binary" step from the coverage job in `.github/workflows/ci.yml`
- Replaced the step with an inline comment explaining that `cargo test` already produces `target/debug/omni-dev` with coverage instrumentation, making an explicit `cargo build` call redundant and wasteful

**Documentation:**
- Added an explanatory comment in the workflow YAML clarifying why no separate binary build step is required and what would go wrong if it were added back (feature-set divergence causing unnecessary recompilation)

**Testing:**
- No test code changes; this is a CI pipeline simplification only

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified that the coverage workflow logic is preserved — the PR-comment step still finds `omni-dev` at `target/debug/omni-dev` after `cargo test` completes
- [x] Backward compatibility verified — no change to workflow inputs, outputs, or observable behaviour

**Test Coverage:**
- No new application code introduced; coverage metrics are unaffected.

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Performance impact — confirm that removing the build step genuinely avoids redundant recompilation and does not break the downstream `omni-dev coverage diff` invocation in the PR-comment step

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] Performance improvement (describe below)

Removing the redundant `cargo build --bin omni-dev` step eliminates unnecessary recompilation of approximately a dozen crates in the coverage CI job. When `cargo build --bin omni-dev` runs after `cargo test`, Cargo detects that the feature set differs (dev-dependencies are excluded) and recompiles the affected crates from scratch. Dropping this step saves that compile time on every pull request coverage run.

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a pure CI pipeline simplification with no changes to application code, public APIs, or user-facing behaviour.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the explicit build step but suppressing the warning — rejected because the recompilation is genuinely wasteful and the comment approach documents the intent more clearly for future contributors.