### PR TITLE
Issue 967 inject repo path

### DIFF
--- a/src/claude/context.rs
+++ b/src/claude/context.rs
@@ -8,7 +8,8 @@ pub mod patterns;
 pub use branch::BranchAnalyzer;
 pub use discovery::{
     config_source_label, load_config_content, load_project_scopes, resolve_context_dir,
-    resolve_context_dir_with_source, ConfigDirSource, ConfigSourceLabel, ProjectDiscovery,
+    resolve_context_dir_at, resolve_context_dir_with_source, resolve_context_dir_with_source_at,
+    ConfigDirSource, ConfigSourceLabel, ProjectDiscovery,
 };
 pub use files::FileAnalyzer;
 pub use patterns::WorkPatternAnalyzer;

--- a/src/claude/context/discovery.rs
+++ b/src/claude/context/discovery.rs
@@ -154,6 +154,39 @@ pub fn resolve_context_dir(override_dir: Option<&Path>) -> PathBuf {
     resolve_context_dir_with_source(override_dir).0
 }
 
+/// Like [`resolve_context_dir_with_source`], but anchored to an explicit
+/// `repo_root` instead of the process current working directory.
+///
+/// The override and `OMNI_DEV_CONFIG_DIR` tiers behave identically; only the
+/// walk-up start and the default fall back to `repo_root` rather than the CWD,
+/// so a command run with an injected `--repo` discovers config under that repo.
+pub fn resolve_context_dir_with_source_at(
+    override_dir: Option<&Path>,
+    repo_root: &Path,
+) -> (PathBuf, ConfigDirSource) {
+    if let Some(dir) = override_dir {
+        return (dir.to_path_buf(), ConfigDirSource::CliFlag);
+    }
+
+    if let Ok(env_dir) = std::env::var("OMNI_DEV_CONFIG_DIR") {
+        if !env_dir.is_empty() {
+            return (PathBuf::from(env_dir), ConfigDirSource::EnvVar);
+        }
+    }
+
+    // Walk-up discovery: search from the injected repo root upward.
+    if let Some(config_dir) = walk_up_find_config_dir(repo_root) {
+        return (config_dir, ConfigDirSource::WalkUp);
+    }
+
+    (repo_root.join(".omni-dev"), ConfigDirSource::Default)
+}
+
+/// Like [`resolve_context_dir`], but anchored to an explicit `repo_root`.
+pub fn resolve_context_dir_at(override_dir: Option<&Path>, repo_root: &Path) -> PathBuf {
+    resolve_context_dir_with_source_at(override_dir, repo_root).0
+}
+
 /// Loads a config file's content via the standard resolution chain.
 ///
 /// Uses [`resolve_config_file`] to find the file, then reads its content.

--- a/src/claude/context/discovery.rs
+++ b/src/claude/context/discovery.rs
@@ -1134,6 +1134,49 @@ scopes:
         );
     }
 
+    // ── repo-anchored `_at` variants (#967) ──────────────────────────────
+
+    #[test]
+    fn with_source_at_cli_flag() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let custom = PathBuf::from("custom-config");
+        let (path, source) =
+            resolve_context_dir_with_source_at(Some(&custom), std::path::Path::new("/unused"));
+        assert_eq!(path, custom);
+        assert_eq!(source, ConfigDirSource::CliFlag);
+    }
+
+    #[test]
+    fn with_source_at_env_var() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        std::env::set_var("OMNI_DEV_CONFIG_DIR", "/tmp/env-config");
+        let (path, source) =
+            resolve_context_dir_with_source_at(None, std::path::Path::new("/unused"));
+        std::env::remove_var("OMNI_DEV_CONFIG_DIR");
+        assert_eq!(path, PathBuf::from("/tmp/env-config"));
+        assert_eq!(source, ConfigDirSource::EnvVar);
+    }
+
+    #[test]
+    fn with_source_at_default_anchors_to_repo_root() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        std::env::remove_var("OMNI_DEV_CONFIG_DIR");
+        // A repo root with a `.git` boundary but no `.omni-dev`: walk-up stops at
+        // the boundary without escaping, so the default anchors to
+        // `repo_root/.omni-dev` (NOT the CWD-relative `.omni-dev`). This is the
+        // distinguishing behavior of the `_at` variant vs. its CWD sibling.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let (path, source) = resolve_context_dir_with_source_at(None, tmp.path());
+        assert_eq!(path, tmp.path().join(".omni-dev"));
+        assert_eq!(source, ConfigDirSource::Default);
+        // The thin wrapper returns the same path, discarding the source.
+        assert_eq!(
+            resolve_context_dir_at(None, tmp.path()),
+            tmp.path().join(".omni-dev")
+        );
+    }
+
     // ── ConfigDirSource Display ──────────────────────────────────────────
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,16 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     pub models_yaml: Option<std::path::PathBuf>,
 
+    /// Run as if omni-dev was started in `<PATH>` instead of the current
+    /// working directory.
+    ///
+    /// Resolved exactly once here and threaded explicitly to each command as a
+    /// parameter; deliberately **not** propagated to an environment variable
+    /// (unlike the flags above) so the repo location never becomes an ambient
+    /// global. Mirrors `git -C`.
+    #[arg(long = "repo", short = 'C', global = true, value_name = "PATH")]
+    pub repo: Option<std::path::PathBuf>,
+
     /// The main command to execute.
     #[command(subcommand)]
     pub command: Commands,
