### PR TITLE
feat(cli, lib): implement daemon infrastructure for long-lived services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +138,30 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -233,6 +276,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -253,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,10 +324,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "cc"
@@ -291,6 +383,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -326,7 +428,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -366,10 +468,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -377,6 +479,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -456,6 +567,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +618,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +658,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -548,7 +704,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -559,7 +715,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -567,6 +723,17 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "deadpool"
@@ -605,7 +772,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -651,6 +818,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +837,30 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -669,6 +871,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dunce"
@@ -778,10 +986,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
 
 [[package]]
 name = "filetime"
@@ -820,6 +1059,33 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -892,7 +1158,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -925,6 +1191,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkwayland-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1283,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -976,6 +1337,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "git2"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1378,53 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -998,6 +1438,69 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1017,6 +1520,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1052,6 +1566,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1195,7 +1715,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1322,6 +1842,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,10 +1975,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libappindicator"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
+dependencies = [
+ "gtk-sys",
+ "libloading",
+ "once_cell",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -1448,6 +2026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +2043,25 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
 ]
 
 [[package]]
@@ -1530,6 +2137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +2181,61 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "muda"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "once_cell",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys",
 ]
 
 [[package]]
@@ -1608,10 +2279,204 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "omni-dev"
 version = "0.29.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-trait",
  "axum",
  "base64",
@@ -1639,6 +2504,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "similar 3.1.1",
+ "tao",
  "tar",
  "tempfile",
  "termcolor",
@@ -1648,6 +2514,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tray-icon",
  "ureq",
  "url",
  "wiremock",
@@ -1679,6 +2546,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,7 +2590,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1732,6 +2624,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,7 +2661,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1788,10 +2746,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -1929,6 +2899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,7 +2941,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2088,7 +3064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2209,7 +3185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -2261,7 +3237,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2326,7 +3302,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2337,7 +3313,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2362,6 +3338,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2529,6 +3514,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2555,7 +3550,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2580,6 +3575,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "tao"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+dependencies = [
+ "bitflags",
+ "block2",
+ "core-foundation 0.10.1",
+ "core-graphics",
+ "crossbeam-channel",
+ "dbus",
+ "dispatch2",
+ "dlopen2",
+ "dpi",
+ "gdkwayland-sys",
+ "gdkx11-sys",
+ "gtk",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-sys",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "tao-macros",
+ "unicode-segmentation",
+ "url",
+ "windows",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +3648,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2638,7 +3703,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2649,7 +3714,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2659,6 +3724,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2711,7 +3790,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2758,6 +3837,81 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2826,7 +3980,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2866,6 +4020,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tray-icon"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
+dependencies = [
+ "crossbeam-channel",
+ "dirs",
+ "libappindicator",
+ "muda",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "once_cell",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3010,6 +4185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,7 +4303,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3221,6 +4402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +4439,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,9 +4481,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3272,7 +4505,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3283,8 +4516,14 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -3293,14 +4532,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3309,7 +4567,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3318,7 +4585,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3354,7 +4621,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3394,7 +4661,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3403,6 +4670,24 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3544,6 +4829,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,7 +4885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3593,10 +4896,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3612,7 +4915,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3661,6 +4964,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,7 +5040,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3720,7 +5061,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3740,7 +5081,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3780,7 +5121,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3788,3 +5129,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,22 @@ quick-xml = "0.40.1"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal", "user"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Menu-bar tray deps (enabled by the `menu-bar` feature). `muda` (the menu
+# library) is used via tray-icon's `tray_icon::menu` re-export, so it is not a
+# direct dependency. `tao` provides the main-thread macOS event loop the tray
+# requires; `arboard` backs the "Copy console snippet" clipboard action.
+arboard = { version = "3.6.1", optional = true }
+tao = { version = "0.35.3", optional = true }
+tray-icon = { version = "0.24.1", optional = true }
+
 [features]
 mcp = ["dep:rmcp"]
+# macOS menu-bar tray for the daemon. Off by default; the tray deps are
+# macOS-only (see the `[target.'cfg(target_os = "macos")']` table) and the tray
+# code is additionally gated on `cfg(target_os = "macos")`, so enabling this on
+# another platform is a no-op.
+menu-bar = ["dep:tray-icon", "dep:tao", "dep:arboard"]
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ureq = "3"
 quick-xml = "0.40.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
+nix = { version = "0.31", default-features = false, features = ["signal", "user"] }
 
 [features]
 mcp = ["dep:rmcp"]

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -9,7 +9,7 @@
 //! → control plane returns the HTTP response.
 
 use std::collections::{BTreeMap, HashMap};
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
@@ -284,6 +284,12 @@ impl BridgeServer {
         let max_body_bytes = config.max_body_bytes;
         let max_concurrent = config.max_concurrent;
 
+        // Also accept the WebSocket plane on IPv6 loopback (`::1`) at the same
+        // port, best-effort. A browser connecting to `ws://localhost` may resolve
+        // it to `::1` rather than `127.0.0.1`; binding both means the pasted
+        // snippet connects either way. Still loopback-only — ADR-0036 unchanged.
+        let ws_listener_v6 = TcpListener::bind((Ipv6Addr::LOCALHOST, ws_port)).await.ok();
+
         let state = AppState {
             token: Arc::new(token),
             config: Arc::new(config),
@@ -296,22 +302,13 @@ impl BridgeServer {
         let shutdown = CancellationToken::new();
         let mut tasks = JoinSet::new();
 
-        // WebSocket accept loop (cancellable).
-        let ws_state = state.clone();
-        let ws_shutdown = shutdown.clone();
-        tasks.spawn(async move {
-            loop {
-                tokio::select! {
-                    () = ws_shutdown.cancelled() => break,
-                    accepted = ws_listener.accept() => match accepted {
-                        Ok((stream, _peer)) => {
-                            tokio::spawn(handle_ws_conn(stream, ws_state.clone()));
-                        }
-                        Err(e) => tracing::warn!("WebSocket accept error: {e}"),
-                    },
-                }
-            }
-        });
+        // WebSocket accept loops (cancellable), one per bound loopback address.
+        spawn_ws_accept(&mut tasks, ws_listener, state.clone(), shutdown.clone());
+        if let Some(listener) = ws_listener_v6 {
+            spawn_ws_accept(&mut tasks, listener, state.clone(), shutdown.clone());
+        } else {
+            tracing::debug!("IPv6 loopback (::1) WebSocket bind unavailable; IPv4 only");
+        }
 
         // Control plane (axum) with graceful shutdown: drains in-flight requests
         // before the serve future resolves.
@@ -428,6 +425,30 @@ fn print_startup(config: &BridgeConfig, token: &str) {
 }
 
 // ── WebSocket plane ──────────────────────────────────────────────────
+
+/// Spawns a cancellable accept loop for one WebSocket-plane listener; each
+/// accepted connection is handled on its own task. Used once per bound loopback
+/// address (IPv4 and, when available, IPv6) feeding the shared [`AppState`].
+fn spawn_ws_accept(
+    tasks: &mut JoinSet<()>,
+    listener: TcpListener,
+    state: AppState,
+    shutdown: CancellationToken,
+) {
+    tasks.spawn(async move {
+        loop {
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                accepted = listener.accept() => match accepted {
+                    Ok((stream, _peer)) => {
+                        tokio::spawn(handle_ws_conn(stream, state.clone()));
+                    }
+                    Err(e) => tracing::warn!("WebSocket accept error: {e}"),
+                },
+            }
+        }
+    });
+}
 
 /// Handles one inbound TCP connection on the WebSocket plane: authenticates the
 /// upgrade, registers the connection, and pumps replies into the correlator.

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -28,8 +28,10 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use futures::{SinkExt, StreamExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, oneshot, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
 
 use crate::browser::auth;
 use crate::browser::protocol::{
@@ -37,6 +39,17 @@ use crate::browser::protocol::{
     ResponseEnvelope, StatusResponse, StreamItem, StreamLine, TabInfo,
 };
 use crate::browser::snippet;
+
+/// Default WebSocket-plane port.
+pub const DEFAULT_WS_PORT: u16 = 9999;
+/// Default HTTP control-plane port.
+pub const DEFAULT_CONTROL_PORT: u16 = 9998;
+/// Default per-request timeout, in seconds.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+/// Default maximum browser response body size (8 MiB).
+pub const DEFAULT_MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+/// Default maximum concurrent in-flight requests.
+pub const DEFAULT_MAX_CONCURRENT: usize = 64;
 
 /// Resolved runtime configuration for a bridge instance.
 #[derive(Debug, Clone)]
@@ -53,6 +66,21 @@ pub struct BridgeConfig {
     pub max_body_bytes: usize,
     /// Maximum number of concurrent in-flight requests.
     pub max_concurrent: usize,
+}
+
+impl Default for BridgeConfig {
+    /// The documented default ports and limits, shared by the `serve` CLI and
+    /// the daemon-hosted bridge so the two never drift.
+    fn default() -> Self {
+        Self {
+            ws_port: DEFAULT_WS_PORT,
+            control_port: DEFAULT_CONTROL_PORT,
+            request_timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            allow_origin: None,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            max_concurrent: DEFAULT_MAX_CONCURRENT,
+        }
+    }
 }
 
 /// A registered waiter for a given id: either a buffered one-shot (resolved by a
@@ -161,66 +189,220 @@ struct AppState {
     /// Connected tabs keyed by connection id (the public routing selector). A
     /// new authenticated connection never displaces an existing one — each lives
     /// under its own key — so the non-eviction guarantee holds per-connection.
-    tabs: Arc<Mutex<HashMap<u64, WsConn>>>,
+    ///
+    /// A `std::sync::Mutex` (not tokio's): the guard is never held across an
+    /// `.await`, so a synchronous lock keeps [`AppState::status_snapshot`] and
+    /// [`BridgeServer::disconnect_tab`] non-async — matching [`Correlator`].
+    tabs: Arc<StdMutex<HashMap<u64, WsConn>>>,
     in_flight: Arc<Semaphore>,
     conn_counter: Arc<AtomicU64>,
 }
 
+impl AppState {
+    /// Locks the tab registry, recovering from a poisoned mutex (mirrors
+    /// [`Correlator::lock`]).
+    fn lock_tabs(&self) -> std::sync::MutexGuard<'_, HashMap<u64, WsConn>> {
+        self.tabs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Builds a [`StatusResponse`] snapshot of the connected tabs and pending
+    /// request count. Shared by the `GET /__bridge/status` handler and
+    /// [`BridgeServer::status`] so neither makes an internal HTTP self-call.
+    fn status_snapshot(&self) -> StatusResponse {
+        let mut tabs: Vec<TabInfo> = {
+            let guard = self.lock_tabs();
+            guard
+                .iter()
+                .map(|(id, conn)| TabInfo {
+                    id: *id,
+                    origin: conn.origin.clone(),
+                })
+                .collect()
+        };
+        tabs.sort_by_key(|t| t.id);
+        // `browser_origin` is v1 back-compat: meaningful only when exactly one
+        // tab is connected; ambiguous (so `None`) for zero or several.
+        let browser_origin = match tabs.as_slice() {
+            [only] => only.origin.clone(),
+            _ => None,
+        };
+        StatusResponse {
+            connected: !tabs.is_empty(),
+            browser_origin,
+            tabs,
+            pending: self.correlator.pending_count(),
+        }
+    }
+}
+
+/// A running bridge instance: both loopback-TCP planes bound and serving, with
+/// a [`CancellationToken`] for graceful shutdown.
+///
+/// Created by [`BridgeServer::start`], which returns once the planes are bound
+/// (fail-closed) and the accept loops are spawned. A standalone `serve` calls
+/// [`wait`](Self::wait) (run until Ctrl-C); a supervisor (the daemon) instead
+/// drives [`status`](Self::status) / [`disconnect_tab`](Self::disconnect_tab) /
+/// [`shutdown`](Self::shutdown) directly.
+pub struct BridgeServer {
+    state: AppState,
+    control_port: u16,
+    ws_port: u16,
+    shutdown: CancellationToken,
+    tasks: JoinSet<()>,
+}
+
+impl BridgeServer {
+    /// Binds both planes (fail-closed), spawns the accept loops, and returns
+    /// immediately. `token` is the already-resolved session token (never
+    /// sourced from argv).
+    pub async fn start(mut config: BridgeConfig, token: String) -> Result<Self> {
+        let control_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, config.control_port))
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to bind control plane to 127.0.0.1:{} (already in use?)",
+                    config.control_port
+                )
+            })?;
+        let ws_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, config.ws_port))
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to bind WebSocket plane to 127.0.0.1:{} (already in use?)",
+                    config.ws_port
+                )
+            })?;
+
+        // Read back the OS-assigned ports so port-0 (random) is reflected
+        // everywhere: the snippet, the printed instructions, and the Host check.
+        config.control_port = control_listener.local_addr()?.port();
+        config.ws_port = ws_listener.local_addr()?.port();
+        let control_port = config.control_port;
+        let ws_port = config.ws_port;
+        let max_body_bytes = config.max_body_bytes;
+        let max_concurrent = config.max_concurrent;
+
+        let state = AppState {
+            token: Arc::new(token),
+            config: Arc::new(config),
+            correlator: Correlator::new(),
+            tabs: Arc::new(StdMutex::new(HashMap::new())),
+            in_flight: Arc::new(Semaphore::new(max_concurrent)),
+            conn_counter: Arc::new(AtomicU64::new(1)),
+        };
+
+        let shutdown = CancellationToken::new();
+        let mut tasks = JoinSet::new();
+
+        // WebSocket accept loop (cancellable).
+        let ws_state = state.clone();
+        let ws_shutdown = shutdown.clone();
+        tasks.spawn(async move {
+            loop {
+                tokio::select! {
+                    () = ws_shutdown.cancelled() => break,
+                    accepted = ws_listener.accept() => match accepted {
+                        Ok((stream, _peer)) => {
+                            tokio::spawn(handle_ws_conn(stream, ws_state.clone()));
+                        }
+                        Err(e) => tracing::warn!("WebSocket accept error: {e}"),
+                    },
+                }
+            }
+        });
+
+        // Control plane (axum) with graceful shutdown: drains in-flight requests
+        // before the serve future resolves.
+        let control_state = state.clone();
+        let control_shutdown = shutdown.clone();
+        tasks.spawn(async move {
+            let app = control_router(control_state, max_body_bytes);
+            if let Err(e) = axum::serve(control_listener, app)
+                .with_graceful_shutdown(control_shutdown.cancelled_owned())
+                .await
+            {
+                tracing::warn!("Control-plane server error: {e}");
+            }
+        });
+
+        Ok(Self {
+            state,
+            control_port,
+            ws_port,
+            shutdown,
+            tasks,
+        })
+    }
+
+    /// The bound control-plane port (resolved if `0` was requested).
+    pub fn control_port(&self) -> u16 {
+        self.control_port
+    }
+
+    /// The bound WebSocket-plane port (resolved if `0` was requested).
+    pub fn ws_port(&self) -> u16 {
+        self.ws_port
+    }
+
+    /// A synchronous snapshot of connection status (the same payload the
+    /// `GET /__bridge/status` endpoint returns).
+    pub fn status(&self) -> StatusResponse {
+        self.state.status_snapshot()
+    }
+
+    /// Disconnects the tab with the given connection id: sends a WebSocket
+    /// Close and drops it from the registry. Errors if no such tab is connected.
+    pub fn disconnect_tab(&self, id: u64) -> Result<()> {
+        let mut tabs = self.state.lock_tabs();
+        match tabs.remove(&id) {
+            Some(conn) => {
+                let _ = conn.sender.send(Message::Close(None));
+                Ok(())
+            }
+            None => anyhow::bail!("no connected tab with id {id}"),
+        }
+    }
+
+    /// Runs until Ctrl-C, then shuts down gracefully. Used by standalone
+    /// `serve` (a supervisor calls [`shutdown`](Self::shutdown) directly).
+    pub async fn wait(self) -> Result<()> {
+        let _ = tokio::signal::ctrl_c().await;
+        self.shutdown().await;
+        Ok(())
+    }
+
+    /// Cancels the planes and drains spawned tasks (bounded by a timeout, after
+    /// which any stragglers are aborted when the [`JoinSet`] drops).
+    pub async fn shutdown(self) {
+        let Self {
+            mut tasks,
+            shutdown,
+            ..
+        } = self;
+        shutdown.cancel();
+        let drain = async { while tasks.join_next().await.is_some() {} };
+        if tokio::time::timeout(Duration::from_secs(10), drain)
+            .await
+            .is_err()
+        {
+            tracing::warn!("bridge shutdown timed out; remaining tasks will be aborted");
+        }
+    }
+}
+
 /// Binds both planes (fail-closed) and serves until the process is stopped.
 ///
