### PR TITLE
test(git): deterministically cover flaky git-analysis lines

### DIFF
--- a/src/cli/git/info.rs
+++ b/src/cli/git/info.rs
@@ -284,6 +284,18 @@ mod tests {
     }
 
     #[test]
+    fn execute_against_injected_repo_succeeds() {
+        // Drives `execute()` (not just `run_info`) so its run_info+println body
+        // is covered deterministically via the injected repo path. Those lines
+        // were previously only hit by the live-repo dispatch test and flickered
+        // covered<->uncovered depending on the checkout state.
+        let (temp_dir, _commits) = init_repo_with_commits();
+        InfoCommand { base_branch: None }
+            .execute(Some(temp_dir.path()))
+            .unwrap();
+    }
+
+    #[test]
     fn run_info_with_explicit_missing_base_errors() {
         let (temp_dir, _commits) = init_repo_with_commits();
         let err = run_info(Some("no-such-branch"), Some(temp_dir.path())).unwrap_err();

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -265,8 +265,16 @@ impl CommitAnalysis {
 
     /// Detects conventional commit type based on files and existing message.
     fn detect_commit_type(commit: &Commit, file_changes: &FileChanges) -> String {
-        let message = commit.message().unwrap_or("");
+        Self::detect_commit_type_from_message(commit.message().unwrap_or(""), file_changes)
+    }
 
+    /// Pure type inference from a commit `message` and its `file_changes`.
+    ///
+    /// Separated from [`Self::detect_commit_type`] so the branch logic can be exercised
+    /// deterministically by unit tests; the `&Commit`-taking wrapper requires a
+    /// live repository whose state varies run-to-run (which makes coverage of
+    /// these branches flicker — see the conventional-type tests below).
+    fn detect_commit_type_from_message(message: &str, file_changes: &FileChanges) -> String {
         // Check if message already has conventional commit format
         if let Some(existing_type) = Self::extract_conventional_type(message) {
             return existing_type;
@@ -404,7 +412,20 @@ impl CommitAnalysis {
         file_changes: &FileChanges,
     ) -> String {
         let current_message = commit.message().unwrap_or("").lines().next().unwrap_or("");
+        Self::generate_proposed_message_from(current_message, commit_type, scope, file_changes)
+    }
 
+    /// Pure message generation from the commit's first line and its analysis.
+    ///
+    /// Separated from [`Self::generate_proposed_message`] so the scope/format branches
+    /// can be unit-tested deterministically (the `&Commit` wrapper needs a live
+    /// repository).
+    fn generate_proposed_message_from(
+        current_message: &str,
+        commit_type: &str,
+        scope: &str,
+        file_changes: &FileChanges,
+    ) -> String {
         // If already properly formatted, return as-is
         if Self::extract_conventional_type(current_message).is_some() {
             return current_message.to_string();
@@ -1768,6 +1789,137 @@ diff_file: "/tmp/test.diff"
         assert_eq!(partial.base.original_message, original_message);
         assert!(partial.pre_validated_checks.is_empty());
 
+        Ok(())
+    }
+
+    // ── detect_commit_type_from_message (deterministic type inference) ──
+    //
+    // These pin every branch of the type-inference chain so its coverage no
+    // longer depends on whatever commit the live-repo dispatch tests analyze.
+
+    fn infer_type(message: &str, files: &[(&str, &str)]) -> String {
+        CommitAnalysis::detect_commit_type_from_message(message, &make_file_changes(files))
+    }
+
+    #[test]
+    fn commit_type_existing_conventional_wins() {
+        assert_eq!(infer_type("feat(cli): add", &[("A", "src/x.rs")]), "feat");
+    }
+
+    #[test]
+    fn commit_type_test_files() {
+        assert_eq!(infer_type("update", &[("A", "tests/foo_test.rs")]), "test");
+    }
+
+    #[test]
+    fn commit_type_docs_files() {
+        assert_eq!(infer_type("update", &[("M", "README.md")]), "docs");
+    }
+
+    #[test]
+    fn commit_type_config_added_is_feat() {
+        assert_eq!(infer_type("update", &[("A", "Cargo.toml")]), "feat");
+    }
+
+    #[test]
+    fn commit_type_config_modified_is_chore() {
+        assert_eq!(infer_type("update", &[("M", "Cargo.toml")]), "chore");
+    }
+
+    #[test]
+    fn commit_type_added_source_is_feat() {
+        assert_eq!(infer_type("add module", &[("A", "src/lib.rs")]), "feat");
+    }
+
+    #[test]
+    fn commit_type_fix_from_message() {
+        // Modified (not added) .rs file ⇒ falls through to the message check.
+        assert_eq!(infer_type("fix the bug", &[("M", "src/lib.rs")]), "fix");
+    }
+
+    #[test]
+    fn commit_type_refactor_when_more_deletions() {
+        assert_eq!(
+            infer_type("cleanup", &[("D", "src/a.rs"), ("D", "src/b.rs")]),
+            "refactor"
+        );
+    }
+
+    #[test]
+    fn commit_type_default_chore() {
+        assert_eq!(infer_type("update stuff", &[("M", "src/c.rs")]), "chore");
+    }
+
+    // ── generate_proposed_message_from (scope/format branches) ──
+
+    #[test]
+    fn proposed_message_with_scope() {
+        let fc = make_file_changes(&[("A", "src/x.rs")]);
+        let msg = CommitAnalysis::generate_proposed_message_from("do thing", "feat", "cli", &fc);
+        assert_eq!(msg, "feat(cli): do thing");
+    }
+
+    #[test]
+    fn proposed_message_without_scope() {
+        let fc = make_file_changes(&[("A", "src/x.rs")]);
+        let msg = CommitAnalysis::generate_proposed_message_from("do thing", "feat", "", &fc);
+        assert_eq!(msg, "feat: do thing");
+    }
+
+    #[test]
+    fn proposed_message_keeps_already_conventional() {
+        let fc = make_file_changes(&[("A", "src/x.rs")]);
+        let msg = CommitAnalysis::generate_proposed_message_from("fix(x): y", "feat", "cli", &fc);
+        assert_eq!(msg, "fix(x): y");
+    }
+
+    #[test]
+    fn proposed_message_generates_description_when_empty() {
+        let fc = make_file_changes(&[("A", "src/x.rs")]);
+        let msg = CommitAnalysis::generate_proposed_message_from("", "chore", "", &fc);
+        assert!(msg.starts_with("chore: "), "got: {msg}");
+    }
+
+    // ── analyze_file_changes (Delta arms) ──
+    //
+    // Exercises the Added/Deleted/Modified arms against a constructed repo, so
+    // their coverage is deterministic rather than dependent on the live HEAD
+    // commit (which is what made `Delta::Deleted` flicker run-to-run).
+
+    #[test]
+    fn analyze_file_changes_covers_delta_arms() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let repo = git2::Repository::init(dir.path())?;
+        let sig = git2::Signature::now("T", "t@e.com")?;
+
+        // Commit 1: add a.txt and b.txt.
+        for (name, content) in [("a.txt", "a"), ("b.txt", "b")] {
+            std::fs::write(dir.path().join(name), content)?;
+        }
+        let mut index = repo.index()?;
+        index.add_path(std::path::Path::new("a.txt"))?;
+        index.add_path(std::path::Path::new("b.txt"))?;
+        index.write()?;
+        let tree1 = repo.find_tree(index.write_tree()?)?;
+        let c1 = repo.commit(Some("HEAD"), &sig, &sig, "init", &tree1, &[])?;
+
+        // Commit 2: delete a.txt (Deleted), modify b.txt (Modified), add c.txt (Added).
+        std::fs::remove_file(dir.path().join("a.txt"))?;
+        std::fs::write(dir.path().join("b.txt"), "b2")?;
+        std::fs::write(dir.path().join("c.txt"), "c")?;
+        let mut index = repo.index()?;
+        index.remove_path(std::path::Path::new("a.txt"))?;
+        index.add_path(std::path::Path::new("b.txt"))?;
+        index.add_path(std::path::Path::new("c.txt"))?;
+        index.write()?;
+        let tree2 = repo.find_tree(index.write_tree()?)?;
+        let parent = repo.find_commit(c1)?;
+        let c2 = repo.commit(Some("HEAD"), &sig, &sig, "change", &tree2, &[&parent])?;
+
+        let commit2 = repo.find_commit(c2)?;
+        let changes = CommitAnalysis::analyze_file_changes(&repo, &commit2)?;
+        assert_eq!(changes.files_added, 1, "c.txt added");
+        assert_eq!(changes.files_deleted, 1, "a.txt deleted");
         Ok(())
     }
 }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -449,6 +449,39 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn current_branch_on_a_branch() -> Result<()> {
+        let temp_dir = init_tmp_repo();
+        let p = temp_dir.path();
+        std::fs::write(p.join("f.txt"), "x")?;
+        git_in(p, &["add", "."]);
+        git_in(p, &["commit", "-m", "init"]);
+        let repo = GitRepository::open_at(p)?;
+        // The branch name is whichever the local git default is (main/master);
+        // either way it must resolve to a non-"HEAD" shorthand.
+        assert_ne!(repo.get_current_branch()?, "HEAD");
+        Ok(())
+    }
+
+    #[test]
+    fn current_branch_errors_in_detached_head() -> Result<()> {
+        // CI checks PRs out as a detached HEAD, which is what makes the bail at
+        // the end of `get_current_branch` flicker run-to-run; pin it here.
+        let temp_dir = init_tmp_repo();
+        let p = temp_dir.path();
+        std::fs::write(p.join("f.txt"), "x")?;
+        git_in(p, &["add", "."]);
+        git_in(p, &["commit", "-m", "init"]);
+        git_in(p, &["checkout", "--detach", "HEAD"]);
+        let repo = GitRepository::open_at(p)?;
+        let result = repo.get_current_branch();
+        assert!(
+            matches!(&result, Err(e) if e.to_string().contains("detached HEAD")),
+            "expected detached-HEAD error, got: {result:?}"
+        );
+        Ok(())
+    }
+
     // ── remote operations via the git CLI (issue #903) ─────────────
 
     /// Runs `git` in `dir` with a deterministic identity, asserting success.


### PR DESCRIPTION
## Description

Coverage comparisons in this project diff two independent instrumented runs: a baseline (main branch) and the head branch. Any line whose execution depends on live repository state — such as which commit is checked out, whether HEAD is detached, or what files changed in the latest commit — will flip between covered and uncovered between those runs. This is pure measurement noise, not a real coverage regression.

This PR pins every previously-flickering line with deterministic tests so they are always covered regardless of live repo state:

- `detect_commit_type` and `generate_proposed_message` in `commit.rs` were only exercised by analysing the live HEAD commit, whose file list varies run-to-run.
- `Delta::Deleted` in `analyze_file_changes` flickered because HEAD sometimes had deletions and sometimes did not.
- `get_current_branch`'s detached-HEAD bail was covered on PR builds (where CI checks out a detached HEAD) but not on main builds.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Addresses flaky coverage lines identified during diff/patch coverage analysis on the main branch CI run.

## Changes Made

**Core Changes:**
- Extracted `CommitAnalysis::detect_commit_type_from_message(message: &str, file_changes: &FileChanges)` as a pure helper in `src/git/commit.rs`; the original `detect_commit_type(&Commit, &FileChanges)` now delegates to it, isolating type-inference branch logic from the live `&Commit` dependency.
- Extracted `CommitAnalysis::generate_proposed_message_from(current_message, commit_type, scope, file_changes)` as a pure helper in `src/git/commit.rs`; the original `generate_proposed_message` delegates to it for the same reason.

**Testing:**
- Added 9 unit tests in `src/git/commit.rs` covering every branch of `detect_commit_type_from_message`: existing conventional type, test files, docs files, config added vs. modified, source file added, fix-from-message, refactor-from-deletions, and default chore.
- Added 4 unit tests in `src/git/commit.rs` covering every branch of `generate_proposed_message_from`: with scope, without scope, already-conventional passthrough, and empty-description auto-generation.
- Added `analyze_file_changes_covers_delta_arms` in `src/git/commit.rs` — constructs a real git2 repo, makes a commit that adds, modifies, and deletes files, and asserts the correct `files_added`/`files_deleted` counts, eliminating the `Delta::Deleted` flicker.
- Added `current_branch_on_a_branch` in `src/git/repository.rs` — constructs a repo, commits, and asserts `get_current_branch` returns a non-`HEAD` shorthand.
- Added `current_branch_errors_in_detached_head` in `src/git/repository.rs` — constructs a repo, detaches HEAD with `git checkout --detach`, and asserts `get_current_branch` returns a detached-HEAD error, pinning the bail path that previously only triggered in CI PR builds.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

**Test Coverage:**
- Each previously-flickering line is now covered on every run (both main and PR builds).
- No production logic was changed; coverage improvement is purely additive.

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new deterministic coverage tests
cargo test commit_type_
cargo test proposed_message_
cargo test analyze_file_changes_covers_delta_arms
cargo test current_branch_on_a_branch
cargo test current_branch_errors_in_detached_head

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility — the two new pure helpers (`detect_commit_type_from_message` and `generate_proposed_message_from`) are private `fn` items; no public API was changed.
- [x] Test correctness — the hermetic construction of temp repos in the `analyze_file_changes_covers_delta_arms`, `current_branch_on_a_branch`, and `current_branch_errors_in_detached_head` tests, ensuring no process-global CWD or state mutation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The two new pure helpers (`detect_commit_type_from_message` and `generate_proposed_message_from`) are private `fn` items; no public API was changed. All existing callers (`detect_commit_type` and `generate_proposed_message`) continue to work identically by delegating to the new helpers.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Design rationale for the pure-helper split:**
The `&Commit`-taking methods require a live `git2::Repository` to construct, which means their internal branches are only exercised when a real repository with appropriate content exists. By extracting the branch logic into pure `&str`/`&FileChanges` functions, every type and scope inference branch becomes unit-testable with simple inline data — no repository required. This pattern follows the repo's existing seam of exercising git logic against constructed inputs/repos rather than the live checkout.

**Known Limitations:**
- All new tests are hermetic (no CWD or other process-global mutation), which is the intended design for predictable parallel test execution.

**Alternatives Considered:**
- Mocking the `&Commit` type instead of extracting pure helpers — rejected because mocking `git2::Commit` is not straightforward and the extraction approach results in cleaner, more testable code regardless.