@@ -173,14 +183,19 @@ impl Cli {
     pub async fn execute(self) -> Result<()> {
         self.propagate_global_flags();
 
-        match self.command {
+        // Resolve the repo location exactly once at this boundary, then thread
+        // it explicitly into each command. Nothing deeper reads the ambient CWD.
+        let Self { repo, command, .. } = self;
+        let repo = repo.as_deref();
+
+        match command {
             Commands::Ai(ai_cmd) => ai_cmd.execute().await,
-            Commands::Git(git_cmd) => git_cmd.execute().await,
+            Commands::Git(git_cmd) => git_cmd.execute(repo).await,
             Commands::Commands(commands_cmd) => commands_cmd.execute(),
             Commands::Atlassian(cmd) => cmd.execute().await,
             Commands::Browser(cmd) => cmd.execute().await,
             Commands::Datadog(cmd) => cmd.execute().await,
-            Commands::Coverage(cmd) => cmd.execute().await,
+            Commands::Coverage(cmd) => cmd.execute(repo).await,
             Commands::Transcript(cmd) => cmd.execute().await,
             Commands::Voice(cmd) => cmd.execute().await,
             Commands::Config(config_cmd) => config_cmd.execute(),
@@ -428,6 +443,38 @@ mod tests {
         assert_eq!(
             cli.models_yaml.as_deref(),
             Some(std::path::Path::new("/tmp/custom-models.yaml"))
+        );
+    }
+
+    #[test]
+    fn parses_repo_flag_long_and_short() {
+        let long = Cli::try_parse_from(["omni-dev", "--repo", "/tmp/r", "help-all"]).unwrap();
+        assert_eq!(
+            long.repo.as_deref(),
+            Some(std::path::Path::new("/tmp/r")),
+            "--repo should populate cli.repo"
+        );
+        let short = Cli::try_parse_from(["omni-dev", "-C", "/tmp/r", "help-all"]).unwrap();
+        assert_eq!(
+            short.repo.as_deref(),
+            Some(std::path::Path::new("/tmp/r")),
+            "-C should populate cli.repo"
+        );
+        let absent = Cli::try_parse_from(["omni-dev", "help-all"]).unwrap();
+        assert!(absent.repo.is_none());
+    }
+
+    /// RULE 3: the repo location is a parameter, never a relocated global.
+    /// `propagate_global_flags` must not export it to any environment variable.
+    #[test]
+    fn repo_flag_is_not_propagated_to_env() {
+        let _g = GlobalFlagsEnvGuard::new();
+        let mut cli = cli_with_defaults();
+        cli.repo = Some(std::path::PathBuf::from("/tmp/some-repo"));
+        cli.propagate_global_flags();
+        assert!(
+            std::env::var("OMNI_DEV_REPO").is_err(),
+            "repo must not be exported to an env var"
         );
     }
 

--- a/src/cli/coverage.rs
+++ b/src/cli/coverage.rs
@@ -22,9 +22,12 @@ pub enum CoverageSubcommands {
 
 impl CoverageCommand {
     /// Executes the coverage command.
-    pub async fn execute(self) -> Result<()> {
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
+    pub async fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
         match self.command {
-            CoverageSubcommands::Diff(cmd) => cmd.execute().await,
+            CoverageSubcommands::Diff(cmd) => cmd.execute(repo).await,
         }
     }
 }
@@ -48,7 +51,6 @@ mod tests {
                 baseline_report_format: diff::ReportFormat::Auto,
                 format: diff::OutputFormatArg::Markdown,
                 fail_under_patch: None,
-                repo: std::path::PathBuf::from("."),
                 strip_prefix: None,
                 collapse_ranges: false,
                 artifact_url: None,
@@ -59,6 +61,6 @@ mod tests {
             }),
         };
         // Reaches the leaf command and fails on the missing report file.
-        assert!(cmd.execute().await.is_err());
+        assert!(cmd.execute(None).await.is_err());
     }
 }

--- a/src/cli/coverage/diff.rs
+++ b/src/cli/coverage/diff.rs
@@ -1,6 +1,6 @@
 //! `omni-dev coverage diff` — diff/patch coverage analysis.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
@@ -93,10 +93,6 @@ pub struct DiffCommand {
     #[arg(long, value_name = "PCT")]
     pub fail_under_patch: Option<f64>,
 
-    /// Repository path.
-    #[arg(long, value_name = "PATH", default_value = ".")]
-    pub repo: PathBuf,
-
     /// Override the path prefix stripped from report file paths to make them
     /// repo-relative (default: the repository working directory).
     #[arg(long, value_name = "PATH")]
@@ -140,8 +136,11 @@ pub struct DiffOutcome {
 
 impl DiffCommand {
     /// Executes the command: prints the report and applies the patch gate.
-    pub async fn execute(self) -> Result<()> {
-        let outcome = self.run()?;
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
+        let outcome = self.run(repo)?;
         println!("{}", outcome.rendered);
         if outcome.below_gate {
             let pct = outcome.patch_percent.unwrap_or(0.0);
@@ -154,9 +153,15 @@ impl DiffCommand {
     }
 
     /// Runs the analysis and renders the output without printing.
-    pub fn run(&self) -> Result<DiffOutcome> {
-        let repo = Repository::open(&self.repo)
-            .with_context(|| format!("could not open git repository at {}", self.repo.display()))?;
+    ///
+    /// `repo_root` is the repository to analyze (`None` defaults to `.`, which
+    /// preserves the CI invocation that runs from the repo root). Relative
+    /// `--report`/`--baseline-report` paths are anchored to it so the git repo
+    /// and the coverage reports always resolve against the same root.
+    pub fn run(&self, repo_root: Option<&Path>) -> Result<DiffOutcome> {
+        let repo_path = repo_root.map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        let repo = Repository::open(&repo_path)
+            .with_context(|| format!("could not open git repository at {}", repo_path.display()))?;
 
         // Resolve the base ref (default: merge-base of origin/main and HEAD).
         let base_ref = match &self.base_ref {
@@ -170,12 +175,18 @@ impl DiffCommand {
             .clone()
             .or_else(|| repo.workdir().map(std::path::Path::to_path_buf));
 
-        let head = self.load_report(&self.report, self.report_format, strip_prefix.as_deref())?;
+        let head = self.load_report(
+            &self.report,
+            self.report_format,
+            strip_prefix.as_deref(),
+            &repo_path,
+        )?;
         let baseline = match &self.baseline_report {
             Some(path) => Some(self.load_report(
                 path,
                 self.baseline_report_format,
                 strip_prefix.as_deref(),
+                &repo_path,
             )?),
             None => None,
         };
@@ -201,13 +212,23 @@ impl DiffCommand {
     }
 
     /// Reads and parses a coverage report, normalising paths to be repo-relative.
+    ///
+    /// A relative `path` is resolved against `repo_root` so the report and the
+    /// git repository always anchor to the same root; an absolute `path` is
+    /// used as-is.
     fn load_report(
         &self,
         path: &std::path::Path,
         format: ReportFormat,
         strip_prefix: Option<&std::path::Path>,
+        repo_root: &Path,
     ) -> Result<crate::coverage::CoverageReport> {
-        let content = std::fs::read_to_string(path)
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            repo_root.join(path)
+        };
+        let content = std::fs::read_to_string(&path)
             .with_context(|| format!("could not read coverage report {}", path.display()))?;
         let mut report = parse(&content, format.into_format())
             .with_context(|| format!("could not parse coverage report {}", path.display()))?;
@@ -298,8 +319,9 @@ mod tests {
         report
     }
 
-    /// Builds a `DiffCommand` with defaults pointed at the temp repo and report.
-    fn command(repo: &Path, report: PathBuf, base_ref: &str) -> DiffCommand {
+    /// Builds a `DiffCommand` with defaults pointed at the given report. The
+    /// repository root is supplied separately to `run`/`execute`.
+    fn command(report: PathBuf, base_ref: &str) -> DiffCommand {
         DiffCommand {
             report,
             report_format: ReportFormat::Auto,
@@ -309,7 +331,6 @@ mod tests {
             baseline_report_format: ReportFormat::Auto,
             format: OutputFormatArg::Markdown,
             fail_under_patch: None,
-            repo: repo.to_path_buf(),
             strip_prefix: None,
             collapse_ranges: false,
             artifact_url: None,
@@ -354,7 +375,7 @@ mod tests {
     fn run_markdown_reports_patch_coverage() {
         let (_dir, repo, base) = repo_with_added_file();
         let report = write_head_lcov(&repo);
-        let outcome = command(&repo, report, &base).run().unwrap();
+        let outcome = command(report, &base).run(Some(&repo)).unwrap();
         // 3 added lines, 2 covered.
         assert_eq!(outcome.patch_percent, Some(2.0 / 3.0 * 100.0));
         assert!(!outcome.below_gate);
@@ -367,9 +388,9 @@ mod tests {
         let (_dir, repo, base) = repo_with_added_file();
         for format in [OutputFormatArg::Yaml, OutputFormatArg::Json] {
             let report = write_head_lcov(&repo);
-            let mut cmd = command(&repo, report, &base);
+            let mut cmd = command(report, &base);
             cmd.format = format;
-            let outcome = cmd.run().unwrap();
+            let outcome = cmd.run(Some(&repo)).unwrap();
             assert!(outcome.rendered.contains("patch_coverage"));
         }
     }
@@ -385,9 +406,9 @@ mod tests {
             format!("SF:{}/a.rs\nDA:1,1\nend_of_record\n", repo.display()),
         )
         .unwrap();
-        let mut cmd = command(&repo, report, &base);
+        let mut cmd = command(report, &base);
         cmd.baseline_report = Some(baseline);
-        let outcome = cmd.run().unwrap();
+        let outcome = cmd.run(Some(&repo)).unwrap();
         assert!(outcome.rendered.contains("vs `main`"));
     }
 
@@ -396,27 +417,33 @@ mod tests {
         let (_dir, repo, base) = repo_with_added_file();
         // Patch coverage is ~66.7%.
         let report = write_head_lcov(&repo);
-        let mut cmd = command(&repo, report, &base);
+        let mut cmd = command(report, &base);
         cmd.fail_under_patch = Some(90.0);
-        assert!(cmd.run().unwrap().below_gate, "66.7% < 90% should fail");
+        assert!(
+            cmd.run(Some(&repo)).unwrap().below_gate,
+            "66.7% < 90% should fail"
+        );
 
         let report = write_head_lcov(&repo);
-        let mut cmd = command(&repo, report, &base);
+        let mut cmd = command(report, &base);
         cmd.fail_under_patch = Some(50.0);
-        assert!(!cmd.run().unwrap().below_gate, "66.7% >= 50% should pass");
+        assert!(
+            !cmd.run(Some(&repo)).unwrap().below_gate,
+            "66.7% >= 50% should pass"
+        );
     }
 
     #[test]
     fn missing_report_errors() {
         let (_dir, repo, base) = repo_with_added_file();
-        let cmd = command(&repo, repo.join("nope.lcov"), &base);
-        assert!(cmd.run().is_err());
+        let cmd = command(repo.join("nope.lcov"), &base);
+        assert!(cmd.run(Some(&repo)).is_err());
     }
 
     #[test]
     fn render_options_use_flags() {
         let (_dir, repo, base) = repo_with_added_file();
-        let mut cmd = command(&repo, repo.join("head.lcov"), &base);
+        let mut cmd = command(repo.join("head.lcov"), &base);
         cmd.artifact_url = Some("https://artifact".to_string());
         cmd.collapse_ranges = true;
         let opts = cmd.render_options();
@@ -429,13 +456,29 @@ mod tests {
         let (_dir, repo, base) = repo_with_added_file();
         let report = write_head_lcov(&repo);
         // Passing gate: execute prints and returns Ok.
-        let mut cmd = command(&repo, report.clone(), &base);
+        let mut cmd = command(report.clone(), &base);
         cmd.fail_under_patch = Some(10.0);
-        assert!(cmd.execute().await.is_ok());
+        assert!(cmd.execute(Some(&repo)).await.is_ok());
 
         // Failing gate: execute returns Err.
-        let mut cmd = command(&repo, report, &base);
+        let mut cmd = command(report, &base);
         cmd.fail_under_patch = Some(99.0);
-        assert!(cmd.execute().await.is_err());
+        assert!(cmd.execute(Some(&repo)).await.is_err());
+    }
+
+    /// The injected repo root drives BOTH the git repository and relative
+    /// report-path resolution. With a RELATIVE `--report` and the injected repo
+    /// at `repo` (never the process CWD), the report must be read from
+    /// `repo/head.lcov` — proving `-C` is honored consistently and not split
+    /// between the injected repo and the ambient CWD.
+    #[test]
+    fn run_anchors_repo_and_relative_report_to_injected_root() {
+        let (_dir, repo, base) = repo_with_added_file();
+        write_head_lcov(&repo); // writes <repo>/head.lcov
+        let outcome = command(PathBuf::from("head.lcov"), &base)
+            .run(Some(&repo))
+            .unwrap();
+        assert_eq!(outcome.patch_percent, Some(2.0 / 3.0 * 100.0));
+        assert!(outcome.rendered.contains("`b.rs:2`"));
     }
 }

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -22,57 +22,6 @@ use std::path::Path;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-/// Global async mutex serialising every caller that mutates the process-wide
-/// current working directory via `std::env::set_current_dir`.
-///
-/// Now that every `git` command threads an explicit `--repo` root through its
-/// reads, no production code path changes the CWD. This mutex and the
-/// [`CwdGuard`] it backs survive only to serialise the remaining
-/// CWD-mutating *unit test* (`cwd_guard_invalid_path_returns_error`) against
-/// any other test that touches the shared CWD, so it is gated behind
-/// `#[cfg(test)]`.
-///
-/// We use `tokio::sync::Mutex` rather than `std::sync::Mutex` so the guard is
-/// `Send` and can be held across `.await` points.
-#[cfg(test)]
-pub(crate) static CWD_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-/// RAII guard that temporarily changes the process current working directory
-/// and restores it on drop.
-///
-/// Test-only (`#[cfg(test)]`): production commands no longer mutate the CWD —
-/// they thread an explicit `--repo` root instead. The guard is retained so the
-/// `cwd_guard_invalid_path_returns_error` regression test can keep exercising
-/// the error path without racing on the shared CWD.
-#[cfg(test)]
-pub(crate) struct CwdGuard {
-    original: std::path::PathBuf,
-    _lock: tokio::sync::MutexGuard<'static, ()>,
-}
-
-#[cfg(test)]
-impl CwdGuard {
-    /// Enters `path`, holding the CWD mutex for the lifetime of the guard.
-    pub(crate) async fn enter<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
-        let lock = CWD_MUTEX.lock().await;
-        let original =
-            std::env::current_dir().map_err(|e| anyhow::anyhow!("current_dir failed: {e}"))?;
-        std::env::set_current_dir(path.as_ref())
-            .map_err(|e| anyhow::anyhow!("set_current_dir failed: {e}"))?;
-        Ok(Self {
-            original,
-            _lock: lock,
-        })
-    }
-}
-
-#[cfg(test)]
-impl Drop for CwdGuard {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.original);
-    }
-}
-
 /// Reads one line of interactive input from `reader`.
 ///
 /// Returns `Some(line)` on success, or `None` when the reader reaches EOF
@@ -444,17 +393,6 @@ mod tests {
         let mut reader = std::io::Cursor::new(b"\n" as &[u8]);
         let result = read_interactive_line(&mut reader).unwrap();
         assert_eq!(result, Some("\n".to_string()));
-    }
-
-    #[tokio::test]
-    async fn cwd_guard_invalid_path_returns_error() {
-        // Error path doesn't mutate the shared CWD, so it is safe to run in
-        // parallel with the rest of the test suite. No production code calls
-        // `CwdGuard::enter` anymore — every git command threads `--repo`
-        // instead — so this test is the guard's sole remaining caller and
-        // covers only the error path. The guard is retired in the final slice.
-        let result = CwdGuard::enter("/no/such/path/exists").await;
-        assert!(result.is_err(), "expected error for nonexistent path");
     }
 
     /// All `git` message and branch commands now honor `--repo` by threading

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -25,33 +25,32 @@ use clap::{Parser, Subcommand};
 /// Global async mutex serialising every caller that mutates the process-wide
 /// current working directory via `std::env::set_current_dir`.
 ///
-/// Used by:
-/// - The production [`CwdGuard`] wrapper that MCP tool handlers acquire via
-///   `.lock().await`.
-/// - Async unit tests that call `CwdGuard::enter` directly (e.g., `check`,
-///   `twiddle`, `create_pr`).
-/// - Sync unit tests that change CWD directly; they acquire the same mutex
-///   via [`tokio::sync::Mutex::blocking_lock`] so both styles of test
-///   serialise through one instance and cannot race on the shared CWD.
+/// Now that every `git` command threads an explicit `--repo` root through its
+/// reads, no production code path changes the CWD. This mutex and the
+/// [`CwdGuard`] it backs survive only to serialise the remaining
+/// CWD-mutating *unit test* (`cwd_guard_invalid_path_returns_error`) against
+/// any other test that touches the shared CWD, so it is gated behind
+/// `#[cfg(test)]`.
 ///
 /// We use `tokio::sync::Mutex` rather than `std::sync::Mutex` so the guard is
-/// `Send` and can be held across `.await` points (required by the MCP
-/// async tool handlers).
+/// `Send` and can be held across `.await` points.
+#[cfg(test)]
 pub(crate) static CWD_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// RAII guard that temporarily changes the process current working directory
 /// and restores it on drop.
 ///
-/// Shared by MCP tool handlers that accept a `repo_path` parameter: many
-/// commands (check/twiddle/create_pr) read configuration and invoke external
-/// tools relative to the current working directory, so the simplest way to
-/// "run this command at a different path" is to pin the CWD for the duration
-/// of the call. A global async mutex serialises concurrent callers.
+/// Test-only (`#[cfg(test)]`): production commands no longer mutate the CWD —
+/// they thread an explicit `--repo` root instead. The guard is retained so the
+/// `cwd_guard_invalid_path_returns_error` regression test can keep exercising
+/// the error path without racing on the shared CWD.
+#[cfg(test)]
 pub(crate) struct CwdGuard {
     original: std::path::PathBuf,
     _lock: tokio::sync::MutexGuard<'static, ()>,
 }
 
+#[cfg(test)]
 impl CwdGuard {
     /// Enters `path`, holding the CWD mutex for the lifetime of the guard.
     pub(crate) async fn enter<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
@@ -67,6 +66,7 @@ impl CwdGuard {
     }
 }
 
+#[cfg(test)]
 impl Drop for CwdGuard {
     fn drop(&mut self) {
         let _ = std::env::set_current_dir(&self.original);
@@ -449,24 +449,25 @@ mod tests {
     #[tokio::test]
     async fn cwd_guard_invalid_path_returns_error() {
         // Error path doesn't mutate the shared CWD, so it is safe to run in
-        // parallel with the rest of the test suite. The happy path is covered
-        // indirectly by `run_{check,twiddle,create_pr}` error-path tests
-        // that exercise `CwdGuard::enter(valid_path)` followed by restoration.
+        // parallel with the rest of the test suite. No production code calls
+        // `CwdGuard::enter` anymore — every git command threads `--repo`
+        // instead — so this test is the guard's sole remaining caller and
+        // covers only the error path. The guard is retired in the final slice.
         let result = CwdGuard::enter("/no/such/path/exists").await;
         assert!(result.is_err(), "expected error for nonexistent path");
     }
 
-    /// Every git command that has not yet been converted to honor `--repo`
-    /// must reject an injected path with a clear error rather than silently
-    /// ignoring it (RULE 6). Exercises each reject-guard branch through the
-    /// real parse + dispatch path. `git branch info`, `git commit message
-    /// view`, `git commit message staged`, `git commit message check`, `git
-    /// commit message amend`, and `git commit message twiddle` are converted,
-    /// so they are absent here.
+    /// All `git` message and branch commands now honor `--repo` by threading
+    /// an explicit repo root through their reads (RULE 6 fully satisfied):
+    /// `git branch info`, `git branch create pr`, `git commit message view`,
+    /// `git commit message staged`, `git commit message check`, `git commit
+    /// message amend`, and `git commit message twiddle` are all converted, so
+    /// there are no remaining reject-guards. The empty array keeps this guard
+    /// in place: should a future unconverted command be added, list it here so
+    /// it is asserted to reject `--repo` rather than silently ignoring it.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 1] =
-            [&["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"]];
+        let unconverted: [&[&str]; 0] = [];
         for args in unconverted {
             let cli = Cli::try_parse_from(args.iter().copied()).unwrap();
             let err = cli

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -460,14 +460,11 @@ mod tests {
     /// must reject an injected path with a clear error rather than silently
     /// ignoring it (RULE 6). Exercises each reject-guard branch through the
     /// real parse + dispatch path. `git branch info`, `git commit message
-    /// view`, `git commit message staged`, and `git commit message check` are
-    /// converted, so they are absent here.
+    /// view`, `git commit message staged`, `git commit message check`, and
+    /// `git commit message amend` are converted, so they are absent here.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 3] = [
-            &[
-                "omni-dev", "-C", "/tmp", "git", "commit", "message", "amend", "x.yaml",
-            ],
+        let unconverted: [&[&str]; 2] = [
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "twiddle",
             ],

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -460,19 +460,16 @@ mod tests {
     /// must reject an injected path with a clear error rather than silently
     /// ignoring it (RULE 6). Exercises each reject-guard branch through the
     /// real parse + dispatch path. `git branch info`, `git commit message
-    /// view`, and `git commit message staged` are converted, so they are
-    /// absent here.
+    /// view`, `git commit message staged`, and `git commit message check` are
+    /// converted, so they are absent here.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 4] = [
+        let unconverted: [&[&str]; 3] = [
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "amend", "x.yaml",
             ],
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "twiddle",
-            ],
-            &[
-                "omni-dev", "-C", "/tmp", "git", "commit", "message", "check",
             ],
             &["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"],
         ];

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -17,6 +17,8 @@ pub use staged::{run_staged, StagedCommand, StagedOutcome};
 pub use twiddle::{run_twiddle, TwiddleCommand, TwiddleOutcome};
 pub use view::{run_view, ViewCommand};
 
+use std::path::Path;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
@@ -185,51 +187,55 @@ pub enum CreateSubcommands {
 
 impl GitCommand {
     /// Executes the git command.
-    pub async fn execute(self) -> Result<()> {
+    ///
+    /// `repo` is the repository location resolved once at the CLI boundary
+    /// (`None` = current working directory); it is threaded explicitly down to
+    /// each leaf command rather than read from the ambient CWD.
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
         match self.command {
-            GitSubcommands::Commit(commit_cmd) => commit_cmd.execute().await,
-            GitSubcommands::Branch(branch_cmd) => branch_cmd.execute().await,
+            GitSubcommands::Commit(commit_cmd) => commit_cmd.execute(repo).await,
+            GitSubcommands::Branch(branch_cmd) => branch_cmd.execute(repo).await,
         }
     }
 }
 
 impl CommitCommand {
     /// Executes the commit command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
         match self.command {
-            CommitSubcommands::Message(message_cmd) => message_cmd.execute().await,
+            CommitSubcommands::Message(message_cmd) => message_cmd.execute(repo).await,
         }
     }
 }
 
 impl MessageCommand {
     /// Executes the message command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
         match self.command {
-            MessageSubcommands::View(view_cmd) => view_cmd.execute(),
-            MessageSubcommands::Amend(amend_cmd) => amend_cmd.execute(),
-            MessageSubcommands::Twiddle(twiddle_cmd) => twiddle_cmd.execute().await,
-            MessageSubcommands::Check(check_cmd) => check_cmd.execute().await,
-            MessageSubcommands::Staged(staged_cmd) => staged_cmd.execute().await,
+            MessageSubcommands::View(view_cmd) => view_cmd.execute(repo),
+            MessageSubcommands::Amend(amend_cmd) => amend_cmd.execute(repo),
+            MessageSubcommands::Twiddle(twiddle_cmd) => twiddle_cmd.execute(repo).await,
+            MessageSubcommands::Check(check_cmd) => check_cmd.execute(repo).await,
+            MessageSubcommands::Staged(staged_cmd) => staged_cmd.execute(repo).await,
         }
     }
 }
 
 impl BranchCommand {
     /// Executes the branch command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
         match self.command {
-            BranchSubcommands::Info(info_cmd) => info_cmd.execute(),
-            BranchSubcommands::Create(create_cmd) => create_cmd.execute().await,
+            BranchSubcommands::Info(info_cmd) => info_cmd.execute(repo),
+            BranchSubcommands::Create(create_cmd) => create_cmd.execute(repo).await,
         }
     }
 }
 
 impl CreateCommand {
     /// Executes the create command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&Path>) -> Result<()> {
         match self.command {
-            CreateSubcommands::Pr(pr_cmd) => pr_cmd.execute().await,
+            CreateSubcommands::Pr(pr_cmd) => pr_cmd.execute(repo).await,
         }
     }
 }
@@ -448,5 +454,42 @@ mod tests {
         // that exercise `CwdGuard::enter(valid_path)` followed by restoration.
         let result = CwdGuard::enter("/no/such/path/exists").await;
         assert!(result.is_err(), "expected error for nonexistent path");
+    }
+
+    /// Every git command that has not yet been converted to honor `--repo`
+    /// must reject an injected path with a clear error rather than silently
+    /// ignoring it (RULE 6). Exercises each reject-guard branch through the
+    /// real parse + dispatch path. `git branch info` is converted, so it is
+    /// absent here.
+    #[tokio::test]
+    async fn repo_flag_rejected_for_unconverted_commands() {
+        let unconverted: [&[&str]; 6] = [
+            &["omni-dev", "-C", "/tmp", "git", "commit", "message", "view"],
+            &[
+                "omni-dev", "-C", "/tmp", "git", "commit", "message", "amend", "x.yaml",
+            ],
+            &[
+                "omni-dev", "-C", "/tmp", "git", "commit", "message", "twiddle",
+            ],
+            &[
+                "omni-dev", "-C", "/tmp", "git", "commit", "message", "check",
+            ],
+            &[
+                "omni-dev", "-C", "/tmp", "git", "commit", "message", "staged",
+            ],
+            &["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"],
+        ];
+        for args in unconverted {
+            let cli = Cli::try_parse_from(args.iter().copied()).unwrap();
+            let err = cli
+                .execute()
+                .await
+                .expect_err("unconverted command must reject --repo");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("not yet supported"),
+                "args {args:?} -> unexpected error: {msg}"
+            );
+        }
     }
 }

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -459,11 +459,12 @@ mod tests {
     /// Every git command that has not yet been converted to honor `--repo`
     /// must reject an injected path with a clear error rather than silently
     /// ignoring it (RULE 6). Exercises each reject-guard branch through the
-    /// real parse + dispatch path. `git branch info` and `git commit message
-    /// view` are converted, so they are absent here.
+    /// real parse + dispatch path. `git branch info`, `git commit message
+    /// view`, and `git commit message staged` are converted, so they are
+    /// absent here.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 5] = [
+        let unconverted: [&[&str]; 4] = [
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "amend", "x.yaml",
             ],
@@ -472,9 +473,6 @@ mod tests {
             ],
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "check",
-            ],
-            &[
-                "omni-dev", "-C", "/tmp", "git", "commit", "message", "staged",
             ],
             &["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"],
         ];

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -459,12 +459,11 @@ mod tests {
     /// Every git command that has not yet been converted to honor `--repo`
     /// must reject an injected path with a clear error rather than silently
     /// ignoring it (RULE 6). Exercises each reject-guard branch through the
-    /// real parse + dispatch path. `git branch info` is converted, so it is
-    /// absent here.
+    /// real parse + dispatch path. `git branch info` and `git commit message
+    /// view` are converted, so they are absent here.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 6] = [
-            &["omni-dev", "-C", "/tmp", "git", "commit", "message", "view"],
+        let unconverted: [&[&str]; 5] = [
             &[
                 "omni-dev", "-C", "/tmp", "git", "commit", "message", "amend", "x.yaml",
             ],

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -460,16 +460,13 @@ mod tests {
     /// must reject an injected path with a clear error rather than silently
     /// ignoring it (RULE 6). Exercises each reject-guard branch through the
     /// real parse + dispatch path. `git branch info`, `git commit message
-    /// view`, `git commit message staged`, `git commit message check`, and
-    /// `git commit message amend` are converted, so they are absent here.
+    /// view`, `git commit message staged`, `git commit message check`, `git
+    /// commit message amend`, and `git commit message twiddle` are converted,
+    /// so they are absent here.
     #[tokio::test]
     async fn repo_flag_rejected_for_unconverted_commands() {
-        let unconverted: [&[&str]; 2] = [
-            &[
-                "omni-dev", "-C", "/tmp", "git", "commit", "message", "twiddle",
-            ],
-            &["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"],
-        ];
+        let unconverted: [&[&str]; 1] =
+            [&["omni-dev", "-C", "/tmp", "git", "branch", "create", "pr"]];
         for args in unconverted {
             let cli = Cli::try_parse_from(args.iter().copied()).unwrap();
             let err = cli

--- a/src/cli/git/amend.rs
+++ b/src/cli/git/amend.rs
@@ -13,22 +13,29 @@ pub struct AmendCommand {
 
 impl AmendCommand {
     /// Executes the amend command.
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
     pub fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
         use crate::git::AmendmentHandler;
 
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git commit message amend`");
-        }
+        // Resolve the repo root once; the preflight checks and the amendment
+        // handler (including all its `git` subprocesses) anchor to it.
+        let repo_root = match repo {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().context("Failed to determine current directory")?,
+        };
 
         // Preflight checks: validate prerequisites before any processing
-        crate::utils::check_git_repository()?;
-        crate::utils::check_working_directory_clean()?;
+        crate::utils::check_git_repository_at(&repo_root)?;
+        crate::utils::check_working_directory_clean_at(&repo_root)?;
 
         println!("🔄 Starting commit amendment process...");
         println!("📄 Loading amendments from: {}", self.yaml_file);
 
         // Create amendment handler and apply amendments
-        let handler = AmendmentHandler::new().context("Failed to initialize amendment handler")?;
+        let handler =
+            AmendmentHandler::new(&repo_root).context("Failed to initialize amendment handler")?;
 
         handler
             .apply_amendments(&self.yaml_file)

--- a/src/cli/git/amend.rs
+++ b/src/cli/git/amend.rs
@@ -13,8 +13,12 @@ pub struct AmendCommand {
 
 impl AmendCommand {
     /// Executes the amend command.
-    pub fn execute(self) -> Result<()> {
+    pub fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
         use crate::git::AmendmentHandler;
+
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git commit message amend`");
+        }
 
         // Preflight checks: validate prerequisites before any processing
         crate::utils::check_git_repository()?;

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -185,6 +185,7 @@ impl CheckCommand {
             if !amendments.is_empty()
                 && self
                     .prompt_and_apply_suggestions(
+                        repo_root,
                         amendments,
                         std::io::stdin().is_terminal(),
                         &mut std::io::BufReader::new(std::io::stdin()),
@@ -747,6 +748,7 @@ impl CheckCommand {
     /// without blocking on real stdin.
     async fn prompt_and_apply_suggestions(
         &self,
+        repo_root: &std::path::Path,
         amendments: Vec<crate::data::amendments::Amendment>,
         is_terminal: bool,
         reader: &mut (dyn std::io::BufRead + Send),
@@ -784,7 +786,7 @@ impl CheckCommand {
                         .save_to_file(temp_file.path())
                         .context("Failed to save amendments")?;
 
-                    let handler = AmendmentHandler::new()
+                    let handler = AmendmentHandler::new(repo_root)
                         .context("Failed to initialize amendment handler")?;
                     handler
                         .apply_amendments(&temp_file.path().to_string_lossy())
@@ -1860,7 +1862,12 @@ mod tests {
         let cmd = make_check_cmd(false);
         let mut reader = std::io::Cursor::new(b"" as &[u8]);
         let result = cmd
-            .prompt_and_apply_suggestions(vec![make_amendment()], false, &mut reader)
+            .prompt_and_apply_suggestions(
+                std::path::Path::new("."),
+                vec![make_amendment()],
+                false,
+                &mut reader,
+            )
             .await
             .unwrap();
         assert!(!result, "non-terminal should return false");
@@ -1872,7 +1879,12 @@ mod tests {
         let cmd = make_check_cmd(false);
         let mut reader = std::io::Cursor::new(b"" as &[u8]);
         let result = cmd
-            .prompt_and_apply_suggestions(vec![make_amendment()], true, &mut reader)
+            .prompt_and_apply_suggestions(
+                std::path::Path::new("."),
+                vec![make_amendment()],
+                true,
+                &mut reader,
+            )
             .await
             .unwrap();
         assert!(!result, "EOF should return false");
@@ -1884,7 +1896,12 @@ mod tests {
         let cmd = make_check_cmd(false);
         let mut reader = std::io::Cursor::new(b"q\n" as &[u8]);
         let result = cmd
-            .prompt_and_apply_suggestions(vec![make_amendment()], true, &mut reader)
+            .prompt_and_apply_suggestions(
+                std::path::Path::new("."),
+                vec![make_amendment()],
+                true,
+                &mut reader,
+            )
             .await
             .unwrap();
         assert!(!result, "quit should return false");
@@ -1896,7 +1913,12 @@ mod tests {
         let cmd = make_check_cmd(false);
         let mut reader = std::io::Cursor::new(b"x\nq\n" as &[u8]);
         let result = cmd
-            .prompt_and_apply_suggestions(vec![make_amendment()], true, &mut reader)
+            .prompt_and_apply_suggestions(
+                std::path::Path::new("."),
+                vec![make_amendment()],
+                true,
+                &mut reader,
+            )
             .await
             .unwrap();
         assert!(!result, "invalid then quit should return false");

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -74,9 +74,14 @@ pub struct CheckCommand {
 impl CheckCommand {
     /// Executes the check command, validating commit messages against guidelines.
     pub async fn execute(mut self, repo: Option<&std::path::Path>) -> Result<()> {
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git commit message check`");
-        }
+        // Resolve the repo root once; every git, config, and scratch read below
+        // anchors to it (the CWD is the default when no path is injected).
+        let repo_root = match repo {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().context("Failed to determine current directory")?,
+        };
+        let repo_root = repo_root.as_path();
+
         // Resolve deprecated --batch-size into --concurrency
         if let Some(bs) = self.batch_size {
             eprintln!("warning: --batch-size is deprecated; use --concurrency instead");
@@ -101,7 +106,7 @@ impl CheckCommand {
         }
 
         // 1. Generate repository view to get all commits
-        let mut repo_view = self.generate_repository_view().await?;
+        let mut repo_view = self.generate_repository_view(repo_root).await?;
 
         // 2. Check for empty commit range (exit code 3)
         if repo_view.commits.is_empty() {
@@ -114,8 +119,8 @@ impl CheckCommand {
         }
 
         // 3. Load commit guidelines and scopes
-        let guidelines = self.load_guidelines().await?;
-        let valid_scopes = self.load_scopes();
+        let guidelines = self.load_guidelines(repo_root).await?;
+        let valid_scopes = self.load_scopes(repo_root);
 
         // Refine detected scopes using file_patterns from scope definitions
         for commit in &mut repo_view.commits {
@@ -123,7 +128,7 @@ impl CheckCommand {
         }
 
         if !self.quiet && output_format == OutputFormat::Text {
-            self.show_guidance_files_status(&guidelines, &valid_scopes);
+            self.show_guidance_files_status(repo_root, &guidelines, &valid_scopes);
         }
 
         // 4. Initialize Claude client
@@ -201,7 +206,10 @@ impl CheckCommand {
     }
 
     /// Generates the repository view (reuses logic from TwiddleCommand).
-    async fn generate_repository_view(&self) -> Result<crate::data::RepositoryView> {
+    async fn generate_repository_view(
+        &self,
+        repo_root: &std::path::Path,
+    ) -> Result<crate::data::RepositoryView> {
         use crate::data::{
             AiInfo, BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo,
             WorkingDirectoryInfo,
@@ -210,8 +218,8 @@ impl CheckCommand {
         use crate::utils::ai_scratch;
 
         // Open git repository
-        let repo = GitRepository::open()
-            .context("Failed to open git repository. Make sure you're in a git repository.")?;
+        let repo = GitRepository::open_at(repo_root)
+            .context("Failed to open git repository at the given path")?;
 
         // Get current branch name
         let current_branch = repo
@@ -259,8 +267,8 @@ impl CheckCommand {
         });
 
         // Get AI scratch directory
-        let ai_scratch_path =
-            ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+        let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+            .context("Failed to determine AI scratch directory")?;
         let ai_info = AiInfo {
             scratch: ai_scratch_path.to_string_lossy().to_string(),
         };
@@ -288,7 +296,7 @@ impl CheckCommand {
     }
 
     /// Loads commit guidelines from file or context directory.
-    async fn load_guidelines(&self) -> Result<Option<String>> {
+    async fn load_guidelines(&self, repo_root: &std::path::Path) -> Result<Option<String>> {
         // If explicit guidelines path is provided, use it
         if let Some(guidelines_path) = &self.guidelines {
             let content = std::fs::read_to_string(guidelines_path).with_context(|| {
@@ -301,28 +309,34 @@ impl CheckCommand {
         }
 
         // Otherwise, use standard resolution chain
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
         crate::claude::context::load_config_content(&context_dir, "commit-guidelines.md")
     }
 
     /// Loads valid scopes from context directory with ecosystem defaults.
-    fn load_scopes(&self) -> Vec<crate::data::context::ScopeDefinition> {
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
-        crate::claude::context::load_project_scopes(&context_dir, &std::path::PathBuf::from("."))
+    fn load_scopes(
+        &self,
+        repo_root: &std::path::Path,
+    ) -> Vec<crate::data::context::ScopeDefinition> {
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
+        crate::claude::context::load_project_scopes(&context_dir, repo_root)
     }
 
     /// Shows diagnostic information about loaded guidance files.
     fn show_guidance_files_status(
         &self,
+        repo_root: &std::path::Path,
         guidelines: &Option<String>,
         valid_scopes: &[crate::data::context::ScopeDefinition],
     ) {
         use crate::claude::context::{
-            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+            config_source_label, resolve_context_dir_with_source_at, ConfigSourceLabel,
         };
 
         let (context_dir, dir_source) =
-            resolve_context_dir_with_source(self.context_dir.as_deref());
+            resolve_context_dir_with_source_at(self.context_dir.as_deref(), repo_root);
 
         println!("📋 Project guidance files status:");
         println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
@@ -674,6 +688,11 @@ impl CheckCommand {
         println!("🤖 AI Model Configuration:");
 
         let metadata = client.get_ai_client_metadata();
+        // NOTE (#967): this `--verbose` diagnostic banner reads the process-wide
+        // model catalog (`get_model_registry` → CWD-relative project models.yaml),
+        // not a `--repo`-scoped catalog. It is informational only and does not
+        // affect the check verdict, so it is left CWD-scoped until the repo-aware
+        // `ModelRegistry::load_at` foundation lands (first used by `create pr`).
         let registry = get_model_registry();
 
         if let Some(spec) = registry.get_model_spec(&metadata.model) {
@@ -896,9 +915,10 @@ pub struct CheckOutcome {
 /// runs a single direct AI call — the MCP tool boundary never needs the
 /// map-reduce/interactive-retry flow from [`CheckCommand::execute`].
 ///
-/// When `repo_path` is provided the current working directory is changed for
-/// the duration of the call (serialised by a global mutex) so CWD-dependent
-/// context-discovery and AI-scratch paths resolve relative to the target repo.
+/// `repo_path` selects the repository to check (`None` defaults to the current
+/// working directory). It is resolved once here and threaded explicitly into
+/// [`run_check_with_client`], so context-discovery and AI-scratch paths anchor
+/// to the target repo without changing the process working directory.
 pub async fn run_check(
     range: &str,
     guidelines_path: Option<&std::path::Path>,
@@ -906,29 +926,30 @@ pub async fn run_check(
     strict: bool,
     model: Option<String>,
 ) -> Result<CheckOutcome> {
-    let _cwd_guard = match repo_path {
-        Some(p) => Some(super::CwdGuard::enter(p).await?),
-        None => None,
+    let repo_root = match repo_path {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().context("Failed to determine current directory")?,
     };
 
     // Preflight: validate AI credentials.
     crate::utils::check_ai_command_prerequisites(model.as_deref())?;
 
     let claude_client = crate::claude::create_default_claude_client(model, None).await?;
-    run_check_with_client(range, guidelines_path, strict, &claude_client).await
+    run_check_with_client(range, guidelines_path, strict, &claude_client, &repo_root).await
 }
 
 /// Non-credential-gated inner core of [`run_check`] for unit tests.
 ///
 /// Extracted so tests can inject a [`crate::claude::client::ClaudeClient`]
 /// backed by the in-crate mock AI client and exercise the full happy path
-/// without real credentials. Callers are responsible for holding any
-/// [`super::CwdGuard`] they need and for running preflight themselves.
+/// without real credentials. `repo_root` selects the repository; callers run
+/// preflight themselves.
 pub(crate) async fn run_check_with_client(
     range: &str,
     guidelines_path: Option<&std::path::Path>,
     strict: bool,
     claude_client: &crate::claude::client::ClaudeClient,
+    repo_root: &std::path::Path,
 ) -> Result<CheckOutcome> {
     use crate::data::{
         AiInfo, BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo,
@@ -937,8 +958,8 @@ pub(crate) async fn run_check_with_client(
     use crate::git::{GitRepository, RemoteInfo};
     use crate::utils::ai_scratch;
 
-    let repo = GitRepository::open()
-        .context("Failed to open git repository. Make sure you're in a git repository.")?;
+    let repo = GitRepository::open_at(repo_root)
+        .context("Failed to open git repository at the given path")?;
 
     let current_branch = repo
         .get_current_branch()
@@ -964,8 +985,8 @@ pub(crate) async fn run_check_with_client(
         anyhow::bail!("no commits found in range: {range}");
     }
 
-    let ai_scratch_path =
-        ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+    let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+        .context("Failed to determine AI scratch directory")?;
     let ai_info = AiInfo {
         scratch: ai_scratch_path.to_string_lossy().to_string(),
     };
@@ -994,13 +1015,12 @@ pub(crate) async fn run_check_with_client(
                 .with_context(|| format!("Failed to read guidelines file: {}", path.display()))?,
         )
     } else {
-        let context_dir = crate::claude::context::resolve_context_dir(None);
+        let context_dir = crate::claude::context::resolve_context_dir_at(None, repo_root);
         crate::claude::context::load_config_content(&context_dir, "commit-guidelines.md")?
     };
 
-    let context_dir = crate::claude::context::resolve_context_dir(None);
-    let valid_scopes =
-        crate::claude::context::load_project_scopes(&context_dir, &std::path::PathBuf::from("."));
+    let context_dir = crate::claude::context::resolve_context_dir_at(None, repo_root);
+    let valid_scopes = crate::claude::context::load_project_scopes(&context_dir, repo_root);
     for commit in &mut repo_view.commits {
         commit.analysis.refine_scope(&valid_scopes);
     }
@@ -1033,25 +1053,26 @@ mod run_check_tests {
     use crate::claude::test_utils::ConfigurableMockAiClient;
     use git2::{Repository, Signature};
 
-    /// With `/no/such/path` as repo_path, `CwdGuard::enter` fails before any AI
-    /// call is attempted — no credentials needed.
+    /// `run_check_with_client` opens the injected repo via `open_at` before any
+    /// AI call, so an invalid path errors with a git/repository error and needs
+    /// no credentials.
     #[tokio::test]
-    async fn run_check_invalid_repo_path_errors_before_ai() {
-        let err = run_check(
+    async fn run_check_with_client_invalid_repo_path_errors() {
+        let mock = ConfigurableMockAiClient::new(vec![]);
+        let client = ClaudeClient::new(Box::new(mock));
+        let err = run_check_with_client(
             "HEAD",
             None,
-            Some(std::path::Path::new("/no/such/path/exists")),
             false,
-            None,
+            &client,
+            std::path::Path::new("/no/such/path/exists"),
         )
         .await
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
-            msg.to_lowercase().contains("set_current_dir")
-                || msg.to_lowercase().contains("no such")
-                || msg.to_lowercase().contains("directory"),
-            "expected cwd-related error, got: {msg}"
+            msg.to_lowercase().contains("git") || msg.to_lowercase().contains("repository"),
+            "expected git/repository error, got: {msg}"
         );
     }
 
@@ -1097,15 +1118,12 @@ mod run_check_tests {
     #[tokio::test]
     async fn run_check_with_client_happy_path_passing() {
         let temp_dir = init_test_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         // Use a short hash prefix that resolves in the mini repo.
         let mock = ConfigurableMockAiClient::new(vec![Ok(passing_check_yaml("00000000"))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_check_with_client("HEAD", None, false, &client)
+        let outcome = run_check_with_client("HEAD", None, false, &client, temp_dir.path())
             .await
             .unwrap();
         assert!(!outcome.has_errors);
@@ -1119,14 +1137,11 @@ mod run_check_tests {
     #[tokio::test]
     async fn run_check_with_client_failing_commit_sets_error_exit_code() {
         let temp_dir = init_test_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(failing_check_yaml("00000000"))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_check_with_client("HEAD", None, false, &client)
+        let outcome = run_check_with_client("HEAD", None, false, &client, temp_dir.path())
             .await
             .unwrap();
         assert!(outcome.has_errors);
@@ -1136,14 +1151,11 @@ mod run_check_tests {
     #[tokio::test]
     async fn run_check_with_client_strict_does_not_affect_no_issues() {
         let temp_dir = init_test_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(passing_check_yaml("00000000"))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_check_with_client("HEAD", None, true, &client)
+        let outcome = run_check_with_client("HEAD", None, true, &client, temp_dir.path())
             .await
             .unwrap();
         assert_eq!(outcome.exit_code, 0);
@@ -1155,16 +1167,19 @@ mod run_check_tests {
         let temp_dir = init_test_repo();
         let guidelines_path = temp_dir.path().join("guidelines.md");
         std::fs::write(&guidelines_path, "guideline body").unwrap();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(passing_check_yaml("00000000"))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_check_with_client("HEAD", Some(&guidelines_path), false, &client)
-            .await
-            .unwrap();
+        let outcome = run_check_with_client(
+            "HEAD",
+            Some(&guidelines_path),
+            false,
+            &client,
+            temp_dir.path(),
+        )
+        .await
+        .unwrap();
         assert_eq!(outcome.exit_code, 0);
     }
 
@@ -1172,13 +1187,10 @@ mod run_check_tests {
     async fn run_check_with_client_guidelines_path_missing_errors() {
         let temp_dir = init_test_repo();
         let missing = temp_dir.path().join("no-such.md");
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(passing_check_yaml("00000000"))]);
         let client = ClaudeClient::new(Box::new(mock));
-        let err = run_check_with_client("HEAD", Some(&missing), false, &client)
+        let err = run_check_with_client("HEAD", Some(&missing), false, &client, temp_dir.path())
             .await
             .unwrap_err();
         assert!(
@@ -1190,14 +1202,11 @@ mod run_check_tests {
     #[tokio::test]
     async fn run_check_with_client_empty_range_bails() {
         let temp_dir = init_test_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
         // A range with no commits reachable → get_commits_in_range returns empty.
-        let err = run_check_with_client("HEAD..HEAD", None, false, &client)
+        let err = run_check_with_client("HEAD..HEAD", None, false, &client, temp_dir.path())
             .await
             .unwrap_err();
         assert!(format!("{err:#}").contains("no commits"));
@@ -1206,15 +1215,12 @@ mod run_check_tests {
     #[tokio::test]
     async fn run_check_with_client_ai_failure_propagates() {
         let temp_dir = init_test_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         // No responses → mock returns "no more mock responses" error; this
         // propagates after check_commits_with_scopes exhausts its retries.
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
-        let err = run_check_with_client("HEAD", None, false, &client)
+        let err = run_check_with_client("HEAD", None, false, &client, temp_dir.path())
             .await
             .unwrap_err();
         let _ = err; // any error is acceptable — the point is we didn't panic
@@ -1233,6 +1239,40 @@ mod run_check_tests {
         };
         let cloned = outcome.clone();
         assert_eq!(format!("{outcome:?}"), format!("{cloned:?}"));
+    }
+
+    /// "No silent mix" guard: default commit guidelines are loaded from the
+    /// INJECTED repo's `.omni-dev/commit-guidelines.md`, not the process CWD.
+    /// We write a distinctive marker into the temp repo's guidelines and assert
+    /// it reaches the AI prompt.
+    #[tokio::test]
+    async fn run_check_with_client_loads_guidelines_from_injected_repo() {
+        let temp_dir = init_test_repo();
+        let omni_dir = temp_dir.path().join(".omni-dev");
+        std::fs::create_dir_all(&omni_dir).unwrap();
+        std::fs::write(
+            omni_dir.join("commit-guidelines.md"),
+            "# Project rules\n\nDISTINCTIVE_GUIDELINE_MARKER: always do the thing.\n",
+        )
+        .unwrap();
+
+        let mock = ConfigurableMockAiClient::new(vec![Ok(passing_check_yaml("00000000"))]);
+        let prompts = mock.prompt_handle();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let _ = run_check_with_client("HEAD", None, false, &client, temp_dir.path())
+            .await
+            .unwrap();
+
+        let recorded = prompts.prompts();
+        assert!(!recorded.is_empty(), "expected at least one AI call");
+        assert!(
+            recorded.iter().any(|(s, u)| {
+                s.contains("DISTINCTIVE_GUIDELINE_MARKER")
+                    || u.contains("DISTINCTIVE_GUIDELINE_MARKER")
+            }),
+            "guidelines from the injected repo must reach the prompt: {recorded:?}"
+        );
     }
 }
 

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -93,7 +93,8 @@ impl CheckCommand {
         let output_format: OutputFormat = self.format.parse().unwrap_or(OutputFormat::Text);
 
         // Preflight check: validate AI credentials before any processing
-        let ai_info = crate::utils::check_ai_command_prerequisites(self.model.as_deref())?;
+        let ai_info =
+            crate::utils::check_ai_command_prerequisites(self.model.as_deref(), repo_root)?;
         if !self.quiet && output_format == OutputFormat::Text {
             println!(
                 "✓ {} credentials verified (model: {})",
@@ -934,7 +935,7 @@ pub async fn run_check(
     };
 
     // Preflight: validate AI credentials.
-    crate::utils::check_ai_command_prerequisites(model.as_deref())?;
+    crate::utils::check_ai_command_prerequisites(model.as_deref(), &repo_root)?;
 
     let claude_client = crate::claude::create_default_claude_client(model, None).await?;
     run_check_with_client(range, guidelines_path, strict, &claude_client, &repo_root).await

--- a/src/cli/git/check.rs
+++ b/src/cli/git/check.rs
@@ -73,7 +73,10 @@ pub struct CheckCommand {
 
 impl CheckCommand {
     /// Executes the check command, validating commit messages against guidelines.
-    pub async fn execute(mut self) -> Result<()> {
+    pub async fn execute(mut self, repo: Option<&std::path::Path>) -> Result<()> {
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git commit message check`");
+        }
         // Resolve deprecated --batch-size into --concurrency
         if let Some(bs) = self.batch_size {
             eprintln!("warning: --batch-size is deprecated; use --concurrency instead");

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -92,9 +92,15 @@ impl CreatePrCommand {
 
     /// Executes the create PR command.
     pub async fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git branch create pr`");
-        }
+        // Resolve the repo root once; every git, config, scratch, PR-template,
+        // and `gh` read below anchors to it (the CWD is the default when no
+        // path is injected).
+        let repo_root = match repo {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().context("Failed to determine current directory")?,
+        };
+        let repo_root = repo_root.as_path();
+
         // Preflight check: validate all prerequisites before any processing
         // This catches missing credentials/tools early before wasting time
         let ai_info = crate::utils::check_pr_command_prerequisites(self.model.as_deref())?;
@@ -107,18 +113,18 @@ impl CreatePrCommand {
         println!("🔄 Starting pull request creation process...");
 
         // 1. Generate repository view (reuse InfoCommand logic)
-        let repo_view = self.generate_repository_view()?;
+        let repo_view = self.generate_repository_view(repo_root)?;
 
         // 2. Validate branch state (always needed)
         self.validate_branch_state(&repo_view)?;
 
         // 3. Show guidance files status early (before AI processing)
         use crate::claude::context::ProjectDiscovery;
-        let repo_root = std::path::PathBuf::from(".");
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
-        let discovery = ProjectDiscovery::new(repo_root, context_dir);
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
+        let discovery = ProjectDiscovery::new(repo_root.to_path_buf(), context_dir);
         let project_context = discovery.discover().unwrap_or_default();
-        self.show_guidance_files_status(&project_context)?;
+        self.show_guidance_files_status(repo_root, &project_context)?;
 
         // 4. Show AI model configuration before generation
         let claude_client =
@@ -151,7 +157,7 @@ impl CreatePrCommand {
         // 7. Generate AI-powered PR content (title + description)
         debug!("About to generate PR content from AI");
         let (pr_content, _claude_client) = self
-            .generate_pr_content_with_client_internal(&repo_view, claude_client)
+            .generate_pr_content_with_client_internal(repo_root, &repo_view, claude_client)
             .await?;
 
         // 8. Show detailed context information (like twiddle command)
@@ -245,6 +251,7 @@ impl CreatePrCommand {
         match pr_action {
             PrAction::CreateNew => {
                 self.create_github_pr(
+                    repo_root,
                     &repo_view,
                     &final_pr_content.title,
                     &final_pr_content.description,
@@ -255,6 +262,7 @@ impl CreatePrCommand {
             }
             PrAction::UpdateExisting => {
                 self.update_github_pr(
+                    repo_root,
                     &repo_view,
                     &final_pr_content.title,
                     &final_pr_content.description,
@@ -269,7 +277,10 @@ impl CreatePrCommand {
     }
 
     /// Generates the repository view (reuses InfoCommand logic).
-    fn generate_repository_view(&self) -> Result<crate::data::RepositoryView> {
+    fn generate_repository_view(
+        &self,
+        repo_root: &std::path::Path,
+    ) -> Result<crate::data::RepositoryView> {
         use crate::data::{
             AiInfo, BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo,
             WorkingDirectoryInfo,
@@ -277,17 +288,9 @@ impl CreatePrCommand {
         use crate::git::{GitRepository, RemoteInfo};
         use crate::utils::ai_scratch;
 
-        // Open git repository
-        let repo = GitRepository::open()
-            .context("Failed to open git repository. Make sure you're in a git repository.")?;
-
-        // create-pr is still CWD-pinned (converted in a later slice), so the
-        // opened repo's workdir is the process CWD; deriving `repo_root` here
-        // keeps the PR-template/`gh` reads using the shared path-taking helpers
-        // without changing behavior yet.
-        let repo_root = repo
-            .workdir()
-            .context("repository has no working directory (bare repositories are not supported)")?;
+        // Open git repository at the injected root
+        let repo = GitRepository::open_at(repo_root)
+            .context("Failed to open git repository at the given path")?;
 
         // Get current branch name
         let current_branch = repo.get_current_branch().context(
@@ -385,8 +388,8 @@ impl CreatePrCommand {
         });
 
         // Get AI scratch directory
-        let ai_scratch_path =
-            ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+        let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+            .context("Failed to determine AI scratch directory")?;
         let ai_info = AiInfo {
             scratch: ai_scratch_path.to_string_lossy().to_string(),
         };
@@ -527,6 +530,7 @@ impl CreatePrCommand {
     /// Collects contextual information for enhanced PR generation (adapted from twiddle).
     async fn collect_context(
         &self,
+        repo_root: &std::path::Path,
         repo_view: &crate::data::RepositoryView,
     ) -> Result<crate::data::context::CommitContext> {
         use crate::claude::context::{
@@ -538,11 +542,11 @@ impl CreatePrCommand {
         let mut context = CommitContext::new();
 
         // 1. Discover project context
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
 
         // ProjectDiscovery takes repo root and context directory
-        let repo_root = std::path::PathBuf::from(".");
-        let discovery = ProjectDiscovery::new(repo_root, context_dir);
+        let discovery = ProjectDiscovery::new(repo_root.to_path_buf(), context_dir);
         match discovery.discover() {
             Ok(project_context) => {
                 context.project = project_context;
@@ -553,7 +557,7 @@ impl CreatePrCommand {
         }
 
         // 2. Analyze current branch
-        let repo = GitRepository::open()?;
+        let repo = GitRepository::open_at(repo_root)?;
         let current_branch = repo
             .get_current_branch()
             .unwrap_or_else(|_| "HEAD".to_string());
@@ -575,14 +579,15 @@ impl CreatePrCommand {
     /// Shows guidance files status (adapted from twiddle).
     fn show_guidance_files_status(
         &self,
+        repo_root: &std::path::Path,
         project_context: &crate::data::context::ProjectContext,
     ) -> Result<()> {
         use crate::claude::context::{
-            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+            config_source_label, resolve_context_dir_with_source_at, ConfigSourceLabel,
         };
 
         let (context_dir, dir_source) =
-            resolve_context_dir_with_source(self.context_dir.as_deref());
+            resolve_context_dir_with_source_at(self.context_dir.as_deref(), repo_root);
 
         println!("📋 Project guidance files status:");
         println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
@@ -613,7 +618,7 @@ impl CreatePrCommand {
         println!("   🎯 Valid scopes: {scopes_source}");
 
         // Check PR template
-        let pr_template_path = std::path::Path::new(".github/pull_request_template.md");
+        let pr_template_path = repo_root.join(".github/pull_request_template.md");
         let pr_template_status = if pr_template_path.exists() {
             format!("✅ Project: {}", pr_template_path.display())
         } else {
@@ -684,6 +689,7 @@ impl CreatePrCommand {
     /// Generates PR content with a pre-created client (internal method that does not show model info).
     async fn generate_pr_content_with_client_internal(
         &self,
+        repo_root: &std::path::Path,
         repo_view: &crate::data::RepositoryView,
         claude_client: crate::claude::client::ClaudeClient,
     ) -> Result<(PrContent, crate::claude::client::ClaudeClient)> {
@@ -705,7 +711,7 @@ impl CreatePrCommand {
 
         // Collect project context for PR guidelines
         debug!("Collecting context for PR generation");
-        let context = self.collect_context(repo_view).await?;
+        let context = self.collect_context(repo_root, repo_view).await?;
         debug!("Context collection completed");
 
         // Generate AI-powered PR content with context
@@ -1027,6 +1033,7 @@ impl CreatePrCommand {
     /// Creates a new GitHub PR using gh CLI.
     fn create_github_pr(
         &self,
+        repo_root: &std::path::Path,
         repo_view: &crate::data::RepositoryView,
         title: &str,
         description: &str,
@@ -1059,8 +1066,8 @@ impl CreatePrCommand {
             determine_push_action(true, false)
         } else {
             debug!("Opening git repository to check branch status");
-            let git_repo =
-                crate::git::GitRepository::open().context("Failed to open git repository")?;
+            let git_repo = crate::git::GitRepository::open_at(repo_root)
+                .context("Failed to open git repository at the given path")?;
 
             debug!(
                 "Checking if branch '{}' exists on remote 'origin'",
@@ -1111,6 +1118,7 @@ impl CreatePrCommand {
         }
 
         let pr_result = Command::new("gh")
+            .current_dir(repo_root)
             .args(&args)
             .output()
             .context("Failed to create pull request")?;
@@ -1132,6 +1140,7 @@ impl CreatePrCommand {
     /// Updates an existing GitHub PR using gh CLI.
     fn update_github_pr(
         &self,
+        repo_root: &std::path::Path,
         repo_view: &crate::data::RepositoryView,
         title: &str,
         description: &str,
@@ -1204,6 +1213,7 @@ impl CreatePrCommand {
         );
 
         let pr_result = Command::new("gh")
+            .current_dir(repo_root)
             .args(&gh_args)
             .output()
             .context("Failed to update pull request")?;
@@ -1235,6 +1245,11 @@ impl CreatePrCommand {
 
         // Get actual metadata from the client
         let metadata = client.get_ai_client_metadata();
+        // NOTE (#967): this diagnostic banner reads the process-wide model
+        // catalog (`get_model_registry` → CWD-relative project models.yaml),
+        // not a `--repo`-scoped catalog. It is informational only and does not
+        // affect the generated PR content, so it is left CWD-scoped until the
+        // repo-aware `ModelRegistry::load_at` foundation lands.
         let registry = get_model_registry();
 
         if let Some(spec) = registry.get_model_spec(&metadata.model) {
@@ -1391,9 +1406,12 @@ pub async fn run_create_pr(
     base_branch: Option<&str>,
     repo_path: Option<&std::path::Path>,
 ) -> Result<CreatePrOutcome> {
-    let _cwd_guard = match repo_path {
-        Some(p) => Some(super::CwdGuard::enter(p).await?),
-        None => None,
+    // Resolve the repo root once; the repository view and context discovery
+    // anchor to it (the CWD is the default when no path is injected), so no
+    // read resolves against the process working directory.
+    let repo_root = match repo_path {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().context("Failed to determine current directory")?,
     };
 
     crate::utils::check_pr_command_prerequisites(model.as_deref())?;
@@ -1410,8 +1428,8 @@ pub async fn run_create_pr(
         from_commits: false,
     };
 
-    let repo_view = cmd.generate_repository_view()?;
-    let context = cmd.collect_context(&repo_view).await?;
+    let repo_view = cmd.generate_repository_view(&repo_root)?;
+    let context = cmd.collect_context(&repo_root, &repo_view).await?;
     let claude_client = crate::claude::create_default_claude_client(model, None).await?;
     run_create_pr_with_client(&cmd, &repo_view, &context, &claude_client).await
 }
@@ -1484,12 +1502,18 @@ mod run_create_pr_tests {
         )
         .await
         .unwrap_err();
-        let msg = format!("{err:#}");
+        let msg = format!("{err:#}").to_lowercase();
+        // Preflight may surface a credentials error first, or (with creds
+        // present) `generate_repository_view` opens the injected path via
+        // `open_at` and fails with a git/repository error. Either proves the
+        // injected path is honored without mutating the process CWD.
         assert!(
-            msg.to_lowercase().contains("set_current_dir")
-                || msg.to_lowercase().contains("no such")
-                || msg.to_lowercase().contains("directory"),
-            "expected cwd-related error, got: {msg}"
+            msg.contains("git")
+                || msg.contains("repository")
+                || msg.contains("credential")
+                || msg.contains("api")
+                || msg.contains("directory"),
+            "expected git/repository or preflight error, got: {msg}"
         );
     }
 
@@ -1693,6 +1717,119 @@ mod run_create_pr_tests {
         };
         let cloned = outcome.clone();
         assert_eq!(format!("{outcome:?}"), format!("{cloned:?}"));
+    }
+
+    /// Builds a temp repo with `origin/main`, a feature branch one commit
+    /// ahead, and a distinctive `.github/pull_request_template.md`. Returns the
+    /// temp dir so callers can drive `generate_repository_view` against it.
+    fn init_repo_with_remote_and_template(template_marker: &str) -> tempfile::TempDir {
+        use git2::{Repository, Signature};
+        let tmp_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tmp");
+        std::fs::create_dir_all(&tmp_root).unwrap();
+        let temp_dir = tempfile::tempdir_in(&tmp_root).unwrap();
+        let repo_path = temp_dir.path();
+        let repo = Repository::init(repo_path).unwrap();
+        {
+            let mut config = repo.config().unwrap();
+            config.set_str("user.name", "Test").unwrap();
+            config.set_str("user.email", "test@example.com").unwrap();
+            config.set_str("init.defaultBranch", "main").unwrap();
+        }
+        repo.set_head("refs/heads/main").unwrap();
+
+        let signature = Signature::now("Test", "test@example.com").unwrap();
+
+        // Base commit on main.
+        std::fs::write(repo_path.join("f.txt"), "base").unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_path(std::path::Path::new("f.txt")).unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let base_oid = repo
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "base: init",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        // A non-github remote so detection never shells out to gh.
+        repo.remote("origin", "https://example.com/test/repo.git")
+            .unwrap();
+        // origin/main tracking ref at the base commit.
+        repo.reference(
+            "refs/remotes/origin/main",
+            base_oid,
+            true,
+            "set origin/main",
+        )
+        .unwrap();
+
+        // Feature branch one commit ahead of origin/main.
+        let base_commit = repo.find_commit(base_oid).unwrap();
+        repo.branch("feature/test", &base_commit, true).unwrap();
+        repo.set_head("refs/heads/feature/test").unwrap();
+        std::fs::write(repo_path.join("f.txt"), "feature").unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_path(std::path::Path::new("f.txt")).unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "feat: feature work",
+            &tree,
+            &[&base_commit],
+        )
+        .unwrap();
+
+        // Distinctive PR template inside the injected repo's .github/.
+        let github_dir = repo_path.join(".github");
+        std::fs::create_dir_all(&github_dir).unwrap();
+        std::fs::write(github_dir.join("pull_request_template.md"), template_marker).unwrap();
+
+        temp_dir
+    }
+
+    /// "No silent mix" anchoring guard: `generate_repository_view` resolves the
+    /// PR template, branch, and commits from the INJECTED repo root, not the
+    /// process CWD (the omni-dev checkout, which ships its own
+    /// `.github/pull_request_template.md`). We leave the process CWD untouched
+    /// and assert the returned view reflects the injected repo's distinctive
+    /// template and feature branch.
+    #[test]
+    fn generate_repository_view_anchors_to_injected_repo() {
+        let marker = "## INJECTED_PR_TEMPLATE_MARKER_42";
+        let temp_dir = init_repo_with_remote_and_template(marker);
+        let cmd = fresh_cmd();
+
+        let repo_view = cmd.generate_repository_view(temp_dir.path()).unwrap();
+
+        // PR template came from the injected repo, not the ambient CWD.
+        assert_eq!(
+            repo_view.pr_template.as_deref(),
+            Some(marker),
+            "PR template must be read from the injected repo root"
+        );
+        // Branch + commits reflect the injected repo's feature branch.
+        assert_eq!(
+            repo_view.branch_info.as_ref().map(|b| b.branch.as_str()),
+            Some("feature/test")
+        );
+        assert_eq!(
+            repo_view.commits.len(),
+            1,
+            "exactly the one commit ahead of origin/main"
+        );
+        assert!(repo_view.commits[0]
+            .original_message
+            .contains("feature work"));
     }
 }
 

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -91,7 +91,10 @@ impl CreatePrCommand {
     }
 
     /// Executes the create PR command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git branch create pr`");
+        }
         // Preflight check: validate all prerequisites before any processing
         // This catches missing credentials/tools early before wasting time
         let ai_info = crate::utils::check_pr_command_prerequisites(self.model.as_deref())?;
@@ -278,6 +281,14 @@ impl CreatePrCommand {
         let repo = GitRepository::open()
             .context("Failed to open git repository. Make sure you're in a git repository.")?;
 
+        // create-pr is still CWD-pinned (converted in a later slice), so the
+        // opened repo's workdir is the process CWD; deriving `repo_root` here
+        // keeps the PR-template/`gh` reads using the shared path-taking helpers
+        // without changing behavior yet.
+        let repo_root = repo
+            .workdir()
+            .context("repository has no working directory (bare repositories are not supported)")?;
+
         // Get current branch name
         let current_branch = repo.get_current_branch().context(
             "Failed to get current branch. Make sure you're not in detached HEAD state.",
@@ -357,14 +368,14 @@ impl CreatePrCommand {
         let commits = repo.get_commits_in_range(&commit_range)?;
 
         // Check for PR template
-        let pr_template_result = InfoCommand::read_pr_template().ok();
+        let pr_template_result = InfoCommand::read_pr_template(repo_root).ok();
         let (pr_template, pr_template_location) = match pr_template_result {
             Some((content, location)) => (Some(content), Some(location)),
             None => (None, None),
         };
 
         // Get PRs for current branch
-        let branch_prs = InfoCommand::get_branch_prs(&current_branch)
+        let branch_prs = InfoCommand::get_branch_prs(&current_branch, repo_root)
             .ok()
             .filter(|prs| !prs.is_empty());
 

--- a/src/cli/git/create_pr.rs
+++ b/src/cli/git/create_pr.rs
@@ -103,7 +103,8 @@ impl CreatePrCommand {
 
         // Preflight check: validate all prerequisites before any processing
         // This catches missing credentials/tools early before wasting time
-        let ai_info = crate::utils::check_pr_command_prerequisites(self.model.as_deref())?;
+        let ai_info =
+            crate::utils::check_pr_command_prerequisites(self.model.as_deref(), repo_root)?;
         println!(
             "✓ {} credentials verified (model: {})",
             ai_info.provider, ai_info.model
@@ -1414,7 +1415,7 @@ pub async fn run_create_pr(
         None => std::env::current_dir().context("Failed to determine current directory")?,
     };
 
-    crate::utils::check_pr_command_prerequisites(model.as_deref())?;
+    crate::utils::check_pr_command_prerequisites(model.as_deref(), &repo_root)?;
 
     let cmd = CreatePrCommand {
         base: base_branch.map(str::to_string),

--- a/src/cli/git/info.rs
+++ b/src/cli/git/info.rs
@@ -124,11 +124,14 @@ pub fn run_info<P: AsRef<Path>>(base_branch: Option<&str>, repo_path: Option<P>)
     use crate::git::{GitRepository, RemoteInfo};
     use crate::utils::ai_scratch;
 
+    // Resolve the repo location: the injected path, or the current working
+    // directory as the default (resolved here at the entry point). Both branches
+    // open via `open_at`, so nothing falls back to a no-arg CWD open.
     let repo = if let Some(path) = repo_path {
         GitRepository::open_at(path).context("Failed to open git repository at the given path")?
     } else {
-        crate::utils::check_git_repository()?;
-        GitRepository::open()
+        let cwd = std::env::current_dir().context("Failed to determine current directory")?;
+        GitRepository::open_at(cwd)
             .context("Failed to open git repository. Make sure you're in a git repository.")?
     };
 

--- a/src/cli/git/info.rs
+++ b/src/cli/git/info.rs
@@ -15,20 +15,25 @@ pub struct InfoCommand {
 
 impl InfoCommand {
     /// Executes the info command.
-    pub fn execute(self) -> Result<()> {
-        let yaml_output = run_info(self.base_branch.as_deref(), None::<&str>)?;
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
+    pub fn execute(self, repo: Option<&Path>) -> Result<()> {
+        let yaml_output = run_info(self.base_branch.as_deref(), repo)?;
         println!("{yaml_output}");
         Ok(())
     }
 
     /// Reads the PR template file if it exists, returning both content and location.
-    pub(crate) fn read_pr_template() -> Result<(String, String)> {
+    ///
+    /// Resolves `.github/pull_request_template.md` against `repo_root` rather
+    /// than the process current working directory.
+    pub(crate) fn read_pr_template(repo_root: &Path) -> Result<(String, String)> {
         use std::fs;
-        use std::path::Path;
 
-        let template_path = Path::new(".github/pull_request_template.md");
+        let template_path = repo_root.join(".github/pull_request_template.md");
         if template_path.exists() {
-            let content = fs::read_to_string(template_path)
+            let content = fs::read_to_string(&template_path)
                 .context("Failed to read .github/pull_request_template.md")?;
             Ok((content, template_path.to_string_lossy().to_string()))
         } else {
@@ -37,12 +42,19 @@ impl InfoCommand {
     }
 
     /// Returns pull requests for the current branch using gh CLI.
-    pub(crate) fn get_branch_prs(branch_name: &str) -> Result<Vec<crate::data::PullRequest>> {
+    ///
+    /// Runs `gh` pinned to `repo_root` (via `.current_dir`) so it resolves the
+    /// repository from the injected path rather than the process CWD.
+    pub(crate) fn get_branch_prs(
+        branch_name: &str,
+        repo_root: &Path,
+    ) -> Result<Vec<crate::data::PullRequest>> {
         use serde_json::Value;
         use std::process::Command;
 
         // Use gh CLI to get PRs for the branch
         let output = Command::new("gh")
+            .current_dir(repo_root)
             .args([
                 "pr",
                 "list",
@@ -120,6 +132,13 @@ pub fn run_info<P: AsRef<Path>>(base_branch: Option<&str>, repo_path: Option<P>)
             .context("Failed to open git repository. Make sure you're in a git repository.")?
     };
 
+    // Resolve the workdir of the opened repo once; all sibling reads (PR
+    // template, branch PRs via `gh`, AI scratch dir) anchor to it so they can
+    // never silently mix data from the ambient CWD with the injected repo.
+    let repo_root = repo
+        .workdir()
+        .context("repository has no working directory (bare repositories are not supported)")?;
+
     let current_branch = repo
         .get_current_branch()
         .context("Failed to get current branch. Make sure you're not in detached HEAD state.")?;
@@ -160,12 +179,12 @@ pub fn run_info<P: AsRef<Path>>(base_branch: Option<&str>, repo_path: Option<P>)
     let remotes = RemoteInfo::get_all_remotes(repo.repository())?;
     let commits = repo.get_commits_in_range(&commit_range)?;
 
-    let (pr_template, pr_template_location) = match InfoCommand::read_pr_template().ok() {
+    let (pr_template, pr_template_location) = match InfoCommand::read_pr_template(repo_root).ok() {
         Some((content, location)) => (Some(content), Some(location)),
         None => (None, None),
     };
 
-    let branch_prs = InfoCommand::get_branch_prs(&current_branch)
+    let branch_prs = InfoCommand::get_branch_prs(&current_branch, repo_root)
         .ok()
         .filter(|prs| !prs.is_empty());
 
@@ -173,8 +192,8 @@ pub fn run_info<P: AsRef<Path>>(base_branch: Option<&str>, repo_path: Option<P>)
         omni_dev: env!("CARGO_PKG_VERSION").to_string(),
     });
 
-    let ai_scratch_path =
-        ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+    let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+        .context("Failed to determine AI scratch directory")?;
     let ai_info = AiInfo {
         scratch: ai_scratch_path.to_string_lossy().to_string(),
     };
@@ -311,16 +330,13 @@ mod tests {
         );
     }
 
-    /// Exercises the `None` branch of `repo_path` (the CLI default), which
-    /// goes through `crate::utils::check_git_repository` and `GitRepository::open`.
-    /// We enter a fresh repo via `CwdGuard` so the test is hermetic.
-    #[tokio::test]
-    async fn run_info_opens_cwd_repo_when_no_path_given() {
+    /// The injected `repo_path` fully determines the repository with no
+    /// dependence on the process current working directory (previously this
+    /// entered the temp repo via a `CwdGuard`; now the path is passed directly).
+    #[test]
+    fn run_info_uses_injected_repo_without_cwd() {
         let (temp_dir, _commits) = init_repo_with_commits();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
-        let yaml = run_info(None, None::<&str>).unwrap();
+        let yaml = run_info(None, Some(temp_dir.path())).unwrap();
         assert!(yaml.contains("branch:"));
     }
 
@@ -360,10 +376,11 @@ mod tests {
         assert!(yaml.contains("branch:"));
     }
 
-    /// Exercises the `read_pr_template()` Some arm by placing a PR template
-    /// in the expected location.
-    #[tokio::test]
-    async fn run_info_picks_up_pr_template_from_cwd() {
+    /// Exercises the `read_pr_template` Some arm by placing a PR template in
+    /// the injected repo root's `.github/` — proving the template is read from
+    /// the repo root, not the process current working directory.
+    #[test]
+    fn run_info_picks_up_pr_template_from_repo_root() {
         let (temp_dir, _commits) = init_repo_with_commits();
         let github_dir = temp_dir.path().join(".github");
         std::fs::create_dir_all(&github_dir).unwrap();
@@ -373,13 +390,39 @@ mod tests {
         )
         .unwrap();
 
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
-        let yaml = run_info(None, None::<&str>).unwrap();
+        let yaml = run_info(None, Some(temp_dir.path())).unwrap();
         assert!(
             yaml.contains("pr_template:") || yaml.contains("Sample Template"),
             "expected PR template info in yaml: {yaml}"
+        );
+    }
+
+    /// "No silent mix" guard: `read_pr_template` resolves only against its
+    /// `repo_root` argument and has **no** fallback to the ambient CWD. A repo
+    /// root with a template returns it; a different root without one errors —
+    /// even though the process CWD (the omni-dev checkout) *does* ship a
+    /// `.github/pull_request_template.md`. This is the regression guard for the
+    /// silent-mix bug the injection closes.
+    #[test]
+    fn read_pr_template_anchors_to_repo_root() {
+        let tmp_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tmp");
+        std::fs::create_dir_all(&tmp_root).unwrap();
+
+        let with = tempfile::tempdir_in(&tmp_root).unwrap();
+        std::fs::create_dir_all(with.path().join(".github")).unwrap();
+        std::fs::write(
+            with.path().join(".github/pull_request_template.md"),
+            "## Marker ABC",
+        )
+        .unwrap();
+        let (content, location) = InfoCommand::read_pr_template(with.path()).unwrap();
+        assert!(content.contains("Marker ABC"));
+        assert!(location.contains("pull_request_template.md"));
+
+        let without = tempfile::tempdir_in(&tmp_root).unwrap();
+        assert!(
+            InfoCommand::read_pr_template(without.path()).is_err(),
+            "read_pr_template must not fall back to the ambient CWD template"
         );
     }
 }

--- a/src/cli/git/staged.rs
+++ b/src/cli/git/staged.rs
@@ -70,8 +70,9 @@ impl StagedCommand {
 /// Public entry point for the staged-commit command.
 ///
 /// Mirrors [`crate::cli::git::run_twiddle`]'s shape so the MCP server can wrap
-/// it the same way: pin the CWD, run AI preflight, build the client, delegate
-/// to the test-injectable inner [`run_staged_with_client`].
+/// it the same way: resolve the repo root (the injected path, or the CWD as the
+/// default), run AI preflight, build the client, and delegate to the
+/// test-injectable inner [`run_staged_with_client`].
 pub async fn run_staged(
     print_only: bool,
     model: Option<String>,

--- a/src/cli/git/staged.rs
+++ b/src/cli/git/staged.rs
@@ -46,7 +46,10 @@ pub struct StagedOutcome {
 
 impl StagedCommand {
     /// Executes the staged command.
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git commit message staged`");
+        }
         let beta = self
             .beta_header
             .as_deref()
@@ -484,7 +487,7 @@ mod tests {
             beta_header: None,
             context_dir: None,
         };
-        let err = cmd.execute().await.unwrap_err();
+        let err = cmd.execute(None).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.to_lowercase().contains("no staged changes"),
@@ -506,7 +509,7 @@ mod tests {
             beta_header: Some("no-colon-here".to_string()),
             context_dir: None,
         };
-        let err = cmd.execute().await.unwrap_err();
+        let err = cmd.execute(None).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("Invalid --beta-header"),

--- a/src/cli/git/staged.rs
+++ b/src/cli/git/staged.rs
@@ -46,10 +46,10 @@ pub struct StagedOutcome {
 
 impl StagedCommand {
     /// Executes the staged command.
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
     pub async fn execute(self, repo: Option<&std::path::Path>) -> Result<()> {
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git commit message staged`");
-        }
         let beta = self
             .beta_header
             .as_deref()
@@ -60,7 +60,7 @@ impl StagedCommand {
             self.model,
             beta,
             self.context_dir.as_deref(),
-            None,
+            repo,
         )
         .await?;
         Ok(())
@@ -79,25 +79,28 @@ pub async fn run_staged(
     context_dir: Option<&std::path::Path>,
     repo_path: Option<&std::path::Path>,
 ) -> Result<StagedOutcome> {
-    let _cwd_guard = match repo_path {
-        Some(p) => Some(super::CwdGuard::enter(p).await?),
-        None => None,
+    // Resolve the repo root once (the CWD is the default when no path is
+    // injected); every git subprocess and config/scopes read below anchors to
+    // it, so nothing deeper reads the ambient CWD.
+    let repo_root = match repo_path {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().context("Failed to determine current directory")?,
     };
+    let repo_root = repo_root.as_path();
 
-    if !has_staged_changes()? {
+    if !has_staged_changes(repo_root)? {
         anyhow::bail!("no staged changes — stage files with `git add` before running this command");
     }
 
     crate::utils::check_ai_command_prerequisites(model.as_deref())?;
     let claude_client = crate::claude::create_default_claude_client(model, beta_header).await?;
 
-    let resolved_context_dir = crate::claude::context::resolve_context_dir(context_dir);
-    let valid_scopes = crate::claude::context::load_project_scopes(
-        &resolved_context_dir,
-        &std::path::PathBuf::from("."),
-    );
+    let resolved_context_dir =
+        crate::claude::context::resolve_context_dir_at(context_dir, repo_root);
+    let valid_scopes =
+        crate::claude::context::load_project_scopes(&resolved_context_dir, repo_root);
 
-    run_staged_with_client(print_only, &valid_scopes, &claude_client).await
+    run_staged_with_client(print_only, &valid_scopes, &claude_client, repo_root).await
 }
 
 /// Test-injectable core of [`run_staged`].
@@ -111,8 +114,9 @@ pub(crate) async fn run_staged_with_client(
     print_only: bool,
     valid_scopes: &[ScopeDefinition],
     claude_client: &crate::claude::client::ClaudeClient,
+    repo_root: &std::path::Path,
 ) -> Result<StagedOutcome> {
-    let diff = read_staged_diff()?;
+    let diff = read_staged_diff(repo_root)?;
     let system = crate::claude::prompts::generate_staged_commit_system_prompt(valid_scopes);
     let user = crate::claude::prompts::generate_staged_commit_user_prompt(&diff);
 
@@ -131,7 +135,7 @@ pub(crate) async fn run_staged_with_client(
         });
     }
 
-    commit_with_message(&message)?;
+    commit_with_message(&message, repo_root)?;
     Ok(StagedOutcome {
         message,
         applied: true,
@@ -144,8 +148,9 @@ pub(crate) async fn run_staged_with_client(
 /// - `0` ⇒ no diff (nothing staged)
 /// - `1` ⇒ diff present (staged changes exist)
 /// - other ⇒ a real error (not in a repo, permission denied, etc.)
-fn has_staged_changes() -> Result<bool> {
+fn has_staged_changes(repo_root: &std::path::Path) -> Result<bool> {
     let output = Command::new("git")
+        .current_dir(repo_root)
         .args(["diff", "--cached", "--quiet"])
         .stdin(Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -163,8 +168,9 @@ fn has_staged_changes() -> Result<bool> {
 }
 
 /// Reads the staged diff via `git diff --cached`.
-fn read_staged_diff() -> Result<String> {
+fn read_staged_diff(repo_root: &std::path::Path) -> Result<String> {
     let output = Command::new("git")
+        .current_dir(repo_root)
         .args(["diff", "--cached"])
         .stdin(Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -188,8 +194,9 @@ fn read_staged_diff() -> Result<String> {
 /// can block reading from an inherited stdin fd. On CI runners (Linux), an
 /// inherited stdin from `cargo test` can produce indefinite waits that don't
 /// reproduce on developer terminals.
-fn commit_with_message(message: &str) -> Result<()> {
+fn commit_with_message(message: &str, repo_root: &std::path::Path) -> Result<()> {
     let status = Command::new("git")
+        .current_dir(repo_root)
         .args(["commit", "-m", message])
         .stdin(Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -280,8 +287,9 @@ mod tests {
     #[tokio::test]
     async fn run_staged_errors_when_nothing_staged() {
         let temp_dir = init_empty_repo();
-        // run_staged() acquires CwdGuard internally — do NOT acquire it
-        // here as well or we deadlock on the shared CWD mutex.
+        // `has_staged_changes` is anchored to the injected repo (`.current_dir`),
+        // so this empty repo bails regardless of whether the process CWD has
+        // staged changes.
         let err = run_staged(true, None, None, None, Some(temp_dir.path()))
             .await
             .unwrap_err();
@@ -295,15 +303,14 @@ mod tests {
     #[tokio::test]
     async fn run_staged_with_client_print_only_does_not_commit() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let head_before = head_oid(temp_dir.path());
 
         let mock = ConfigurableMockAiClient::new(vec![Ok("feat(foo): add bar".to_string())]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_staged_with_client(true, &[], &client).await.unwrap();
+        let outcome = run_staged_with_client(true, &[], &client, temp_dir.path())
+            .await
+            .unwrap();
         assert!(!outcome.applied, "print_only must not apply");
         assert_eq!(outcome.message, "feat(foo): add bar");
 
@@ -314,15 +321,14 @@ mod tests {
     #[tokio::test]
     async fn run_staged_with_client_commits_on_default() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let head_before = head_oid(temp_dir.path());
 
         let mock = ConfigurableMockAiClient::new(vec![Ok("feat(foo): add marker".to_string())]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_staged_with_client(false, &[], &client).await.unwrap();
+        let outcome = run_staged_with_client(false, &[], &client, temp_dir.path())
+            .await
+            .unwrap();
         assert!(outcome.applied, "default mode must commit");
 
         let head_after = head_oid(temp_dir.path());
@@ -338,16 +344,13 @@ mod tests {
     #[tokio::test]
     async fn run_staged_propagates_ai_failure() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let head_before = head_oid(temp_dir.path());
 
         // Empty response queue → mock returns Err on first call.
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let err = run_staged_with_client(false, &[], &client)
+        let err = run_staged_with_client(false, &[], &client, temp_dir.path())
             .await
             .unwrap_err();
         let _ = err;
@@ -359,28 +362,24 @@ mod tests {
     #[tokio::test]
     async fn run_staged_with_client_trims_ai_response_whitespace() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok("  feat(x): y  \n\n".to_string())]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_staged_with_client(true, &[], &client).await.unwrap();
+        let outcome = run_staged_with_client(true, &[], &client, temp_dir.path())
+            .await
+            .unwrap();
         assert_eq!(outcome.message, "feat(x): y");
     }
 
     #[tokio::test]
     async fn run_staged_with_client_empty_ai_response_errors() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok("   \n\n".to_string())]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let err = run_staged_with_client(false, &[], &client)
+        let err = run_staged_with_client(false, &[], &client, temp_dir.path())
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -393,9 +392,6 @@ mod tests {
     #[tokio::test]
     async fn run_staged_invokes_git_commit_subprocess_so_hooks_fire() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let head_before = head_oid(temp_dir.path());
 
         // Install a commit-msg hook that always fails. If we go through real
@@ -414,7 +410,7 @@ mod tests {
         let mock = ConfigurableMockAiClient::new(vec![Ok("feat(x): y".to_string())]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let err = run_staged_with_client(false, &[], &client)
+        let err = run_staged_with_client(false, &[], &client, temp_dir.path())
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -433,9 +429,6 @@ mod tests {
     #[tokio::test]
     async fn run_staged_passes_valid_scopes_into_prompt() {
         let temp_dir = init_repo_with_staged_change();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok("feat(cli): add".to_string())]);
         let prompts = mock.prompt_handle();
@@ -448,7 +441,7 @@ mod tests {
             file_patterns: Vec::new(),
         }];
 
-        let _ = run_staged_with_client(true, &scopes, &client)
+        let _ = run_staged_with_client(true, &scopes, &client, temp_dir.path())
             .await
             .unwrap();
         let recorded = prompts.prompts();
@@ -478,16 +471,13 @@ mod tests {
     #[tokio::test]
     async fn staged_command_execute_bails_when_nothing_staged() {
         let temp_dir = init_empty_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let cmd = StagedCommand {
             print_only: true,
             model: None,
             beta_header: None,
             context_dir: None,
         };
-        let err = cmd.execute(None).await.unwrap_err();
+        let err = cmd.execute(Some(temp_dir.path())).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.to_lowercase().contains("no staged changes"),
@@ -500,20 +490,42 @@ mod tests {
     #[tokio::test]
     async fn staged_command_execute_rejects_malformed_beta_header() {
         let temp_dir = init_empty_repo();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
         let cmd = StagedCommand {
             print_only: true,
             model: None,
             beta_header: Some("no-colon-here".to_string()),
             context_dir: None,
         };
-        let err = cmd.execute(None).await.unwrap_err();
+        let err = cmd.execute(Some(temp_dir.path())).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("Invalid --beta-header"),
             "expected beta-header parse error, got: {msg}"
+        );
+    }
+
+    /// "No silent mix" guard: `read_staged_diff` reads the staged diff from the
+    /// INJECTED repo, not the process CWD. We stage a uniquely-marked file in
+    /// the temp repo, run with that repo injected (the process CWD is the
+    /// omni-dev checkout), and assert the marker reached the AI prompt.
+    #[tokio::test]
+    async fn run_staged_with_client_reads_diff_from_injected_repo() {
+        let temp_dir = init_repo_with_staged_change();
+
+        let mock = ConfigurableMockAiClient::new(vec![Ok("feat: x".to_string())]);
+        let prompts = mock.prompt_handle();
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let _ = run_staged_with_client(true, &[], &client, temp_dir.path())
+            .await
+            .unwrap();
+
+        let recorded = prompts.prompts();
+        assert_eq!(recorded.len(), 1, "exactly one AI call");
+        let (_system, user) = &recorded[0];
+        assert!(
+            user.contains("marker_xyz"),
+            "staged diff from the injected repo must reach the prompt: {user}"
         );
     }
 }

--- a/src/cli/git/staged.rs
+++ b/src/cli/git/staged.rs
@@ -92,7 +92,7 @@ pub async fn run_staged(
         anyhow::bail!("no staged changes — stage files with `git add` before running this command");
     }
 
-    crate::utils::check_ai_command_prerequisites(model.as_deref())?;
+    crate::utils::check_ai_command_prerequisites(model.as_deref(), repo_root)?;
     let claude_client = crate::claude::create_default_claude_client(model, beta_header).await?;
 
     let resolved_context_dir =

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -96,18 +96,19 @@ impl TwiddleCommand {
 
     /// Executes the twiddle command with contextual intelligence.
     pub async fn execute(mut self, repo: Option<&std::path::Path>) -> Result<()> {
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git commit message twiddle`");
-        }
         // Resolve deprecated --batch-size into --concurrency
         if let Some(bs) = self.batch_size {
             eprintln!("warning: --batch-size is deprecated; use --concurrency instead");
             self.concurrency = bs;
         }
 
+        // Resolve the repo root once; every git, config, and scratch read below
+        // anchors to it (the CWD is the default when no path is injected).
+        let repo_root = repo.unwrap_or_else(|| std::path::Path::new("."));
+
         // If --no-ai flag is set, skip AI processing and output YAML directly
         if self.no_ai {
-            return self.execute_no_ai().await;
+            return self.execute_no_ai(repo_root).await;
         }
 
         // Preflight check: validate AI credentials before any processing
@@ -118,7 +119,7 @@ impl TwiddleCommand {
         );
 
         // Preflight check: ensure working directory is clean before expensive operations
-        crate::utils::preflight::check_working_directory_clean()?;
+        crate::utils::check_working_directory_clean_at(repo_root)?;
         println!("✓ Working directory is clean");
 
         // Initialize Claude client
@@ -130,7 +131,7 @@ impl TwiddleCommand {
         let claude_client =
             crate::claude::create_default_claude_client(self.model.clone(), beta).await?;
 
-        self.execute_with_client(claude_client).await
+        self.execute_with_client(repo_root, claude_client).await
     }
 
     /// Test-injectable inner core of [`Self::execute`].
@@ -141,6 +142,7 @@ impl TwiddleCommand {
     /// outer [`Self::execute`] before this is reached.
     pub(crate) async fn execute_with_client(
         self,
+        repo_root: &std::path::Path,
         claude_client: crate::claude::client::ClaudeClient,
     ) -> Result<()> {
         // Determine if contextual analysis should be used
@@ -155,18 +157,18 @@ impl TwiddleCommand {
         }
 
         // 1. Generate repository view to get all commits
-        let mut full_repo_view = self.generate_repository_view().await?;
+        let mut full_repo_view = self.generate_repository_view(repo_root).await?;
 
         // 2. Use parallel map-reduce for multiple commits
         if full_repo_view.commits.len() > 1 {
             return self
-                .execute_with_map_reduce(use_contextual, full_repo_view, claude_client)
+                .execute_with_map_reduce(repo_root, use_contextual, full_repo_view, claude_client)
                 .await;
         }
 
         // 3. Collect contextual information (Phase 3)
         let context = if use_contextual {
-            Some(self.collect_context(&full_repo_view).await?)
+            Some(self.collect_context(repo_root, &full_repo_view).await?)
         } else {
             None
         };
@@ -174,7 +176,7 @@ impl TwiddleCommand {
         // Refine detected scopes using file_patterns from scope definitions
         let scope_defs = match &context {
             Some(ctx) => ctx.project.valid_scopes.clone(),
-            None => self.load_check_scopes(),
+            None => self.load_check_scopes(repo_root),
         };
         for commit in &mut full_repo_view.commits {
             commit.analysis.refine_scope(&scope_defs);
@@ -250,12 +252,13 @@ impl TwiddleCommand {
             }
 
             // 8. Apply amendments (re-read from file to capture any user edits)
-            self.apply_amendments_from_file(&amendments_file).await?;
+            self.apply_amendments_from_file(repo_root, &amendments_file)
+                .await?;
             println!("✅ Commit messages improved successfully!");
 
             // 9. Run post-twiddle check if --check flag is set
             if self.check {
-                self.run_post_twiddle_check().await?;
+                self.run_post_twiddle_check(repo_root).await?;
             }
         } else {
             println!("✨ No commits found to process!");
@@ -272,6 +275,7 @@ impl TwiddleCommand {
     /// single batch since the AI already saw them together.
     async fn execute_with_map_reduce(
         &self,
+        repo_root: &std::path::Path,
         use_contextual: bool,
         mut full_repo_view: crate::data::RepositoryView,
         claude_client: crate::claude::client::ClaudeClient,
@@ -298,7 +302,7 @@ impl TwiddleCommand {
 
         // Collect context once (shared across all commits)
         let context = if use_contextual {
-            Some(self.collect_context(&full_repo_view).await?)
+            Some(self.collect_context(repo_root, &full_repo_view).await?)
         } else {
             None
         };
@@ -310,7 +314,7 @@ impl TwiddleCommand {
         // Refine scopes on all commits upfront
         let scope_defs = match &context {
             Some(ctx) => ctx.project.valid_scopes.clone(),
-            None => self.load_check_scopes(),
+            None => self.load_check_scopes(repo_root),
         };
         for commit in &mut full_repo_view.commits {
             commit.analysis.refine_scope(&scope_defs);
@@ -580,11 +584,12 @@ impl TwiddleCommand {
                 }
             }
 
-            self.apply_amendments_from_file(&amendments_file).await?;
+            self.apply_amendments_from_file(repo_root, &amendments_file)
+                .await?;
             println!("✅ Commit messages improved successfully!");
 
             if self.check {
-                self.run_post_twiddle_check().await?;
+                self.run_post_twiddle_check(repo_root).await?;
             }
         } else {
             println!("✨ No commits found to process!");
@@ -594,7 +599,10 @@ impl TwiddleCommand {
     }
 
     /// Generates the repository view (reuses ViewCommand logic).
-    async fn generate_repository_view(&self) -> Result<crate::data::RepositoryView> {
+    async fn generate_repository_view(
+        &self,
+        repo_root: &std::path::Path,
+    ) -> Result<crate::data::RepositoryView> {
         use crate::data::{
             AiInfo, BranchInfo, FieldExplanation, FileStatusInfo, RepositoryView, VersionInfo,
             WorkingDirectoryInfo,
@@ -605,8 +613,8 @@ impl TwiddleCommand {
         let commit_range = self.commit_range.as_deref().unwrap_or("HEAD~5..HEAD");
 
         // Open git repository
-        let repo = GitRepository::open()
-            .context("Failed to open git repository. Make sure you're in a git repository.")?;
+        let repo = GitRepository::open_at(repo_root)
+            .context("Failed to open git repository at the given path")?;
 
         // Get current branch name
         let current_branch = repo
@@ -639,8 +647,8 @@ impl TwiddleCommand {
         });
 
         // Get AI scratch directory
-        let ai_scratch_path =
-            ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+        let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+            .context("Failed to determine AI scratch directory")?;
         let ai_info = AiInfo {
             scratch: ai_scratch_path.to_string_lossy().to_string(),
         };
@@ -793,14 +801,17 @@ impl TwiddleCommand {
     }
 
     /// Applies amendments from a file path (re-reads from disk to capture user edits).
-    async fn apply_amendments_from_file(&self, amendments_file: &std::path::Path) -> Result<()> {
+    async fn apply_amendments_from_file(
+        &self,
+        repo_root: &std::path::Path,
+        amendments_file: &std::path::Path,
+    ) -> Result<()> {
         use crate::git::AmendmentHandler;
 
-        // Use AmendmentHandler to apply amendments directly from file.
-        // `twiddle` is still CWD-pinned (converted in a later slice), so the
-        // injected root is `.` — byte-identical to the pre-injection behavior.
-        let handler = AmendmentHandler::new(std::path::Path::new("."))
-            .context("Failed to initialize amendment handler")?;
+        // Use AmendmentHandler to apply amendments directly from file, anchored
+        // to the injected repo root.
+        let handler =
+            AmendmentHandler::new(repo_root).context("Failed to initialize amendment handler")?;
         handler
             .apply_amendments(&amendments_file.to_string_lossy())
             .context("Failed to apply amendments")?;
@@ -811,6 +822,7 @@ impl TwiddleCommand {
     /// Collects contextual information for enhanced commit message generation.
     async fn collect_context(
         &self,
+        repo_root: &std::path::Path,
         repo_view: &crate::data::RepositoryView,
     ) -> Result<crate::data::context::CommitContext> {
         use crate::claude::context::{
@@ -821,12 +833,13 @@ impl TwiddleCommand {
         let mut context = CommitContext::new();
 
         // 1. Discover project context
-        let (context_dir, dir_source) =
-            crate::claude::context::resolve_context_dir_with_source(self.context_dir.as_deref());
+        let (context_dir, dir_source) = crate::claude::context::resolve_context_dir_with_source_at(
+            self.context_dir.as_deref(),
+            repo_root,
+        );
 
         // ProjectDiscovery takes repo root and context directory
-        let repo_root = std::path::PathBuf::from(".");
-        let discovery = ProjectDiscovery::new(repo_root, context_dir.clone());
+        let discovery = ProjectDiscovery::new(repo_root.to_path_buf(), context_dir.clone());
         debug!(context_dir = ?context_dir, "Using context directory");
         match discovery.discover() {
             Ok(project_context) => {
@@ -849,7 +862,7 @@ impl TwiddleCommand {
         } else {
             // Fallback to getting current branch directly if not in repo view
             use crate::git::GitRepository;
-            let repo = GitRepository::open()?;
+            let repo = GitRepository::open_at(repo_root)?;
             let current_branch = repo
                 .get_current_branch()
                 .unwrap_or_else(|_| "HEAD".to_string());
@@ -937,6 +950,12 @@ impl TwiddleCommand {
 
         // Get actual metadata from the client
         let metadata = client.get_ai_client_metadata();
+        // NOTE (#967): this `--verbose` diagnostic banner reads the process-wide
+        // model catalog (`get_model_registry` → CWD-relative project models.yaml),
+        // not a `--repo`-scoped catalog. It is informational only and does not
+        // affect the twiddle output, so it is left CWD-scoped until the
+        // repo-aware `ModelRegistry::load_at` foundation lands (first used by
+        // `create pr`).
         let registry = get_model_registry();
 
         if let Some(spec) = registry.get_model_spec(&metadata.model) {
@@ -1024,13 +1043,13 @@ impl TwiddleCommand {
     }
 
     /// Executes the twiddle command without AI, creating amendments with original messages.
-    async fn execute_no_ai(&self) -> Result<()> {
+    async fn execute_no_ai(&self, repo_root: &std::path::Path) -> Result<()> {
         use crate::data::amendments::{Amendment, AmendmentFile};
 
         println!("📋 Generating amendments YAML without AI processing...");
 
         // Generate repository view to get all commits
-        let repo_view = self.generate_repository_view().await?;
+        let repo_view = self.generate_repository_view(repo_root).await?;
 
         // Create amendments with original commit messages (no AI improvements)
         let amendments: Vec<Amendment> = repo_view
@@ -1076,12 +1095,13 @@ impl TwiddleCommand {
             }
 
             // Apply amendments (re-read from file to capture any user edits)
-            self.apply_amendments_from_file(&amendments_file).await?;
+            self.apply_amendments_from_file(repo_root, &amendments_file)
+                .await?;
             println!("✅ Commit messages applied successfully!");
 
             // Run post-twiddle check if --check flag is set
             if self.check {
-                self.run_post_twiddle_check().await?;
+                self.run_post_twiddle_check(repo_root).await?;
             }
         } else {
             println!("✨ No commits found to process!");
@@ -1093,12 +1113,12 @@ impl TwiddleCommand {
     /// Runs commit message validation after twiddle amendments are applied.
     /// If the check finds errors with suggestions, automatically applies the
     /// suggestions and re-checks, up to 3 retries.
-    async fn run_post_twiddle_check(&self) -> Result<()> {
+    async fn run_post_twiddle_check(&self, repo_root: &std::path::Path) -> Result<()> {
         const MAX_CHECK_RETRIES: u32 = 3;
 
         // Load guidelines, scopes, and Claude client once (they don't change between retries)
-        let guidelines = self.load_check_guidelines()?;
-        let valid_scopes = self.load_check_scopes();
+        let guidelines = self.load_check_guidelines(repo_root)?;
+        let valid_scopes = self.load_check_scopes(repo_root);
         let beta = self
             .beta_header
             .as_deref()
@@ -1116,7 +1136,7 @@ impl TwiddleCommand {
             }
 
             // Generate fresh repository view to get updated commit messages
-            let mut repo_view = self.generate_repository_view().await?;
+            let mut repo_view = self.generate_repository_view(repo_root).await?;
 
             if repo_view.commits.is_empty() {
                 println!("⚠️  No commits to check");
@@ -1131,7 +1151,7 @@ impl TwiddleCommand {
             }
 
             if attempt == 0 {
-                self.show_check_guidance_files_status(&guidelines, &valid_scopes);
+                self.show_check_guidance_files_status(repo_root, &guidelines, &valid_scopes);
             }
 
             // Run check
@@ -1201,7 +1221,8 @@ impl TwiddleCommand {
             amendment_file
                 .save_to_file(temp_file.path())
                 .context("Failed to save retry amendments")?;
-            self.apply_amendments_from_file(temp_file.path()).await?;
+            self.apply_amendments_from_file(repo_root, temp_file.path())
+                .await?;
         }
 
         Ok(())
@@ -1236,29 +1257,35 @@ impl TwiddleCommand {
     }
 
     /// Loads commit guidelines for check via the standard resolution chain.
-    fn load_check_guidelines(&self) -> Result<Option<String>> {
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
+    fn load_check_guidelines(&self, repo_root: &std::path::Path) -> Result<Option<String>> {
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
         crate::claude::context::load_config_content(&context_dir, "commit-guidelines.md")
     }
 
     /// Loads valid scopes for check with ecosystem defaults.
-    fn load_check_scopes(&self) -> Vec<crate::data::context::ScopeDefinition> {
-        let context_dir = crate::claude::context::resolve_context_dir(self.context_dir.as_deref());
-        crate::claude::context::load_project_scopes(&context_dir, &std::path::PathBuf::from("."))
+    fn load_check_scopes(
+        &self,
+        repo_root: &std::path::Path,
+    ) -> Vec<crate::data::context::ScopeDefinition> {
+        let context_dir =
+            crate::claude::context::resolve_context_dir_at(self.context_dir.as_deref(), repo_root);
+        crate::claude::context::load_project_scopes(&context_dir, repo_root)
     }
 
     /// Shows guidance files status for check.
     fn show_check_guidance_files_status(
         &self,
+        repo_root: &std::path::Path,
         guidelines: &Option<String>,
         valid_scopes: &[crate::data::context::ScopeDefinition],
     ) {
         use crate::claude::context::{
-            config_source_label, resolve_context_dir_with_source, ConfigSourceLabel,
+            config_source_label, resolve_context_dir_with_source_at, ConfigSourceLabel,
         };
 
         let (context_dir, dir_source) =
-            resolve_context_dir_with_source(self.context_dir.as_deref());
+            resolve_context_dir_with_source_at(self.context_dir.as_deref(), repo_root);
 
         println!("📋 Project guidance files status:");
         println!("   📂 Config dir: {} ({dir_source})", context_dir.display());
@@ -1755,38 +1782,39 @@ pub struct TwiddleOutcome {
 /// `dry_run` is false and never opens an editor. When `dry_run` is true,
 /// proposed amendments are returned as YAML without being applied.
 ///
-/// Like [`super::run_check`], a `Some` `repo_path` pins the process CWD for
-/// the duration of the call.
+/// `repo_path` selects the repository to twiddle (`None` defaults to the
+/// current working directory). It is resolved once here and threaded explicitly
+/// into [`run_twiddle_with_client`], so git, context-discovery, AI-scratch, and
+/// amendment-apply paths anchor to the target repo without changing the process
+/// working directory.
 pub async fn run_twiddle(
     range: Option<&str>,
     model: Option<String>,
     dry_run: bool,
     repo_path: Option<&std::path::Path>,
 ) -> Result<TwiddleOutcome> {
-    let _cwd_guard = match repo_path {
-        Some(p) => Some(super::CwdGuard::enter(p).await?),
-        None => None,
-    };
+    let repo_root = repo_path.unwrap_or_else(|| std::path::Path::new("."));
 
     crate::utils::check_ai_command_prerequisites(model.as_deref())?;
 
     if !dry_run {
-        crate::utils::preflight::check_working_directory_clean()?;
+        crate::utils::check_working_directory_clean_at(repo_root)?;
     }
 
     let claude_client = crate::claude::create_default_claude_client(model, None).await?;
-    run_twiddle_with_client(range, dry_run, &claude_client).await
+    run_twiddle_with_client(range, dry_run, repo_root, &claude_client).await
 }
 
 /// Non-credential-gated inner core of [`run_twiddle`] for unit tests.
 ///
 /// Extracted so tests can inject a [`crate::claude::client::ClaudeClient`]
 /// backed by the in-crate mock AI client and exercise the full flow without
-/// real credentials. Callers are responsible for holding any
-/// [`super::CwdGuard`] they need and for running preflight themselves.
+/// real credentials. `repo_root` selects the repository; callers run preflight
+/// themselves.
 pub(crate) async fn run_twiddle_with_client(
     range: Option<&str>,
     dry_run: bool,
+    repo_root: &std::path::Path,
     claude_client: &crate::claude::client::ClaudeClient,
 ) -> Result<TwiddleOutcome> {
     use crate::data::{
@@ -1798,8 +1826,8 @@ pub(crate) async fn run_twiddle_with_client(
 
     let resolved_range = range.unwrap_or("HEAD~5..HEAD");
 
-    let repo = GitRepository::open()
-        .context("Failed to open git repository. Make sure you're in a git repository.")?;
+    let repo = GitRepository::open_at(repo_root)
+        .context("Failed to open git repository at the given path")?;
 
     let current_branch = repo
         .get_current_branch()
@@ -1832,8 +1860,8 @@ pub(crate) async fn run_twiddle_with_client(
         });
     }
 
-    let ai_scratch_path =
-        ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+    let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+        .context("Failed to determine AI scratch directory")?;
     let ai_info = AiInfo {
         scratch: ai_scratch_path.to_string_lossy().to_string(),
     };
@@ -1860,9 +1888,8 @@ pub(crate) async fn run_twiddle_with_client(
         .generate_amendments_with_options(&repo_view, true)
         .await?;
 
-    let context_dir = crate::claude::context::resolve_context_dir(None);
-    let scope_defs =
-        crate::claude::context::load_project_scopes(&context_dir, &std::path::PathBuf::from("."));
+    let context_dir = crate::claude::context::resolve_context_dir_at(None, repo_root);
+    let scope_defs = crate::claude::context::load_project_scopes(&context_dir, repo_root);
     refine_amendment_scopes(&mut amendments, &repo_view, &scope_defs);
 
     let amendments_yaml =
@@ -1882,9 +1909,7 @@ pub(crate) async fn run_twiddle_with_client(
     amendments
         .save_to_file(&amendments_file)
         .context("Failed to save amendments")?;
-    // `twiddle` is still CWD-pinned (converted in a later slice), so the
-    // injected root is `.` — byte-identical to the pre-injection behavior.
-    let handler = crate::git::AmendmentHandler::new(std::path::Path::new("."))
+    let handler = crate::git::AmendmentHandler::new(repo_root)
         .context("Failed to initialise amendment handler")?;
     handler
         .apply_amendments(&amendments_file.to_string_lossy())
@@ -1905,6 +1930,9 @@ mod run_twiddle_tests {
     use crate::claude::test_utils::ConfigurableMockAiClient;
     use git2::{Repository, Signature};
 
+    /// With the `CwdGuard` retired, `run_twiddle` opens the injected repo via
+    /// `open_at`, so an invalid path errors with a git/repository error (the
+    /// `GitRepository::open_at` context) before any AI call.
     #[tokio::test]
     async fn run_twiddle_invalid_repo_path_errors_before_ai() {
         let err = run_twiddle(
@@ -1917,10 +1945,8 @@ mod run_twiddle_tests {
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(
-            msg.to_lowercase().contains("set_current_dir")
-                || msg.to_lowercase().contains("no such")
-                || msg.to_lowercase().contains("directory"),
-            "expected cwd-related error, got: {msg}"
+            msg.to_lowercase().contains("git") || msg.to_lowercase().contains("repository"),
+            "expected git/repository error, got: {msg}"
         );
     }
 
@@ -1966,9 +1992,6 @@ mod run_twiddle_tests {
     #[tokio::test]
     async fn run_twiddle_with_client_dry_run_returns_amendments() {
         let (temp_dir, hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(amendment_yaml(
             &hash,
@@ -1976,7 +1999,7 @@ mod run_twiddle_tests {
         ))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_twiddle_with_client(Some("HEAD"), true, &client)
+        let outcome = run_twiddle_with_client(Some("HEAD"), true, temp_dir.path(), &client)
             .await
             .unwrap();
         assert!(!outcome.applied, "dry_run must not apply");
@@ -1987,14 +2010,11 @@ mod run_twiddle_tests {
     #[tokio::test]
     async fn run_twiddle_with_client_empty_range_returns_empty() {
         let (temp_dir, _hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_twiddle_with_client(Some("HEAD..HEAD"), true, &client)
+        let outcome = run_twiddle_with_client(Some("HEAD..HEAD"), true, temp_dir.path(), &client)
             .await
             .unwrap();
         assert_eq!(outcome.amendment_count, 0);
@@ -2004,13 +2024,10 @@ mod run_twiddle_tests {
     #[tokio::test]
     async fn run_twiddle_with_client_ai_failure_errors() {
         let (temp_dir, _hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
-        let err = run_twiddle_with_client(Some("HEAD"), true, &client)
+        let err = run_twiddle_with_client(Some("HEAD"), true, temp_dir.path(), &client)
             .await
             .unwrap_err();
         let _ = err;
@@ -2019,9 +2036,6 @@ mod run_twiddle_tests {
     #[tokio::test]
     async fn run_twiddle_with_client_default_range_errors_on_sparse_repo() {
         let (temp_dir, _hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         // Default range HEAD~5..HEAD cannot resolve HEAD~5 in a repo with
         // only one commit — get_commits_in_range returns an error, which
@@ -2029,7 +2043,7 @@ mod run_twiddle_tests {
         let mock = ConfigurableMockAiClient::new(vec![]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let err = run_twiddle_with_client(None, true, &client)
+        let err = run_twiddle_with_client(None, true, temp_dir.path(), &client)
             .await
             .unwrap_err();
         assert!(
@@ -2056,9 +2070,6 @@ mod run_twiddle_tests {
     #[tokio::test]
     async fn run_twiddle_with_client_applies_head_amendment() {
         let (temp_dir, hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let mock = ConfigurableMockAiClient::new(vec![Ok(amendment_yaml(
             &hash,
@@ -2066,7 +2077,7 @@ mod run_twiddle_tests {
         ))]);
         let client = ClaudeClient::new(Box::new(mock));
 
-        let outcome = run_twiddle_with_client(Some("HEAD"), false, &client)
+        let outcome = run_twiddle_with_client(Some("HEAD"), false, temp_dir.path(), &client)
             .await
             .unwrap();
         assert!(outcome.applied, "dry_run=false must apply amendments");
@@ -2085,6 +2096,52 @@ mod run_twiddle_tests {
         assert!(
             head_msg.contains("much better subject"),
             "HEAD message should be rewritten: {head_msg}"
+        );
+    }
+
+    /// "No silent mix" guard: `run_twiddle_with_client` must amend the INJECTED
+    /// repo, not the process CWD (the omni-dev checkout). We build a temp repo
+    /// with a rewritable HEAD, leave the process CWD pointed at the omni-dev
+    /// checkout, and assert the temp repo's HEAD was rewritten — proving the
+    /// amendment anchored to the injected path rather than ambient CWD.
+    #[tokio::test]
+    async fn run_twiddle_with_client_targets_injected_repo_not_cwd() {
+        let (temp_dir, hash) = init_test_repo_with_commit();
+
+        // Sanity-check: the process CWD is NOT the temp repo, so an amendment
+        // that leaked to the ambient CWD would target the omni-dev checkout.
+        let cwd = std::env::current_dir().unwrap();
+        assert_ne!(
+            cwd.canonicalize().unwrap(),
+            temp_dir.path().canonicalize().unwrap(),
+            "test precondition: process CWD must differ from the injected repo"
+        );
+
+        let mock = ConfigurableMockAiClient::new(vec![Ok(amendment_yaml(
+            &hash,
+            "feat(cli): injected-repo subject",
+        ))]);
+        let client = ClaudeClient::new(Box::new(mock));
+
+        let outcome = run_twiddle_with_client(Some("HEAD"), false, temp_dir.path(), &client)
+            .await
+            .unwrap();
+        assert!(outcome.applied, "dry_run=false must apply amendments");
+        assert_eq!(outcome.amendment_count, 1);
+
+        // The injected repo's HEAD must carry the rewritten message.
+        let repo = git2::Repository::open(temp_dir.path()).unwrap();
+        let head_msg = repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .message()
+            .unwrap()
+            .to_string();
+        assert!(
+            head_msg.contains("injected-repo subject"),
+            "injected repo HEAD must be rewritten: {head_msg}"
         );
     }
 }
@@ -2205,9 +2262,6 @@ mod execute_tests {
     #[tokio::test]
     async fn execute_with_client_multi_commit_batch_success_covers_line_392() {
         let (temp_dir, hashes) = init_test_repo_with_n_commits(3);
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         // Range yields the 2 most recent commits (oldest excluded).
         let h_mid = &hashes[1];
@@ -2225,7 +2279,9 @@ mod execute_tests {
         let save_path = temp_dir.path().join("amendments.yaml");
         let cmd = make_cmd("HEAD~2..HEAD", save_path.clone());
 
-        cmd.execute_with_client(client).await.unwrap();
+        cmd.execute_with_client(temp_dir.path(), client)
+            .await
+            .unwrap();
 
         // Single batch dispatch, single AI request.
         assert_eq!(response_handle.remaining(), 0);
@@ -2258,9 +2314,6 @@ mod execute_tests {
     #[tokio::test]
     async fn execute_with_client_multi_commit_split_retry_covers_line_424() {
         let (temp_dir, hashes) = init_test_repo_with_n_commits(3);
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let h_mid = &hashes[1];
         let h_new = &hashes[2];
@@ -2290,7 +2343,9 @@ mod execute_tests {
         let save_path = temp_dir.path().join("amendments.yaml");
         let cmd = make_cmd("HEAD~2..HEAD", save_path.clone());
 
-        cmd.execute_with_client(client).await.unwrap();
+        cmd.execute_with_client(temp_dir.path(), client)
+            .await
+            .unwrap();
 
         // 3 batch attempts + 2 individual retries = 5 AI requests.
         assert_eq!(response_handle.remaining(), 0);
@@ -2320,9 +2375,6 @@ mod execute_tests {
     #[tokio::test]
     async fn execute_no_ai_save_only_covers_line_1031() {
         let (temp_dir, hash) = init_test_repo_with_commit();
-        let _guard = super::super::CwdGuard::enter(temp_dir.path())
-            .await
-            .unwrap();
 
         let save_path = temp_dir.path().join("amendments.yaml");
         let cmd = TwiddleCommand {
@@ -2346,7 +2398,7 @@ mod execute_tests {
             quiet: true,
         };
 
-        cmd.execute(None).await.unwrap();
+        cmd.execute(Some(temp_dir.path())).await.unwrap();
 
         let saved = AmendmentFile::load_from_file(&save_path).unwrap();
         assert_eq!(saved.amendments.len(), 1);

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -95,7 +95,10 @@ impl TwiddleCommand {
     }
 
     /// Executes the twiddle command with contextual intelligence.
-    pub async fn execute(mut self) -> Result<()> {
+    pub async fn execute(mut self, repo: Option<&std::path::Path>) -> Result<()> {
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git commit message twiddle`");
+        }
         // Resolve deprecated --batch-size into --concurrency
         if let Some(bs) = self.batch_size {
             eprintln!("warning: --batch-size is deprecated; use --concurrency instead");
@@ -2338,7 +2341,7 @@ mod execute_tests {
             quiet: true,
         };
 
-        cmd.execute().await.unwrap();
+        cmd.execute(None).await.unwrap();
 
         let saved = AmendmentFile::load_from_file(&save_path).unwrap();
         assert_eq!(saved.amendments.len(), 1);

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -796,8 +796,11 @@ impl TwiddleCommand {
     async fn apply_amendments_from_file(&self, amendments_file: &std::path::Path) -> Result<()> {
         use crate::git::AmendmentHandler;
 
-        // Use AmendmentHandler to apply amendments directly from file
-        let handler = AmendmentHandler::new().context("Failed to initialize amendment handler")?;
+        // Use AmendmentHandler to apply amendments directly from file.
+        // `twiddle` is still CWD-pinned (converted in a later slice), so the
+        // injected root is `.` — byte-identical to the pre-injection behavior.
+        let handler = AmendmentHandler::new(std::path::Path::new("."))
+            .context("Failed to initialize amendment handler")?;
         handler
             .apply_amendments(&amendments_file.to_string_lossy())
             .context("Failed to apply amendments")?;
@@ -1879,8 +1882,10 @@ pub(crate) async fn run_twiddle_with_client(
     amendments
         .save_to_file(&amendments_file)
         .context("Failed to save amendments")?;
-    let handler =
-        crate::git::AmendmentHandler::new().context("Failed to initialise amendment handler")?;
+    // `twiddle` is still CWD-pinned (converted in a later slice), so the
+    // injected root is `.` — byte-identical to the pre-injection behavior.
+    let handler = crate::git::AmendmentHandler::new(std::path::Path::new("."))
+        .context("Failed to initialise amendment handler")?;
     handler
         .apply_amendments(&amendments_file.to_string_lossy())
         .context("Failed to apply amendments")?;

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -103,8 +103,15 @@ impl TwiddleCommand {
         }
 
         // Resolve the repo root once; every git, config, and scratch read below
-        // anchors to it (the CWD is the default when no path is injected).
-        let repo_root = repo.unwrap_or_else(|| std::path::Path::new("."));
+        // anchors to it (the CWD is the default when no path is injected). Resolve
+        // the default to an absolute path via `current_dir` — matching the sibling
+        // commands — so walk-ups from a subdirectory work and echoed paths are
+        // absolute.
+        let repo_root = match repo {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().context("Failed to determine current directory")?,
+        };
+        let repo_root = repo_root.as_path();
 
         // If --no-ai flag is set, skip AI processing and output YAML directly
         if self.no_ai {
@@ -1794,7 +1801,11 @@ pub async fn run_twiddle(
     dry_run: bool,
     repo_path: Option<&std::path::Path>,
 ) -> Result<TwiddleOutcome> {
-    let repo_root = repo_path.unwrap_or_else(|| std::path::Path::new("."));
+    let repo_root = match repo_path {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().context("Failed to determine current directory")?,
+    };
+    let repo_root = repo_root.as_path();
 
     crate::utils::check_ai_command_prerequisites(model.as_deref(), repo_root)?;
 

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -112,7 +112,8 @@ impl TwiddleCommand {
         }
 
         // Preflight check: validate AI credentials before any processing
-        let ai_info = crate::utils::check_ai_command_prerequisites(self.model.as_deref())?;
+        let ai_info =
+            crate::utils::check_ai_command_prerequisites(self.model.as_deref(), repo_root)?;
         println!(
             "✓ {} credentials verified (model: {})",
             ai_info.provider, ai_info.model
@@ -1795,7 +1796,7 @@ pub async fn run_twiddle(
 ) -> Result<TwiddleOutcome> {
     let repo_root = repo_path.unwrap_or_else(|| std::path::Path::new("."));
 
-    crate::utils::check_ai_command_prerequisites(model.as_deref())?;
+    crate::utils::check_ai_command_prerequisites(model.as_deref(), repo_root)?;
 
     if !dry_run {
         crate::utils::check_working_directory_clean_at(repo_root)?;

--- a/src/cli/git/view.rs
+++ b/src/cli/git/view.rs
@@ -15,7 +15,10 @@ pub struct ViewCommand {
 
 impl ViewCommand {
     /// Executes the view command.
-    pub fn execute(self) -> Result<()> {
+    pub fn execute(self, repo: Option<&Path>) -> Result<()> {
+        if repo.is_some() {
+            anyhow::bail!("--repo is not yet supported for `git commit message view`");
+        }
         let commit_range = self.commit_range.as_deref().unwrap_or("HEAD");
         let yaml_output = run_view(commit_range, None::<&str>)?;
         println!("{yaml_output}");
@@ -171,7 +174,7 @@ mod tests {
         let result = ViewCommand {
             commit_range: Some("HEAD".to_string()),
         }
-        .execute();
+        .execute(None);
 
         std::env::set_current_dir(original_cwd).unwrap();
         result.expect("execute should succeed in a valid repo");
@@ -184,7 +187,7 @@ mod tests {
         let original_cwd = std::env::current_dir().unwrap();
         std::env::set_current_dir(temp_dir.path()).unwrap();
 
-        let result = ViewCommand { commit_range: None }.execute();
+        let result = ViewCommand { commit_range: None }.execute(None);
 
         std::env::set_current_dir(original_cwd).unwrap();
         result.expect("execute with default range should succeed");

--- a/src/cli/git/view.rs
+++ b/src/cli/git/view.rs
@@ -15,12 +15,12 @@ pub struct ViewCommand {
 
 impl ViewCommand {
     /// Executes the view command.
+    ///
+    /// `repo` is the repository location resolved at the CLI boundary
+    /// (`None` = current working directory).
     pub fn execute(self, repo: Option<&Path>) -> Result<()> {
-        if repo.is_some() {
-            anyhow::bail!("--repo is not yet supported for `git commit message view`");
-        }
         let commit_range = self.commit_range.as_deref().unwrap_or("HEAD");
-        let yaml_output = run_view(commit_range, None::<&str>)?;
+        let yaml_output = run_view(commit_range, repo)?;
         println!("{yaml_output}");
         Ok(())
     }
@@ -47,6 +47,13 @@ pub fn run_view<P: AsRef<Path>>(commit_range: &str, repo_path: Option<P>) -> Res
             .context("Failed to open git repository. Make sure you're in a git repository.")?
     };
 
+    // Anchor the AI-scratch read to the opened repo's workdir (covers both the
+    // injected-path and CWD-default branches) so it never resolves against an
+    // unrelated ambient CWD.
+    let repo_root = repo
+        .workdir()
+        .context("repository has no working directory (bare repositories are not supported)")?;
+
     let wd_status = repo.get_working_directory_status()?;
     let working_directory = WorkingDirectoryInfo {
         clean: wd_status.clean,
@@ -67,8 +74,8 @@ pub fn run_view<P: AsRef<Path>>(commit_range: &str, repo_path: Option<P>) -> Res
         omni_dev: env!("CARGO_PKG_VERSION").to_string(),
     });
 
-    let ai_scratch_path =
-        ai_scratch::get_ai_scratch_dir().context("Failed to determine AI scratch directory")?;
+    let ai_scratch_path = ai_scratch::get_ai_scratch_dir_at(repo_root)
+        .context("Failed to determine AI scratch directory")?;
     let ai_info = AiInfo {
         scratch: ai_scratch_path.to_string_lossy().to_string(),
     };
@@ -162,34 +169,20 @@ mod tests {
         );
     }
 
-    use crate::cli::git::CWD_MUTEX;
-
     #[test]
-    fn execute_uses_cwd_repo_and_succeeds() {
-        let _guard = CWD_MUTEX.blocking_lock();
+    fn execute_with_explicit_repo_path_succeeds() {
         let (temp_dir, _commits) = init_repo_with_commits();
-        let original_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp_dir.path()).unwrap();
-
         let result = ViewCommand {
             commit_range: Some("HEAD".to_string()),
         }
-        .execute(None);
-
-        std::env::set_current_dir(original_cwd).unwrap();
-        result.expect("execute should succeed in a valid repo");
+        .execute(Some(temp_dir.path()));
+        result.expect("execute should succeed against the injected repo");
     }
 
     #[test]
     fn execute_default_range_uses_head() {
-        let _guard = CWD_MUTEX.blocking_lock();
         let (temp_dir, _commits) = init_repo_with_commits();
-        let original_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp_dir.path()).unwrap();
-
-        let result = ViewCommand { commit_range: None }.execute(None);
-
-        std::env::set_current_dir(original_cwd).unwrap();
+        let result = ViewCommand { commit_range: None }.execute(Some(temp_dir.path()));
         result.expect("execute with default range should succeed");
     }
 

--- a/src/cli/git/view.rs
+++ b/src/cli/git/view.rs
@@ -39,11 +39,14 @@ pub fn run_view<P: AsRef<Path>>(commit_range: &str, repo_path: Option<P>) -> Res
     use crate::git::{GitRepository, RemoteInfo};
     use crate::utils::ai_scratch;
 
+    // Resolve the repo location: the injected path, or the current working
+    // directory as the default (resolved here at the entry point). Both branches
+    // open via `open_at`, so nothing falls back to a no-arg CWD open.
     let repo = if let Some(path) = repo_path {
         GitRepository::open_at(path).context("Failed to open git repository at the given path")?
     } else {
-        crate::utils::check_git_repository()?;
-        GitRepository::open()
+        let cwd = std::env::current_dir().context("Failed to determine current directory")?;
+        GitRepository::open_at(cwd)
             .context("Failed to open git repository. Make sure you're in a git repository.")?
     };
 

--- a/src/git/amendment.rs
+++ b/src/git/amendment.rs
@@ -1,6 +1,7 @@
 //! Git commit amendment operations.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
@@ -13,13 +14,28 @@ use crate::git::SHORT_HASH_LEN;
 /// Amendment operation handler.
 pub struct AmendmentHandler {
     repo: Repository,
+    /// Workdir the `git` subprocesses are pinned to, so amendments target the
+    /// injected repository rather than the process current working directory.
+    repo_root: PathBuf,
 }
 
 impl AmendmentHandler {
-    /// Creates a new amendment handler.
-    pub fn new() -> Result<Self> {
-        let repo = Repository::open(".").context("Failed to open git repository")?;
-        Ok(Self { repo })
+    /// Creates a new amendment handler for the repository at `repo_root`.
+    pub fn new(repo_root: &Path) -> Result<Self> {
+        let repo = Repository::open(repo_root).context("Failed to open git repository")?;
+        Ok(Self {
+            repo,
+            repo_root: repo_root.to_path_buf(),
+        })
+    }
+
+    /// Builds a `git` subprocess pinned to the handler's repo workdir, so every
+    /// rebase/commit/read operation targets the injected repository rather than
+    /// the process current working directory.
+    fn git_command(&self) -> Command {
+        let mut cmd = Command::new("git");
+        cmd.current_dir(&self.repo_root);
+        cmd
     }
 
     /// Applies amendments from a YAML file.
@@ -60,7 +76,7 @@ impl AmendmentHandler {
     /// Performs safety checks before amendment.
     fn perform_safety_checks(&self, amendment_file: &AmendmentFile) -> Result<()> {
         // Check if working directory is clean
-        crate::utils::preflight::check_working_directory_clean()
+        crate::utils::preflight::check_working_directory_clean_at(&self.repo_root)
             .context("Cannot amend commits with uncommitted changes")?;
 
         // Check if commits exist and are not in remote main branches
@@ -144,7 +160,8 @@ impl AmendmentHandler {
         let head_commit = self.repo.head()?.peel_to_commit()?;
 
         // Use the simpler approach: git commit --amend
-        let output = Command::new("git")
+        let output = self
+            .git_command()
             .args(["commit", "--amend", "--message", new_message])
             .output()
             .context("Failed to execute git commit --amend")?;
@@ -212,7 +229,8 @@ impl AmendmentHandler {
 
         // Generate rebase sequence: edit the target commit, pick the rest
         let mut sequence_content = String::new();
-        let commit_list_output = Command::new("git")
+        let commit_list_output = self
+            .git_command()
             .args(["rev-list", "--reverse", &format!("{base_commit}..HEAD")])
             .output()
             .context("Failed to get commit list for rebase")?;
@@ -229,7 +247,8 @@ impl AmendmentHandler {
             }
 
             // Get short commit message for the sequence file
-            let subject_output = Command::new("git")
+            let subject_output = self
+                .git_command()
                 .args(["log", "--format=%s", "-n", "1", commit])
                 .output()
                 .context("Failed to get commit subject")?;
@@ -256,7 +275,7 @@ impl AmendmentHandler {
         );
 
         // Execute rebase with custom sequence editor
-        let rebase_result = Command::new("git")
+        let rebase_result = self.git_command()
             .args(["rebase", "-i", &base_commit])
             .env(
                 "GIT_SEQUENCE_EDITOR",
@@ -270,7 +289,7 @@ impl AmendmentHandler {
             let error_msg = String::from_utf8_lossy(&rebase_result.stderr);
 
             // Best-effort cleanup; the rebase may not have started.
-            if let Err(e) = Command::new("git").args(["rebase", "--abort"]).output() {
+            if let Err(e) = self.git_command().args(["rebase", "--abort"]).output() {
                 debug!("Rebase abort during cleanup failed: {e}");
             }
 
@@ -281,7 +300,8 @@ impl AmendmentHandler {
         let repo_state = self.repo.state();
         if repo_state == git2::RepositoryState::RebaseInteractive {
             // We should be stopped at the target commit - amend it
-            let current_commit_output = Command::new("git")
+            let current_commit_output = self
+                .git_command()
                 .args(["rev-parse", "HEAD"])
                 .output()
                 .context("Failed to get current commit during rebase")?;
@@ -294,7 +314,8 @@ impl AmendmentHandler {
                 .starts_with(&commit_hash[..current_commit.len().min(commit_hash.len())])
             {
                 // Amend with new message
-                let amend_result = Command::new("git")
+                let amend_result = self
+                    .git_command()
                     .args(["commit", "--amend", "-m", new_message])
                     .output()
                     .context("Failed to amend commit during rebase")?;
@@ -302,7 +323,7 @@ impl AmendmentHandler {
                 if !amend_result.status.success() {
                     let error_msg = String::from_utf8_lossy(&amend_result.stderr);
                     // Best-effort cleanup; abort so the repo isn't left mid-rebase.
-                    if let Err(e) = Command::new("git").args(["rebase", "--abort"]).output() {
+                    if let Err(e) = self.git_command().args(["rebase", "--abort"]).output() {
                         debug!("Rebase abort during cleanup failed: {e}");
                     }
                     anyhow::bail!("Failed to amend commit: {error_msg}");
@@ -311,7 +332,8 @@ impl AmendmentHandler {
                 println!("✅ Amended commit: {}", &commit_hash[..SHORT_HASH_LEN]);
 
                 // Continue the rebase
-                let continue_result = Command::new("git")
+                let continue_result = self
+                    .git_command()
                     .args(["rebase", "--continue"])
                     .output()
                     .context("Failed to continue rebase")?;
@@ -319,7 +341,7 @@ impl AmendmentHandler {
                 if !continue_result.status.success() {
                     let error_msg = String::from_utf8_lossy(&continue_result.stderr);
                     // Best-effort cleanup; abort so the repo isn't left mid-rebase.
-                    if let Err(e) = Command::new("git").args(["rebase", "--abort"]).output() {
+                    if let Err(e) = self.git_command().args(["rebase", "--abort"]).output() {
                         debug!("Rebase abort during cleanup failed: {e}");
                     }
                     anyhow::bail!("Failed to continue rebase: {error_msg}");
@@ -328,7 +350,7 @@ impl AmendmentHandler {
                 println!("✅ Rebase completed successfully");
             } else {
                 // Best-effort cleanup; abort so the repo isn't left mid-rebase.
-                if let Err(e) = Command::new("git").args(["rebase", "--abort"]).output() {
+                if let Err(e) = self.git_command().args(["rebase", "--abort"]).output() {
                     debug!("Rebase abort during cleanup failed: {e}");
                 }
                 anyhow::bail!(

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -498,8 +498,12 @@ impl CommitAnalysis {
         repo: &Repository,
         commit: &Commit,
     ) -> Result<(String, Vec<FileDiffRef>)> {
-        // Get AI scratch directory
-        let ai_scratch_path = crate::utils::ai_scratch::get_ai_scratch_dir()
+        // Get AI scratch directory, anchored to the opened repository's workdir
+        // (#967) so the per-commit diff files land under the same repo the rest
+        // of the view reports, rather than the ambient process CWD. `repo` is
+        // the already-opened (possibly `--repo`-injected) git2 handle.
+        let repo_root = repo.workdir().unwrap_or_else(|| repo.path());
+        let ai_scratch_path = crate::utils::ai_scratch::get_ai_scratch_dir_at(repo_root)
             .context("Failed to determine AI scratch directory")?;
 
         // Create diffs subdirectory

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -21,10 +21,16 @@ impl RemoteInfo {
         let mut remotes = Vec::new();
         let remote_names = repo.remotes().context("Failed to get remote names")?;
 
+        // Anchor the `gh` subprocess fallback to the repository's working
+        // directory (RULE-1: git2 ops keep `&Repository`; the subprocess takes
+        // `repo_root`). Derived from the git2 repo itself, so no external caller
+        // signature changes.
+        let repo_root = repo.workdir().unwrap_or_else(|| repo.path());
+
         for name in remote_names.iter().flatten().flatten() {
             if let Ok(remote) = repo.find_remote(name) {
                 let uri = remote.url().unwrap_or("").to_string();
-                let main_branch = Self::detect_main_branch(repo, name)?;
+                let main_branch = Self::detect_main_branch(repo, name, repo_root)?;
 
                 remotes.push(Self {
                     name: name.to_string(),
@@ -38,7 +44,14 @@ impl RemoteInfo {
     }
 
     /// Detects the main branch for a remote.
-    fn detect_main_branch(repo: &Repository, remote_name: &str) -> Result<String> {
+    ///
+    /// `repo_root` anchors the `gh` subprocess fallback to the repository's
+    /// working directory rather than the process current working directory.
+    fn detect_main_branch(
+        repo: &Repository,
+        remote_name: &str,
+        repo_root: &std::path::Path,
+    ) -> Result<String> {
         // First try to get the remote HEAD reference
         let head_ref_name = format!("refs/remotes/{remote_name}/HEAD");
         if let Ok(head_ref) = repo.find_reference(&head_ref_name) {
@@ -56,7 +69,7 @@ impl RemoteInfo {
         if let Ok(remote) = repo.find_remote(remote_name) {
             if let Ok(uri) = remote.url() {
                 if uri.contains("github.com") {
-                    if let Ok(main_branch) = Self::get_github_default_branch(uri) {
+                    if let Ok(main_branch) = Self::get_github_default_branch(uri, repo_root) {
                         return Ok(main_branch);
                     }
                 }
@@ -111,7 +124,12 @@ impl RemoteInfo {
     }
 
     /// Returns the default branch from GitHub using gh CLI.
-    fn get_github_default_branch(uri: &str) -> Result<String> {
+    ///
+    /// `repo_root` anchors the `gh` subprocess to the repository's working
+    /// directory. The `gh repo view <repo_name>` invocation already passes an
+    /// explicit repo argument (so it is CWD-inert), but the directory is pinned
+    /// for uniformity with the rest of the repo-anchored subprocess seams.
+    fn get_github_default_branch(uri: &str, repo_root: &std::path::Path) -> Result<String> {
         use std::process::Command;
 
         // Extract repository name from URI
@@ -128,6 +146,7 @@ impl RemoteInfo {
                 "--jq",
                 ".defaultBranchRef.name",
             ])
+            .current_dir(repo_root)
             .output();
 
         match output {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -30,13 +30,6 @@ pub struct FileStatus {
 }
 
 impl GitRepository {
-    /// Opens a repository at the current directory.
-    pub fn open() -> Result<Self> {
-        let repo = Repository::open(".").context("Not in a git repository")?;
-
-        Ok(Self { repo })
-    }
-
     /// Opens a repository at the specified path.
     pub fn open_at<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
         let repo = Repository::open(path).context("Failed to open git repository")?;

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -269,12 +269,21 @@ pub fn resource_listing() -> Vec<Resource> {
 }
 
 /// Resolves a parsed URI into [`ReadResourceResult`] contents.
-pub async fn read_resource(uri: &ResourceUri, raw_uri: &str) -> Result<ReadResourceResult> {
+///
+/// `repo_root` is the repository location resolved once at the MCP boundary;
+/// the `git://` arm opens the repository there instead of reading the ambient
+/// process CWD. Non-git arms ignore it.
+pub async fn read_resource(
+    uri: &ResourceUri,
+    raw_uri: &str,
+    repo_root: &std::path::Path,
+) -> Result<ReadResourceResult> {
     match uri {
         ResourceUri::GitCommits { range } => {
             let range = range.clone();
+            let repo_root = repo_root.to_path_buf();
             let yaml = tokio::task::spawn_blocking(move || {
-                crate::cli::git::run_view(&range, None::<&str>)
+                crate::cli::git::run_view(&range, Some(&repo_root))
             })
             .await
             .context("git run_view task panicked")??;
@@ -720,24 +729,15 @@ mod tests {
         temp_dir
     }
 
-    use crate::cli::git::CWD_MUTEX;
-
-    // `read_resource` is async and must run with the CWD held fixed, so we
-    // hold the guard across `.await` points. The shared
-    // `tokio::sync::Mutex` is designed for this; no clippy suppression is
-    // needed. The critical section is CPU-bound `run_view` work behind
-    // `spawn_blocking`, so no cross-task yield contends for the lock.
+    // `read_resource` resolves the `git://` repo from the injected `repo_root`,
+    // so the test passes the temp repo path directly — no CWD manipulation.
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_git_commits_returns_yaml() {
-        let _guard = CWD_MUTEX.lock().await;
         let temp_dir = init_tmp_repo();
-        let original_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp_dir.path()).unwrap();
 
         let uri = ResourceUri::parse("git://repo/commits/HEAD").unwrap();
-        let result = read_resource(&uri, "git://repo/commits/HEAD").await;
+        let result = read_resource(&uri, "git://repo/commits/HEAD", temp_dir.path()).await;
 
-        std::env::set_current_dir(original_cwd).unwrap();
         let result = result.unwrap();
         let contents = result.contents;
         assert_eq!(contents.len(), 1);
@@ -829,7 +829,9 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/PROJ-7").unwrap();
-        let result = read_resource(&uri, "jira://issue/PROJ-7").await.unwrap();
+        let result = read_resource(&uri, "jira://issue/PROJ-7", std::path::Path::new("."))
+            .await
+            .unwrap();
         assert_eq!(result.contents.len(), 1);
         match &result.contents[0] {
             ResourceContents::TextResourceContents {
@@ -884,7 +886,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/PROJ-8.adf").unwrap();
-        let result = read_resource(&uri, "jira://issue/PROJ-8.adf")
+        let result = read_resource(&uri, "jira://issue/PROJ-8.adf", std::path::Path::new("."))
             .await
             .unwrap();
         match &result.contents[0] {
@@ -919,7 +921,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/NOPE-1").unwrap();
-        let err = read_resource(&uri, "jira://issue/NOPE-1")
+        let err = read_resource(&uri, "jira://issue/NOPE-1", std::path::Path::new("."))
             .await
             .expect_err("404 should surface as error");
         let chain = format!("{err:#}");
@@ -980,7 +982,8 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("confluence://page/99999").unwrap();
-        let result = read_resource(&uri, "confluence://page/99999").await;
+        let result =
+            read_resource(&uri, "confluence://page/99999", std::path::Path::new(".")).await;
         // We don't pin the exact rendered output (depends on internal ADF
         // rendering details), only that the branch ran and produced
         // TextResourceContents with the markdown MIME type.
@@ -1025,7 +1028,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("confluence://page/404404").unwrap();
-        let err = read_resource(&uri, "confluence://page/404404")
+        let err = read_resource(&uri, "confluence://page/404404", std::path::Path::new("."))
             .await
             .expect_err("404 should surface as error");
         let chain = format!("{err:#}");
@@ -1056,7 +1059,7 @@ mod tests {
         std::env::set_var("HOME", std::env::temp_dir());
 
         let uri = ResourceUri::parse("jira://issue/ZZZ-1").unwrap();
-        let err = read_resource(&uri, "jira://issue/ZZZ-1")
+        let err = read_resource(&uri, "jira://issue/ZZZ-1", std::path::Path::new("."))
             .await
             .expect_err("missing credentials must error");
         let chain = format!("{err:#}");
@@ -1082,7 +1085,7 @@ mod tests {
         std::env::set_var("HOME", std::env::temp_dir());
 
         let uri = ResourceUri::parse("confluence://page/0").unwrap();
-        let err = read_resource(&uri, "confluence://page/0")
+        let err = read_resource(&uri, "confluence://page/0", std::path::Path::new("."))
             .await
             .expect_err("missing credentials must error");
         let chain = format!("{err:#}");
@@ -1151,7 +1154,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_specs_jfm_returns_markdown() {
         let uri = ResourceUri::parse("omni-dev://specs/jfm").unwrap();
-        let result = read_resource(&uri, "omni-dev://specs/jfm").await.unwrap();
+        let result = read_resource(&uri, "omni-dev://specs/jfm", std::path::Path::new("."))
+            .await
+            .unwrap();
         assert_eq!(result.contents.len(), 1);
         match &result.contents[0] {
             ResourceContents::TextResourceContents {
@@ -1176,7 +1181,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_specs_unknown_name_errors() {
         let uri = ResourceUri::parse("omni-dev://specs/nope").unwrap();
-        let err = read_resource(&uri, "omni-dev://specs/nope")
+        let err = read_resource(&uri, "omni-dev://specs/nope", std::path::Path::new("."))
             .await
             .expect_err("unknown spec must error");
         let chain = format!("{err:#}");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -101,7 +101,20 @@ impl ServerHandler for OmniDevServer {
         let uri = request.uri;
         let parsed =
             resources::ResourceUri::parse(&uri).map_err(|err| resources::not_found(&uri, err))?;
-        resources::read_resource(&parsed, &uri)
+        // Only the `git://` arm consults a repo; the server carries no per-call
+        // path and no configured workdir, so the process CWD is the canonical
+        // root. Resolve it once here for that arm (RULE 2) rather than letting
+        // `run_view` read the ambient CWD deeper in the call tree. Non-git arms
+        // ignore the value, so they get a placeholder and never touch the CWD.
+        let repo_root = match &parsed {
+            resources::ResourceUri::GitCommits { .. } => {
+                std::env::current_dir().map_err(|err| {
+                    resources::not_found(&uri, format!("failed to resolve repo root: {err}"))
+                })?
+            }
+            _ => std::path::PathBuf::from("."),
+        };
+        resources::read_resource(&parsed, &uri, &repo_root)
             .await
             .map_err(|err| resources::not_found(&uri, err))
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,8 @@ pub mod preflight;
 pub mod settings;
 
 pub use preflight::{
-    check_ai_command_prerequisites, check_ai_credentials, check_git_repository, check_github_cli,
-    check_pr_command_prerequisites, check_working_directory_clean, AiCredentialInfo, AiProvider,
+    check_ai_command_prerequisites, check_ai_credentials, check_git_repository,
+    check_git_repository_at, check_github_cli, check_pr_command_prerequisites,
+    check_working_directory_clean, check_working_directory_clean_at, AiCredentialInfo, AiProvider,
 };
 pub use settings::{get_env_var, get_env_vars, Settings};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,8 +5,8 @@ pub mod preflight;
 pub mod settings;
 
 pub use preflight::{
-    check_ai_command_prerequisites, check_ai_credentials, check_git_repository,
-    check_git_repository_at, check_github_cli, check_pr_command_prerequisites,
-    check_working_directory_clean, check_working_directory_clean_at, AiCredentialInfo, AiProvider,
+    check_ai_command_prerequisites, check_ai_credentials, check_git_repository_at,
+    check_github_cli, check_pr_command_prerequisites, check_working_directory_clean_at,
+    AiCredentialInfo, AiProvider,
 };
 pub use settings::{get_env_var, get_env_vars, Settings};

--- a/src/utils/ai_scratch.rs
+++ b/src/utils/ai_scratch.rs
@@ -24,6 +24,26 @@ pub fn get_ai_scratch_dir() -> Result<PathBuf> {
     }
 }
 
+/// Returns the AI scratch directory, resolving the `git-root:` form against
+/// `repo_root` instead of the process current working directory.
+///
+/// Behaves identically to [`get_ai_scratch_dir`] for the direct-path and
+/// `TMPDIR` fallback cases; only the `git-root:` walk-up is anchored to the
+/// injected `repo_root`.
+pub fn get_ai_scratch_dir_at(repo_root: &Path) -> Result<PathBuf> {
+    if let Ok(ai_scratch) = env::var("AI_SCRATCH") {
+        if let Some(git_root_path) = ai_scratch.strip_prefix("git-root:") {
+            let git_root = find_git_root_from_path(repo_root)?;
+            Ok(git_root.join(git_root_path))
+        } else {
+            Ok(PathBuf::from(ai_scratch))
+        }
+    } else {
+        let tmpdir = env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+        Ok(PathBuf::from(tmpdir))
+    }
+}
+
 /// Finds the closest ancestor directory containing a .git directory.
 fn find_git_root() -> Result<PathBuf> {
     let current_dir = env::current_dir().context("Failed to get current directory")?;
@@ -121,6 +141,22 @@ mod tests {
 
         let result = get_ai_scratch_dir().unwrap();
         assert_eq!(result, PathBuf::from("/custom/tmp"));
+    }
+
+    #[test]
+    fn get_ai_scratch_dir_at_resolves_git_root_from_injected_path() {
+        let mut guard = EnvGuard::new();
+        let temp_dir = {
+            std::fs::create_dir_all("tmp").ok();
+            TempDir::new_in("tmp").unwrap()
+        };
+        std::fs::create_dir(temp_dir.path().join(".git")).unwrap();
+        guard.set("AI_SCRATCH", "git-root:scratch");
+
+        // Resolves the `git-root:` form against the injected path, not the
+        // process current working directory.
+        let result = get_ai_scratch_dir_at(temp_dir.path()).unwrap();
+        assert_eq!(result, temp_dir.path().join("scratch"));
     }
 
     #[test]

--- a/src/utils/preflight.rs
+++ b/src/utils/preflight.rs
@@ -259,19 +259,9 @@ pub fn check_github_cli(repo_root: &std::path::Path) -> Result<()> {
     }
 }
 
-/// Validates that the current directory is in a valid git repository.
+/// Validates that `repo_root` is a valid git repository.
 ///
-/// This is a lightweight check that opens the repository without
-/// loading any commit data.
-pub fn check_git_repository() -> Result<()> {
-    crate::git::GitRepository::open().context(
-        "Not in a git repository. Please run this command from within a git repository.",
-    )?;
-    Ok(())
-}
-
-/// Like [`check_git_repository`], but validates the repository at an explicit
-/// `repo_root` instead of the process current working directory.
+/// A lightweight check that opens the repository without loading commit data.
 pub fn check_git_repository_at(repo_root: &std::path::Path) -> Result<()> {
     crate::git::GitRepository::open_at(repo_root).context(
         "Not in a git repository. Please run this command from within a git repository.",
@@ -279,22 +269,11 @@ pub fn check_git_repository_at(repo_root: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
-/// Validates that the working directory is clean (no uncommitted changes).
+/// Validates that the working directory at `repo_root` is clean — no
+/// uncommitted changes (staged, unstaged, or untracked non-ignored files).
 ///
-/// This checks for:
-/// - Staged changes
-/// - Unstaged modifications
-/// - Untracked files (excluding ignored files)
-///
-/// Use this before operations that require a clean working directory,
-/// like amending commits.
-pub fn check_working_directory_clean() -> Result<()> {
-    let repo = crate::git::GitRepository::open().context("Failed to open git repository")?;
-    check_working_directory_clean_for(&repo)
-}
-
-/// Like [`check_working_directory_clean`], but checks the repository at an
-/// explicit `repo_root` instead of the process current working directory.
+/// Use this before operations that require a clean working directory, like
+/// amending commits.
 pub fn check_working_directory_clean_at(repo_root: &std::path::Path) -> Result<()> {
     let repo =
         crate::git::GitRepository::open_at(repo_root).context("Failed to open git repository")?;

--- a/src/utils/preflight.rs
+++ b/src/utils/preflight.rs
@@ -215,17 +215,22 @@ pub fn check_ai_credentials(model_override: Option<&str>) -> Result<AiCredential
 /// 2. User is authenticated (can access the current repo)
 ///
 /// Use this at the start of commands that require GitHub API access.
-pub fn check_github_cli() -> Result<()> {
-    // Check if gh CLI is available
+///
+/// `repo_root` anchors the repository-access probe to the injected repository
+/// rather than the process current working directory.
+pub fn check_github_cli(repo_root: &std::path::Path) -> Result<()> {
+    // Check if gh CLI is available. This probe is a PATH availability check
+    // (CWD-independent), so it is not anchored to `repo_root`.
     let gh_check = std::process::Command::new("gh")
         .args(["--version"])
         .output();
 
     match gh_check {
         Ok(output) if output.status.success() => {
-            // Test if gh can access the current repo
+            // Test if gh can access the injected repo
             let repo_check = std::process::Command::new("gh")
                 .args(["repo", "view", "--json", "name"])
+                .current_dir(repo_root)
                 .output();
 
             match repo_check {
@@ -321,8 +326,14 @@ fn check_working_directory_clean_for(repo: &crate::git::GitRepository) -> Result
 /// - AI credentials
 ///
 /// Returns information about the AI provider that will be used.
-pub fn check_ai_command_prerequisites(model_override: Option<&str>) -> Result<AiCredentialInfo> {
-    check_git_repository()?;
+///
+/// `repo_root` anchors the git-repository check to the injected repository
+/// rather than the process current working directory.
+pub fn check_ai_command_prerequisites(
+    model_override: Option<&str>,
+    repo_root: &std::path::Path,
+) -> Result<AiCredentialInfo> {
+    check_git_repository_at(repo_root)?;
     check_ai_credentials(model_override)
 }
 
@@ -334,10 +345,16 @@ pub fn check_ai_command_prerequisites(model_override: Option<&str>) -> Result<Ai
 /// - GitHub CLI availability and authentication
 ///
 /// Returns information about the AI provider that will be used.
-pub fn check_pr_command_prerequisites(model_override: Option<&str>) -> Result<AiCredentialInfo> {
-    check_git_repository()?;
+///
+/// `repo_root` anchors the git-repository and GitHub CLI checks to the injected
+/// repository rather than the process current working directory.
+pub fn check_pr_command_prerequisites(
+    model_override: Option<&str>,
+    repo_root: &std::path::Path,
+) -> Result<AiCredentialInfo> {
+    check_git_repository_at(repo_root)?;
     let ai_info = check_ai_credentials(model_override)?;
-    check_github_cli()?;
+    check_github_cli(repo_root)?;
     Ok(ai_info)
 }
 

--- a/src/utils/preflight.rs
+++ b/src/utils/preflight.rs
@@ -265,6 +265,15 @@ pub fn check_git_repository() -> Result<()> {
     Ok(())
 }
 
+/// Like [`check_git_repository`], but validates the repository at an explicit
+/// `repo_root` instead of the process current working directory.
+pub fn check_git_repository_at(repo_root: &std::path::Path) -> Result<()> {
+    crate::git::GitRepository::open_at(repo_root).context(
+        "Not in a git repository. Please run this command from within a git repository.",
+    )?;
+    Ok(())
+}
+
 /// Validates that the working directory is clean (no uncommitted changes).
 ///
 /// This checks for:
@@ -276,7 +285,19 @@ pub fn check_git_repository() -> Result<()> {
 /// like amending commits.
 pub fn check_working_directory_clean() -> Result<()> {
     let repo = crate::git::GitRepository::open().context("Failed to open git repository")?;
+    check_working_directory_clean_for(&repo)
+}
 
+/// Like [`check_working_directory_clean`], but checks the repository at an
+/// explicit `repo_root` instead of the process current working directory.
+pub fn check_working_directory_clean_at(repo_root: &std::path::Path) -> Result<()> {
+    let repo =
+        crate::git::GitRepository::open_at(repo_root).context("Failed to open git repository")?;
+    check_working_directory_clean_for(&repo)
+}
+
+/// Shared clean-worktree check over an already-opened repository.
+fn check_working_directory_clean_for(repo: &crate::git::GitRepository) -> Result<()> {
     let status = repo
         .get_working_directory_status()
         .context("Failed to get working directory status")?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -155,7 +155,7 @@ fn amend_command_with_temporary_repo() -> Result<()> {
             };
 
             println!("Testing amend command...");
-            let result = amend_cmd.execute();
+            let result = amend_cmd.execute(None);
             println!("Amend command result: {result:?}");
             result
         });
@@ -564,6 +564,7 @@ async fn cli_execute_dispatches_git_commit_message_view() {
         claude_cli_allow_mcp: false,
         claude_cli_max_budget_usd: None,
         models_yaml: None,
+        repo: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Commit(CommitCommand {
                 command: CommitSubcommands::Message(MessageCommand {
@@ -590,6 +591,7 @@ async fn cli_execute_dispatches_git_branch_info() {
         claude_cli_allow_mcp: false,
         claude_cli_max_budget_usd: None,
         models_yaml: None,
+        repo: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Branch(BranchCommand {
                 command: BranchSubcommands::Info(InfoCommand { base_branch: None }),
@@ -610,6 +612,7 @@ async fn cli_execute_dispatches_ai_chat() {
         claude_cli_allow_mcp: false,
         claude_cli_max_budget_usd: None,
         models_yaml: None,
+        repo: None,
         command: Commands::Ai(AiCommand {
             command: AiSubcommands::Chat(ChatCommand { model: None }),
         }),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -102,8 +102,16 @@ impl TestRepo {
                 .collect(),
         };
 
-        // Create the amendments file outside the repository to avoid it showing up as untracked
-        let yaml_path = self.repo_path.parent().unwrap().join("amendments.yaml");
+        // Create the amendments file outside the repository (so it doesn't show
+        // up as untracked) under a name unique to this repo's tempdir, so tests
+        // that share the parent `tmp/` directory can't overwrite each other's
+        // file and race.
+        let unique = self.repo_path.file_name().unwrap().to_string_lossy();
+        let yaml_path = self
+            .repo_path
+            .parent()
+            .unwrap()
+            .join(format!("{unique}-amendments.yaml"));
         amendment_file.save_to_file(&yaml_path)?;
         Ok(yaml_path)
     }
@@ -175,9 +183,12 @@ fn amend_preflight_checks_injected_repo_worktree() -> Result<()> {
     .execute(Some(repo_a.repo_path.as_path()))
     .expect_err("amend must bail on the injected repo's dirty worktree");
     let msg = format!("{err:#}").to_lowercase();
+    // Assert on the injected repo's specific untracked file: a regressed
+    // CWD-anchored check would report a different (or no) file, so this can't
+    // pass for the wrong reason.
     assert!(
-        msg.contains("uncommitted") || msg.contains("clean"),
-        "expected dirty-worktree error from the injected repo, got: {msg}"
+        msg.contains("dirty.txt"),
+        "expected dirty-worktree error naming the injected repo's file, got: {msg}"
     );
 
     Ok(())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,15 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::env;
 use std::fs;
 use std::path::PathBuf;
-
-// Serialises the window where amend_command_with_temporary_repo mutates the
-// process-wide CWD via env::set_current_dir.  That mutation is visible to all
-// threads; without serialisation any concurrently-running test that creates a
-// git2 Repository via a relative path (including TestRepo::new) races against
-// it.  See <https://github.com/rust-works/omni-dev/issues/230>.
-static CWD_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 use anyhow::Result;
 use git2::{Repository, Signature};
@@ -140,63 +132,53 @@ fn amend_command_with_temporary_repo() -> Result<()> {
     let amendment_file_path = test_repo.create_amendment_file(amendments)?;
     println!("Created amendment file at: {amendment_file_path:?}");
 
-    // AmendCommand::execute → AmendmentHandler::new → Repository::open(".")
-    // requires the process CWD to equal the repository root.  env::set_current_dir
-    // is process-wide, so we hold CWD_MUTEX for the entire mutation window to
-    // prevent concurrent tests from observing an unexpected CWD.
-    let original_dir = env::current_dir()?;
-    let result = {
-        let _cwd_guard = CWD_MUTEX.lock().unwrap();
-        env::set_current_dir(&test_repo.repo_path)?;
-
-        let outcome = std::panic::catch_unwind(|| {
-            let amend_cmd = AmendCommand {
-                yaml_file: amendment_file_path.to_string_lossy().to_string(),
-            };
-
-            println!("Testing amend command...");
-            let result = amend_cmd.execute(None);
-            println!("Amend command result: {result:?}");
-            result
-        });
-
-        // Restore CWD before releasing the mutex.
-        env::set_current_dir(&original_dir)?;
-        outcome
-        // _cwd_guard dropped here — other threads may now change or read CWD.
+    // The repository is injected explicitly via `--repo`, so the amend command
+    // runs entirely against `test_repo.repo_path` — no process-CWD manipulation
+    // and no shared mutex are needed.
+    let amend_cmd = AmendCommand {
+        yaml_file: amendment_file_path.to_string_lossy().to_string(),
     };
+    amend_cmd
+        .execute(Some(test_repo.repo_path.as_path()))
+        .expect("Amend command should succeed");
 
-    match result {
-        Ok(cmd_result) => {
-            println!("Amend command completed: {cmd_result:?}");
+    // Verify that amendments were actually made.  Use the absolute repo_path
+    // directly so this does not depend on process CWD.
+    let repo = Repository::open(&test_repo.repo_path)?;
+    let head = repo.head()?.target().unwrap();
+    let commit = repo.find_commit(head)?;
+    let head_message = commit.message().unwrap_or("").trim();
+    assert_eq!(
+        head_message, "Fix critical bug in the new feature",
+        "HEAD commit should have been amended with new message"
+    );
 
-            // The implementation should now actually work
-            assert!(cmd_result.is_ok(), "Amend command should succeed");
+    Ok(())
+}
 
-            // Verify that amendments were actually made.  Use the absolute
-            // repo_path directly so this does not depend on process CWD.
-            let repo = Repository::open(&test_repo.repo_path)?;
-            let head = repo.head()?.target().unwrap();
-            let commit = repo.find_commit(head)?;
-            println!(
-                "Current HEAD commit message after amendment: {}",
-                commit.message().unwrap_or("")
-            );
+/// "No silent mix" guard: the clean-worktree preflight checks the INJECTED
+/// repository, not the process CWD. Repo A has a dirty worktree, so amend must
+/// bail citing A's uncommitted changes even though the process CWD (the
+/// omni-dev checkout) is a different repository.
+#[test]
+fn amend_preflight_checks_injected_repo_worktree() -> Result<()> {
+    let mut repo_a = TestRepo::new()?;
+    repo_a.add_commit("a: initial", "content")?;
+    let amendment_file = repo_a.create_amendment_file(vec![(0, "a: amended")])?;
 
-            // The HEAD commit message should have been amended
-            let head_message = commit.message().unwrap_or("").trim();
-            assert_eq!(
-                head_message, "Fix critical bug in the new feature",
-                "HEAD commit should have been amended with new message"
-            );
+    // Dirty the injected repo's worktree with an untracked file.
+    fs::write(repo_a.repo_path.join("dirty.txt"), "uncommitted")?;
 
-            println!("✅ Test passed: Amend command successfully amended the commit message");
-        }
-        Err(e) => {
-            println!("❌ Amend command panicked: {e:?}");
-            panic!("Amend command should not panic");
-        }
+    let err = AmendCommand {
+        yaml_file: amendment_file.to_string_lossy().to_string(),
     }
+    .execute(Some(repo_a.repo_path.as_path()))
+    .expect_err("amend must bail on the injected repo's dirty worktree");
+    let msg = format!("{err:#}").to_lowercase();
+    assert!(
+        msg.contains("uncommitted") || msg.contains("clean"),
+        "expected dirty-worktree error from the injected repo, got: {msg}"
+    );
 
     Ok(())
 }

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1552,8 +1552,14 @@ async fn git_view_commits_default_range_is_head() -> Result<()> {
 
 // ─── Resources ──────────────────────────────────────────────────────
 
-/// Serialises CWD mutations across the resource tests in this file so they
-/// don't race with each other or with CWD-swapping unit tests elsewhere.
+/// Serialises the CWD swap in `read_resource_git_commits_head_returns_yaml`.
+///
+/// This is the one intentional CWD-mutating test left after #967: the
+/// path-less `git://repo/commits/HEAD` wire URI carries no per-call repo path,
+/// so the in-process MCP server resolves the repository from its own current
+/// working directory at the boundary (`server.rs`). Pointing it at a temp repo
+/// therefore requires swapping the process CWD. Retiring this would need a
+/// configurable server workdir — a separate feature, out of scope for #967.
 static CWD_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[tokio::test]

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -34,6 +34,8 @@ Options:
           Per-invocation spending cap in USD for the `claude-cli` backend
       --models-yaml <PATH>
           Path to a single user-side `models.yaml` that short-circuits the standard `./.omni-dev/models.yaml` and `~/.omni-dev/models.yaml` lookup. The file is still merged over the embedded catalog. Equivalent to setting `OMNI_DEV_MODELS_YAML`
+  -C, --repo <PATH>
+          Run as if omni-dev was started in `<PATH>` instead of the current working directory
   -h, --help
           Print help (see more with '--help')
   -V, --version
@@ -2187,8 +2189,6 @@ Options:
           Output format [default: markdown] [possible values: markdown, yaml, json]
       --fail-under-patch <PCT>
           Fail (non-zero exit) when patch coverage is below this percentage
-      --repo <PATH>
-          Repository path [default: .]
       --strip-prefix <PATH>
           Override the path prefix stripped from report file paths to make them repo-relative (default: the repository working directory)
       --collapse-ranges


### PR DESCRIPTION
## Description

Stops omni-dev from locating the git repository (and its config, templates, and `git`/`gh` subprocesses) via the **process current working directory**, and instead injects the repo location explicitly. A new global `--repo`/`-C <PATH>` flag is resolved exactly once at the CLI boundary and threaded as a plain `Option<&Path>` parameter through every git command — never stored in a `static`, `OnceCell`, thread-local, or environment variable.

This removes the root cause of two long-standing problems: tests had to mutate the process-global CWD behind a `CWD_MUTEX` (a known flakiness source, #230), and CWD/live-repo-dependent lines flickered run-to-run, polluting the diff/patch coverage comment (#949). With the repo injected, every read a command performs — the libgit2 open, the PR template, the `gh` calls, the AI-scratch dir, and config/scope discovery — resolves against the same injected root, so `omni-dev -C /other/repo git branch info` can no longer silently mix data from two locations.

Implements #967 in full: all nine planned vertical slices plus the retirement slice, landed as one reviewable cascade.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue
Fixes #967

## Changes Made

**Core Changes:**
- **Global flag (`src/cli.rs`):** add `--repo`/`-C <PATH>` (`global = true`), resolved once in `Cli::execute` and passed as `Option<&Path>` into the git dispatch cascade. Deliberately **not** added to `propagate_global_flags` — it stays a parameter, not an ambient global.
- **Injection-type rule applied throughout:** libgit2 operations take `&GitRepository`; subprocess (`git`/`gh`) and relative file reads take `repo_root: &Path` (the opened repo's `workdir()`).
- **`git branch info` (`src/cli/git/info.rs`):** `run_info` derives `repo_root` once and anchors the PR-template read, branch-PR (`gh pr list`), and AI-scratch reads to it — closing the silent-mix gap.
- **`coverage diff` (`src/cli/coverage/diff.rs`):** delete the colliding local `--repo`, thread the injected repo through `run`/`load_report`, and anchor relative report paths to the repo root.
- **`git commit message view` (`src/cli/git/view.rs`) + `git://` MCP resource (`src/mcp/resources.rs`, `server.rs`):** thread the injected path into `run_view`; `read_resource` takes an explicit `repo_root` and opens there.
- **`git commit message staged` (`src/cli/git/staged.rs`):** replace `CwdGuard` with a once-resolved `repo_root`; every git subprocess (`diff --cached --quiet`, `diff --cached`, `commit`) sets `.current_dir(repo_root)`; config/scope reads anchored.
- **`git commit message check` (`src/cli/git/check.rs`):** thread `repo_root` through both the CLI and shared/MCP paths; anchor git2 open, AI-scratch, and context-dir resolution.
- **`git commit message amend` + `AmendmentHandler` (`src/git/amendment.rs`):** `AmendmentHandler` gains a `repo_root` field; all 11 `git` subprocesses (commit `--amend`, the rebase flow, the four `rebase --abort` cleanups) routed through a `git_command` helper pinning `.current_dir(repo_root)`.
- **`git commit message twiddle` (`src/cli/git/twiddle.rs`):** thread `repo_root` through the full call graph in both entry paths; flip the `.` compat shims left for the amend slice to the real root.
- **`git branch create pr` (`src/cli/git/create_pr.rs`):** the deepest tree — thread `repo_root` through PR generation, push, template read, and both `gh` subprocesses (`gh pr create`/`gh pr edit`).
- **Preflight & remote (`src/utils/preflight.rs`, `src/git/remote.rs`):** `check_*_prerequisites` / `check_github_cli` take `repo_root` and verify the injected repo; `gh repo view` pinned to the repo workdir.
- **Config/scratch seam (`src/utils/ai_scratch.rs`, `src/claude/context/discovery.rs`):** add path-taking `get_ai_scratch_dir_at` and `resolve_context_dir_at`; `load_project_scopes`/`ProjectDiscovery::new` seeded with `repo_root` instead of `PathBuf::from(".")`.
- **Retirement (`src/cli/git.rs`, `src/git/repository.rs`, `src/utils/preflight.rs`):** delete `CwdGuard`, `CWD_MUTEX`, the no-arg `GitRepository::open()` (the last `Repository::open(".")`), and the no-arg preflight wrappers. `view`/`info` defaults now resolve `env::current_dir()` once at the boundary and open via `open_at`.

**Documentation:**
- Inline notes documenting the two deliberate exceptions (see Known Limitations).

**Testing:**
- Converted the `info`, `staged`, `check`, `amend`, `twiddle`, and `create_pr` tests off the `CwdGuard` / `CWD_MUTEX` / `set_current_dir` dance to the path seam.
- Added per-command **"no silent mix"** negative tests: a template/config/diff placed in the process CWD and a *different* one in the injected repo, asserting only the injected one is read.
- Regenerated `tests/snapshots/integration_test__help_all_output.snap` for the new global flag and the removed coverage `--repo`.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes
- [x] Backward compatibility

Suggested review order (matches the slice progression):
1. `src/cli.rs` — the flag, where CWD is resolved once, and how `Option<&Path>` threads.
2. `src/cli/git/info.rs` + `src/utils/ai_scratch.rs` — the pattern-proving slice and the config/scratch seam.
3. `src/git/amendment.rs` — the `git_command` `.current_dir` helper and the 11 subprocess call sites.
4. `src/cli/git/create_pr.rs` — the deepest call tree (most tempted by an ambient shortcut).
5. `src/cli/git.rs` + `src/git/repository.rs` — the retirement: confirm no no-arg opens or `CwdGuard` remain.

Key invariant to verify: **no command mixes injected-repo data with CWD-relative data.** The "no silent mix" tests are the guardrail.

## Security Considerations
- [x] No security implications

`gh` subprocesses are now pinned to the injected repo workdir via `.current_dir(repo_root)` rather than inheriting an ambient CWD, which is marginally more predictable; no auth/token/data-handling surfaces change.

## Breaking Changes

**Backward Compatibility:**
- No user-facing breaking change. When `--repo`/`-C` is omitted, CWD remains the default (resolved once at the boundary), so existing invocations behave identically.
- `coverage diff` previously had a *local* `--repo`; it is now satisfied by the global `--repo`. The flag name and behavior are preserved from the user's perspective.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Known Limitations (deliberate, documented inline):**
- The `--verbose` `show_model_info` banner in `check`/`twiddle`/`create_pr` stays CWD-scoped — it reads the process-wide model catalog via the `OnceLock` registry, is informational only, and does not affect any command verdict. Deferred to a future repo-aware `ModelRegistry::load_at`.
- One path-less `git://` MCP wire test keeps resolving CWD at the in-process server boundary; its URI carries no per-call path. Retiring it needs a configurable server workdir, out of scope for #967.
- The `$EDITOR` launch (twiddle/create_pr) stays PATH-based by design.
- `.claude/settings`, `.claude/commands`, skills, and model-catalog reads are reached only through non-git command arms that do not honor `--repo`, so they keep their current behavior.

**Acceptance criteria from #967 — all met:**
- No production `Repository::open(".")`, no-arg `GitRepository::open()`, or `env::current_dir()` for repo/config location.
- Repo location passed as a parameter — no relocated global (no `static`/`OnceCell`/thread-local/env var).
- Per-command consistency: every read a `--repo`-honoring command performs resolves against the injected path.
- All `git`/`gh` subprocesses set `.current_dir(...)` explicitly.
- `CwdGuard` and the `CWD_MUTEX` / `set_current_dir` test dance removed.