+/// Thin wrapper over [`BridgeServer::start`] + [`BridgeServer::wait`] that also
+/// prints the startup banner — preserved so `omni-dev browser bridge serve` is
+/// behaviourally unchanged.
+///
 /// `token` is the already-resolved session token (never sourced from argv).
-pub async fn run(mut config: BridgeConfig, token: String) -> Result<()> {
-    let control_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, config.control_port))
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to bind control plane to 127.0.0.1:{} (already in use?)",
-                config.control_port
-            )
-        })?;
-    let ws_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, config.ws_port))
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to bind WebSocket plane to 127.0.0.1:{} (already in use?)",
-                config.ws_port
-            )
-        })?;
-
-    // Read back the OS-assigned ports so port-0 (random) is reflected
-    // everywhere: the snippet, the printed instructions, and the Host check.
-    config.control_port = control_listener.local_addr()?.port();
-    config.ws_port = ws_listener.local_addr()?.port();
-
-    let token = Arc::new(token);
-    let state = AppState {
-        token: token.clone(),
-        config: Arc::new(config.clone()),
-        correlator: Correlator::new(),
-        tabs: Arc::new(Mutex::new(HashMap::new())),
-        in_flight: Arc::new(Semaphore::new(config.max_concurrent)),
-        conn_counter: Arc::new(AtomicU64::new(1)),
-    };
-
-    print_startup(&config, &token);
-
-    // WebSocket accept loop.
-    let ws_state = state.clone();
-    tokio::spawn(async move {
-        loop {
-            match ws_listener.accept().await {
-                Ok((stream, _peer)) => {
-                    tokio::spawn(handle_ws_conn(stream, ws_state.clone()));
-                }
-                Err(e) => tracing::warn!("WebSocket accept error: {e}"),
-            }
-        }
-    });
-
-    let app = control_router(state, config.max_body_bytes);
-    axum::serve(control_listener, app)
-        .await
-        .context("Control-plane server error")
+pub async fn run(config: BridgeConfig, token: String) -> Result<()> {
+    let server = BridgeServer::start(config, token).await?;
+    print_startup(server.state.config.as_ref(), &server.state.token);
+    server.wait().await
 }
 
 /// Prints the bound ports, session token, and paste-ready snippet to stdout.
@@ -324,10 +506,9 @@ async fn handle_ws_conn(stream: TcpStream, state: AppState) {
     );
 
     let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
