### PR TITLE
chore(discovery): expand crates.io keywords, clap about, and docs.rs landing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.29.0"
 edition = "2021"
 authors = ["John Ky <newhoggy@gmail.com>"]
 license = "BSD-3-Clause"
-description = "A powerful Git commit message analysis and amendment toolkit"
+description = "AI-powered git commit rewriter, PR generator, and MCP server for Jira, Confluence, and Datadog."
 repository = "https://github.com/rust-works/omni-dev"
 homepage = "https://github.com/rust-works/omni-dev"
 documentation = "https://docs.rs/omni-dev"
 readme = "README.md"
-keywords = ["git", "commit", "conventional-commits", "development", "cli"]
+keywords = ["git", "ai", "claude", "mcp", "conventional-commits"]
 categories = ["development-tools", "command-line-utilities"]
 rust-version = "1.80.0"
 # Keep the published crate under crates.io's 10 MiB upload limit by dropping

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,7 +42,10 @@ pub enum AiBackend {
 /// before dispatching to a [`Commands`] variant.
 #[derive(Parser)]
 #[command(name = "omni-dev")]
-#[command(about = "A comprehensive development toolkit", long_about = None)]
+#[command(
+    about = "AI-powered git commit rewriter, PR generator, and MCP server for Jira, Confluence, and Datadog.",
+    long_about = None
+)]
 #[command(version)]
 pub struct Cli {
     /// Selects the AI backend used by commands that invoke an AI model.

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -182,7 +182,7 @@ mod tests {
         let gen = HelpGenerator::new();
         let help = gen.render_command_help(&gen.app, "");
         // The main app help should include the about text
-        assert!(help.contains("comprehensive development toolkit"));
+        assert!(help.contains("AI-powered git commit rewriter"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //!
 //! omni-dev is primarily a command-line tool; this crate also exposes the
 //! library types that power it for programmatic use. See the [`cli`] module
-//! for the command-line surface, and [`mcp`] (feature-gated) for the MCP
-//! server implementation.
+//! for the command-line surface, and the `mcp` module (gated on the `mcp`
+//! feature) for the MCP server implementation.
 //!
 //! ## Highlights
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,38 @@
 //! # omni-dev
 //!
-//! A comprehensive development toolkit written in Rust.
+//! AI-powered git commit rewriter, PR generator, and MCP server for Jira,
+//! Confluence, and Datadog.
 //!
-//! ## Features
+//! omni-dev is primarily a command-line tool; this crate also exposes the
+//! library types that power it for programmatic use. See the [`cli`] module
+//! for the command-line surface, and [`mcp`] (feature-gated) for the MCP
+//! server implementation.
 //!
-//! - Fast and efficient development tools
-//! - Extensible architecture
-//! - Memory safe and reliable
+//! ## Highlights
 //!
-//! ## Quick Start
+//! - Analyse and rewrite git commit messages with a configurable AI backend
+//!   (Anthropic API, AWS Bedrock, OpenAI, Ollama, or a local `claude` CLI
+//!   subprocess) — see [`claude`].
+//! - Generate pull-request titles and descriptions from branch history.
+//! - Read, edit, and create Jira issues and Confluence pages via JFM
+//!   (JIRA-Flavoured Markdown) — see [`atlassian`].
+//! - Query Datadog metrics, logs, monitors, and dashboards — see [`datadog`].
+//! - Expose every CLI capability as an MCP server for AI assistants by
+//!   enabling the `mcp` feature.
+//!
+//! ## Installation
+//!
+//! ```text
+//! cargo install omni-dev
+//! omni-dev --help
+//! ```
+//!
+//! ## Library example
 //!
 //! ```rust
-//! use omni_dev::*;
+//! use omni_dev::VERSION;
 //!
-//! println!("Hello from omni-dev!");
+//! println!("omni-dev v{VERSION}");
 //! ```
 
 #![warn(missing_docs)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -275,7 +275,7 @@ fn binary_help_flag_succeeds() {
         .expect("failed to run binary");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("comprehensive development toolkit"));
+    assert!(stdout.contains("AI-powered git commit rewriter"));
 }
 
 #[test]

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2,9 +2,9 @@
 source: tests/integration_test.rs
 expression: help_output
 ---
-omni-dev - A comprehensive development toolkit
+omni-dev - AI-powered git commit rewriter, PR generator, and MCP server for Jira, Confluence, and Datadog.
 
-A comprehensive development toolkit
+AI-powered git commit rewriter, PR generator, and MCP server for Jira, Confluence, and Datadog.
 
 Usage: omni-dev [OPTIONS] <COMMAND>
 


### PR DESCRIPTION
## Summary

Closes #835. Three discovery surfaces still described omni-dev as just a git-commit toolkit, hiding the AI/MCP/multi-backend scope. This PR aligns all three with the one-line pitch.

- **`Cargo.toml`** — replace `keywords` and `description`:
  - `keywords`: `["git", "commit", "conventional-commits", "development", "cli"]` → `["git", "ai", "claude", "mcp", "conventional-commits"]` (`development`/`cli` already covered by `categories`).
  - `description`: stale toolkit line → "AI-powered git commit rewriter, PR generator, and MCP server for Jira, Confluence, and Datadog."
- **`src/cli.rs`** — the clap top-level `#[command(about = ...)]` is the first line of every shell user's `--help`. Now matches the new pitch.
- **`src/lib.rs`** — the crate-root rustdoc is the docs.rs landing page. Replaced the generic placeholder with the pitch, feature highlights linking to the relevant modules, install snippet, and a passing public-API doctest.

Fallout:
- Two hardcoded assertions in `tests/integration_test.rs` and `src/cli/help.rs` that looked for the old banner string — updated to a distinctive substring of the new banner.
- `tests/snapshots/integration_test__help_all_output.snap` — regenerated via `cargo insta accept`; the only diff is the two banner lines.

## Notes

- The keyword change requires a version bump for crates.io to re-index, which will happen on the next release cut.
- `docs/plan/help-all-command.md` contains a historical example of the old banner — left untouched as a planning artefact.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo test` (4913 passed, 0 failed)
- [x] `cargo test --doc` (new lib.rs example passes)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Snapshot diff reviewed before `cargo insta accept`
- [ ] Visual check of `omni-dev --help` after merge
- [ ] Visual check of crates.io card and docs.rs landing after next release