### PR TITLE
refactor(cli, mcp): drop git commits resource

### DIFF
--- a/docs/contributing/adding-an-mcp-tool.md
+++ b/docs/contributing/adding-an-mcp-tool.md
@@ -118,7 +118,7 @@ the combined router automatically.
 
 Tools take parameters and return content; **resources** are URI-addressable
 content an MCP client fetches without a tool call (e.g.
-`omni-dev://specs/jfm`, `git://repo/commits/HEAD`). If your extension is
+`omni-dev://specs/jfm`, `jira://issue/PROJ-1`). If your extension is
 better modelled as a resource than a tool:
 
 1. Add a variant to `ResourceUri` and a parse arm in `ResourceUri::parse()`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -179,7 +179,6 @@ The server exposes URI-addressable content alongside tools.
 
 | URI template | Returns |
 |--------------|---------|
-| `git://repo/commits/{range}` | YAML commit analysis (mirrors `git_view_commits`) |
 | `jira://issue/{key}` | JIRA issue body as JFM markdown |
 | `jira://issue/{key}.adf` | JIRA issue body as ADF JSON |
 | `confluence://page/{id}` | Confluence page as JFM markdown |
@@ -236,9 +235,8 @@ restarting the MCP server.
   `RUST_LOG=omni_dev::mcp=trace`.
 - **"Failed to open git repository":** the assistant runs `omni-dev-mcp` with
   its own working directory. Tools that open a git repository use that
-  directory unless an explicit `repo_path` parameter (or a resource URI
-  placing you elsewhere) overrides it. Confirm the assistant launched the
-  server from inside the repo you expected.
+  directory unless an explicit `repo_path` parameter overrides it. Confirm the
+  assistant launched the server from inside the repo you expected.
 - **Tool not found:** confirm the binary was built with `--features mcp`.
   `omni-dev-mcp --help` should print without error if the build succeeded.
 - **Atlassian / Datadog tools return auth errors:** run the matching

--- a/src/cli/git/info.rs
+++ b/src/cli/git/info.rs
@@ -346,8 +346,8 @@ mod tests {
     }
 
     /// The injected `repo_path` fully determines the repository with no
