### PR TITLE
feat(coverage): scope diff/patch deltas to changed files by default

### DIFF
--- a/src/cli/coverage.rs
+++ b/src/cli/coverage.rs
@@ -53,6 +53,7 @@ mod tests {
                 fail_under_patch: None,
                 strip_prefix: None,
                 collapse_ranges: false,
+                all_files: false,
                 artifact_url: None,
                 run_url: None,
                 base_sha: None,

--- a/src/cli/coverage/diff.rs
+++ b/src/cli/coverage/diff.rs
@@ -7,7 +7,8 @@ use clap::{Parser, ValueEnum};
 use git2::Repository;
 
 use crate::coverage::{
-    analyze, default_base_ref, parse, render, DiffModel, Format, OutputFormat, RenderOptions,
+    analyze, default_base_ref, parse, render, DiffModel, DiffScope, Format, OutputFormat,
+    RenderOptions,
 };
 
 /// Coverage report format selector (CLI mirror of [`Format`] plus auto-detect).
@@ -102,6 +103,16 @@ pub struct DiffCommand {
     #[arg(long)]
     pub collapse_ranges: bool,
 
+    /// Report per-file deltas and indirect changes for ALL files, not just the
+    /// ones this diff touches.
+    ///
+    /// By default the project-delta and indirect-change sections are scoped to
+    /// files the diff modifies, because coverage is measured by two independent
+    /// test runs and lines in untouched files flip purely from run-to-run
+    /// variance. This flag restores the unscoped (noisier) report.
+    #[arg(long)]
+    pub all_files: bool,
+
     /// Link to the full coverage-summary artifact (markdown footer).
     #[arg(long, value_name = "URL")]
     pub artifact_url: Option<String>,
@@ -192,7 +203,12 @@ impl DiffCommand {
         };
 
         let diff = DiffModel::between(&repo, &base_ref, self.head_ref.as_deref())?;
-        let result = analyze(&head, &diff, baseline.as_ref());
+        let scope = if self.all_files {
+            DiffScope::All
+        } else {
+            DiffScope::DiffOnly
+        };
+        let result = analyze(&head, &diff, baseline.as_ref(), scope);
 
         let opts = self.render_options();
         let rendered = render(&result, &opts, self.format.into())?;
@@ -333,6 +349,7 @@ mod tests {
             fail_under_patch: None,
             strip_prefix: None,
             collapse_ranges: false,
+            all_files: false,
             artifact_url: None,
             run_url: None,
             base_sha: None,
@@ -430,6 +447,51 @@ mod tests {
         assert!(
             !cmd.run(Some(&repo)).unwrap().below_gate,
             "66.7% >= 50% should pass"
+        );
+    }
+
+    #[test]
+    fn all_files_scope_surfaces_untouched_file() {
+        // `a.rs` is unchanged between base and head, so the diff never touches
+        // it. Its coverage moves by a single line (2/4 → 3/4): a small enough
+        // net move that DiffOnly drops it as noise, but a 25 pp shift that the
+        // delta table renders once `--all-files` widens the scope to `All`.
+        let (_dir, repo, base) = repo_with_added_file();
+        let head = format!(
+            "SF:{a}\nDA:1,1\nDA:2,1\nDA:3,1\nDA:4,0\nend_of_record\n\
+             SF:{b}\nDA:1,1\nDA:2,0\nDA:3,4\nend_of_record\n",
+            a = repo.join("a.rs").display(),
+            b = repo.join("b.rs").display(),
+        );
+        let report = repo.join("head.lcov");
+        fs::write(&report, head).unwrap();
+        let baseline = repo.join("base.lcov");
+        fs::write(
+            &baseline,
+            format!(
+                "SF:{}\nDA:1,1\nDA:2,1\nDA:3,0\nDA:4,0\nend_of_record\n",
+                repo.join("a.rs").display()
+            ),
+        )
+        .unwrap();
+
+        // Default (DiffOnly): the untouched `a.rs` row is filtered out as noise.
+        let mut scoped = command(report.clone(), &base);
+        scoped.baseline_report = Some(baseline.clone());
+        let scoped_md = scoped.run(Some(&repo)).unwrap().rendered;
+        assert!(
+            !scoped_md.contains("`a.rs`"),
+            "DiffOnly must hide untouched a.rs"
+        );
+
+        // --all-files (All): the untouched `a.rs` row is now surfaced.
+        let mut all = command(report, &base);
+        all.baseline_report = Some(baseline);
+        all.all_files = true;
+        let all_md = all.run(Some(&repo)).unwrap().rendered;
+        assert!(
+            all_md.contains("`a.rs`"),
+            "All scope must surface untouched a.rs"
         );
     }
 

--- a/src/coverage/analysis.rs
+++ b/src/coverage/analysis.rs
@@ -18,6 +18,33 @@ use super::model::{CoverageReport, FileCoverage};
 /// A base-side → head-side line mapper used during indirect-change detection.
 type BaseToHead<'a> = Box<dyn Fn(u32) -> Option<u32> + 'a>;
 
+/// Minimum net covered-line change for an *unchanged* file (one the diff never
+/// touched) to be surfaced under [`DiffScope::DiffOnly`]. Small run-to-run flips
+/// (the usual cross-run measurement noise) stay below this; a real cross-file
+/// effect — e.g. a PR that removes a test, dropping a whole module's coverage —
+/// exceeds it and is reported in `notable_unchanged`.
+const NOTABLE_UNCHANGED_LINES: u64 = 10;
+
+/// Which files the project-delta and indirect-change sections report on.
+///
+/// Coverage is measured by running the test suite twice (baseline vs head), and
+/// that measurement is not perfectly reproducible — lines in code with any
+/// run-to-run variance flip even when the source is identical. Only changes in
+/// files the diff *touches* are causally attributable to the PR; everything else
+/// is measurement noise. `DiffOnly` (the default) reports only touched files,
+/// with a magnitude-gated note for substantially-moved unchanged files so real
+/// cross-file effects still surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiffScope {
+    /// Report deltas/indirect only for files the diff touches (plus the
+    /// `notable_unchanged` magnitude-gated note). The default.
+    #[default]
+    DiffOnly,
+    /// Report deltas/indirect for *all* files (legacy; includes the cross-run
+    /// measurement noise on files the PR never modified).
+    All,
+}
+
 /// Covered / uncovered tally over a set of lines.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PatchCoverage {
@@ -105,9 +132,17 @@ pub struct CoverageDiff {
     pub total_after: Option<f64>,
     /// Baseline project coverage percentage (requires a baseline).
     pub total_before: Option<f64>,
-    /// Per-file project deltas (requires a baseline).
+    /// Per-file project deltas (requires a baseline). Under [`DiffScope::DiffOnly`]
+    /// this lists only files the diff touched.
     pub file_deltas: Vec<FileDelta>,
-    /// Indirect coverage flips on unchanged lines (requires a baseline).
+    /// Files the diff did *not* touch whose coverage nonetheless moved by at
+    /// least [`NOTABLE_UNCHANGED_LINES`] covered lines (requires a baseline; only
+    /// populated under [`DiffScope::DiffOnly`]). These are flagged separately as
+    /// not attributable to the PR, so a real cross-file regression still shows
+    /// while small measurement-noise flips stay hidden.
+    pub notable_unchanged: Vec<FileDelta>,
+    /// Indirect coverage flips on unchanged lines (requires a baseline). Under
+    /// [`DiffScope::DiffOnly`] this lists only flips within files the diff touched.
     pub indirect: Vec<IndirectChange>,
 }
 
@@ -123,11 +158,12 @@ impl CoverageDiff {
     }
 }
 
-/// Runs the full attribution.
+/// Runs the full attribution at the given [`DiffScope`].
 pub fn analyze(
     head: &CoverageReport,
     diff: &DiffModel,
     baseline: Option<&CoverageReport>,
+    scope: DiffScope,
 ) -> CoverageDiff {
     let mut result = CoverageDiff {
         total_after: head.percent(),
@@ -139,8 +175,8 @@ pub fn analyze(
 
     if let Some(baseline) = baseline {
         result.total_before = baseline.percent();
-        project_delta(head, baseline, &mut result);
-        indirect_changes(head, baseline, diff, &mut result);
+        project_delta(head, baseline, diff, scope, &mut result);
+        indirect_changes(head, baseline, diff, scope, &mut result);
     }
 
     result
@@ -185,27 +221,59 @@ fn patch_coverage(head: &CoverageReport, diff: &DiffModel, result: &mut Coverage
         .sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 }
 
-/// Computes per-file and total project deltas against the baseline.
-fn project_delta(head: &CoverageReport, baseline: &CoverageReport, result: &mut CoverageDiff) {
+/// Computes per-file project deltas against the baseline.
+///
+/// Under [`DiffScope::DiffOnly`], a file the diff did not touch goes to
+/// `file_deltas` only if its coverage moved by at least
+/// [`NOTABLE_UNCHANGED_LINES`] covered lines (→ `notable_unchanged`); smaller
+/// moves are dropped as measurement noise.
+fn project_delta(
+    head: &CoverageReport,
+    baseline: &CoverageReport,
+    diff: &DiffModel,
+    scope: DiffScope,
+    result: &mut CoverageDiff,
+) {
     for (path, file) in &head.files {
-        result.file_deltas.push(FileDelta {
+        let delta = FileDelta {
             path: path.clone(),
             before: baseline.files.get(path).and_then(FileCoverage::percent),
             after: file.percent(),
-        });
+        };
+
+        if scope == DiffScope::All || diff.files.contains_key(path) {
+            result.file_deltas.push(delta);
+            continue;
+        }
+
+        // Untouched file under DiffOnly: surface only a substantial net move.
+        let covered_after = file.covered_lines();
+        let covered_before = baseline
+            .files
+            .get(path)
+            .map_or(0, FileCoverage::covered_lines);
+        let net = covered_after.abs_diff(covered_before);
+        if net >= NOTABLE_UNCHANGED_LINES {
+            result.notable_unchanged.push(delta);
+        }
     }
     result.file_deltas.sort_by(|a, b| a.path.cmp(&b.path));
+    result.notable_unchanged.sort_by(|a, b| a.path.cmp(&b.path));
 }
 
 /// Detects coverage flips on lines whose content did not change.
 ///
-/// Covers both changed files (aligned through their [`FileDiff`]) and entirely
-/// unchanged files (identity alignment), since coverage can shift on a file the
-/// diff never touched (e.g. a callee changed).
+/// Changed files are aligned through their [`FileDiff`]. Under [`DiffScope::All`],
+/// entirely-unchanged files are also compared by identity alignment; under
+/// [`DiffScope::DiffOnly`] (the default) they are skipped, because a per-line
+/// flip in a file the PR never touched is cross-run measurement noise, not a
+/// real change (its file-level move, if substantial, is reported via
+/// `notable_unchanged` instead).
 fn indirect_changes(
     head: &CoverageReport,
     baseline: &CoverageReport,
     diff: &DiffModel,
+    scope: DiffScope,
     result: &mut CoverageDiff,
 ) {
     // Index changed files by their base-side path.
@@ -224,9 +292,13 @@ fn indirect_changes(
                     fd.new_path.as_str(),
                     Box::new(move |l| fd.map_base_to_head(l)),
                 )
-            } else if head.files.contains_key(base_path) && !diff.files.contains_key(base_path) {
+            } else if scope == DiffScope::All
+                && head.files.contains_key(base_path)
+                && !diff.files.contains_key(base_path)
+            {
                 // File untouched by the diff: identity alignment. (A file added by
                 // the diff is excluded — its lines are direct, not indirect.)
+                // Only under `All` scope — otherwise these per-line flips are noise.
                 (base_path.as_str(), Box::new(Some))
             } else {
                 // Deleted in head — nothing to compare.
@@ -298,7 +370,7 @@ mod tests {
         // File has lines 1..4; the diff added lines 2 and 3.
         let head = report(&[("src/a.rs", &[(1, 1), (2, 1), (3, 0), (4, 1)])]);
         let diff = diff_added("src/a.rs", false, &[2, 3]);
-        let out = analyze(&head, &diff, None);
+        let out = analyze(&head, &diff, None, DiffScope::All);
         assert_eq!(
             out.patch,
             PatchCoverage {
@@ -315,7 +387,7 @@ mod tests {
         // Added lines 2 (uncovered), 5 (not instrumented — absent from report).
         let head = report(&[("src/a.rs", &[(1, 1), (2, 0)])]);
         let diff = diff_added("src/a.rs", false, &[2, 5]);
-        let out = analyze(&head, &diff, None);
+        let out = analyze(&head, &diff, None, DiffScope::All);
         assert_eq!(
             out.patch,
             PatchCoverage {
@@ -329,7 +401,7 @@ mod tests {
     fn new_file_patch_coverage() {
         let head = report(&[("src/new.rs", &[(1, 1), (2, 0), (3, 1)])]);
         let diff = diff_added("src/new.rs", true, &[1, 2, 3]);
-        let out = analyze(&head, &diff, None);
+        let out = analyze(&head, &diff, None, DiffScope::All);
         assert_eq!(
             out.patch,
             PatchCoverage {
@@ -346,7 +418,7 @@ mod tests {
         let baseline = report(&[("src/a.rs", &[(1, 1), (2, 0)])]); // 50%
         let head = report(&[("src/a.rs", &[(1, 1), (2, 1)])]); // 100%
         let diff = diff_added("src/a.rs", false, &[2]);
-        let out = analyze(&head, &diff, Some(&baseline));
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::All);
         assert!(out.has_baseline);
         assert_eq!(out.total_before, Some(50.0));
         assert_eq!(out.total_after, Some(100.0));
@@ -359,7 +431,7 @@ mod tests {
         let baseline = report(&[]);
         let head = report(&[("src/new.rs", &[(1, 1)])]);
         let diff = diff_added("src/new.rs", true, &[1]);
-        let out = analyze(&head, &diff, Some(&baseline));
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::All);
         assert_eq!(out.file_deltas[0].before, None);
         assert_eq!(out.file_deltas[0].after, Some(100.0));
     }
@@ -370,7 +442,7 @@ mod tests {
         let baseline = report(&[("src/b.rs", &[(5, 3)])]);
         let head = report(&[("src/b.rs", &[(5, 0)])]);
         let diff = diff_added("src/a.rs", true, &[1]); // unrelated change
-        let out = analyze(&head, &diff, Some(&baseline));
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::All);
         assert_eq!(out.indirect.len(), 1);
         assert_eq!(out.indirect[0].path, "src/b.rs");
         assert_eq!(out.indirect[0].base_line, 5);
@@ -401,7 +473,7 @@ mod tests {
         let baseline = report(&[("src/b.rs", &[(5, 0)])]);
         let head = report(&[("src/b.rs", &[(5, 3)])]);
         let diff = diff_added("src/a.rs", true, &[1]);
-        let out = analyze(&head, &diff, Some(&baseline));
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::All);
         assert_eq!(out.indirect_newly_covered(), 1);
         assert!(out.indirect[0].became_covered);
     }
@@ -412,8 +484,64 @@ mod tests {
         let baseline = report(&[("src/a.rs", &[(1, 1)])]);
         let head = report(&[("src/a.rs", &[(1, 0)])]);
         let diff = diff_added("src/a.rs", true, &[1]); // new file → no old_path
-        let out = analyze(&head, &diff, Some(&baseline));
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::All);
         // New file has no base mapping, so no indirect entries from it.
         assert!(out.indirect.is_empty());
+    }
+
+    // ── DiffScope::DiffOnly (noise filter) ──
+
+    #[test]
+    fn diff_only_suppresses_untouched_file_indirect() {
+        // Same as indirect_change_on_unchanged_file, but DiffOnly drops the flip.
+        let baseline = report(&[("src/b.rs", &[(5, 3)])]);
+        let head = report(&[("src/b.rs", &[(5, 0)])]);
+        let diff = diff_added("src/a.rs", true, &[1]); // unrelated change
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::DiffOnly);
+        assert!(
+            out.indirect.is_empty(),
+            "an untouched-file flip is cross-run noise under DiffOnly"
+        );
+        // A one-line move is below the notable threshold → not surfaced.
+        assert!(out.notable_unchanged.is_empty());
+    }
+
+    #[test]
+    fn diff_only_delta_table_scoped_to_changed_files() {
+        let baseline = report(&[
+            ("src/a.rs", &[(1, 1), (2, 0)]),
+            ("src/b.rs", &[(1, 1), (2, 1)]),
+        ]);
+        let head = report(&[
+            ("src/a.rs", &[(1, 1), (2, 1)]),
+            ("src/b.rs", &[(1, 1), (2, 0)]),
+        ]);
+        let diff = diff_added("src/a.rs", false, &[2]); // only a.rs is touched
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::DiffOnly);
+        let paths: Vec<&str> = out.file_deltas.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(paths, vec!["src/a.rs"], "only the changed file appears");
+        assert!(out.notable_unchanged.is_empty(), "b.rs moved < threshold");
+    }
+
+    #[test]
+    fn diff_only_surfaces_substantial_unchanged_move() {
+        // An untouched file loses 12 covered lines (e.g. its only test was removed).
+        let before: Vec<(u32, u64)> = (1..=12).map(|n| (n, 1)).collect();
+        let after: Vec<(u32, u64)> = (1..=12).map(|n| (n, 0)).collect();
+        let baseline = report(&[("src/c.rs", &before)]);
+        let head = report(&[("src/c.rs", &after)]);
+        let diff = diff_added("src/a.rs", true, &[1]); // unrelated
+        let out = analyze(&head, &diff, Some(&baseline), DiffScope::DiffOnly);
+        assert!(out.file_deltas.is_empty(), "c.rs is not in the diff");
+        assert_eq!(
+            out.notable_unchanged.len(),
+            1,
+            "12-line drop exceeds threshold"
+        );
+        assert_eq!(out.notable_unchanged[0].path, "src/c.rs");
+        assert!(
+            out.indirect.is_empty(),
+            "per-line indirect still suppressed"
+        );
     }
 }

--- a/src/coverage/mod.rs
+++ b/src/coverage/mod.rs
@@ -22,7 +22,7 @@ pub mod llvm_json;
 pub mod model;
 pub mod render;
 
-pub use analysis::{analyze, CoverageDiff};
+pub use analysis::{analyze, CoverageDiff, DiffScope};
 pub use diff::{default_base_ref, DiffModel};
 pub use format::{parse, Format};
 pub use model::{CoverageReport, FileCoverage};

--- a/src/coverage/render.rs
+++ b/src/coverage/render.rs
@@ -173,6 +173,7 @@ fn render_markdown(diff: &CoverageDiff, opts: &RenderOptions) -> String {
 
     if diff.has_baseline {
         render_delta_table(diff, &mut out);
+        render_notable_unchanged(diff, &mut out);
     } else {
         out.push_str(
             "_No baseline available yet (first run, or the `main` baseline artifact was \
@@ -242,6 +243,40 @@ fn render_delta_table(diff: &CoverageDiff, out: &mut String) {
         ));
     }
     out.push('\n');
+}
+
+/// Renders the magnitude-gated note for unchanged files whose coverage moved
+/// substantially — flagged as *not* attributable to the PR (measurement variance
+/// or a cross-file effect like a removed test), kept collapsed so it does not
+/// crowd out the actionable sections.
+fn render_notable_unchanged(diff: &CoverageDiff, out: &mut String) {
+    if diff.notable_unchanged.is_empty() {
+        return;
+    }
+    out.push_str(&format!(
+        "<details><summary>ℹ️ {} unchanged file(s) also moved (not attributed to this PR)</summary>\n\n",
+        diff.notable_unchanged.len()
+    ));
+    out.push_str(
+        "These files were not modified by this diff; the shift is either measurement variance \
+         between the two runs or a cross-file effect (e.g. a removed test).\n\n",
+    );
+    out.push_str("| File | Before | After | Δ |\n");
+    out.push_str("|------|-------:|------:|---|\n");
+    for fd in &diff.notable_unchanged {
+        let change = match fd.delta() {
+            None => "🆕 new".to_string(),
+            Some(d) => format!("{} {} pp", arrow(d), fmt_num(d)),
+        };
+        out.push_str(&format!(
+            "| `{}` | {} | {} | {} |\n",
+            fd.path,
+            pct(fd.before),
+            pct(fd.after),
+            change
+        ));
+    }
+    out.push_str("\n</details>\n\n");
 }
 
 fn render_patch_section(diff: &CoverageDiff, opts: &RenderOptions, out: &mut String) {
@@ -381,6 +416,10 @@ struct ProjectDeltaView {
     total_before: Option<f64>,
     total_after: Option<f64>,
     files: Vec<FileDeltaView>,
+    /// Unchanged files (not touched by the diff) that nonetheless moved
+    /// substantially — flagged as not attributable to the PR.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    notable_unchanged: Vec<FileDeltaView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -432,19 +471,17 @@ impl CoverageDiffView {
             .collect();
 
         let (project_delta, indirect_changes) = if diff.has_baseline {
+            let file_delta_view = |fd: &crate::coverage::analysis::FileDelta| FileDeltaView {
+                path: fd.path.clone(),
+                before: fd.before.map(round2),
+                after: fd.after.map(round2),
+                delta: fd.delta().map(round2),
+            };
             let project_delta = ProjectDeltaView {
                 total_before: diff.total_before.map(round2),
                 total_after: diff.total_after.map(round2),
-                files: diff
-                    .file_deltas
-                    .iter()
-                    .map(|fd| FileDeltaView {
-                        path: fd.path.clone(),
-                        before: fd.before.map(round2),
-                        after: fd.after.map(round2),
-                        delta: fd.delta().map(round2),
-                    })
-                    .collect(),
+                files: diff.file_deltas.iter().map(file_delta_view).collect(),
+                notable_unchanged: diff.notable_unchanged.iter().map(file_delta_view).collect(),
             };
             let indirect_changes = IndirectView {
                 newly_covered: diff.indirect_newly_covered(),
@@ -704,6 +741,7 @@ mod tests {
                     after: None, // After renders as em dash
                 },
             ],
+            notable_unchanged: Vec::new(),
             indirect: Vec::new(),
         }
     }
@@ -794,5 +832,44 @@ mod tests {
 
         let yaml = render(&diff, &RenderOptions::default(), OutputFormat::Yaml).unwrap();
         assert!(yaml.contains("project_delta:"));
+    }
+
+    #[test]
+    fn markdown_renders_notable_unchanged_note() {
+        let mut diff = baseline_diff();
+        diff.notable_unchanged = vec![
+            FileDelta {
+                path: "src/other.rs".to_string(),
+                before: Some(80.0),
+                after: Some(60.0),
+            },
+            // Absent from the baseline → delta() is None → renders as "🆕 new".
+            FileDelta {
+                path: "src/fresh.rs".to_string(),
+                before: None,
+                after: Some(55.0),
+            },
+        ];
+        let md = render(&diff, &RenderOptions::default(), OutputFormat::Markdown).unwrap();
+        assert!(md.contains("unchanged file(s) also moved (not attributed to this PR)"));
+        assert!(md.contains("`src/other.rs`"));
+        assert!(md.contains("🔴 -20 pp"));
+        assert!(md.contains("| `src/fresh.rs` | — | 55% | 🆕 new |"));
+    }
+
+    #[test]
+    fn json_includes_notable_unchanged() {
+        let mut diff = baseline_diff();
+        diff.notable_unchanged = vec![FileDelta {
+            path: "src/other.rs".to_string(),
+            before: Some(80.0),
+            after: Some(60.0),
+        }];
+        let json = render(&diff, &RenderOptions::default(), OutputFormat::Json).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            value["project_delta"]["notable_unchanged"][0]["path"],
+            "src/other.rs"
+        );
     }
 }

--- a/tests/coverage_diff_test.rs
+++ b/tests/coverage_diff_test.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use git2::{Repository, Signature};
 use tempfile::TempDir;
 
-use omni_dev::coverage::{analyze, CoverageReport, DiffModel, FileCoverage};
+use omni_dev::coverage::{analyze, CoverageReport, DiffModel, DiffScope, FileCoverage};
 
 /// A temporary git repo whose commits each define the full file set (files
 /// omitted from a commit are removed), so renames and deletions work.
@@ -121,7 +121,7 @@ fn new_file_patch_coverage() -> Result<()> {
 
     // Head report: line 1 & 3 covered, line 2 uncovered.
     let head = cov(&[("b.rs", &[(1, 1), (2, 0), (3, 4)])]);
-    let result = analyze(&head, &diff, None);
+    let result = analyze(&head, &diff, None, DiffScope::DiffOnly);
     assert_eq!(result.patch.covered, 2);
     assert_eq!(result.patch.uncovered, 1);
     assert_eq!(result.uncovered_new_lines, vec![("b.rs".to_string(), 2)]);
@@ -142,7 +142,7 @@ fn modified_file_mixed_coverage() -> Result<()> {
 
     // New line 3 covered, new line 4 uncovered.
     let head = cov(&[("m.rs", &[(1, 1), (2, 1), (3, 1), (4, 0), (5, 1)])]);
-    let result = analyze(&head, &diff, None);
+    let result = analyze(&head, &diff, None, DiffScope::DiffOnly);
     assert_eq!(result.patch.covered, 1);
     assert_eq!(result.patch.uncovered, 1);
     assert_eq!(result.uncovered_new_lines, vec![("m.rs".to_string(), 4)]);
@@ -166,7 +166,7 @@ fn line_shift_detects_indirect_change() -> Result<()> {
     // Baseline: l3 covered. Head: same line (now line 5) uncovered.
     let baseline = cov(&[("s.rs", &[(3, 2)])]);
     let head = cov(&[("s.rs", &[(2, 1), (3, 1), (5, 0)])]);
-    let result = analyze(&head, &diff, Some(&baseline));
+    let result = analyze(&head, &diff, Some(&baseline), DiffScope::DiffOnly);
 
     assert_eq!(result.indirect.len(), 1, "expected one indirect flip");
     let change = &result.indirect[0];
@@ -194,7 +194,7 @@ fn rename_does_not_show_false_lost_coverage() -> Result<()> {
     // Same coverage before (old path) and after (new path) ⇒ no flips.
     let baseline = cov(&[("old.rs", &[(2, 1), (3, 1), (4, 1)])]);
     let head = cov(&[("new.rs", &[(2, 1), (3, 1), (4, 1)])]);
-    let result = analyze(&head, &diff, Some(&baseline));
+    let result = analyze(&head, &diff, Some(&baseline), DiffScope::DiffOnly);
     assert_eq!(result.patch.total(), 0, "a pure rename adds no lines");
     assert!(
         result.indirect.is_empty(),

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2193,6 +2193,8 @@ Options:
           Override the path prefix stripped from report file paths to make them repo-relative (default: the repository working directory)
       --collapse-ranges
           Collapse consecutive uncovered new lines into ranges (e.g. `9-11`)
+      --all-files
+          Report per-file deltas and indirect changes for ALL files, not just the ones this diff touches
       --artifact-url <URL>
           Link to the full coverage-summary artifact (markdown footer)
       --run-url <URL>


### PR DESCRIPTION
## Description

Coverage reports compare two independent instrumented test runs (baseline vs head). Because these runs are not perfectly reproducible, lines in files the PR never touched can flip between covered and uncovered purely from run-to-run variance. This surfaces as phantom per-file deltas and spurious "indirect coverage changes" for files entirely unrelated to the PR — making the report noisy and hard to act on.

This PR introduces `DiffScope::DiffOnly` as the default behaviour: the project-delta and indirect-change sections are scoped to files the diff actually touches. Real cross-file effects (e.g. a PR that removes a test, dropping a whole module's coverage) still surface via a magnitude-gated "notable unchanged files" note (threshold: ≥ 10 net covered lines), so only small measurement-noise flips are suppressed.

The legacy unscoped (noisier) report is still available via the new `--all-files` CLI flag.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

No issue linked — this is a quality-of-life improvement identified from real-world coverage report noise.

## Changes Made

**Core Analysis (`src/coverage/analysis.rs`):**
- Added `DiffScope` enum (`DiffOnly` [default], `All`) with doc-comments explaining the rationale
- Added `NOTABLE_UNCHANGED_LINES = 10` constant — minimum net covered-line change for an untouched file to be surfaced
- Added `notable_unchanged: Vec<FileDelta>` field to `CoverageDiff` — untouched files whose coverage moved substantially
- Updated `analyze()` signature to accept `scope: DiffScope`
- Updated `project_delta()` to route untouched files: small moves are dropped as noise; moves ≥ threshold go to `notable_unchanged`
- Updated `indirect_changes()` to skip identity-aligned (entirely unchanged) files under `DiffOnly`, since per-line flips there are cross-run noise

**CLI (`src/cli/coverage/diff.rs`, `src/cli/coverage.rs`):**
- Added `--all-files` flag to `DiffCommand` that sets `DiffScope::All`, restoring the unscoped (legacy) report
- Added descriptive help text explaining why the default scopes to diff-touched files

**Rendering (`src/coverage/render.rs`):**
- Added `render_notable_unchanged()` — renders a collapsed `<details>` summary for unchanged files that moved substantially, clearly labelled as not attributable to the PR
- Added `notable_unchanged: Vec<FileDeltaView>` to `ProjectDeltaView` (skipped in serialisation when empty)
- Refactored repeated `FileDeltaView` mapping into a shared closure in `CoverageDiffView::from()`
- Wired `render_notable_unchanged()` into the markdown render path alongside `render_delta_table()`

**Public API (`src/coverage/mod.rs`):**
- Re-exported `DiffScope` alongside `analyze` and `CoverageDiff`

**Tests (`tests/coverage_diff_test.rs`, `src/coverage/analysis.rs`, `src/coverage/render.rs`):**
- Updated all existing `analyze()` call-sites in unit and integration tests to pass explicit `DiffScope`
- Added `diff_only_suppresses_untouched_file_indirect` — verifies that a one-line flip on an untouched file is suppressed under `DiffOnly`
- Added `diff_only_delta_table_scoped_to_changed_files` — verifies `file_deltas` only contains diff-touched files; untouched file below threshold absent from `notable_unchanged`
- Added `diff_only_surfaces_substantial_unchanged_move` — verifies a 12-line drop on an untouched file appears in `notable_unchanged` while staying out of `file_deltas` and `indirect`
- Added `markdown_renders_notable_unchanged_note` — verifies the `<details>` collapse section appears with correct content
- Added `json_includes_notable_unchanged` — verifies `notable_unchanged` is serialised into JSON output

**Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help snapshot to include the new `--all-files` flag and its description

## Testing

**Automated Testing:**
- [x] All existing tests pass (updated `analyze()` call-sites with explicit `DiffScope` argument)
- [x] New tests added for new functionality (5 new tests covering DiffOnly suppression, scoping, notable threshold, and rendering)
- [x] Integration tests updated/added
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (DiffOnly default: delta table shows only touched files)
- [x] Tested error/edge cases (small untouched-file moves suppressed; large moves surfaced in collapsed note)
- [ ] Cross-platform testing (not applicable for this logic change)
- [x] Backward compatibility verified (`--all-files` restores legacy behaviour)

### Test Commands
```bash
# Core test suite
cargo test

# Run coverage-specific tests
cargo test coverage

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications — none
- [ ] Performance impact — negligible (extra filter pass over `file_deltas`)
- [x] Architecture changes — `DiffScope` now threads through `analyze`, `project_delta`, and `indirect_changes`; callers must pass scope explicitly
- [x] Error handling — `notable_unchanged` is empty by default; rendering guard is in place
- [ ] User experience — collapsed `<details>` keeps the actionable sections prominent while preserving visibility of real cross-file effects
- [x] Backward compatibility — `--all-files` restores the pre-existing unscoped report; no existing flags removed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact — the added filtering is a linear pass over `file_deltas` that was already being populated; negligible overhead

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- The `NOTABLE_UNCHANGED_LINES` threshold (currently 10) could be made configurable via a CLI flag if users find the default too aggressive or too lenient.
- The collapsed `<details>` note could include a link to docs explaining cross-run measurement variance for users unfamiliar with the concept.

**Known Limitations:**
- The notable-unchanged threshold is a fixed heuristic; it suppresses small measurement flips well but may occasionally hide a real 1–9 line regression in an untouched file.

**Alternatives Considered:**
- Keeping `DiffScope::All` as the default and making `DiffOnly` opt-in — rejected because the noise is confusing by default and `--all-files` provides an easy escape hatch.
- Removing indirect change reporting for untouched files entirely without the magnitude-gated note — rejected because real cross-file regressions (e.g. a removed test dropping a whole module's coverage) would become invisible.