-    {
-        let mut guard = state.tabs.lock().await;
-        guard.insert(conn_id, WsConn { sender: tx, origin });
-    }
+    state
+        .lock_tabs()
+        .insert(conn_id, WsConn { sender: tx, origin });
 
     let (mut sink, mut read) = ws_stream.split();
     let writer = tokio::spawn(async move {
@@ -359,7 +540,7 @@ async fn handle_ws_conn(stream: TcpStream, state: AppState) {
     writer.abort();
     // Drop only this connection's registry entry (keyed by its unique id, so a
     // reconnect under a new id is never clobbered).
-    if state.tabs.lock().await.remove(&conn_id).is_some() {
+    if state.lock_tabs().remove(&conn_id).is_some() {
         tracing::info!("Browser disconnected (conn {conn_id})");
     }
 }
@@ -425,29 +606,7 @@ async fn guard(State(state): State<AppState>, request: Request, next: Next) -> R
 }
 
 async fn status_handler(State(state): State<AppState>) -> Json<StatusResponse> {
-    let mut tabs: Vec<TabInfo> = {
-        let guard = state.tabs.lock().await;
-        guard
-            .iter()
-            .map(|(id, conn)| TabInfo {
-                id: *id,
-                origin: conn.origin.clone(),
-            })
-            .collect()
-    };
-    tabs.sort_by_key(|t| t.id);
-    // `browser_origin` is v1 back-compat: meaningful only when exactly one tab
-    // is connected; ambiguous (so `None`) for zero or several.
-    let browser_origin = match tabs.as_slice() {
-        [only] => only.origin.clone(),
-        _ => None,
-    };
-    Json(StatusResponse {
-        connected: !tabs.is_empty(),
-        browser_origin,
-        tabs,
-        pending: state.correlator.pending_count(),
-    })
+    Json(state.status_snapshot())
 }
 
 /// `POST /__bridge/request` — full-fidelity control endpoint. A `stream: true`
@@ -766,7 +925,7 @@ async fn dispatch(
     };
 
     {
-        let tabs = state.tabs.lock().await;
+        let tabs = state.lock_tabs();
         let (_conn_id, sender) = match resolve_target(&tabs, req.target.as_deref()) {
             Ok(t) => t,
             Err(e) => {
@@ -860,7 +1019,8 @@ async fn send_cancel(state: &AppState, conn_id: u64, id: u64) {
     let Ok(frame) = serde_json::to_string(&CancelCommand::new(id)) else {
         return;
     };
-    if let Some(conn) = state.tabs.lock().await.get(&conn_id) {
+    let tabs = state.lock_tabs();
+    if let Some(conn) = tabs.get(&conn_id) {
         let _ = conn.sender.send(Message::Text(frame.into()));
     }
 }
@@ -919,7 +1079,7 @@ async fn start_stream(
     };
 
     let conn_id = {
-        let tabs = state.tabs.lock().await;
+        let tabs = state.lock_tabs();
         let (conn_id, sender) = match resolve_target(&tabs, req.target.as_deref()) {
             Ok(t) => t,
             Err(e) => {
@@ -1288,7 +1448,7 @@ mod tests {
                 max_concurrent: 8,
             }),
             correlator: Correlator::new(),
-            tabs: Arc::new(Mutex::new(HashMap::new())),
+            tabs: Arc::new(StdMutex::new(HashMap::new())),
             in_flight: Arc::new(Semaphore::new(8)),
             conn_counter: Arc::new(AtomicU64::new(1)),
         }
@@ -1299,7 +1459,7 @@ mod tests {
     async fn insert_dead_tab(state: &AppState, id: u64) {
         let (sender, rx) = mpsc::unbounded_channel();
         drop(rx);
-        state.tabs.lock().await.insert(
+        state.lock_tabs().insert(
             id,
             WsConn {
                 sender,
@@ -1554,4 +1714,57 @@ mod tests {
     }
 
     use futures::FutureExt;
+
+    /// A `BridgeConfig` bound to random free ports, for lifecycle tests.
+    fn ephemeral_config() -> BridgeConfig {
+        BridgeConfig {
+            ws_port: 0,
+            control_port: 0,
+            request_timeout: Duration::from_secs(5),
+            allow_origin: None,
+            max_body_bytes: 1024,
+            max_concurrent: 8,
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_server_start_status_shutdown() {
+        let server = BridgeServer::start(ephemeral_config(), "tok".to_string())
+            .await
+            .unwrap();
+        // Ports were resolved from the OS (port 0 → a real bound port).
+        assert_ne!(server.control_port(), 0);
+        assert_ne!(server.ws_port(), 0);
+        // No browser is connected yet.
+        let status = server.status();
+        assert!(!status.connected);
+        assert!(status.tabs.is_empty());
+        assert_eq!(status.pending, 0);
+        // Graceful shutdown drains and returns.
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn disconnect_unknown_tab_is_error() {
+        let server = BridgeServer::start(ephemeral_config(), "tok".to_string())
+            .await
+            .unwrap();
+        let err = server.disconnect_tab(999).unwrap_err();
+        assert!(err.to_string().contains("no connected tab"));
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn start_fails_closed_on_taken_control_port() {
+        // Occupy a port, then ask the bridge to bind the same one.
+        let squatter = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let taken = squatter.local_addr().unwrap().port();
+        let config = BridgeConfig {
+            control_port: taken,
+            ..ephemeral_config()
+        };
+        assert!(BridgeServer::start(config, "tok".to_string())
+            .await
+            .is_err());
+    }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -15,4 +15,4 @@ pub mod harvest;
 pub mod protocol;
 pub mod snippet;
 
-pub use bridge::{run, BridgeConfig};
+pub use bridge::{run, BridgeConfig, BridgeServer};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ pub mod commands;
 pub mod completions;
 pub mod config;
 pub mod coverage;
+pub mod daemon;
 pub mod datadog;
 pub mod git;
 pub mod help;
@@ -133,6 +134,8 @@ pub enum Commands {
     Atlassian(atlassian::AtlassianCommand),
     /// Browser bridge: drive authenticated requests through a browser tab.
     Browser(browser::BrowserCommand),
+    /// Daemon: host long-lived services (e.g. the browser bridge).
+    Daemon(daemon::DaemonCommand),
     /// Datadog: read-only API operations.
     Datadog(datadog::DatadogCommand),
     /// Coverage: diff/patch coverage analysis for PR comments.
@@ -194,6 +197,7 @@ impl Cli {
             Commands::Commands(commands_cmd) => commands_cmd.execute(),
             Commands::Atlassian(cmd) => cmd.execute().await,
             Commands::Browser(cmd) => cmd.execute().await,
+            Commands::Daemon(cmd) => cmd.execute().await,
             Commands::Datadog(cmd) => cmd.execute().await,
             Commands::Coverage(cmd) => cmd.execute(repo).await,
             Commands::Transcript(cmd) => cmd.execute().await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -209,6 +209,22 @@ impl Cli {
     }
 }
 
+#[cfg(all(target_os = "macos", feature = "menu-bar"))]
+impl Cli {
+    /// If this invocation is `daemon run` without `--no-menu`, resolves the
+    /// daemon configuration so `main` can host it with a macOS menu-bar tray on
+    /// the main thread. Returns `None` for every other invocation (which runs
+    /// normally on the async runtime).
+    pub fn menu_bar_run_config(&self) -> Option<Result<crate::daemon::DaemonRunConfig>> {
+        match &self.command {
+            Commands::Daemon(daemon::DaemonCommand {
+                command: daemon::DaemonSubcommands::Run(run),
+            }) if !run.no_menu => Some(run.clone().into_run_config()),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -4,8 +4,35 @@ pub(crate) mod bridge;
 pub(crate) mod harvest;
 pub(crate) mod request;
 
+use std::path::Path;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+
+use crate::browser::auth;
+
+/// Resolves a thin-client session token for `request` / `harvest`.
+///
+/// Tries `--token-file` then `OMNI_BRIDGE_TOKEN` (via
+/// [`auth::resolve_existing_token`]); if neither is set, falls back to the
+/// daemon-written token file ([`crate::daemon::paths::token_path`]) when it
+/// exists, so clients work transparently against a daemon-hosted bridge. The
+/// original "no token" error is preserved when nothing resolves.
+pub(crate) fn resolve_client_token(token_file: Option<&Path>) -> Result<String> {
+    match auth::resolve_existing_token(token_file) {
+        Ok(token) => Ok(token),
+        Err(e) => {
+            if token_file.is_none() {
+                if let Ok(path) = crate::daemon::paths::token_path() {
+                    if path.exists() {
+                        return auth::resolve_existing_token(Some(&path));
+                    }
+                }
+            }
+            Err(e)
+        }
+    }
+}
 
 /// Browser bridge: drive authenticated requests through a browser tab.
 #[derive(Parser)]

--- a/src/cli/browser/bridge.rs
+++ b/src/cli/browser/bridge.rs
@@ -8,18 +8,11 @@ use clap::{Parser, Subcommand};
 
 use super::harvest::HarvestCommand;
 use super::request::RequestCommand;
+use crate::browser::bridge::{
+    DEFAULT_CONTROL_PORT, DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_CONCURRENT, DEFAULT_TIMEOUT_SECS,
+    DEFAULT_WS_PORT,
+};
 use crate::browser::{self, auth, BridgeConfig};
-
-/// Default WebSocket-plane port.
-const DEFAULT_WS_PORT: u16 = 9999;
-/// Default HTTP control-plane port.
-const DEFAULT_CONTROL_PORT: u16 = 9998;
-/// Default per-request timeout, in seconds.
-const DEFAULT_TIMEOUT_SECS: u64 = 30;
-/// Default maximum browser response body size (8 MiB).
-const DEFAULT_MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
-/// Default maximum concurrent in-flight requests.
-const DEFAULT_MAX_CONCURRENT: usize = 64;
 
 /// Bridge: run the server (`serve`) or send a request through it (`request`).
 #[derive(Parser)]

--- a/src/cli/browser/harvest.rs
+++ b/src/cli/browser/harvest.rs
@@ -6,11 +6,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::browser::auth;
+use crate::browser::bridge::DEFAULT_CONTROL_PORT;
 use crate::browser::harvest::facebook;
-
-/// Default control-plane port (matches `bridge`'s default).
-const DEFAULT_CONTROL_PORT: u16 = 9998;
 
 /// Harvest a logged-in browser session's own data through the bridge.
 ///
@@ -140,7 +137,7 @@ impl PostsCommand {
              changes. Your own account only. Stable alternative: Facebook's \"Download Your \
              Information\" export."
         );
-        let token = auth::resolve_existing_token(self.token_file.as_deref())?;
+        let token = super::resolve_client_token(self.token_file.as_deref())?;
         let since = self.since.as_deref().map(parse_since).transpose()?;
         let output = match self.output {
             Some(path) => facebook::Output::File(path),

--- a/src/cli/browser/request.rs
+++ b/src/cli/browser/request.rs
@@ -12,11 +12,9 @@ use clap::{Parser, ValueEnum};
 use futures::StreamExt as _;
 
 use crate::browser::auth;
+use crate::browser::bridge::DEFAULT_CONTROL_PORT;
 use crate::browser::client::BridgeClient;
 use crate::browser::protocol::{ControlRequest, ResponseEnvelope, StreamLine};
-
-/// Default control-plane port (matches `bridge`'s default).
-const DEFAULT_CONTROL_PORT: u16 = 9998;
 
 /// Fetch credentials mode forwarded to the browser `fetch()`.
 ///
@@ -108,7 +106,7 @@ pub struct RequestCommand {
 impl RequestCommand {
     /// Executes the request command.
     pub async fn execute(self) -> Result<()> {
-        let token = auth::resolve_existing_token(self.token_file.as_deref())?;
+        let token = super::resolve_client_token(self.token_file.as_deref())?;
         let headers = parse_headers(&self.headers)?;
         let body = resolve_body(self.body.as_deref())?;
 

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -1,0 +1,102 @@
+//! `omni-dev daemon` — supervise the long-lived daemon and its services.
+
+pub(crate) mod control;
+pub(crate) mod restart;
+pub(crate) mod run;
+pub(crate) mod start;
+pub(crate) mod status;
+pub(crate) mod stop;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Daemon: host long-lived services (e.g. the browser bridge) under one
+/// supervised, menu-bar-controllable process.
+#[derive(Parser)]
+pub struct DaemonCommand {
+    /// The daemon subcommand to execute.
+    #[command(subcommand)]
+    pub command: DaemonSubcommands,
+}
+
+/// Daemon subcommands.
+#[derive(Subcommand)]
+pub enum DaemonSubcommands {
+    /// Runs the daemon in the foreground (the process launchd execs).
+    Run(run::RunCommand),
+    /// Starts the daemon in the background.
+    Start(start::StartCommand),
+    /// Stops the running daemon.
+    Stop(stop::StopCommand),
+    /// Restarts the daemon.
+    Restart(restart::RestartCommand),
+    /// Reports daemon and per-service status.
+    Status(status::StatusCommand),
+}
+
+impl DaemonCommand {
+    /// Executes the daemon command.
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            DaemonSubcommands::Run(cmd) => cmd.execute().await,
+            DaemonSubcommands::Start(cmd) => cmd.execute().await,
+            DaemonSubcommands::Stop(cmd) => cmd.execute().await,
+            DaemonSubcommands::Restart(cmd) => cmd.execute().await,
+            DaemonSubcommands::Status(cmd) => cmd.execute().await,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Mirrors the `omni-dev daemon` argv surface for parse tests.
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(subcommand)]
+        cmd: DaemonSubcommands,
+    }
+
+    fn parse(args: &[&str]) -> DaemonSubcommands {
+        let mut full = vec!["omni-dev"];
+        full.extend_from_slice(args);
+        Wrapper::try_parse_from(full).unwrap().cmd
+    }
+
+    #[test]
+    fn parses_all_subcommands() {
+        assert!(matches!(parse(&["run"]), DaemonSubcommands::Run(_)));
+        assert!(matches!(parse(&["start"]), DaemonSubcommands::Start(_)));
+        assert!(matches!(parse(&["stop"]), DaemonSubcommands::Stop(_)));
+        assert!(matches!(parse(&["restart"]), DaemonSubcommands::Restart(_)));
+        assert!(matches!(parse(&["status"]), DaemonSubcommands::Status(_)));
+    }
+
+    #[test]
+    fn socket_override_parses() {
+        let DaemonSubcommands::Run(cmd) = parse(&["run", "--socket", "/tmp/x.sock"]) else {
+            panic!("expected run");
+        };
+        assert_eq!(cmd.socket.as_deref(), Some(Path::new("/tmp/x.sock")));
+    }
+
+    #[test]
+    fn status_json_flag_parses() {
+        let DaemonSubcommands::Status(cmd) = parse(&["status", "--json"]) else {
+            panic!("expected status");
+        };
+        assert!(cmd.json);
+    }
+
+    #[test]
+    fn socket_defaults_to_none() {
+        let DaemonSubcommands::Status(cmd) = parse(&["status"]) else {
+            panic!("expected status");
+        };
+        assert!(cmd.socket.is_none());
+        assert!(!cmd.json);
+    }
+}

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -99,4 +99,21 @@ mod tests {
         assert!(cmd.socket.is_none());
         assert!(!cmd.json);
     }
+
+    /// `daemon status` against a socket with no daemon dispatches through to the
+    /// "not running" path (table and `--json`) without erroring or side effects.
+    #[tokio::test]
+    async fn status_dispatch_reports_not_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("absent.sock");
+        for json in [false, true] {
+            let cmd = DaemonCommand {
+                command: DaemonSubcommands::Status(status::StatusCommand {
+                    socket: Some(socket.clone()),
+                    json,
+                }),
+            };
+            cmd.execute().await.unwrap();
+        }
+    }
 }

--- a/src/cli/daemon/control.rs
+++ b/src/cli/daemon/control.rs
@@ -60,3 +60,19 @@ pub(super) async fn wait_until_down(socket: &Path) -> Result<()> {
         socket.display()
     )
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn wait_until_down_returns_when_no_daemon() {
+        // Nothing is listening on this socket, so `ping` fails on the first try
+        // and the helper returns quickly. (No daemon is launched.)
+        let dir = tempfile::tempdir().unwrap();
+        wait_until_down(&dir.path().join("absent.sock"))
+            .await
+            .unwrap();
+    }
+}

--- a/src/cli/daemon/control.rs
+++ b/src/cli/daemon/control.rs
@@ -1,0 +1,62 @@
+//! Shared launch/poll helpers for the daemon launcher subcommands
+//! (`start` / `restart`).
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::daemon::client::DaemonClient;
+
+/// Launches a background daemon bound to `socket`.
+///
+/// macOS installs and loads a launchd LaunchAgent (auto-start at login);
+/// elsewhere a detached `omni-dev daemon run` is spawned.
+#[cfg(target_os = "macos")]
+pub(super) fn launch(socket: &Path) -> Result<()> {
+    crate::daemon::launchd::install_and_load(socket)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn launch(socket: &Path) -> Result<()> {
+    use anyhow::Context;
+    let exe = std::env::current_exe().context("could not resolve the current executable")?;
+    std::process::Command::new(exe)
+        .arg("daemon")
+        .arg("run")
+        .arg("--socket")
+        .arg(socket)
+        .spawn()
+        .context("failed to spawn the daemon process")?;
+    Ok(())
+}
+
+/// Polls until the daemon answers `ping`, or times out (~5s).
+pub(super) async fn wait_until_ready(socket: &Path) -> Result<()> {
+    let client = DaemonClient::new(socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    anyhow::bail!(
+        "daemon did not become ready within 5s (socket {})",
+        socket.display()
+    )
+}
+
+/// Polls until the daemon stops answering `ping`, or times out (~5s).
+pub(super) async fn wait_until_down(socket: &Path) -> Result<()> {
+    let client = DaemonClient::new(socket);
+    for _ in 0..50 {
+        if client.ping().await.is_err() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    anyhow::bail!(
+        "daemon did not stop within 5s (socket {})",
+        socket.display()
+    )
+}

--- a/src/cli/daemon/restart.rs
+++ b/src/cli/daemon/restart.rs
@@ -1,0 +1,38 @@
+//! `omni-dev daemon restart` — stop then start the daemon.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use super::control;
+use crate::daemon::client::DaemonClient;
+use crate::daemon::server;
+
+/// Restarts the daemon: stop it (if running), then start it again.
+#[derive(Parser)]
+pub struct RestartCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+}
+
+impl RestartCommand {
+    /// Executes the restart command.
+    pub async fn execute(self) -> Result<()> {
+        let socket_path = server::resolve_socket(self.socket)?;
+        let client = DaemonClient::new(&socket_path);
+        if client.ping().await.is_ok() {
+            client.shutdown().await.ok();
+            #[cfg(target_os = "macos")]
+            {
+                let _ = crate::daemon::launchd::unload();
+            }
+            control::wait_until_down(&socket_path).await?;
+        }
+        control::launch(&socket_path)?;
+        control::wait_until_ready(&socket_path).await?;
+        println!("daemon restarted (socket {})", socket_path.display());
+        Ok(())
+    }
+}

--- a/src/cli/daemon/run.rs
+++ b/src/cli/daemon/run.rs
@@ -5,27 +5,73 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 
-use crate::daemon;
-use crate::daemon::server::{self, DaemonOptions};
+use crate::browser::bridge::{DEFAULT_CONTROL_PORT, DEFAULT_WS_PORT};
+use crate::browser::BridgeConfig;
+use crate::daemon::server;
+use crate::daemon::{self, paths, DaemonRunConfig};
 
 /// Runs the daemon in the foreground.
 ///
 /// Binds the control socket (which doubles as the single-instance lock), starts
-/// every registered service, and blocks until `SIGTERM`/`SIGINT` or a
-/// `daemon stop`. This is the process a launchd LaunchAgent (or `daemon start`)
-/// execs.
-#[derive(Parser)]
+/// every registered service — including the browser bridge on its loopback-TCP
+/// planes — and blocks until `SIGTERM`/`SIGINT` or a `daemon stop`. This is the
+/// process a launchd LaunchAgent (or `daemon start`) execs.
+///
+/// On a macOS build with the `menu-bar` feature, this also shows the menu-bar
+/// tray unless `--no-menu` is given.
+#[derive(Parser, Clone)]
 pub struct RunCommand {
     /// Control-socket path. Defaults to the per-user runtime location.
     #[arg(long, value_name = "PATH")]
     pub socket: Option<PathBuf>,
+
+    /// Browser-bridge WebSocket-plane port (`0` binds a random free port).
+    #[arg(long, default_value_t = DEFAULT_WS_PORT)]
+    pub bridge_ws_port: u16,
+
+    /// Browser-bridge HTTP control-plane port (`0` binds a random free port).
+    #[arg(long, default_value_t = DEFAULT_CONTROL_PORT)]
+    pub bridge_control_port: u16,
+
+    /// Permit this cross-origin for the bridge's WebSocket upgrade and outbound
+    /// URLs (the bridge's `--allow-origin`).
+    #[arg(long, value_name = "URL")]
+    pub bridge_allow_origin: Option<String>,
+
+    /// Read the bridge session token from this `0600` file instead of
+    /// generating one.
+    #[arg(long, value_name = "PATH")]
+    pub bridge_token_file: Option<PathBuf>,
+
+    /// Run headless: never show the macOS menu-bar tray (no effect on non-macOS
+    /// or non-`menu-bar` builds, which are always headless).
+    #[arg(long)]
+    pub no_menu: bool,
 }
 
 impl RunCommand {
-    /// Executes the run command.
+    /// Executes the run command (headless; the menu-bar path is selected in
+    /// `main`, which hands the main thread to the tray).
     pub async fn execute(self) -> Result<()> {
+        daemon::run_headless(self.into_run_config()?).await
+    }
+
+    /// Resolves the CLI flags into a [`DaemonRunConfig`]. Shared by the headless
+    /// `execute` path and the macOS menu-bar path.
+    pub fn into_run_config(self) -> Result<DaemonRunConfig> {
         let socket_path = server::resolve_socket(self.socket)?;
-        let registry = daemon::build_default_registry().await?;
-        server::run(registry, DaemonOptions { socket_path }).await
+        let bridge_token_path = paths::token_path_for_socket(&socket_path);
+        let bridge_config = BridgeConfig {
+            ws_port: self.bridge_ws_port,
+            control_port: self.bridge_control_port,
+            allow_origin: self.bridge_allow_origin,
+            ..BridgeConfig::default()
+        };
+        Ok(DaemonRunConfig {
+            socket_path,
+            bridge_config,
+            bridge_token_file: self.bridge_token_file,
+            bridge_token_path,
+        })
     }
 }

--- a/src/cli/daemon/run.rs
+++ b/src/cli/daemon/run.rs
@@ -1,0 +1,31 @@
+//! `omni-dev daemon run` — become the daemon (foreground).
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::daemon;
+use crate::daemon::server::{self, DaemonOptions};
+
+/// Runs the daemon in the foreground.
+///
+/// Binds the control socket (which doubles as the single-instance lock), starts
+/// every registered service, and blocks until `SIGTERM`/`SIGINT` or a
+/// `daemon stop`. This is the process a launchd LaunchAgent (or `daemon start`)
+/// execs.
+#[derive(Parser)]
+pub struct RunCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+}
+
+impl RunCommand {
+    /// Executes the run command.
+    pub async fn execute(self) -> Result<()> {
+        let socket_path = server::resolve_socket(self.socket)?;
+        let registry = daemon::build_default_registry().await?;
+        server::run(registry, DaemonOptions { socket_path }).await
+    }
+}

--- a/src/cli/daemon/start.rs
+++ b/src/cli/daemon/start.rs
@@ -1,0 +1,37 @@
+//! `omni-dev daemon start` — launch the daemon in the background.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use super::control;
+use crate::daemon::client::DaemonClient;
+use crate::daemon::server;
+
+/// Starts the daemon in the background.
+///
+/// On macOS this installs and loads a per-user launchd LaunchAgent (so the
+/// daemon also starts at login); elsewhere it spawns a detached `daemon run`.
+/// Returns once the control socket accepts connections.
+#[derive(Parser)]
+pub struct StartCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+}
+
+impl StartCommand {
+    /// Executes the start command.
+    pub async fn execute(self) -> Result<()> {
+        let socket_path = server::resolve_socket(self.socket)?;
+        if DaemonClient::new(&socket_path).ping().await.is_ok() {
+            println!("daemon already running (socket {})", socket_path.display());
+            return Ok(());
+        }
+        control::launch(&socket_path)?;
+        control::wait_until_ready(&socket_path).await?;
+        println!("daemon started (socket {})", socket_path.display());
+        Ok(())
+    }
+}

--- a/src/cli/daemon/status.rs
+++ b/src/cli/daemon/status.rs
@@ -1,0 +1,64 @@
+//! `omni-dev daemon status` — report daemon and per-service status.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
+
+use crate::daemon::client::DaemonClient;
+use crate::daemon::protocol::StatusReport;
+use crate::daemon::server;
+
+/// Reports whether the daemon is running and the status of each hosted service.
+#[derive(Parser)]
+pub struct StatusCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+    /// Emit machine-readable JSON instead of a table.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl StatusCommand {
+    /// Executes the status command.
+    pub async fn execute(self) -> Result<()> {
+        let json_out = self.json;
+        let socket_path = server::resolve_socket(self.socket)?;
+        match DaemonClient::new(&socket_path).status().await {
+            Ok(report) => print_running(json_out, &report),
+            Err(_) => print_not_running(json_out),
+        }
+    }
+}
+
+/// Prints the running daemon's aggregated service status.
+fn print_running(json_out: bool, report: &StatusReport) -> Result<()> {
+    if json_out {
+        println!("{}", serde_json::to_string_pretty(report)?);
+        return Ok(());
+    }
+    println!("daemon: running");
+    if report.services.is_empty() {
+        println!("  (no services registered)");
+    }
+    for svc in &report.services {
+        let health = if svc.healthy { "ok" } else { "unhealthy" };
+        println!("  {:<16} {:<10} {}", svc.name, health, svc.summary);
+    }
+    Ok(())
+}
+
+/// Prints the "not running" status (or its JSON equivalent).
+fn print_not_running(json_out: bool) -> Result<()> {
+    if json_out {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "running": false }))?
+        );
+    } else {
+        println!("daemon: not running");
+    }
+    Ok(())
+}

--- a/src/cli/daemon/stop.rs
+++ b/src/cli/daemon/stop.rs
@@ -1,0 +1,39 @@
+//! `omni-dev daemon stop` — stop the running daemon.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::daemon::client::DaemonClient;
+use crate::daemon::server;
+
+/// Stops the running daemon, gracefully draining its services.
+///
+/// On macOS it also boots out the launchd agent so the daemon stays stopped
+/// rather than auto-restarting at the next login.
+#[derive(Parser)]
+pub struct StopCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+}
+
+impl StopCommand {
+    /// Executes the stop command.
+    pub async fn execute(self) -> Result<()> {
+        let socket_path = server::resolve_socket(self.socket)?;
+        let stopped = DaemonClient::new(&socket_path).shutdown().await.is_ok();
+        #[cfg(target_os = "macos")]
+        {
+            // Disable launchd auto-start if this daemon was started via `daemon start`.
+            let _ = crate::daemon::launchd::unload();
+        }
+        if stopped {
+            println!("daemon stopping");
+        } else {
+            println!("daemon not running");
+        }
+        Ok(())
+    }
+}

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -1,0 +1,92 @@
+//! [`DaemonClient`]: a thin client for the daemon's Unix control socket, used
+//! by `daemon status` / `stop` / `restart` and the single-instance `ping`
+//! probe.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use futures::{SinkExt, StreamExt};
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LinesCodec};
+
+use super::protocol::{DaemonEnvelope, DaemonReply, StatusReport};
+
+/// A one-shot client over the daemon's Unix-domain control socket. Each call
+/// opens a fresh connection, sends one [`DaemonEnvelope`], and reads one
+/// [`DaemonReply`].
+#[derive(Debug, Clone)]
+pub struct DaemonClient {
+    socket_path: PathBuf,
+}
+
+impl DaemonClient {
+    /// Creates a client targeting the socket at `socket_path`.
+    pub fn new(socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+        }
+    }
+
+    /// The socket path this client targets.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Sends one envelope and returns the daemon's reply.
+    pub async fn request(&self, envelope: DaemonEnvelope) -> Result<DaemonReply> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to connect to daemon socket {} (is the daemon running?)",
+                    self.socket_path.display()
+                )
+            })?;
+        let mut framed = Framed::new(stream, LinesCodec::new());
+        let line = serde_json::to_string(&envelope).context("failed to encode daemon request")?;
+        framed
+            .send(line)
+            .await
+            .context("failed to send daemon request")?;
+        let response = framed
+            .next()
+            .await
+            .context("daemon closed the connection without replying")?
+            .context("failed to read daemon reply")?;
+        serde_json::from_str(&response).context("failed to decode daemon reply")
+    }
+
+    /// Sends an envelope and returns its payload, turning an `ok: false` reply
+    /// into an `Err`.
+    async fn request_ok(&self, envelope: DaemonEnvelope) -> Result<serde_json::Value> {
+        let reply = self.request(envelope).await?;
+        if reply.ok {
+            Ok(reply.payload)
+        } else {
+            bail!(
+                "daemon returned an error: {}",
+                reply.error.as_deref().unwrap_or("unknown error")
+            )
+        }
+    }
+
+    /// Probes whether a live daemon is answering on the socket.
+    pub async fn ping(&self) -> Result<()> {
+        self.request_ok(DaemonEnvelope::builtin("ping"))
+            .await
+            .map(|_| ())
+    }
+
+    /// Requests aggregated per-service status.
+    pub async fn status(&self) -> Result<StatusReport> {
+        let payload = self.request_ok(DaemonEnvelope::builtin("status")).await?;
+        serde_json::from_value(payload).context("failed to decode daemon status report")
+    }
+
+    /// Asks the daemon to shut down gracefully.
+    pub async fn shutdown(&self) -> Result<()> {
+        self.request_ok(DaemonEnvelope::builtin("shutdown"))
+            .await
+            .map(|_| ())
+    }
+}

--- a/src/daemon/launchd.rs
+++ b/src/daemon/launchd.rs
@@ -1,0 +1,108 @@
+//! macOS launchd integration for `omni-dev daemon start` / `stop`.
+//!
+//! `start` writes a per-user LaunchAgent plist and bootstraps it; the agent
+//! execs `omni-dev daemon run`. `KeepAlive` is set to restart only on
+//! *abnormal* exit (`SuccessfulExit = false`), so a clean `daemon stop` (which
+//! drives the daemon to a zero exit) stays down rather than being respawned.
+//! `RunAtLoad` makes it start at login. See ADR-0039.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+/// Reverse-DNS LaunchAgent label, derived from the project repository
+/// (`github.com/rust-works/omni-dev`).
+pub const LAUNCHD_LABEL: &str = "com.github.rust-works.omni-dev.daemon";
+
+/// Path to the per-user LaunchAgent plist
+/// (`~/Library/LaunchAgents/<label>.plist`).
+pub fn plist_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine the home directory")?;
+    Ok(home
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{LAUNCHD_LABEL}.plist")))
+}
+
+/// Renders a LaunchAgent plist that execs `omni-dev daemon run --socket <socket>`.
+fn render_plist(exe: &Path, socket: &Path) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{exe}</string>
+        <string>daemon</string>
+        <string>run</string>
+        <string>--socket</string>
+        <string>{socket}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>
+"#,
+        label = LAUNCHD_LABEL,
+        exe = exe.display(),
+        socket = socket.display(),
+    )
+}
+
+/// The current user's launchd GUI domain target (`gui/<uid>`).
+fn gui_domain() -> String {
+    format!("gui/{}", nix::unistd::getuid())
+}
+
+/// Writes the plist and bootstraps the agent so the daemon runs now and at
+/// login.
+pub fn install_and_load(socket: &Path) -> Result<()> {
+    let exe = std::env::current_exe().context("could not resolve the current executable")?;
+    let plist = plist_path()?;
+    if let Some(parent) = plist.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(&plist, render_plist(&exe, socket))
+        .with_context(|| format!("failed to write {}", plist.display()))?;
+
+    let domain = gui_domain();
+    // Bootout any prior instance first so bootstrap does not fail as already loaded.
+    let _ = Command::new("launchctl")
+        .args(["bootout", &format!("{domain}/{LAUNCHD_LABEL}")])
+        .output();
+    let output = Command::new("launchctl")
+        .arg("bootstrap")
+        .arg(&domain)
+        .arg(&plist)
+        .output()
+        .context("failed to run `launchctl bootstrap`")?;
+    if !output.status.success() {
+        bail!(
+            "launchctl bootstrap failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Boots out the agent (SIGTERM-ing a running daemon) so it stops and no longer
+/// auto-starts. Best-effort: a not-loaded agent is not an error.
+pub fn unload() -> Result<()> {
+    let domain = gui_domain();
+    let _ = Command::new("launchctl")
+        .args(["bootout", &format!("{domain}/{LAUNCHD_LABEL}")])
+        .output();
+    Ok(())
+}

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,0 +1,46 @@
+//! Process-lifecycle wiring: translate OS termination signals into a graceful
+//! shutdown of the daemon's [`CancellationToken`].
+
+use tokio_util::sync::CancellationToken;
+
+/// Spawns a task that cancels `shutdown` when the process is asked to stop.
+///
+/// On Unix this listens for both `SIGTERM` (what `launchctl bootout` and
+/// service managers send) and `SIGINT` (Ctrl-C in a foreground `daemon run`).
+/// Elsewhere it listens for Ctrl-C only.
+pub fn install_signal_handlers(shutdown: CancellationToken) {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        tokio::spawn(async move {
+            let mut term = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("failed to install SIGTERM handler: {e}");
+                    return;
+                }
+            };
+            let mut interrupt = match signal(SignalKind::interrupt()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("failed to install SIGINT handler: {e}");
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = term.recv() => tracing::info!("received SIGTERM; shutting down"),
+                _ = interrupt.recv() => tracing::info!("received SIGINT; shutting down"),
+            }
+            shutdown.cancel();
+        });
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                tracing::info!("received Ctrl-C; shutting down");
+                shutdown.cancel();
+            }
+        });
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,0 +1,47 @@
+//! The extensible omni-dev daemon: a long-lived supervisor that hosts pluggable
+//! [`DaemonService`](service::DaemonService)s over a local Unix-domain control
+//! socket.
+//!
+//! The daemon owns **lifecycle, single-instance supervision, status
+//! aggregation, and (on macOS) the menu-bar shell**. Each service wraps its own
+//! work and exposes status/control; the browser bridge is the first such
+//! service (#987). The control socket is a private operator/tray channel — it
+//! does **not** carry any service's own data plane (e.g. the bridge keeps its
+//! loopback-TCP planes per ADR-0036). See ADR-0039.
+//!
+//! Process model:
+//! - `daemon run` *becomes* the daemon ([`server::run`]), blocking until a
+//!   signal or a built-in `shutdown` op.
+//! - `daemon start` launches it in the background (a launchd LaunchAgent on
+//!   macOS); `stop` / `restart` / `status` are thin [`client::DaemonClient`]s.
+
+pub mod client;
+pub mod lifecycle;
+pub mod paths;
+pub mod protocol;
+pub mod registry;
+pub mod server;
+pub mod service;
+pub mod services;
+pub mod single_instance;
+
+#[cfg(target_os = "macos")]
+pub mod launchd;
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use registry::ServiceRegistry;
+use services::echo::EchoService;
+
+/// Builds the daemon's default service registry.
+///
+/// Registers only the [`EchoService`] for now; the browser bridge service joins
+/// it in a later change (#987). Kept `async` because real services (the bridge)
+/// perform asynchronous startup when constructed here.
+pub async fn build_default_registry() -> Result<ServiceRegistry> {
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(EchoService));
+    Ok(registry)
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -28,20 +28,69 @@ pub mod single_instance;
 #[cfg(target_os = "macos")]
 pub mod launchd;
 
+#[cfg(all(target_os = "macos", feature = "menu-bar"))]
+pub mod tray;
+
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
 
+use crate::browser::BridgeConfig;
 use registry::ServiceRegistry;
-use services::echo::EchoService;
+use server::DaemonOptions;
+use services::bridge::BridgeService;
 
-/// Builds the daemon's default service registry.
+/// Everything `daemon run` needs to start the daemon, resolved from the CLI.
 ///
-/// Registers only the [`EchoService`] for now; the browser bridge service joins
-/// it in a later change (#987). Kept `async` because real services (the bridge)
-/// perform asynchronous startup when constructed here.
-pub async fn build_default_registry() -> Result<ServiceRegistry> {
+/// Shared by the headless path ([`run_headless`]) and the macOS menu-bar path
+/// ([`tray::run`]) so both start an identical daemon.
+#[derive(Debug, Clone)]
+pub struct DaemonRunConfig {
+    /// Control-socket path (also the single-instance lock).
+    pub socket_path: PathBuf,
+    /// Browser-bridge configuration (ports, allow-origin, limits).
+    pub bridge_config: BridgeConfig,
+    /// Optional file the bridge session token is read from instead of generated.
+    pub bridge_token_file: Option<PathBuf>,
+    /// Where the resolved bridge token is persisted (`0600`) for thin clients.
+    pub bridge_token_path: PathBuf,
+}
+
+/// Builds the daemon's default service registry: starts the browser bridge on
+/// its loopback-TCP planes and registers it.
+///
+/// `bridge_token_file` overrides token generation; `bridge_token_path` is where
+/// the resolved token is persisted (`0600`) for thin-client discovery.
+pub async fn build_default_registry(
+    bridge_config: BridgeConfig,
+    bridge_token_file: Option<&Path>,
+    bridge_token_path: PathBuf,
+) -> Result<ServiceRegistry> {
     let mut registry = ServiceRegistry::new();
-    registry.register(Arc::new(EchoService));
+    let bridge = BridgeService::start(bridge_config, bridge_token_file, bridge_token_path).await?;
+    registry.register(Arc::new(bridge));
     Ok(registry)
+}
+
+/// Runs the daemon headlessly (no tray).
+///
+/// Builds the registry and serves until a signal or `daemon stop`. The default
+/// `daemon run` path on every platform, and the only path when the `menu-bar`
+/// feature is off.
+pub async fn run_headless(cfg: DaemonRunConfig) -> Result<()> {
+    let registry = build_default_registry(
+        cfg.bridge_config,
+        cfg.bridge_token_file.as_deref(),
+        cfg.bridge_token_path,
+    )
+    .await?;
+    server::run(
+        registry,
+        DaemonOptions {
+            socket_path: cfg.socket_path,
+        },
+    )
+    .await
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -45,7 +45,9 @@ use services::bridge::BridgeService;
 /// Everything `daemon run` needs to start the daemon, resolved from the CLI.
 ///
 /// Shared by the headless path ([`run_headless`]) and the macOS menu-bar path
-/// ([`tray::run`]) so both start an identical daemon.
+/// (`tray::run`) so both start an identical daemon. The latter is a plain code
+/// span, not an intra-doc link, because the `tray` module is feature- and
+/// target-gated and absent from the docs build.
 #[derive(Debug, Clone)]
 pub struct DaemonRunConfig {
     /// Control-socket path (also the single-instance lock).

--- a/src/daemon/paths.rs
+++ b/src/daemon/paths.rs
@@ -86,3 +86,59 @@ pub fn check_socket_path_len(path: &Path) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_paths_sit_under_the_runtime_dir() {
+        let rt = runtime_dir().unwrap();
+        assert!(socket_path().unwrap().starts_with(&rt));
+        assert!(token_path().unwrap().starts_with(&rt));
+    }
+
+    #[test]
+    fn token_sits_beside_its_socket() {
+        assert_eq!(
+            token_path_for_socket(Path::new("/tmp/x/daemon.sock")),
+            Path::new("/tmp/x/bridge.token")
+        );
+        // A bare filename (parent is the empty path) still yields a token name.
+        assert_eq!(
+            token_path_for_socket(Path::new("daemon.sock")),
+            Path::new("bridge.token")
+        );
+    }
+
+    #[test]
+    fn socket_path_length_guard() {
+        check_socket_path_len(Path::new("/tmp/short.sock")).unwrap();
+        let too_long = PathBuf::from(format!("/{}", "a".repeat(MAX_SOCKET_PATH_LEN)));
+        assert!(check_socket_path_len(&too_long).is_err());
+    }
+
+    #[test]
+    fn ensure_dir_and_file_perms() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("run");
+        ensure_dir_0700(&sub).unwrap();
+        assert!(sub.is_dir());
+        let file = sub.join("k");
+        std::fs::write(&file, "x").unwrap();
+        set_file_0600(&file).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&sub).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(&file).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/src/daemon/paths.rs
+++ b/src/daemon/paths.rs
@@ -1,0 +1,77 @@
+//! Per-user runtime paths for the daemon (control socket, token file) and the
+//! filesystem-permission helpers that keep them owner-private.
+//!
+//! The runtime directory is resolved via [`dirs::data_dir`] —
+//! `~/Library/Application Support/omni-dev/` on macOS, `~/.local/share/omni-dev/`
+//! on Linux. This deliberately diverges from the `~/.omni-dev` config-file
+//! convention used by [`crate::claude::context`]: that governs user-editable
+//! configuration, whereas these are *runtime* artifacts of a long-lived
+//! menu-bar app, for which the platform data directory is the native home.
+//! See ADR-0039.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+/// macOS caps a `sockaddr_un` path at 104 bytes (including the NUL
+/// terminator); Linux allows 108. Use the smaller, portable bound.
+pub const MAX_SOCKET_PATH_LEN: usize = 104;
+
+/// The per-user runtime directory holding the daemon's socket and token file.
+pub fn runtime_dir() -> Result<PathBuf> {
+    let base = dirs::data_dir().context("could not determine the user data directory")?;
+    Ok(base.join("omni-dev"))
+}
+
+/// Default control-socket path: `<runtime_dir>/daemon.sock`.
+pub fn socket_path() -> Result<PathBuf> {
+    Ok(runtime_dir()?.join("daemon.sock"))
+}
+
+/// Default bridge token-file path: `<runtime_dir>/bridge.token`.
+pub fn token_path() -> Result<PathBuf> {
+    Ok(runtime_dir()?.join("bridge.token"))
+}
+
+/// Creates `dir` (and ancestors) if absent and tightens it to owner-only
+/// (`0700`) on Unix.
+pub fn ensure_dir_0700(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create directory {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("failed to set 0700 on {}", dir.display()))?;
+    }
+    Ok(())
+}
+
+/// Tightens an existing file to owner read/write only (`0600`) on Unix.
+pub fn set_file_0600(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set 0600 on {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+/// Fails closed if the socket path is too long for the platform's
+/// `sockaddr_un`, with an actionable message instead of an opaque bind error.
+pub fn check_socket_path_len(path: &Path) -> Result<()> {
+    let len = path.as_os_str().len();
+    if len >= MAX_SOCKET_PATH_LEN {
+        bail!(
+            "socket path is {len} bytes, exceeding the {MAX_SOCKET_PATH_LEN}-byte limit: {} — \
+             pass a shorter --socket path",
+            path.display()
+        );
+    }
+    Ok(())
+}

--- a/src/daemon/paths.rs
+++ b/src/daemon/paths.rs
@@ -28,9 +28,20 @@ pub fn socket_path() -> Result<PathBuf> {
     Ok(runtime_dir()?.join("daemon.sock"))
 }
 
-/// Default bridge token-file path: `<runtime_dir>/bridge.token`.
+/// Default bridge token-file path: `<runtime_dir>/bridge.token`. Thin clients
+/// (`request`/`harvest`) fall back to this when no `--token-file`/env is set.
 pub fn token_path() -> Result<PathBuf> {
     Ok(runtime_dir()?.join("bridge.token"))
+}
+
+/// The bridge token file co-located with a control socket
+/// (`<socket dir>/bridge.token`), so a custom `--socket` keeps its token beside
+/// it. For the default socket this equals [`token_path`].
+pub fn token_path_for_socket(socket: &Path) -> PathBuf {
+    socket.parent().map_or_else(
+        || PathBuf::from("bridge.token"),
+        |dir| dir.join("bridge.token"),
+    )
 }
 
 /// Creates `dir` (and ancestors) if absent and tightens it to owner-only

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1,0 +1,89 @@
+//! Wire types for the daemon's Unix-domain control socket.
+//!
+//! The control plane speaks newline-delimited JSON (NDJSON): one
+//! [`DaemonEnvelope`] request per line, one [`DaemonReply`] response per line.
+//! New optional fields use `#[serde(default, skip_serializing_if = ...)]` so
+//! older peers stay byte-compatible on the wire.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::service::ServiceStatus;
+
+/// The reserved service name for the daemon's own built-in operations
+/// (`ping`, `status`, `shutdown`). A `None` `service` targets the same.
+pub const DAEMON_SERVICE: &str = "daemon";
+
+/// A request sent to the daemon over the control socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonEnvelope {
+    /// Target service [`name`](super::service::DaemonService::name). `None`
+    /// (or `"daemon"`) routes to the built-in daemon ops.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service: Option<String>,
+    /// Operation name, interpreted by the target service (or the daemon).
+    pub op: String,
+    /// Operation payload; `null` when the op takes no arguments.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub payload: Value,
+}
+
+impl DaemonEnvelope {
+    /// Builds an envelope targeting a named service.
+    pub fn service(name: impl Into<String>, op: impl Into<String>, payload: Value) -> Self {
+        Self {
+            service: Some(name.into()),
+            op: op.into(),
+            payload,
+        }
+    }
+
+    /// Builds an envelope targeting the built-in daemon ops.
+    pub fn builtin(op: impl Into<String>) -> Self {
+        Self {
+            service: None,
+            op: op.into(),
+            payload: Value::Null,
+        }
+    }
+}
+
+/// A response returned by the daemon over the control socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonReply {
+    /// Whether the operation succeeded.
+    pub ok: bool,
+    /// Success payload; `null` for ops that return nothing.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub payload: Value,
+    /// Error message when [`ok`](Self::ok) is `false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl DaemonReply {
+    /// Builds a successful reply carrying `payload`.
+    pub fn ok(payload: Value) -> Self {
+        Self {
+            ok: true,
+            payload,
+            error: None,
+        }
+    }
+
+    /// Builds a failure reply carrying an error message.
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            payload: Value::Null,
+            error: Some(message.into()),
+        }
+    }
+}
+
+/// The payload of a built-in `status` reply: per-service status snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusReport {
+    /// One entry per registered service, in registration order.
+    pub services: Vec<ServiceStatus>,
+}

--- a/src/daemon/registry.rs
+++ b/src/daemon/registry.rs
@@ -1,0 +1,64 @@
+//! The [`ServiceRegistry`]: the daemon's set of hosted services, plus routing.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use super::service::{DaemonService, ServiceStatus};
+
+/// Holds the daemon's registered services and routes control-socket envelopes
+/// to them by [`name`](DaemonService::name).
+#[derive(Clone, Default)]
+pub struct ServiceRegistry {
+    services: Vec<Arc<dyn DaemonService>>,
+}
+
+impl ServiceRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a service. Later lookups match by [`DaemonService::name`]; the
+    /// caller is responsible for not registering two services with the same
+    /// name (the first registered wins on lookup).
+    pub fn register(&mut self, service: Arc<dyn DaemonService>) {
+        self.services.push(service);
+    }
+
+    /// Returns the registered service with the given name, if any.
+    pub fn get(&self, name: &str) -> Option<&Arc<dyn DaemonService>> {
+        self.services.iter().find(|s| s.name() == name)
+    }
+
+    /// All registered services, in registration order.
+    pub fn services(&self) -> &[Arc<dyn DaemonService>] {
+        &self.services
+    }
+
+    /// Routes an operation to the named service, erroring if no such service is
+    /// registered.
+    pub async fn dispatch(&self, service: &str, op: &str, payload: Value) -> Result<Value> {
+        let svc = self
+            .get(service)
+            .ok_or_else(|| anyhow!("unknown service: {service}"))?;
+        svc.handle(op, payload).await
+    }
+
+    /// Collects status from every service, in registration order.
+    pub async fn statuses(&self) -> Vec<ServiceStatus> {
+        let mut out = Vec::with_capacity(self.services.len());
+        for svc in &self.services {
+            out.push(svc.status().await);
+        }
+        out
+    }
+
+    /// Gracefully shuts down every service, in registration order.
+    pub async fn shutdown_all(&self) {
+        for svc in &self.services {
+            svc.shutdown().await;
+        }
+    }
+}

--- a/src/daemon/registry.rs
+++ b/src/daemon/registry.rs
@@ -62,3 +62,39 @@ impl ServiceRegistry {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::daemon::services::echo::EchoService;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn routes_known_service_and_rejects_unknown() {
+        let mut registry = ServiceRegistry::new();
+        assert!(registry.services().is_empty());
+        registry.register(Arc::new(EchoService));
+
+        assert!(registry.get("echo").is_some());
+        assert!(registry.get("missing").is_none());
+
+        // Routed op reaches the service; an unknown service is an error.
+        assert_eq!(
+            registry
+                .dispatch("echo", "echo", json!({ "x": 1 }))
+                .await
+                .unwrap(),
+            json!({ "x": 1 })
+        );
+        let err = registry
+            .dispatch("missing", "echo", Value::Null)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown service"));
+
+        // Aggregation iterates every registered service.
+        assert_eq!(registry.statuses().await.len(), 1);
+        registry.shutdown_all().await;
+    }
+}

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -30,6 +30,19 @@ pub struct DaemonOptions {
 /// Binding the socket doubles as the single-instance lock (see
 /// [`single_instance`]).
 pub async fn run(registry: ServiceRegistry, opts: DaemonOptions) -> Result<()> {
+    run_with_shutdown(Arc::new(registry), opts, CancellationToken::new()).await
+}
+
+/// Like [`run`], but with a shared registry and an externally-owned token.
+///
+/// The menu-bar host uses this to share the [`ServiceRegistry`] with the tray
+/// and to stop the daemon from a "Quit" menu action via the
+/// [`CancellationToken`].
+pub async fn run_with_shutdown(
+    registry: Arc<ServiceRegistry>,
+    opts: DaemonOptions,
+    shutdown: CancellationToken,
+) -> Result<()> {
     if let Some(parent) = opts.socket_path.parent() {
         paths::ensure_dir_0700(parent)?;
     }
@@ -38,10 +51,7 @@ pub async fn run(registry: ServiceRegistry, opts: DaemonOptions) -> Result<()> {
     let listener = single_instance::bind_or_reclaim(&opts.socket_path).await?;
     tracing::info!("daemon listening on {}", opts.socket_path.display());
 
-    let shutdown = CancellationToken::new();
     lifecycle::install_signal_handlers(shutdown.clone());
-
-    let registry = Arc::new(registry);
 
     loop {
         tokio::select! {

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -1,0 +1,270 @@
+//! The daemon server core: bind the control socket, accept NDJSON connections,
+//! route envelopes to services (or built-in ops), and shut down gracefully.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use futures::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LinesCodec};
+use tokio_util::sync::CancellationToken;
+
+use super::lifecycle;
+use super::paths;
+use super::protocol::{DaemonEnvelope, DaemonReply, StatusReport, DAEMON_SERVICE};
+use super::registry::ServiceRegistry;
+use super::single_instance;
+
+/// Configuration for a [`run`] invocation.
+#[derive(Debug, Clone)]
+pub struct DaemonOptions {
+    /// Path the control socket is bound to.
+    pub socket_path: PathBuf,
+}
+
+/// Runs the daemon until a `SIGTERM`/`SIGINT` or a built-in `shutdown` op,
+/// then drains every service and removes the socket.
+///
+/// Binding the socket doubles as the single-instance lock (see
+/// [`single_instance`]).
+pub async fn run(registry: ServiceRegistry, opts: DaemonOptions) -> Result<()> {
+    if let Some(parent) = opts.socket_path.parent() {
+        paths::ensure_dir_0700(parent)?;
+    }
+    paths::check_socket_path_len(&opts.socket_path)?;
+
+    let listener = single_instance::bind_or_reclaim(&opts.socket_path).await?;
+    tracing::info!("daemon listening on {}", opts.socket_path.display());
+
+    let shutdown = CancellationToken::new();
+    lifecycle::install_signal_handlers(shutdown.clone());
+
+    let registry = Arc::new(registry);
+
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _addr)) => {
+                        tokio::spawn(handle_connection(
+                            stream,
+                            registry.clone(),
+                            shutdown.clone(),
+                        ));
+                    }
+                    Err(e) => tracing::warn!("daemon accept error: {e}"),
+                }
+            }
+        }
+    }
+
+    tracing::info!("daemon shutting down; draining services");
+    registry.shutdown_all().await;
+    if let Err(e) = std::fs::remove_file(&opts.socket_path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                "failed to remove socket {}: {e}",
+                opts.socket_path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Serves one client connection: decode each NDJSON line, dispatch it, and
+/// write back one reply line, until the client hangs up or shutdown fires.
+async fn handle_connection(
+    stream: UnixStream,
+    registry: Arc<ServiceRegistry>,
+    shutdown: CancellationToken,
+) {
+    let mut framed = Framed::new(stream, LinesCodec::new());
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            line = framed.next() => {
+                let Some(line) = line else { break };
+                let reply = match line {
+                    Ok(line) => dispatch_line(&line, &registry, &shutdown).await,
+                    Err(e) => DaemonReply::err(format!("read error: {e}")),
+                };
+                let encoded = match serde_json::to_string(&reply) {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        tracing::warn!("failed to encode daemon reply: {e}");
+                        break;
+                    }
+                };
+                if let Err(e) = framed.send(encoded).await {
+                    tracing::debug!("daemon client write failed: {e}");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Parses one NDJSON request line and produces its reply.
+async fn dispatch_line(
+    line: &str,
+    registry: &ServiceRegistry,
+    shutdown: &CancellationToken,
+) -> DaemonReply {
+    let envelope: DaemonEnvelope = match serde_json::from_str(line) {
+        Ok(envelope) => envelope,
+        Err(e) => return DaemonReply::err(format!("invalid envelope: {e}")),
+    };
+    match envelope.service.as_deref() {
+        None | Some(DAEMON_SERVICE) => handle_builtin(&envelope.op, registry, shutdown).await,
+        Some(name) => match registry
+            .dispatch(name, &envelope.op, envelope.payload)
+            .await
+        {
+            Ok(payload) => DaemonReply::ok(payload),
+            Err(e) => DaemonReply::err(e.to_string()),
+        },
+    }
+}
+
+/// Handles the daemon's own built-in operations.
+async fn handle_builtin(
+    op: &str,
+    registry: &ServiceRegistry,
+    shutdown: &CancellationToken,
+) -> DaemonReply {
+    match op {
+        "ping" => DaemonReply::ok(json!({ "pong": true })),
+        "status" => {
+            let report = StatusReport {
+                services: registry.statuses().await,
+            };
+            match serde_json::to_value(report) {
+                Ok(payload) => DaemonReply::ok(payload),
+                Err(e) => DaemonReply::err(format!("failed to encode status: {e}")),
+            }
+        }
+        "shutdown" => {
+            shutdown.cancel();
+            DaemonReply::ok(json!({ "stopping": true }))
+        }
+        other => DaemonReply::err(format!("unknown daemon op: {other}")),
+    }
+}
+
+/// Resolves the control-socket path: the explicit override, or the per-user
+/// default from [`paths::socket_path`].
+pub fn resolve_socket(socket: Option<PathBuf>) -> Result<PathBuf> {
+    match socket {
+        Some(path) => Ok(path),
+        None => paths::socket_path().context("failed to resolve the default daemon socket path"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::daemon::services::echo::EchoService;
+    use serde_json::Value;
+    use std::time::Duration;
+
+    /// Spins up a daemon on a temp socket, runs `body`, then shuts it down and
+    /// joins the server task.
+    async fn with_daemon<F, Fut>(body: F)
+    where
+        F: FnOnce(PathBuf) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("d.sock");
+        let mut registry = ServiceRegistry::new();
+        registry.register(Arc::new(EchoService));
+        let opts = DaemonOptions {
+            socket_path: socket.clone(),
+        };
+        let handle = tokio::spawn(run(registry, opts));
+
+        // Wait for the socket to accept.
+        let client = crate::daemon::client::DaemonClient::new(&socket);
+        for _ in 0..50 {
+            if client.ping().await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        body(socket.clone()).await;
+
+        client.shutdown().await.ok();
+        let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn ping_and_status_and_routing() {
+        with_daemon(|socket| async move {
+            let client = crate::daemon::client::DaemonClient::new(&socket);
+
+            // Built-in ping.
+            client.ping().await.unwrap();
+
+            // Built-in status reports the echo service.
+            let report = client.status().await.unwrap();
+            assert_eq!(report.services.len(), 1);
+            assert_eq!(report.services[0].name, "echo");
+            assert!(report.services[0].healthy);
+
+            // Routed op reaches the echo service and round-trips the payload.
+            let reply = client
+                .request(DaemonEnvelope::service(
+                    "echo",
+                    "echo",
+                    json!({ "hello": "world" }),
+                ))
+                .await
+                .unwrap();
+            assert!(reply.ok);
+            assert_eq!(reply.payload, json!({ "hello": "world" }));
+
+            // Unknown service is an error, not a panic.
+            let reply = client
+                .request(DaemonEnvelope::service("nope", "x", Value::Null))
+                .await
+                .unwrap();
+            assert!(!reply.ok);
+            assert!(reply.error.unwrap().contains("unknown service"));
+
+            // Unknown built-in op is an error.
+            let reply = client
+                .request(DaemonEnvelope::builtin("frobnicate"))
+                .await
+                .unwrap();
+            assert!(!reply.ok);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn second_bind_is_refused_while_first_is_live() {
+        with_daemon(|socket| async move {
+            let mut registry = ServiceRegistry::new();
+            registry.register(Arc::new(EchoService));
+            let err = single_instance::bind_or_reclaim(&socket).await.unwrap_err();
+            assert!(err.to_string().contains("already running"));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn stale_socket_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("d.sock");
+        // A leftover regular file at the socket path stands in for a stale
+        // socket: nothing is listening, so the ping probe fails and we reclaim.
+        std::fs::write(&socket, b"stale").unwrap();
+        let listener = single_instance::bind_or_reclaim(&socket).await.unwrap();
+        drop(listener);
+    }
+}

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -1,0 +1,89 @@
+//! The [`DaemonService`] abstraction: a pluggable unit of work hosted by the
+//! daemon supervisor.
+//!
+//! A service has a stable [`name`](DaemonService::name), answers operations
+//! routed to it over the control socket ([`handle`](DaemonService::handle)),
+//! contributes a tray submenu ([`menu`](DaemonService::menu) /
+//! [`menu_action`](DaemonService::menu_action)), reports structured status for
+//! `daemon status` ([`status`](DaemonService::status)), and participates in
+//! graceful shutdown ([`shutdown`](DaemonService::shutdown)). See ADR-0039.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A long-lived unit of work supervised by the daemon.
+///
+/// Implementations are registered in a [`ServiceRegistry`](super::registry::ServiceRegistry)
+/// and are assumed live from registration until [`shutdown`](Self::shutdown).
+#[async_trait]
+pub trait DaemonService: Send + Sync {
+    /// Stable identifier used to route control-socket envelopes to this service
+    /// (the envelope's `service` field) and to label its status/menu.
+    fn name(&self) -> &'static str;
+
+    /// Handles an operation routed to this service, returning a JSON payload.
+    async fn handle(&self, op: &str, payload: Value) -> Result<Value>;
+
+    /// Cheap snapshot of the service's tray submenu, polled by the menu-bar
+    /// shell. Must not block.
+    fn menu(&self) -> MenuSnapshot;
+
+    /// Performs a tray menu action previously surfaced by [`menu`](Self::menu),
+    /// identified by its [`MenuAction::id`].
+    async fn menu_action(&self, action_id: &str) -> Result<()>;
+
+    /// Structured status for `daemon status` aggregation.
+    async fn status(&self) -> ServiceStatus;
+
+    /// Gracefully stops the service, draining in-flight work. Called once on
+    /// daemon shutdown.
+    async fn shutdown(&self);
+}
+
+/// Structured per-service status, aggregated by the built-in `status` op and
+/// surfaced by `omni-dev daemon status`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceStatus {
+    /// The reporting service's [`name`](DaemonService::name).
+    pub name: String,
+    /// Whether the service is currently operating normally.
+    pub healthy: bool,
+    /// One-line human-readable summary (e.g. `"1 tab connected"`).
+    pub summary: String,
+    /// Service-specific structured detail; `null` when there is none.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub detail: Value,
+}
+
+/// A cheap snapshot of a service's tray submenu, rebuilt on each poll.
+#[derive(Debug, Clone, Default)]
+pub struct MenuSnapshot {
+    /// Submenu title (the parent menu-bar entry label).
+    pub title: String,
+    /// Ordered submenu entries.
+    pub items: Vec<MenuItem>,
+}
+
+/// A single entry in a [`MenuSnapshot`].
+#[derive(Debug, Clone)]
+pub enum MenuItem {
+    /// A non-interactive status line.
+    Label(String),
+    /// A horizontal separator.
+    Separator,
+    /// A clickable action dispatched via [`DaemonService::menu_action`].
+    Action(MenuAction),
+}
+
+/// A clickable tray action.
+#[derive(Debug, Clone)]
+pub struct MenuAction {
+    /// Stable identifier passed back to [`DaemonService::menu_action`].
+    pub id: String,
+    /// Human-readable menu label.
+    pub label: String,
+    /// Whether the action is currently selectable.
+    pub enabled: bool,
+}

--- a/src/daemon/services/bridge.rs
+++ b/src/daemon/services/bridge.rs
@@ -137,6 +137,12 @@ impl DaemonService for BridgeService {
                     None => bail!("bridge is not running"),
                 }
             }
+            "token" => {
+                // The raw session token (the "bridge key"). Exposed for the
+                // tray's "Copy bridge key" action; the control socket is
+                // owner-only (`0600`), same trust as the token file.
+                Ok(json!({ "token": self.token.as_str() }))
+            }
             other => bail!("unknown browser-bridge op: {other}"),
         }
     }
@@ -170,7 +176,16 @@ impl DaemonService for BridgeService {
                 } else {
                     "No tab connected".to_string()
                 };
-                let mut items = vec![MenuItem::Label(line), MenuItem::Separator];
+                let mut items = vec![
+                    MenuItem::Label(line),
+                    MenuItem::Label(format!("Key: {}", self.token)),
+                    MenuItem::Separator,
+                ];
+                items.push(MenuItem::Action(MenuAction {
+                    id: "copy-key".to_string(),
+                    label: "Copy bridge key".to_string(),
+                    enabled: true,
+                }));
                 items.push(MenuItem::Action(MenuAction {
                     id: "copy-snippet".to_string(),
                     label: "Copy console snippet".to_string(),
@@ -293,6 +308,18 @@ mod tests {
         let payload = svc.handle("status", Value::Null).await.unwrap();
         assert_eq!(payload.get("connected"), Some(&json!(false)));
 
+        // `token` op returns the raw session key, matching the persisted file.
+        let token = svc
+            .handle("token", Value::Null)
+            .await
+            .unwrap()
+            .get("token")
+            .and_then(Value::as_str)
+            .unwrap()
+            .to_string();
+        assert!(!token.is_empty());
+        assert_eq!(std::fs::read_to_string(&token_path).unwrap().trim(), token);
+
         // Unknown op is an error, not a panic.
         assert!(svc.handle("frobnicate", Value::Null).await.is_err());
 
@@ -308,6 +335,15 @@ mod tests {
         let menu = svc.menu();
         assert_eq!(menu.title, "Browser Bridge");
         assert!(matches!(menu.items.first(), Some(MenuItem::Label(_))));
+        // The key is shown as a label and is copyable.
+        assert!(menu.items.iter().any(|i| matches!(
+            i,
+            MenuItem::Label(text) if text.starts_with("Key: ")
+        )));
+        assert!(menu.items.iter().any(|i| matches!(
+            i,
+            MenuItem::Action(a) if a.id == "copy-key"
+        )));
         assert!(menu.items.iter().any(|i| matches!(
             i,
             MenuItem::Action(a) if a.id == "restart-bridge"

--- a/src/daemon/services/bridge.rs
+++ b/src/daemon/services/bridge.rs
@@ -143,6 +143,22 @@ impl DaemonService for BridgeService {
                 // owner-only (`0600`), same trust as the token file.
                 Ok(json!({ "token": self.token.as_str() }))
             }
+            "request-command" => {
+                // A ready-to-run `request` command with the session key assigned
+                // to OMNI_BRIDGE_TOKEN. The token is URL-safe base64, so it is
+                // shell-safe; single-quoted for robustness. Backs the tray's
+                // "Copy request command" action.
+                let control_port = self.lock().as_ref().map(BridgeServer::control_port);
+                match control_port {
+                    Some(port) => Ok(json!({
+                        "command": format!(
+                            "{}='{}' omni-dev browser bridge request --control-port {port} --url /",
+                            auth::TOKEN_ENV, self.token
+                        )
+                    })),
+                    None => bail!("bridge is not running"),
+                }
+            }
             other => bail!("unknown browser-bridge op: {other}"),
         }
     }
@@ -189,6 +205,11 @@ impl DaemonService for BridgeService {
                 items.push(MenuItem::Action(MenuAction {
                     id: "copy-snippet".to_string(),
                     label: "Copy console snippet".to_string(),
+                    enabled: true,
+                }));
+                items.push(MenuItem::Action(MenuAction {
+                    id: "copy-request".to_string(),
+                    label: "Copy request command".to_string(),
                     enabled: true,
                 }));
                 for tab in &status.tabs {
@@ -320,6 +341,18 @@ mod tests {
         assert!(!token.is_empty());
         assert_eq!(std::fs::read_to_string(&token_path).unwrap().trim(), token);
 
+        // `request-command` op embeds the key in an OMNI_BRIDGE_TOKEN assignment.
+        let cmd = svc
+            .handle("request-command", Value::Null)
+            .await
+            .unwrap()
+            .get("command")
+            .and_then(Value::as_str)
+            .unwrap()
+            .to_string();
+        assert!(cmd.starts_with(&format!("OMNI_BRIDGE_TOKEN='{token}'")));
+        assert!(cmd.contains("browser bridge request --control-port"));
+
         // Unknown op is an error, not a panic.
         assert!(svc.handle("frobnicate", Value::Null).await.is_err());
 
@@ -343,6 +376,10 @@ mod tests {
         assert!(menu.items.iter().any(|i| matches!(
             i,
             MenuItem::Action(a) if a.id == "copy-key"
+        )));
+        assert!(menu.items.iter().any(|i| matches!(
+            i,
+            MenuItem::Action(a) if a.id == "copy-request"
         )));
         assert!(menu.items.iter().any(|i| matches!(
             i,

--- a/src/daemon/services/bridge.rs
+++ b/src/daemon/services/bridge.rs
@@ -1,0 +1,327 @@
+//! The browser-bridge daemon service: hosts the bridge's loopback-TCP planes
+//! under the daemon's lifecycle and exposes status/control to it.
+//!
+//! The security model is unchanged from ADR-0036 — the bridge keeps both its
+//! TCP planes and their bearer-token auth, and the daemon never proxies browser
+//! traffic. The only additive delta is that the resolved session token is
+//! persisted to a `0600` file so thin clients (`request`/`harvest`) can
+//! discover it without the foreground stdout a standalone `serve` prints.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
+
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::browser::protocol::StatusResponse;
+use crate::browser::{auth, snippet, BridgeConfig, BridgeServer};
+use crate::daemon::paths;
+use crate::daemon::service::{DaemonService, MenuAction, MenuItem, MenuSnapshot, ServiceStatus};
+
+/// The browser-bridge service name (the control-socket routing key).
+pub const SERVICE_NAME: &str = "browser-bridge";
+
+/// Hosts a [`BridgeServer`] under the daemon, persisting its session token for
+/// thin-client discovery and allowing in-place restart.
+pub struct BridgeService {
+    /// The running server; `None` only transiently during a restart.
+    inner: StdMutex<Option<BridgeServer>>,
+    config: BridgeConfig,
+    token: Arc<String>,
+    token_path: PathBuf,
+}
+
+impl BridgeService {
+    /// Resolves the session token, persists it to a `0600` file, starts the
+    /// bridge planes, and returns the service.
+    pub async fn start(
+        config: BridgeConfig,
+        token_file: Option<&Path>,
+        token_path: PathBuf,
+    ) -> Result<Self> {
+        let token = auth::resolve_token(token_file)?;
+        write_token(&token_path, &token)?;
+        let server = BridgeServer::start(config.clone(), token.clone()).await?;
+        Ok(Self {
+            inner: StdMutex::new(Some(server)),
+            config,
+            token: Arc::new(token),
+            token_path,
+        })
+    }
+
+    /// Locks the inner server slot, recovering from a poisoned mutex.
+    fn lock(&self) -> MutexGuard<'_, Option<BridgeServer>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Stops the running bridge and starts a fresh one with the same config and
+    /// token. The lock is never held across the awaits.
+    async fn restart(&self) -> Result<()> {
+        let old = self.lock().take();
+        if let Some(server) = old {
+            server.shutdown().await;
+        }
+        let server = BridgeServer::start(self.config.clone(), (*self.token).clone()).await?;
+        *self.lock() = Some(server);
+        Ok(())
+    }
+}
+
+/// Writes `token` to `path` (`0600`), creating its parent directory (`0700`).
+fn write_token(path: &Path, token: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        paths::ensure_dir_0700(parent)?;
+    }
+    std::fs::write(path, token)
+        .with_context(|| format!("failed to write token file {}", path.display()))?;
+    paths::set_file_0600(path)?;
+    Ok(())
+}
+
+/// A one-line summary for `daemon status` / the tray.
+fn summarize(status: &StatusResponse, control_port: u16, ws_port: u16) -> String {
+    if status.connected {
+        format!(
+            "{} tab(s), {} pending (control :{control_port}, ws :{ws_port})",
+            status.tabs.len(),
+            status.pending
+        )
+    } else {
+        format!("no tab connected (control :{control_port}, ws :{ws_port})")
+    }
+}
+
+#[async_trait]
+impl DaemonService for BridgeService {
+    fn name(&self) -> &'static str {
+        SERVICE_NAME
+    }
+
+    async fn handle(&self, op: &str, payload: Value) -> Result<Value> {
+        match op {
+            "status" => {
+                let snapshot = self.lock().as_ref().map(BridgeServer::status);
+                match snapshot {
+                    Some(status) => Ok(serde_json::to_value(status)?),
+                    None => Ok(json!({ "running": false })),
+                }
+            }
+            "disconnect-tab" => {
+                let id = payload
+                    .get("id")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| anyhow!("`disconnect-tab` requires a numeric `id`"))?;
+                let guard = self.lock();
+                let server = guard
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("bridge is not running"))?;
+                server.disconnect_tab(id)?;
+                Ok(json!({ "disconnected": id }))
+            }
+            "restart" => {
+                self.restart().await?;
+                Ok(json!({ "restarted": true }))
+            }
+            "snippet" => {
+                // The paste-ready DevTools snippet (includes the session token).
+                // Exposed for the tray's "Copy console snippet" action; the
+                // control socket is owner-only (`0600`), same trust as the token
+                // file.
+                let ws_port = self.lock().as_ref().map(BridgeServer::ws_port);
+                match ws_port {
+                    Some(port) => Ok(json!({ "snippet": snippet::render(port, &self.token) })),
+                    None => bail!("bridge is not running"),
+                }
+            }
+            other => bail!("unknown browser-bridge op: {other}"),
+        }
+    }
+
+    fn menu(&self) -> MenuSnapshot {
+        let info = self
+            .lock()
+            .as_ref()
+            .map(|s| (s.status(), s.control_port(), s.ws_port()));
+        let items = match info {
+            Some((status, _control, _ws)) => {
+                let line = if status.connected {
+                    let origins: Vec<&str> = status
+                        .tabs
+                        .iter()
+                        .filter_map(|t| t.origin.as_deref())
+                        .collect();
+                    if origins.is_empty() {
+                        format!(
+                            "Connected — {} tab(s) — {} pending",
+                            status.tabs.len(),
+                            status.pending
+                        )
+                    } else {
+                        format!(
+                            "Connected — {} — {} pending",
+                            origins.join(", "),
+                            status.pending
+                        )
+                    }
+                } else {
+                    "No tab connected".to_string()
+                };
+                let mut items = vec![MenuItem::Label(line), MenuItem::Separator];
+                items.push(MenuItem::Action(MenuAction {
+                    id: "copy-snippet".to_string(),
+                    label: "Copy console snippet".to_string(),
+                    enabled: true,
+                }));
+                for tab in &status.tabs {
+                    items.push(MenuItem::Action(MenuAction {
+                        id: format!("disconnect-tab:{}", tab.id),
+                        label: format!("Disconnect tab {}", tab.id),
+                        enabled: true,
+                    }));
+                }
+                items.push(MenuItem::Action(MenuAction {
+                    id: "restart-bridge".to_string(),
+                    label: "Restart bridge".to_string(),
+                    enabled: true,
+                }));
+                items
+            }
+            None => vec![MenuItem::Label("Not running".to_string())],
+        };
+        MenuSnapshot {
+            title: "Browser Bridge".to_string(),
+            items,
+        }
+    }
+
+    async fn menu_action(&self, action_id: &str) -> Result<()> {
+        if action_id == "restart-bridge" {
+            return self.restart().await;
+        }
+        if let Some(id_str) = action_id.strip_prefix("disconnect-tab:") {
+            let id: u64 = id_str
+                .parse()
+                .with_context(|| format!("invalid tab id in action {action_id}"))?;
+            let guard = self.lock();
+            let server = guard
+                .as_ref()
+                .ok_or_else(|| anyhow!("bridge is not running"))?;
+            return server.disconnect_tab(id);
+        }
+        bail!("unknown browser-bridge menu action: {action_id}")
+    }
+
+    async fn status(&self) -> ServiceStatus {
+        let info = self
+            .lock()
+            .as_ref()
+            .map(|s| (s.status(), s.control_port(), s.ws_port()));
+        match info {
+            Some((status, control_port, ws_port)) => ServiceStatus {
+                name: SERVICE_NAME.to_string(),
+                healthy: true,
+                summary: summarize(&status, control_port, ws_port),
+                detail: json!({
+                    "control_port": control_port,
+                    "ws_port": ws_port,
+                    "status": status,
+                }),
+            },
+            None => ServiceStatus {
+                name: SERVICE_NAME.to_string(),
+                healthy: false,
+                summary: "not running".to_string(),
+                detail: Value::Null,
+            },
+        }
+    }
+
+    async fn shutdown(&self) {
+        let server = self.lock().take();
+        if let Some(server) = server {
+            server.shutdown().await;
+        }
+        // Best-effort: don't leave a stale token file behind.
+        let _ = std::fs::remove_file(&self.token_path);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// A bridge service on random ports with its token written to a temp dir.
+    async fn temp_service(dir: &Path) -> BridgeService {
+        let config = BridgeConfig {
+            ws_port: 0,
+            control_port: 0,
+            ..BridgeConfig::default()
+        };
+        let token_path = dir.join("bridge.token");
+        BridgeService::start(config, None, token_path)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn start_writes_token_and_reports_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = temp_service(dir.path()).await;
+
+        // Token file exists and is owner-only.
+        let token_path = dir.path().join("bridge.token");
+        assert!(token_path.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&token_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+
+        // Status: healthy, no tab connected, ports surfaced in detail.
+        let status = svc.status().await;
+        assert_eq!(status.name, "browser-bridge");
+        assert!(status.healthy);
+        assert!(status.detail.get("control_port").is_some());
+
+        // `status` op round-trips a StatusResponse payload.
+        let payload = svc.handle("status", Value::Null).await.unwrap();
+        assert_eq!(payload.get("connected"), Some(&json!(false)));
+
+        // Unknown op is an error, not a panic.
+        assert!(svc.handle("frobnicate", Value::Null).await.is_err());
+
+        svc.shutdown().await;
+        // Token file removed on shutdown.
+        assert!(!token_path.exists());
+    }
+
+    #[tokio::test]
+    async fn menu_lists_status_line_and_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = temp_service(dir.path()).await;
+        let menu = svc.menu();
+        assert_eq!(menu.title, "Browser Bridge");
+        assert!(matches!(menu.items.first(), Some(MenuItem::Label(_))));
+        assert!(menu.items.iter().any(|i| matches!(
+            i,
+            MenuItem::Action(a) if a.id == "restart-bridge"
+        )));
+        svc.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn restart_keeps_service_serving() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = temp_service(dir.path()).await;
+        svc.handle("restart", Value::Null).await.unwrap();
+        // Still healthy after a restart.
+        assert!(svc.status().await.healthy);
+        svc.shutdown().await;
+    }
+}

--- a/src/daemon/services/echo.rs
+++ b/src/daemon/services/echo.rs
@@ -1,0 +1,49 @@
+//! A trivial [`DaemonService`] that echoes its payload back. It exists so the
+//! daemon framework can be exercised end-to-end before — and independently of
+//! — any real service.
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::daemon::service::{DaemonService, MenuItem, MenuSnapshot, ServiceStatus};
+
+/// A stateless service whose only op, `echo`, returns its payload verbatim.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EchoService;
+
+#[async_trait]
+impl DaemonService for EchoService {
+    fn name(&self) -> &'static str {
+        "echo"
+    }
+
+    async fn handle(&self, op: &str, payload: Value) -> Result<Value> {
+        match op {
+            "echo" => Ok(payload),
+            other => bail!("unknown echo op: {other}"),
+        }
+    }
+
+    fn menu(&self) -> MenuSnapshot {
+        MenuSnapshot {
+            title: "Echo".to_string(),
+            items: vec![MenuItem::Label("ready".to_string())],
+        }
+    }
+
+    async fn menu_action(&self, _action_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn status(&self) -> ServiceStatus {
+        ServiceStatus {
+            name: self.name().to_string(),
+            healthy: true,
+            summary: "ready".to_string(),
+            detail: Value::Null,
+        }
+    }
+
+    async fn shutdown(&self) {}
+}

--- a/src/daemon/services/echo.rs
+++ b/src/daemon/services/echo.rs
@@ -47,3 +47,29 @@ impl DaemonService for EchoService {
 
     async fn shutdown(&self) {}
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn echo_service_round_trips_and_reports() {
+        let svc = EchoService;
+        assert_eq!(svc.name(), "echo");
+        // `echo` returns its payload verbatim; any other op errors.
+        assert_eq!(
+            svc.handle("echo", json!({ "a": 1 })).await.unwrap(),
+            json!({ "a": 1 })
+        );
+        assert!(svc.handle("nope", Value::Null).await.is_err());
+        // Menu / status / actions are inert but must not panic.
+        assert_eq!(svc.menu().title, "Echo");
+        svc.menu_action("anything").await.unwrap();
+        let status = svc.status().await;
+        assert_eq!(status.name, "echo");
+        assert!(status.healthy);
+        svc.shutdown().await;
+    }
+}

--- a/src/daemon/services/mod.rs
+++ b/src/daemon/services/mod.rs
@@ -1,7 +1,8 @@
 //! Built-in daemon services.
 //!
 //! Each submodule provides one [`DaemonService`](super::service::DaemonService)
-//! implementation. The browser bridge service joins this module in a later
-//! change (#987); for now only the [`echo`] test service lives here.
+//! implementation: [`bridge`] hosts the browser bridge (the real service);
+//! [`echo`] is a trivial test service used by the framework's own tests.
 
+pub mod bridge;
 pub mod echo;

--- a/src/daemon/services/mod.rs
+++ b/src/daemon/services/mod.rs
@@ -1,0 +1,7 @@
+//! Built-in daemon services.
+//!
+//! Each submodule provides one [`DaemonService`](super::service::DaemonService)
+//! implementation. The browser bridge service joins this module in a later
+//! change (#987); for now only the [`echo`] test service lives here.
+
+pub mod echo;

--- a/src/daemon/single_instance.rs
+++ b/src/daemon/single_instance.rs
@@ -1,0 +1,47 @@
+//! Single-instance supervision: the exclusive socket bind *is* the lock.
+//!
+//! Binding the control socket fails with `EADDRINUSE` when the path is already
+//! occupied. We then [`ping`](super::client::DaemonClient::ping) it: a live
+//! daemon answers (so we refuse to start a second), while a stale socket left
+//! by a crashed daemon does not (so we reclaim it and rebind).
+
+use std::io::ErrorKind;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use tokio::net::UnixListener;
+
+use super::client::DaemonClient;
+use super::paths;
+
+/// Binds the control socket, reclaiming a stale socket from a crashed daemon
+/// but refusing to displace a live one.
+pub async fn bind_or_reclaim(path: &Path) -> Result<UnixListener> {
+    match UnixListener::bind(path) {
+        Ok(listener) => {
+            paths::set_file_0600(path)?;
+            Ok(listener)
+        }
+        Err(e) if e.kind() == ErrorKind::AddrInUse => {
+            if DaemonClient::new(path).ping().await.is_ok() {
+                bail!(
+                    "a daemon is already running (socket {}); use `omni-dev daemon status`",
+                    path.display()
+                );
+            }
+            tracing::warn!(
+                "reclaiming stale daemon socket at {} (no live daemon answered)",
+                path.display()
+            );
+            std::fs::remove_file(path)
+                .with_context(|| format!("failed to remove stale socket {}", path.display()))?;
+            let listener = UnixListener::bind(path)
+                .with_context(|| format!("failed to bind daemon socket {}", path.display()))?;
+            paths::set_file_0600(path)?;
+            Ok(listener)
+        }
+        Err(e) => {
+            Err(e).with_context(|| format!("failed to bind daemon socket {}", path.display()))
+        }
+    }
+}

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -160,7 +160,7 @@ fn event_loop(
     let mut last_sig = signature(&initial);
     let tray = TrayIconBuilder::new()
         .with_menu(Box::new(build_menu(&initial)))
-        .with_title("omni-dev")
+        .with_title("od")
         .with_tooltip("omni-dev daemon")
         .build()
         .context("failed to create the menu-bar tray icon")?;

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -214,6 +214,7 @@ fn handle_action(
     let copy = match action {
         "copy-key" => Some(("token", "token")),
         "copy-snippet" => Some(("snippet", "snippet")),
+        "copy-request" => Some(("request-command", "command")),
         _ => None,
     };
     if let Some((op, field)) = copy {

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -1,0 +1,252 @@
+//! macOS menu-bar tray for the daemon (`cfg(all(target_os = "macos", feature =
+//! "menu-bar"))`).
+//!
+//! The tray must own the **main thread** (macOS GUI event loops require it), so
+//! [`run`] builds the tokio runtime, spawns the daemon server onto it, and
+//! hands the main thread to the `tao` event loop. Each registered service
+//! contributes a submenu built from its [`MenuSnapshot`]; clicks are routed
+//! back to [`DaemonService::menu_action`](crate::daemon::service::DaemonService::menu_action)
+//! (or, for "Copy console snippet", fulfilled locally via the clipboard). A
+//! "Quit" item cancels the shared shutdown token and drains the daemon.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use arboard::Clipboard;
+use serde_json::Value;
+use tao::event_loop::{ControlFlow, EventLoop};
+use tao::platform::run_return::EventLoopExtRunReturn;
+use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
+use tray_icon::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
+use tray_icon::TrayIconBuilder;
+
+use crate::daemon::registry::ServiceRegistry;
+use crate::daemon::server::{self, DaemonOptions};
+use crate::daemon::service::{MenuItem as ServiceMenuItem, MenuSnapshot};
+use crate::daemon::{build_default_registry, DaemonRunConfig};
+
+/// Menu id of the daemon-level Quit item.
+const QUIT_ID: &str = "omni-dev:quit";
+/// Separator between a service name and its action id inside a tray menu id.
+/// `\u{1}` (SOH) never occurs in a service name or action id.
+const DELIM: char = '\u{1}';
+
+/// Runs the daemon with a macOS menu-bar tray, blocking until "Quit".
+///
+/// Builds the runtime, starts the services, spawns the control-socket server,
+/// then drives the tray event loop on the main thread.
+pub fn run(cfg: DaemonRunConfig) -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().context("failed to start the tokio runtime")?;
+    let registry = runtime
+        .block_on(build_default_registry(
+            cfg.bridge_config,
+            cfg.bridge_token_file.as_deref(),
+            cfg.bridge_token_path,
+        ))
+        .context("failed to start the daemon services")?;
+    let registry = Arc::new(registry);
+
+    let shutdown = CancellationToken::new();
+    let server = runtime.spawn(server::run_with_shutdown(
+        registry.clone(),
+        DaemonOptions {
+            socket_path: cfg.socket_path,
+        },
+        shutdown.clone(),
+    ));
+
+    let result = event_loop(runtime.handle().clone(), registry, shutdown.clone());
+
+    // The tray exited ("Quit", or the daemon was stopped externally): stop the
+    // daemon and drain it.
+    shutdown.cancel();
+    match runtime.block_on(server) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!("daemon server error: {e}"),
+        Err(e) => tracing::warn!("daemon server task failed: {e}"),
+    }
+    result
+}
+
+/// Cheap per-service menu snapshots, in registration order.
+fn snapshots(registry: &ServiceRegistry) -> Vec<(&'static str, MenuSnapshot)> {
+    registry
+        .services()
+        .iter()
+        .map(|s| (s.name(), s.menu()))
+        .collect()
+}
+
+/// A stable signature of the current menu, so the tray rebuilds only on change.
+fn signature(snaps: &[(&'static str, MenuSnapshot)]) -> String {
+    let mut sig = String::new();
+    for (name, snap) in snaps {
+        sig.push_str(name);
+        sig.push('/');
+        sig.push_str(&snap.title);
+        sig.push('|');
+        for item in &snap.items {
+            match item {
+                ServiceMenuItem::Label(text) => {
+                    sig.push('L');
+                    sig.push_str(text);
+                }
+                ServiceMenuItem::Separator => sig.push('S'),
+                ServiceMenuItem::Action(action) => {
+                    sig.push('A');
+                    sig.push_str(&action.id);
+                    sig.push('=');
+                    sig.push_str(&action.label);
+                    sig.push(if action.enabled { '+' } else { '-' });
+                }
+            }
+            sig.push(';');
+        }
+    }
+    sig
+}
+
+/// Builds the full tray menu: one submenu per service, plus a Quit item. Action
+/// ids are prefixed with `"<service>{DELIM}"` so clicks route back to the right
+/// service.
+fn build_menu(snaps: &[(&'static str, MenuSnapshot)]) -> Menu {
+    let menu = Menu::new();
+    for (name, snap) in snaps {
+        let submenu = Submenu::new(&snap.title, true);
+        for item in &snap.items {
+            let appended = match item {
+                ServiceMenuItem::Label(text) => submenu.append(&MenuItem::new(text, false, None)),
+                ServiceMenuItem::Separator => submenu.append(&PredefinedMenuItem::separator()),
+                ServiceMenuItem::Action(action) => {
+                    let id = format!("{name}{DELIM}{}", action.id);
+                    submenu.append(&MenuItem::with_id(id, &action.label, action.enabled, None))
+                }
+            };
+            if let Err(e) = appended {
+                tracing::warn!("failed to build tray menu item: {e}");
+            }
+        }
+        if let Err(e) = menu.append(&submenu) {
+            tracing::warn!("failed to add tray submenu: {e}");
+        }
+    }
+    if let Err(e) = menu.append(&PredefinedMenuItem::separator()) {
+        tracing::warn!("failed to add tray separator: {e}");
+    }
+    if let Err(e) = menu.append(&MenuItem::with_id(
+        QUIT_ID,
+        "Quit omni-dev daemon",
+        true,
+        None,
+    )) {
+        tracing::warn!("failed to add quit item: {e}");
+    }
+    menu
+}
+
+/// Builds the tray and pumps the macOS event loop on the main thread, refreshing
+/// the menu ~1 Hz and dispatching clicks until "Quit" or until `shutdown` is
+/// cancelled (a signal, or `daemon stop` over the socket).
+fn event_loop(
+    handle: Handle,
+    registry: Arc<ServiceRegistry>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let mut event_loop: EventLoop<()> = EventLoop::new();
+
+    let initial = snapshots(&registry);
+    let mut last_sig = signature(&initial);
+    let tray = TrayIconBuilder::new()
+        .with_menu(Box::new(build_menu(&initial)))
+        .with_title("omni-dev")
+        .with_tooltip("omni-dev daemon")
+        .build()
+        .context("failed to create the menu-bar tray icon")?;
+
+    let menu_rx = MenuEvent::receiver();
+    let mut clipboard: Option<Clipboard> = None;
+
+    event_loop.run_return(move |_event, _target, control_flow| {
+        // Wake at least once per second to refresh the live menu state.
+        *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_secs(1));
+
+        // Close the tray when the daemon is stopped by a signal or `daemon stop`.
+        if shutdown.is_cancelled() {
+            *control_flow = ControlFlow::Exit;
+            return;
+        }
+
+        let snaps = snapshots(&registry);
+        let sig = signature(&snaps);
+        if sig != last_sig {
+            tray.set_menu(Some(Box::new(build_menu(&snaps))));
+            last_sig = sig;
+        }
+
+        while let Ok(event) = menu_rx.try_recv() {
+            if event.id.as_ref() == QUIT_ID {
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
+            handle_action(&handle, &registry, &mut clipboard, event.id.as_ref());
+        }
+    });
+
+    Ok(())
+}
+
+/// Routes a clicked menu id back to its service: "copy-snippet" is fulfilled via
+/// the clipboard; everything else goes to the service's `menu_action`.
+fn handle_action(
+    handle: &Handle,
+    registry: &ServiceRegistry,
+    clipboard: &mut Option<Clipboard>,
+    full_id: &str,
+) {
+    let Some((service, action)) = full_id.split_once(DELIM) else {
+        tracing::debug!("ignoring tray menu id with no service prefix: {full_id}");
+        return;
+    };
+
+    if action == "copy-snippet" {
+        match handle.block_on(registry.dispatch(service, "snippet", Value::Null)) {
+            Ok(value) => {
+                if let Some(text) = value.get("snippet").and_then(Value::as_str) {
+                    copy_to_clipboard(clipboard, text);
+                } else {
+                    tracing::warn!("snippet op returned no snippet");
+                }
+            }
+            Err(e) => tracing::warn!("copy snippet failed: {e}"),
+        }
+        return;
+    }
+
+    let Some(svc) = registry.get(service) else {
+        tracing::warn!("tray menu action for unknown service: {service}");
+        return;
+    };
+    if let Err(e) = handle.block_on(svc.menu_action(action)) {
+        tracing::warn!("tray menu action {full_id} failed: {e}");
+    }
+}
+
+/// Copies `text` to the system clipboard, lazily creating the handle.
+fn copy_to_clipboard(clipboard: &mut Option<Clipboard>, text: &str) {
+    if clipboard.is_none() {
+        match Clipboard::new() {
+            Ok(handle) => *clipboard = Some(handle),
+            Err(e) => {
+                tracing::warn!("clipboard unavailable: {e}");
+                return;
+            }
+        }
+    }
+    if let Some(handle) = clipboard.as_mut() {
+        if let Err(e) = handle.set_text(text.to_string()) {
+            tracing::warn!("failed to copy to clipboard: {e}");
+        }
+    }
+}

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -210,16 +210,22 @@ fn handle_action(
         return;
     };
 
-    if action == "copy-snippet" {
-        match handle.block_on(registry.dispatch(service, "snippet", Value::Null)) {
+    // Clipboard actions: fetch a string field from a service op and copy it.
+    let copy = match action {
+        "copy-key" => Some(("token", "token")),
+        "copy-snippet" => Some(("snippet", "snippet")),
+        _ => None,
+    };
+    if let Some((op, field)) = copy {
+        match handle.block_on(registry.dispatch(service, op, Value::Null)) {
             Ok(value) => {
-                if let Some(text) = value.get("snippet").and_then(Value::as_str) {
+                if let Some(text) = value.get(field).and_then(Value::as_str) {
                     copy_to_clipboard(clipboard, text);
                 } else {
-                    tracing::warn!("snippet op returned no snippet");
+                    tracing::warn!("`{op}` op returned no `{field}`");
                 }
             }
-            Err(e) => tracing::warn!("copy snippet failed: {e}"),
+            Err(e) => tracing::warn!("copy from `{op}` op failed: {e}"),
         }
         return;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod browser;
 pub mod claude;
 pub mod cli;
 pub mod coverage;
+pub mod daemon;
 pub mod data;
 pub mod datadog;
 pub mod git;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,46 @@ use std::process;
 use clap::Parser;
 use omni_dev::Cli;
 
-#[tokio::main]
-async fn main() {
-    // Initialize tracing subscriber with RUST_LOG environment variable support
-    // Default to "warn" level if RUST_LOG is not set
-    // Write to stderr so debug logs don't interfere with stdout output
+fn main() {
+    init_tracing();
+
+    let cli = Cli::parse();
+
+    // The macOS menu-bar daemon needs the GUI event loop on the main thread,
+    // which a tokio runtime cannot own. Detect `daemon run` (without
+    // `--no-menu`) and hand the main thread to the tray; every other invocation
+    // runs the async CLI on a multi-thread runtime exactly as before.
+    #[cfg(all(target_os = "macos", feature = "menu-bar"))]
+    if let Some(run_config) = cli.menu_bar_run_config() {
+        let cfg = match run_config {
+            Ok(cfg) => cfg,
+            Err(e) => die(&e),
+        };
+        match omni_dev::daemon::tray::run(cfg) {
+            Ok(()) => return,
+            Err(e) => die(&e),
+        }
+    }
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("Error: failed to start the tokio runtime: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = runtime.block_on(cli.execute()) {
+        die(&e);
+    }
+}
+
+/// Initializes the tracing subscriber (stderr, `RUST_LOG`-driven, default
+/// `warn`), keeping daemon/debug logs off stdout.
+fn init_tracing() {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -15,19 +50,15 @@ async fn main() {
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
         )
         .init();
+}
 
-    let cli = Cli::parse();
-
-    if let Err(e) = cli.execute().await {
-        eprintln!("Error: {e}");
-
-        // Print the full error chain if available
-        let mut source = e.source();
-        while let Some(err) = source {
-            eprintln!("  Caused by: {err}");
-            source = err.source();
-        }
-
-        process::exit(1);
+/// Prints an error and its source chain to stderr, then exits non-zero.
+fn die(e: &anyhow::Error) -> ! {
+    eprintln!("Error: {e}");
+    let mut source = e.source();
+    while let Some(err) = source {
+        eprintln!("  Caused by: {err}");
+        source = err.source();
     }
+    process::exit(1);
 }

--- a/src/templates/browser-bridge.js
+++ b/src/templates/browser-bridge.js
@@ -1,5 +1,11 @@
 (() => {
   const PORT = __OMNI_BRIDGE_PORT__, TOKEN = '__OMNI_BRIDGE_TOKEN__';
+  // Use the `localhost` hostname, not a loopback IP: page CSPs commonly allow
+  // `ws://localhost:*` in connect-src but not `ws://127.0.0.1`. The bridge binds
+  // both 127.0.0.1 and ::1, so this connects whichever way localhost resolves.
+  const ENDPOINT = 'ws://localhost:' + PORT;
+  const log = (...a) => console.log('%c[omni-dev]%c', 'color:#3ddc84;font-weight:bold', '', ...a);
+  const warn = (...a) => console.warn('[omni-dev]', ...a);
   let ws, backoff = 500;
   // Readers of in-flight streamed responses, keyed by command id, so a `cancel`
   // frame from the server can stop one mid-flight.
@@ -22,10 +28,19 @@
     return btoa(bin);
   };
   const connect = () => {
-    ws = new WebSocket('ws://localhost:' + PORT, [TOKEN]);
-    ws.onopen = () => { backoff = 500; console.log('✅ omni-dev bridge connected on ' + PORT); };
-    ws.onclose = () => { setTimeout(connect, backoff = Math.min(backoff * 2, 10000)); };
-    ws.onerror = () => ws.close();
+    log('connecting to ' + ENDPOINT + ' …');
+    ws = new WebSocket(ENDPOINT, [TOKEN]);
+    ws.onopen = () => { backoff = 500; log('connected ✅ — ready for requests'); };
+    ws.onerror = () => {
+      warn('WebSocket error connecting to ' + ENDPOINT + '. Check: the daemon is running'
+        + ' (`omni-dev daemon status`); this page’s Content-Security-Policy `connect-src`'
+        + ' allows it; and (on an https page) mixed-content is not blocking ws://.');
+      ws.close();
+    };
+    ws.onclose = (e) => {
+      warn('disconnected (code ' + e.code + '); retrying in ' + backoff + 'ms');
+      setTimeout(connect, backoff = Math.min(backoff * 2, 10000));
+    };
     ws.onmessage = async (event) => {
       const cmd = JSON.parse(event.data);
       // A cancel frame stops an in-flight streamed response by cancelling its reader.

--- a/tests/browser_bridge_test.rs
+++ b/tests/browser_bridge_test.rs
@@ -1226,9 +1226,16 @@ async fn cli_request_client_round_trips() {
 #[tokio::test]
 async fn cli_request_client_without_token_errors() {
     let bin = env!("CARGO_BIN_EXE_omni-dev");
+    // Isolate from any real per-user daemon token file (the `request` client
+    // falls back to `<data dir>/omni-dev/bridge.token`). Point HOME/XDG at an
+    // empty temp dir so that fallback finds nothing and we exercise the true
+    // "no token anywhere" path rather than a stray daemon token on the dev box.
+    let home = tempfile::tempdir().unwrap();
     let out = tokio::process::Command::new(bin)
         .args(["browser", "bridge", "request", "--url", "/x"])
         .env_remove("OMNI_BRIDGE_TOKEN")
+        .env("HOME", home.path())
+        .env_remove("XDG_DATA_HOME")
         .output()
         .await
         .unwrap();

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -1,0 +1,76 @@
+//! End-to-end integration test for the `omni-dev daemon` command tree.
+//!
+//! Spawns the real `daemon run` process on a temp socket and drives it through
+//! the library [`DaemonClient`] (ping → status → shutdown), proving the CLI
+//! wiring and graceful-shutdown path without touching any per-user location.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Command;
+use std::time::Duration;
+
+use omni_dev::daemon::client::DaemonClient;
+
+/// Polls `f` until it returns `true` or the deadline passes.
+async fn wait_for<F>(mut f: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    for _ in 0..200 {
+        if f() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn daemon_run_status_stop_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("d.sock");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .arg("daemon")
+        .arg("run")
+        .arg("--socket")
+        .arg(&socket)
+        .spawn()
+        .expect("failed to spawn `omni-dev daemon run`");
+
+    let client = DaemonClient::new(&socket);
+
+    // The control socket comes up.
+    let mut ready = false;
+    for _ in 0..200 {
+        if client.ping().await.is_ok() {
+            ready = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(ready, "daemon did not become ready");
+
+    // Status reports the registered echo service.
+    let report = client.status().await.expect("status request failed");
+    assert!(
+        report
+            .services
+            .iter()
+            .any(|s| s.name == "echo" && s.healthy),
+        "expected a healthy echo service, got {report:?}"
+    );
+
+    // Graceful shutdown over the socket.
+    client.shutdown().await.expect("shutdown request failed");
+
+    // The process exits on its own (clean exit 0).
+    let exited = wait_for(|| matches!(child.try_wait(), Ok(Some(_)))).await;
+    if !exited {
+        let _ = child.kill();
+    }
+    assert!(exited, "daemon did not exit after shutdown");
+
+    let status = child.wait().unwrap();
+    assert!(status.success(), "daemon exited with failure: {status:?}");
+}

--- a/tests/daemon_test.rs
+++ b/tests/daemon_test.rs
@@ -30,11 +30,20 @@ async fn daemon_run_status_stop_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let socket = dir.path().join("d.sock");
 
+    // Bind the bridge's TCP planes to random free ports so the test never
+    // collides with a real daemon (or another test) on the default 9998/9999.
     let mut child = Command::new(env!("CARGO_BIN_EXE_omni-dev"))
         .arg("daemon")
         .arg("run")
         .arg("--socket")
         .arg(&socket)
+        .arg("--bridge-control-port")
+        .arg("0")
+        .arg("--bridge-ws-port")
+        .arg("0")
+        // Stay headless even when the binary is built with `--features menu-bar`,
+        // so this test never tries to open a macOS tray in a headless run.
+        .arg("--no-menu")
         .spawn()
         .expect("failed to spawn `omni-dev daemon run`");
 
@@ -51,14 +60,14 @@ async fn daemon_run_status_stop_roundtrip() {
     }
     assert!(ready, "daemon did not become ready");
 
-    // Status reports the registered echo service.
+    // Status reports the registered browser-bridge service.
     let report = client.status().await.expect("status request failed");
     assert!(
         report
             .services
             .iter()
-            .any(|s| s.name == "echo" && s.healthy),
-        "expected a healthy echo service, got {report:?}"
+            .any(|s| s.name == "browser-bridge" && s.healthy),
+        "expected a healthy browser-bridge service, got {report:?}"
     );
 
     // Graceful shutdown over the socket.

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2251,8 +2251,20 @@ Runs the daemon in the foreground (the process launchd execs)
 Usage: run [OPTIONS]
 
 Options:
-      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
-  -h, --help           Print help
+      --socket <PATH>
+          Control-socket path. Defaults to the per-user runtime location
+      --bridge-ws-port <BRIDGE_WS_PORT>
+          Browser-bridge WebSocket-plane port (`0` binds a random free port) [default: 9999]
+      --bridge-control-port <BRIDGE_CONTROL_PORT>
+          Browser-bridge HTTP control-plane port (`0` binds a random free port) [default: 9998]
+      --bridge-allow-origin <URL>
+          Permit this cross-origin for the bridge's WebSocket upgrade and outbound URLs (the bridge's `--allow-origin`)
+      --bridge-token-file <PATH>
+          Read the bridge session token from this `0600` file instead of generating one
+      --no-menu
+          Run headless: never show the macOS menu-bar tray (no effect on non-macOS or non-`menu-bar` builds, which are always headless)
+  -h, --help
+          Print help
 
 
 ================================================================================

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -15,6 +15,7 @@ Commands:
   config      Configuration and model information
   atlassian   Atlassian: JIRA and Confluence operations
   browser     Browser bridge: drive authenticated requests through a browser tab
+  daemon      Daemon: host long-lived services (e.g. the browser bridge)
   datadog     Datadog: read-only API operations
   coverage    Coverage: diff/patch coverage analysis for PR comments
   transcript  Transcript and caption fetching from media platforms
@@ -2206,6 +2207,92 @@ Options:
           Commit-URL prefix for linking SHAs (e.g. `https://…/<repo>/commit`)
   -h, --help
           Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev daemon - Daemon: host long-lived services (e.g. the browser bridge)
+
+Daemon: host long-lived services (e.g. the browser bridge)
+
+Usage: daemon <COMMAND>
+
+Commands:
+  run      Runs the daemon in the foreground (the process launchd execs)
+  start    Starts the daemon in the background
+  stop     Stops the running daemon
+  restart  Restarts the daemon
+  status   Reports daemon and per-service status
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+
+
+================================================================================
+
+omni-dev daemon restart - Restarts the daemon
+
+Restarts the daemon
+
+Usage: restart [OPTIONS]
+
+Options:
+      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
+  -h, --help           Print help
+
+
+================================================================================
+
+omni-dev daemon run - Runs the daemon in the foreground (the process launchd execs)
+
+Runs the daemon in the foreground (the process launchd execs)
+
+Usage: run [OPTIONS]
+
+Options:
+      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
+  -h, --help           Print help
+
+
+================================================================================
+
+omni-dev daemon start - Starts the daemon in the background
+
+Starts the daemon in the background
+
+Usage: start [OPTIONS]
+
+Options:
+      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
+  -h, --help           Print help
+
+
+================================================================================
+
+omni-dev daemon status - Reports daemon and per-service status
+
+Reports daemon and per-service status
+
+Usage: status [OPTIONS]
+
+Options:
+      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
+      --json           Emit machine-readable JSON instead of a table
+  -h, --help           Print help
+
+
+================================================================================
+
+omni-dev daemon stop - Stops the running daemon
+
+Stops the running daemon
+
+Usage: stop [OPTIONS]
+
+Options:
+      --socket <PATH>  Control-socket path. Defaults to the per-user runtime location
+  -h, --help           Print help
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR implements an extensible daemon framework that supervises long-lived services (initially the browser bridge, issue #987) under a single per-user process. The daemon binds a private Unix-domain control socket for lifecycle management, enforces single-instance supervision via exclusive socket binding, and routes JSON-encoded operations to pluggable registered services. On macOS, `daemon start` installs a launchd LaunchAgent that auto-starts the daemon at login and restarts it on abnormal exit.

The browser bridge service will be registered as the first real service in a follow-up change. This PR establishes all the infrastructure needed by that work, validated end-to-end with an `EchoService` test implementation.

See ADR-0039 for architectural rationale.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [x] Dependency update

## Related Issue

Relates to #987 (daemon browser bridge — browser bridge service will be registered in a follow-up)

## Changes Made

**CLI Layer (`src/cli/daemon*.rs`):**
- Added `omni-dev daemon` top-level command with five subcommands: `run`, `start`, `stop`, `restart`, `status`
- `run` — becomes the daemon in the foreground (the process launchd execs); accepts `--socket <PATH>` override
- `start` — launches the daemon in the background (idempotent; macOS installs/loads a launchd LaunchAgent, elsewhere spawns detached `daemon run`); polls until the control socket accepts connections
- `stop` — sends a graceful shutdown op and unloads the launchd agent on macOS
- `restart` — stop (if running) + start round-trip with readiness polling
- `status` — reports running state and per-service health; supports `--json` for machine-readable output
- Shared `control.rs` helpers: `launch()` (platform-conditional), `wait_until_ready()` and `wait_until_down()` (50 × 100 ms polling loops)

**Daemon Library (`src/daemon/*.rs`):**
- `server.rs` — main `run()` loop: binds socket, installs signal handlers, accepts NDJSON connections, dispatches to `ServiceRegistry` or built-in ops (`ping`, `status`, `shutdown`), drains services and removes socket on shutdown
- `client.rs` — `DaemonClient`: one-shot Unix-socket client (connect → send envelope → read reply) with `ping()`, `status()`, and `shutdown()` convenience methods
- `protocol.rs` — wire types: `DaemonEnvelope` (request), `DaemonReply` (response), `StatusReport`; NDJSON framing; forward-compatible via `serde(default, skip_serializing_if)`
- `service.rs` — `DaemonService` trait with `name()`, `handle()`, `menu()`, `menu_action()`, `status()`, `shutdown()`; plus `ServiceStatus`, `MenuSnapshot`, `MenuItem`, `MenuAction` types
- `registry.rs` — `ServiceRegistry`: register, lookup by name, dispatch ops, aggregate statuses, shutdown all
- `single_instance.rs` — `bind_or_reclaim()`: exclusive socket bind as the instance lock; pings before reclaiming to distinguish live vs. stale (crashed) daemon
- `lifecycle.rs` — `install_signal_handlers()`: SIGTERM + SIGINT on Unix, Ctrl-C elsewhere; cancels the shared `CancellationToken`
- `paths.rs` — per-user runtime directory (`~/Library/Application Support/omni-dev/` macOS, `~/.local/share/omni-dev/` Linux), socket path, bridge token path, `ensure_dir_0700()`, `set_file_0600()`, `check_socket_path_len()` (104-byte macOS `sockaddr_un` limit)
- `launchd.rs` (macOS-only) — renders and writes a LaunchAgent plist (`com.github.rust-works.omni-dev.daemon`), bootstraps/boots out via `launchctl`; `KeepAlive.SuccessfulExit = false` ensures clean `daemon stop` stays down
- `mod.rs` — `build_default_registry()` registers `EchoService` (browser bridge joins in follow-up)

**Services (`src/daemon/services/`):**
- `echo.rs` — `EchoService`: stateless test service; `echo` op returns its payload verbatim; used to exercise the full framework stack

**Library Root:**
- `src/lib.rs` — added `pub mod daemon;`
- `Cargo.toml` — added `"user"` feature to the `nix` dependency (required for `nix::unistd::getuid()` used in the launchd GUI domain string)

**Testing:**
- `tests/daemon_test.rs` — end-to-end integration test: spawns the real `omni-dev daemon run` binary on a temp socket, exercises ping → status → shutdown lifecycle, asserts clean exit
- `tests/snapshots/integration_test__help_all_output.snap` — updated help snapshot to include the new `daemon` command tree and all subcommand help pages

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite (includes daemon unit tests and integration test)
cargo test

# Run only daemon-related tests
cargo test daemon

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual smoke test (requires built binary)
omni-dev daemon start
omni-dev daemon status
omni-dev daemon status --json
omni-dev daemon stop
```

**Unit tests in `src/daemon/server.rs`:**
- `ping_and_status_and_routing` — verifies ping, status aggregation, service routing, unknown service error, and unknown built-in op error
- `second_bind_is_refused_while_first_is_live` — confirms a second daemon cannot displace a running one
- `stale_socket_is_reclaimed` — confirms a crashed daemon's leftover socket is reclaimed and rebound

**Unit tests in `src/cli/daemon.rs`:**
- `parses_all_subcommands` — all five subcommand variants parse correctly
- `socket_override_parses` — `--socket` flag works on `run`
- `status_json_flag_parses` — `--json` flag works on `status`
- `socket_defaults_to_none` — socket defaults to `None` when not provided

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — control socket is owner-only (`0600`), runtime directory is `0700`; socket path length validated before bind to avoid opaque OS errors
- [x] Architecture changes — new `daemon` module in both `src/lib.rs` and `src/cli.rs`; `DaemonService` trait is the extension point for future services
- [x] Error handling — stale socket reclamation logic in `single_instance.rs`; launchctl failure propagation in `launchd.rs`; `wait_until_ready`/`wait_until_down` timeouts
- [ ] Performance impact
- [ ] User experience
- [x] Backward compatibility

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

The daemon is a background process and the control socket is a low-frequency operator channel (start/stop/status commands). There is no impact on existing CLI command performance.

## Security Considerations

- [x] Security improvement (describe below)

- The runtime directory is created with `0700` permissions (owner-only), preventing other users from inspecting socket or token files.
- The control socket itself is set to `0600` (owner read/write only) immediately after binding via `set_file_0600()`.
- The launchd plist is written to `~/Library/LaunchAgents/` which is already user-scoped.
- Socket path length is validated before bind to produce an actionable error instead of a cryptic OS failure.

## Breaking Changes

None. This is a purely additive feature. All existing CLI commands and library APIs are unchanged.

## Deployment Notes

- [x] No special deployment requirements

On macOS, `omni-dev daemon start` installs a launchd LaunchAgent plist at `~/Library/LaunchAgents/com.github.rust-works.omni-dev.daemon.plist`. This is automatically managed by the `start`/`stop` commands and requires no manual operator action. No environment variable changes or configuration file updates are needed for the daemon itself.

## Additional Notes

**Future Enhancements:**
- Register the browser bridge service in `build_default_registry()` (issue #987, the immediate follow-up to this PR)
- Add menu-bar shell integration consuming `DaemonService::menu()` / `menu_action()` (already stubbed in the trait)
- Support additional OAuth2/service providers by implementing `DaemonService` and registering them

**Known Limitations:**
- Windows is not supported (Unix-domain sockets are used throughout); non-Unix platforms fall back to Ctrl-C-only signal handling and a spawned background process instead of launchd
- Only the `EchoService` test service is registered in this PR; the framework is ready but the real workloads arrive in follow-up changes

**Alternatives Considered:**
- Using a named pipe or TCP loopback instead of a Unix socket — rejected in ADR-0039 in favour of the Unix socket's `EADDRINUSE` bind-as-lock behaviour and owner-only permissions
- Separate daemon binary — rejected to keep the distribution as a single `omni-dev` binary with `daemon run` as the foreground entry point