-    /// dependence on the process current working directory (previously this
-    /// entered the temp repo via a `CwdGuard`; now the path is passed directly).
+    /// dependence on the process current working directory — the path is passed
+    /// directly rather than via any process-CWD mutation.
     #[test]
     fn run_info_uses_injected_repo_without_cwd() {
         let (temp_dir, _commits) = init_repo_with_commits();

--- a/src/cli/git/twiddle.rs
+++ b/src/cli/git/twiddle.rs
@@ -1942,9 +1942,10 @@ mod run_twiddle_tests {
     use crate::claude::test_utils::ConfigurableMockAiClient;
     use git2::{Repository, Signature};
 
-    /// With the `CwdGuard` retired, `run_twiddle` opens the injected repo via
-    /// `open_at`, so an invalid path errors with a git/repository error (the
-    /// `GitRepository::open_at` context) before any AI call.
+    /// `run_twiddle` opens the injected repo via `open_at` with no dependence
+    /// on the process working directory, so an invalid path errors with a
+    /// git/repository error (the `GitRepository::open_at` context) before any
+    /// AI call.
     #[tokio::test]
     async fn run_twiddle_invalid_repo_path_errors_before_ai() {
         let err = run_twiddle(

--- a/src/cli/resources.rs
+++ b/src/cli/resources.rs
@@ -111,8 +111,8 @@ mod tests {
     fn normalize_id_does_not_strip_other_schemes() {
         assert_eq!(normalize_id("jira://issue/X-1"), "jira://issue/X-1");
         assert_eq!(
-            normalize_id("git://repo/commits/HEAD"),
-            "git://repo/commits/HEAD"
+            normalize_id("confluence://page/12345"),
+            "confluence://page/12345"
         );
     }
 

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -24,9 +24,8 @@ use crate::resources;
 
 /// Format suffix for a resource URI.
 ///
-/// `git://` URIs do not carry a format suffix (always YAML). Atlassian URIs
-/// accept an optional `.adf` suffix: absent means JFM markdown, present means
-/// raw ADF JSON.
+/// Atlassian URIs accept an optional `.adf` suffix: absent means JFM markdown,
+/// present means raw ADF JSON.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceFormat {
     /// JFM markdown (the default for Atlassian resources).
@@ -38,11 +37,6 @@ pub enum ResourceFormat {
 /// A parsed omni-dev resource URI.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceUri {
-    /// `git://repo/commits/{range}` — YAML commit analysis.
-    GitCommits {
-        /// A git revision range or single ref (e.g. `HEAD`, `HEAD~3..HEAD`).
-        range: String,
-    },
     /// `jira://issue/{key}` / `jira://issue/{key}.adf` — JIRA issue body.
     JiraIssue {
         /// JIRA issue key (e.g. `PROJ-123`).
@@ -68,9 +62,7 @@ pub enum ResourceUri {
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum UriParseError {
     /// The URI scheme is not one omni-dev knows about.
-    #[error(
-        "unknown URI scheme in `{0}`; expected git://, jira://, confluence://, or omni-dev://"
-    )]
+    #[error("unknown URI scheme in `{0}`; expected jira://, confluence://, or omni-dev://")]
     UnknownScheme(String),
     /// The URI authority/path shape does not match any known template.
     #[error("malformed URI `{0}`: {1}")]
@@ -85,15 +77,6 @@ impl ResourceUri {
     ///
     /// Rejects URIs that do not match one of the known templates.
     pub fn parse(uri: &str) -> Result<Self, UriParseError> {
-        if let Some(rest) = uri.strip_prefix("git://repo/commits/") {
-            if rest.is_empty() {
-                return Err(UriParseError::EmptyIdentifier(uri.to_string()));
-            }
-            return Ok(Self::GitCommits {
-                range: rest.to_string(),
-            });
-        }
-
         if let Some(rest) = uri.strip_prefix("jira://issue/") {
             let (key, format) = split_suffix(rest);
             if key.is_empty() {
@@ -128,12 +111,6 @@ impl ResourceUri {
         // Reject `<scheme>://` URIs with a different path shape explicitly
         // rather than falling through to UnknownScheme, so the client sees
         // what's actually wrong. Placeholders are escaped for the lint.
-        if uri.starts_with("git://") {
-            return Err(UriParseError::Malformed(
-                uri.to_string(),
-                "expected `git://repo/commits/<range>`",
-            ));
-        }
         if uri.starts_with("jira://") {
             return Err(UriParseError::Malformed(
                 uri.to_string(),
@@ -183,13 +160,6 @@ fn specs_only_csv() -> String {
 /// Returned by `list_resource_templates`. URIs are RFC 6570 templates; the
 /// placeholders match the identifiers [`ResourceUri::parse`] understands.
 pub fn resource_templates() -> Vec<ResourceTemplate> {
-    let git_commits = RawResourceTemplate::new("git://repo/commits/{range}", "git_commits")
-        .with_description(
-            "YAML commit analysis for a git range (e.g. `HEAD`, `HEAD~3..HEAD`). \
-             Backed by the same core as `omni-dev git commit message view`.",
-        )
-        .with_mime_type("application/yaml");
-
     let jira_issue_jfm = RawResourceTemplate::new("jira://issue/{key}", "jira_issue_jfm")
         .with_description("JIRA issue rendered as JFM (JIRA-flavoured markdown).")
         .with_mime_type("text/markdown");
@@ -217,7 +187,6 @@ pub fn resource_templates() -> Vec<ResourceTemplate> {
         .with_mime_type("text/markdown");
 
     vec![
-        annotate_template(git_commits),
         annotate_template(jira_issue_jfm),
         annotate_template(jira_issue_adf),
         annotate_template(confluence_page_jfm),
@@ -269,29 +238,8 @@ pub fn resource_listing() -> Vec<Resource> {
 }
 
 /// Resolves a parsed URI into [`ReadResourceResult`] contents.
-///
-/// `repo_root` is the repository location resolved once at the MCP boundary;
-/// the `git://` arm opens the repository there instead of reading the ambient
-/// process CWD. Non-git arms ignore it.
-pub async fn read_resource(
-    uri: &ResourceUri,
-    raw_uri: &str,
-    repo_root: &std::path::Path,
-) -> Result<ReadResourceResult> {
+pub async fn read_resource(uri: &ResourceUri, raw_uri: &str) -> Result<ReadResourceResult> {
     match uri {
-        ResourceUri::GitCommits { range } => {
-            let range = range.clone();
-            let repo_root = repo_root.to_path_buf();
-            let yaml = tokio::task::spawn_blocking(move || {
-                crate::cli::git::run_view(&range, Some(&repo_root))
-            })
-            .await
-            .context("git run_view task panicked")??;
-            Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                yaml, raw_uri,
-            )
-            .with_mime_type("application/yaml")]))
-        }
         ResourceUri::JiraIssue { key, format } => {
             let (client, instance_url) =
                 create_client().context("Failed to load Atlassian credentials")?;
@@ -398,39 +346,6 @@ mod tests {
     // ── Parser ─────────────────────────────────────────────────────
 
     #[test]
-    fn parse_git_commits_head() {
-        let uri = ResourceUri::parse("git://repo/commits/HEAD").unwrap();
-        assert_eq!(
-            uri,
-            ResourceUri::GitCommits {
-                range: "HEAD".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn parse_git_commits_range() {
-        let uri = ResourceUri::parse("git://repo/commits/HEAD~3..HEAD").unwrap();
-        assert_eq!(
-            uri,
-            ResourceUri::GitCommits {
-                range: "HEAD~3..HEAD".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn parse_git_commits_triple_dot_range() {
-        let uri = ResourceUri::parse("git://repo/commits/main...feature").unwrap();
-        assert_eq!(
-            uri,
-            ResourceUri::GitCommits {
-                range: "main...feature".to_string(),
-            }
-        );
-    }
-
-    #[test]
     fn parse_jira_issue_jfm() {
         let uri = ResourceUri::parse("jira://issue/PROJ-123").unwrap();
         assert_eq!(
@@ -514,19 +429,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_git_wrong_path_is_malformed() {
-        let err = ResourceUri::parse("git://repo/bogus").unwrap_err();
-        match err {
-            UriParseError::Malformed(ref uri, reason) => {
-                assert_eq!(uri, "git://repo/bogus");
-                assert!(reason.contains("git://repo/commits/"));
-                assert!(err.to_string().contains("git://repo/bogus"));
-            }
-            other => panic!("expected Malformed, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn parse_jira_wrong_path_is_malformed() {
         let err = ResourceUri::parse("jira://board/123").unwrap_err();
         assert!(matches!(err, UriParseError::Malformed(_, _)));
@@ -536,12 +438,6 @@ mod tests {
     fn parse_confluence_wrong_path_is_malformed() {
         let err = ResourceUri::parse("confluence://space/ENG").unwrap_err();
         assert!(matches!(err, UriParseError::Malformed(_, _)));
-    }
-
-    #[test]
-    fn parse_empty_git_range_is_empty_identifier() {
-        let err = ResourceUri::parse("git://repo/commits/").unwrap_err();
-        assert!(matches!(err, UriParseError::EmptyIdentifier(_)));
     }
 
     #[test]
@@ -578,7 +474,6 @@ mod tests {
             .iter()
             .map(|t| t.raw.uri_template.as_str())
             .collect();
-        assert!(template_uris.contains(&"git://repo/commits/{range}"));
         assert!(template_uris.contains(&"jira://issue/{key}"));
         assert!(template_uris.contains(&"jira://issue/{key}.adf"));
         assert!(template_uris.contains(&"confluence://page/{id}"));
@@ -617,14 +512,14 @@ mod tests {
     fn list_resources_result_has_no_pagination() {
         let result = list_resources_result();
         assert!(result.next_cursor.is_none());
-        assert_eq!(result.resources.len(), 6);
+        assert_eq!(result.resources.len(), 5);
     }
 
     #[test]
     fn list_resource_templates_result_has_no_pagination() {
         let result = list_resource_templates_result();
         assert!(result.next_cursor.is_none());
-        assert_eq!(result.resource_templates.len(), 6);
+        assert_eq!(result.resource_templates.len(), 5);
     }
 
     // ── not_found ──────────────────────────────────────────────────
@@ -694,69 +589,6 @@ mod tests {
         let (text, _) =
             render_content_item(&item, "https://org.atlassian.net", ResourceFormat::Adf).unwrap();
         assert_eq!(text.trim(), "null");
-    }
-
-    // ── read_resource (git path only; Atlassian paths need creds) ──
-
-    use git2::{Repository, Signature};
-
-    fn init_tmp_repo() -> tempfile::TempDir {
-        let tmp_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tmp");
-        std::fs::create_dir_all(&tmp_root).unwrap();
-        let temp_dir = tempfile::tempdir_in(&tmp_root).unwrap();
-        let repo = Repository::init(temp_dir.path()).unwrap();
-        {
-            let mut config = repo.config().unwrap();
-            config.set_str("user.name", "Test").unwrap();
-            config.set_str("user.email", "test@example.com").unwrap();
-        }
-        let signature = Signature::now("Test", "test@example.com").unwrap();
-        std::fs::write(temp_dir.path().join("f.txt"), "x").unwrap();
-        let mut idx = repo.index().unwrap();
-        idx.add_path(std::path::Path::new("f.txt")).unwrap();
-        idx.write().unwrap();
-        let tree_id = idx.write_tree().unwrap();
-        let tree = repo.find_tree(tree_id).unwrap();
-        repo.commit(
-            Some("HEAD"),
-            &signature,
-            &signature,
-            "feat: seed",
-            &tree,
-            &[],
-        )
-        .unwrap();
-        temp_dir
-    }
-
-    // `read_resource` resolves the `git://` repo from the injected `repo_root`,
-    // so the test passes the temp repo path directly — no CWD manipulation.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn read_resource_git_commits_returns_yaml() {
-        let temp_dir = init_tmp_repo();
-
-        let uri = ResourceUri::parse("git://repo/commits/HEAD").unwrap();
-        let result = read_resource(&uri, "git://repo/commits/HEAD", temp_dir.path()).await;
-
-        let result = result.unwrap();
-        let contents = result.contents;
-        assert_eq!(contents.len(), 1);
-        match &contents[0] {
-            ResourceContents::TextResourceContents {
-                text,
-                mime_type,
-                uri: reply_uri,
-                ..
-            } => {
-                assert!(text.contains("commits:"), "yaml missing commits: {text}");
-                assert!(text.contains("feat: seed"), "yaml missing subject: {text}");
-                assert_eq!(mime_type.as_deref(), Some("application/yaml"));
-                assert_eq!(reply_uri, "git://repo/commits/HEAD");
-            }
-            other @ ResourceContents::BlobResourceContents { .. } => {
-                panic!("expected text resource contents, got {other:?}")
-            }
-        }
     }
 
     // ── Atlassian branches of read_resource ────────────────────────
@@ -829,9 +661,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/PROJ-7").unwrap();
-        let result = read_resource(&uri, "jira://issue/PROJ-7", std::path::Path::new("."))
-            .await
-            .unwrap();
+        let result = read_resource(&uri, "jira://issue/PROJ-7").await.unwrap();
         assert_eq!(result.contents.len(), 1);
         match &result.contents[0] {
             ResourceContents::TextResourceContents {
@@ -886,7 +716,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/PROJ-8.adf").unwrap();
-        let result = read_resource(&uri, "jira://issue/PROJ-8.adf", std::path::Path::new("."))
+        let result = read_resource(&uri, "jira://issue/PROJ-8.adf")
             .await
             .unwrap();
         match &result.contents[0] {
@@ -921,7 +751,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("jira://issue/NOPE-1").unwrap();
-        let err = read_resource(&uri, "jira://issue/NOPE-1", std::path::Path::new("."))
+        let err = read_resource(&uri, "jira://issue/NOPE-1")
             .await
             .expect_err("404 should surface as error");
         let chain = format!("{err:#}");
@@ -982,8 +812,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("confluence://page/99999").unwrap();
-        let result =
-            read_resource(&uri, "confluence://page/99999", std::path::Path::new(".")).await;
+        let result = read_resource(&uri, "confluence://page/99999").await;
         // We don't pin the exact rendered output (depends on internal ADF
         // rendering details), only that the branch ran and produced
         // TextResourceContents with the markdown MIME type.
@@ -1028,7 +857,7 @@ mod tests {
         ]);
 
         let uri = ResourceUri::parse("confluence://page/404404").unwrap();
-        let err = read_resource(&uri, "confluence://page/404404", std::path::Path::new("."))
+        let err = read_resource(&uri, "confluence://page/404404")
             .await
             .expect_err("404 should surface as error");
         let chain = format!("{err:#}");
@@ -1059,7 +888,7 @@ mod tests {
         std::env::set_var("HOME", std::env::temp_dir());
 
         let uri = ResourceUri::parse("jira://issue/ZZZ-1").unwrap();
-        let err = read_resource(&uri, "jira://issue/ZZZ-1", std::path::Path::new("."))
+        let err = read_resource(&uri, "jira://issue/ZZZ-1")
             .await
             .expect_err("missing credentials must error");
         let chain = format!("{err:#}");
@@ -1085,7 +914,7 @@ mod tests {
         std::env::set_var("HOME", std::env::temp_dir());
 
         let uri = ResourceUri::parse("confluence://page/0").unwrap();
-        let err = read_resource(&uri, "confluence://page/0", std::path::Path::new("."))
+        let err = read_resource(&uri, "confluence://page/0")
             .await
             .expect_err("missing credentials must error");
         let chain = format!("{err:#}");
@@ -1122,7 +951,7 @@ mod tests {
 
     #[test]
     fn uri_parse_error_variants_display_expected_messages() {
-        let malformed = UriParseError::Malformed("git://x".to_string(), "oops");
+        let malformed = UriParseError::Malformed("jira://x".to_string(), "oops");
         assert!(malformed.to_string().contains("oops"));
         let empty = UriParseError::EmptyIdentifier("jira://issue/".to_string());
         assert!(empty.to_string().contains("empty identifier"));
@@ -1154,9 +983,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_specs_jfm_returns_markdown() {
         let uri = ResourceUri::parse("omni-dev://specs/jfm").unwrap();
-        let result = read_resource(&uri, "omni-dev://specs/jfm", std::path::Path::new("."))
-            .await
-            .unwrap();
+        let result = read_resource(&uri, "omni-dev://specs/jfm").await.unwrap();
         assert_eq!(result.contents.len(), 1);
         match &result.contents[0] {
             ResourceContents::TextResourceContents {
@@ -1181,7 +1008,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_specs_unknown_name_errors() {
         let uri = ResourceUri::parse("omni-dev://specs/nope").unwrap();
-        let err = read_resource(&uri, "omni-dev://specs/nope", std::path::Path::new("."))
+        let err = read_resource(&uri, "omni-dev://specs/nope")
             .await
             .expect_err("unknown spec must error");
         let chain = format!("{err:#}");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -70,8 +70,8 @@ impl ServerHandler for OmniDevServer {
         .with_instructions(
             "omni-dev MCP server. Provides tools for git analysis, commit \
              improvement, and Atlassian integration. Resources expose \
-             URI-addressable content via `git://`, `jira://`, `confluence://`, \
-             and `omni-dev://` (e.g. `omni-dev://specs/jfm` for the \
+             URI-addressable content via `jira://`, `confluence://`, and \
+             `omni-dev://` (e.g. `omni-dev://specs/jfm` for the \
              JIRA-Flavoured Markdown reference — fetch before writing JIRA or \
              Confluence content).",
         )
@@ -101,20 +101,7 @@ impl ServerHandler for OmniDevServer {
         let uri = request.uri;
         let parsed =
             resources::ResourceUri::parse(&uri).map_err(|err| resources::not_found(&uri, err))?;
-        // Only the `git://` arm consults a repo; the server carries no per-call
-        // path and no configured workdir, so the process CWD is the canonical
-        // root. Resolve it once here for that arm (RULE 2) rather than letting
-        // `run_view` read the ambient CWD deeper in the call tree. Non-git arms
-        // ignore the value, so they get a placeholder and never touch the CWD.
-        let repo_root = match &parsed {
-            resources::ResourceUri::GitCommits { .. } => {
-                std::env::current_dir().map_err(|err| {
-                    resources::not_found(&uri, format!("failed to resolve repo root: {err}"))
-                })?
-            }
-            _ => std::path::PathBuf::from("."),
-        };
-        resources::read_resource(&parsed, &uri, &repo_root)
+        resources::read_resource(&parsed, &uri)
             .await
             .map_err(|err| resources::not_found(&uri, err))
     }

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1552,25 +1552,11 @@ async fn git_view_commits_default_range_is_head() -> Result<()> {
 
 // ─── Resources ──────────────────────────────────────────────────────
 
-/// Serialises the CWD swap in `read_resource_git_commits_head_returns_yaml`.
-///
-/// This is the one intentional CWD-mutating test left after #967: the
-/// path-less `git://repo/commits/HEAD` wire URI carries no per-call repo path,
-/// so the in-process MCP server resolves the repository from its own current
-/// working directory at the boundary (`server.rs`). Pointing it at a temp repo
-/// therefore requires swapping the process CWD. Retiring this would need a
-/// configurable server workdir — a separate feature, out of scope for #967.
-static CWD_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 #[tokio::test]
 async fn list_resources_returns_all_uri_templates() -> Result<()> {
     let (client, server_handle) = spawn_server().await;
     let listing = client.list_resources(Option::default()).await?;
     let uris: Vec<&str> = listing.resources.iter().map(|r| r.uri.as_str()).collect();
-    assert!(
-        uris.contains(&"git://repo/commits/{range}"),
-        "got: {uris:?}"
-    );
     assert!(uris.contains(&"jira://issue/{key}"));
     assert!(uris.contains(&"jira://issue/{key}.adf"));
     assert!(uris.contains(&"confluence://page/{id}"));
@@ -1585,7 +1571,7 @@ async fn list_resources_returns_all_uri_templates() -> Result<()> {
 async fn list_resource_templates_returns_descriptions() -> Result<()> {
     let (client, server_handle) = spawn_server().await;
     let listing = client.list_resource_templates(Option::default()).await?;
-    assert_eq!(listing.resource_templates.len(), 6);
+    assert_eq!(listing.resource_templates.len(), 5);
     for tpl in &listing.resource_templates {
         assert!(
             tpl.description.is_some(),
@@ -1603,56 +1589,6 @@ async fn list_resource_templates_returns_descriptions() -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::await_holding_lock)]
-#[tokio::test(flavor = "multi_thread")]
-async fn read_resource_git_commits_head_returns_yaml() -> Result<()> {
-    let mut repo = TestRepo::new()?;
-    repo.add_commit("feat: first resource", "r1")?;
-
-    // The resource handler reads from CWD (no repo_path in the URI), so
-    // swap CWD for the duration of the call. Hold `CWD_MUTEX` across the
-    // await to keep other tests from racing. Safe here because the work
-    // inside `read_resource` is CPU-bound `spawn_blocking`.
-    {
-        let _guard = CWD_MUTEX.lock().unwrap();
-        let original_cwd = std::env::current_dir()?;
-        std::env::set_current_dir(&repo.repo_path)?;
-
-        let (client, server_handle) = spawn_server().await;
-        let result = client
-            .read_resource(ReadResourceRequestParams::new("git://repo/commits/HEAD"))
-            .await;
-
-        std::env::set_current_dir(&original_cwd)?;
-
-        let result = result?;
-        assert_eq!(result.contents.len(), 1);
-        match &result.contents[0] {
-            ResourceContents::TextResourceContents {
-                text,
-                mime_type,
-                uri,
-                ..
-            } => {
-                assert!(text.contains("commits:"), "missing commits section: {text}");
-                assert!(
-                    text.contains("feat: first resource"),
-                    "missing commit subject: {text}"
-                );
-                assert_eq!(mime_type.as_deref(), Some("application/yaml"));
-                assert_eq!(uri, "git://repo/commits/HEAD");
-            }
-            other @ ResourceContents::BlobResourceContents { .. } => {
-                panic!("expected text, got: {other:?}")
-            }
-        }
-
-        client.cancel().await?;
-        let _ = server_handle.await;
-    }
-    Ok(())
-}
-
 #[tokio::test]
 async fn read_resource_unknown_scheme_is_resource_not_found() -> Result<()> {
     let (client, server_handle) = spawn_server().await;
@@ -1664,23 +1600,6 @@ async fn read_resource_unknown_scheme_is_resource_not_found() -> Result<()> {
     // Rendered error text comes through the protocol; it should name the URI.
     assert!(
         rendered.contains("ftp://example.com/foo"),
-        "missing uri in err: {rendered}"
-    );
-    client.cancel().await?;
-    let _ = server_handle.await;
-    Ok(())
-}
-
-#[tokio::test]
-async fn read_resource_malformed_git_uri_is_resource_not_found() -> Result<()> {
-    let (client, server_handle) = spawn_server().await;
-    let err = client
-        .read_resource(ReadResourceRequestParams::new("git://repo/bogus-path"))
-        .await
-        .expect_err("malformed git uri should error");
-    let rendered = err.to_string();
-    assert!(
-        rendered.contains("git://repo/bogus-path"),
         "missing uri in err: {rendered}"
     );
     client.cancel().await?;


### PR DESCRIPTION
## Description

This PR removes the `git://repo/commits/{range}` MCP resource URI and all associated infrastructure, simplifying the resource layer by eliminating the git-specific resource type. The resource system now consolidates exclusively on Atlassian (`jira://`, `confluence://`) and omni-dev (`omni-dev://`) URI schemes.

Git commit analysis capability is **not lost** — it remains fully available via the CLI (`omni-dev git commit message view`) and MCP tools (`git_view_commits`). This change only removes the URI-based resource interface for git commits.

The removal also cleans up a long-standing architectural awkwardness: the `git://` resource was the sole consumer of the `repo_root` parameter in `read_resource()` and required the server to resolve the process CWD at the MCP boundary. With it gone, the function signature simplifies and CWD-mutation concerns are eliminated from the resource layer entirely.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #971

## Changes Made

**Core Changes:**
- Removed `ResourceUri::GitCommits` variant and all parsing/matching logic from `src/mcp/resources.rs`
- Removed `git://repo/commits/{range}` entry from `resource_templates()` and `resource_listing()` (resource count drops from 6 to 5)
- Simplified `read_resource()` signature in `src/mcp/resources.rs` by removing the `repo_root: &std::path::Path` parameter (the `git://` arm was the only consumer)
- Removed git-specific malformed-URI guard (`uri.starts_with("git://")`) from `ResourceUri::parse()`
- Updated `UriParseError::UnknownScheme` error message to list only `jira://`, `confluence://`, and `omni-dev://`
- Simplified `src/mcp/server.rs` `read_resource` handler: removed the CWD-resolution block that matched on `ResourceUri::GitCommits` and forwarded `repo_root`; call site is now `resources::read_resource(&parsed, &uri)`
- Updated server instructions string in `src/mcp/server.rs` to omit `git://` from the listed URI schemes

**Documentation:**
- `docs/mcp.md`: removed `git://repo/commits/{range}` row from the resource URI reference table; updated troubleshooting note to remove the CWD-override caveat that applied only to git resources
- `docs/contributing/adding-an-mcp-tool.md`: replaced `git://repo/commits/HEAD` example with `jira://issue/PROJ-1` in the resources guidance section

**Testing:**
- Removed unit tests for git resource parsing: `parse_git_commits_head`, `parse_git_commits_range`, `parse_git_commits_triple_dot_range`, `parse_git_wrong_path_is_malformed`, `parse_empty_git_range_is_empty_identifier`
- Removed unit test `read_resource_git_commits_returns_yaml` and the `init_tmp_repo` helper from `src/mcp/resources.rs`
- Removed integration tests `read_resource_git_commits_head_returns_yaml` and `read_resource_malformed_git_uri_is_resource_not_found` from `tests/mcp_integration_test.rs`
- Removed the `CWD_MUTEX` static used to serialise CWD-swapping in the now-deleted git integration test
- Updated `list_resources_returns_all_uri_templates` to no longer assert presence of `git://repo/commits/{range}`
- Updated `list_resource_templates_returns_descriptions` count assertion from 6 to 5
- Updated `normalize_id_does_not_strip_other_schemes` in `src/cli/resources.rs` to use `confluence://page/12345` instead of `git://repo/commits/HEAD`
- Simplified test comments in `src/cli/git/info.rs` and `src/cli/git/twiddle.rs` that previously referenced the retired `CwdGuard` pattern
- Updated all `read_resource(...)` call sites in tests to use the new two-argument signature

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested error/edge cases
- [x] Backward compatibility verified (git commit analysis still available via CLI and MCP tools)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes
- [x] Backward compatibility

The key architectural question is whether any MCP clients are relying on `git://repo/commits/{range}` as a resource URI. Clients using the `git_view_commits` **tool** are unaffected; only clients fetching the resource URI directly will see a breaking change.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

The `git://repo/commits/{range}` MCP resource URI is removed. Any MCP client that calls `resources/read` with a `git://repo/commits/...` URI will now receive a `ResourceNotFound` error.

**Migration Required:**
1. Replace `resources/read` calls using `git://repo/commits/<range>` with an equivalent `git_view_commits` tool call supplying the same `range` parameter.
2. Update any resource listing logic that checks for or iterates over the `git://repo/commits/{range}` template — it is no longer returned by `resources/list` or `resources/templates/list`.

**Backward Compatibility:**
- The `git_view_commits` MCP tool is unaffected and provides identical commit-analysis output.
- The `omni-dev git commit message view` CLI command is unaffected.
- All Atlassian and omni-dev resource URIs continue to work exactly as before.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Keeping the resource but making it accept an optional `repo_path` query parameter — rejected because it added complexity and the tool interface already provides a clean, path-aware alternative.
- Gating removal behind a deprecation period — considered unnecessary given the resource was always a thin wrapper over the existing tool.