### PR TITLE
docs(docs): document extensible daemon architecture and browser bridge integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,23 @@ The `omni-dev browser bridge` command tree drives HTTP requests **through an aut
 
 The security model is **core, not an add-on**: both planes are authenticated and default-closed. When touching the trust boundary (auth guards, outbound scope, token handling, the planes), keep [ADR-0036](docs/adrs/adr-0036.md) and the operator guide [docs/browser-bridge.md](docs/browser-bridge.md) in sync. Changes to the CLI surface require the [`update-snapshots`](.claude/skills/update-snapshots/SKILL.md) skill (see Code Changes §5).
 
+The bridge can also be hosted by the **omni-dev daemon** (see the [Daemon](#daemon) section below) as its first migrated service. The daemon supervises lifecycle and adds a menu-bar surface; it does **not** touch this trust boundary — `BridgeService` (`src/daemon/services/bridge.rs`) wraps the same `BridgeServer` planes verbatim, and standalone `serve` keeps working.
+
+### Daemon
+The `omni-dev daemon` command tree hosts long-lived **services** inside one supervised process behind a Unix-domain control socket, with an optional macOS menu-bar shell. The browser bridge is the first service migrated onto it (a trivial `echo` service exercises the framework in tests). Architectural rationale — the service abstraction, the control socket, single-instance supervision, the `run`/launcher split, and the main-thread/runtime inversion for the tray — lives in [ADR-0039](docs/adrs/adr-0039.md).
+
+- `src/daemon/service.rs` — the `DaemonService` trait (`name`/`handle`/`menu`/`menu_action`/`status`/`shutdown`) plus the menu/status types (`MenuSnapshot`, `MenuItem`, `MenuAction`, `ServiceStatus`).
+- `src/daemon/registry.rs` — `ServiceRegistry`: routes a request envelope's `service` field to the matching service; iterates them for `status`/`menu`/`shutdown`.
+- `src/daemon/protocol.rs` — the Unix-socket wire types `DaemonEnvelope { service, op, payload }` / `DaemonReply { ok, payload, error }`, newline-delimited JSON (`tokio_util` `LinesCodec`). A `service` of `None` or the reserved `"daemon"` targets the built-in ops `ping` / `status` / `shutdown`.
+- `src/daemon/server.rs` + `single_instance.rs` + `lifecycle.rs` — the accept loop and dispatch; the exclusive socket bind **is** the single-instance lock (`ping`-probe + stale-socket reclaim); `SIGTERM`/`SIGINT` cancel a shared `CancellationToken` for graceful shutdown.
+- `src/daemon/paths.rs` — runtime paths via `dirs::data_dir()` (`<data>/omni-dev/`, **not** `~/.omni-dev`): `daemon.sock` and `bridge.token`; directory `0700`, socket/token `0600`, 104-byte `sockaddr_un` guard.
+- `src/daemon/launchd.rs` — macOS LaunchAgent (`com.github.rust-works.omni-dev.daemon`, `RunAtLoad`, `KeepAlive.SuccessfulExit=false`) installed/loaded by `daemon start`.
+- `src/daemon/tray.rs` — the macOS menu bar, gated `#[cfg(all(target_os = "macos", feature = "menu-bar"))]` (off by default; pulls in `tray-icon`, `tao`, `arboard`). Compiled out elsewhere.
+- `src/daemon/services/bridge.rs` — `BridgeService`, the first migrated service; wraps `BridgeServer`, persists the session token to the `0600` `bridge.token` file for thin-client discovery.
+- `src/cli/daemon.rs` + `src/cli/daemon/{run,start,stop,restart,status}.rs` — the CLI surface. `run` becomes the daemon (foreground, what launchd execs); `start`/`stop`/`restart` are launchers/clients; `status` prints a per-service table (`--json` for machines).
+
+Hosting the bridge in the daemon does **not** change its security model — keep [ADR-0036](docs/adrs/adr-0036.md), [ADR-0039](docs/adrs/adr-0039.md), and [docs/browser-bridge.md](docs/browser-bridge.md) in sync. Changes to the `daemon` CLI surface require the [`update-snapshots`](.claude/skills/update-snapshots/SKILL.md) skill (see Code Changes §5).
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -62,3 +62,4 @@ by Michael Nygard.
 | [ADR-0036](adr-0036.md)  | ✅ Accepted                              | 2026-05-30 | Confused-Deputy Browser Bridge with Dual-Plane Default-Closed Authentication           |
 | [ADR-0037](adr-0037.md)  | 🔄 Superseded by [ADR-0038](adr-0038.md) | 2026-06-06 | Pure-C Native ASR Backends Behind a Rust FFI Boundary on Non-Windows Targets           |
 | [ADR-0038](adr-0038.md)  | ✅ Accepted                              | 2026-06-13 | Voice Functionality Extracted to the omni-voice Repository                             |
+| [ADR-0039](adr-0039.md)  | ✅ Accepted                              | 2026-06-18 | Extensible omni-dev Daemon Hosting Pluggable Services over a Unix Control Socket       |

--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -182,5 +182,20 @@ prefix.
   it neither widens nor narrows the trust boundary by default; `omit` exists to
   read wildcard-CORS cross-origin assets the browser refuses to expose to a
   credentialed request, and is paired with `--allow-origin`.
+- The bridge can now be **hosted inside the extensible omni-dev daemon**
+  ([ADR-0039](adr-0039.md), #987) instead of only as a standalone `serve`
+  process. This does **not** revisit the trust boundary: both planes stay loopback
+  TCP with bearer auth on each, the control-plane anti-CSRF/anti-rebinding guards
+  and server-side `validate_outbound_url` scope are unchanged, and the default-closed
+  posture holds. The daemon owns only lifecycle, single-instance supervision,
+  status aggregation, and the macOS menu bar — it does **not** proxy browser
+  traffic, and its own operator/tray control channel is a separate Unix-domain
+  socket (`0600`, gated by filesystem permission), not a network surface. The one
+  externally observable delta: the generated session token, previously visible
+  only on the foreground `serve` stdout, is now also written to a `0600`
+  `bridge.token` file under the runtime directory so the thin clients can discover
+  it without a foreground process — the token is still generated (never from
+  argv), still compared in constant time, and the file is still required to be
+  `0600`. `serve` remains supported and unchanged.
 
 See [docs/browser-bridge.md](../browser-bridge.md) for the operator-facing guide.

--- a/docs/adrs/adr-0039.md
+++ b/docs/adrs/adr-0039.md
@@ -1,0 +1,190 @@
+# ADR-0039: Extensible omni-dev Daemon Hosting Pluggable Services over a Unix Control Socket
+
+## Status
+
+✅ Accepted (2026-06-18)
+
+## Context
+
+Several omni-dev capabilities want to be **long-lived** rather than
+per-invocation. The browser bridge ([ADR-0036](adr-0036.md)) is the clearest
+example: it must keep its WebSocket and HTTP control planes bound for as long as
+the operator's authenticated tab is open, yet it was reachable only by running
+`omni-dev browser bridge serve` in a foreground terminal — one process, one
+capability, no shared lifecycle, no menu-bar surface, and a session token that
+existed only on that terminal's stdout.
+
+As more capabilities grow this shape (the browser bridge today; session-scoped
+SSO services and others later), running each as its own foreground process does
+not scale: every one re-implements single-instance locking, signal handling,
+graceful shutdown, status reporting, and (on macOS) a menu-bar presence. We want
+**one** supervised host that owns those concerns once and lets capabilities plug
+in as **services**.
+
+The constraints that shaped the design:
+
+- A capability's own network surface (the bridge's loopback TCP planes) must stay
+  exactly as ADR-0036 specifies — the daemon supervises lifecycle; it must **not**
+  proxy or weaken that trust boundary.
+- The operator/tray control channel is a different trust domain (local-user
+  control: stop, restart, status, menu clicks) and should be local-only by
+  filesystem permission, not by a network token.
+- On macOS a native menu bar needs the platform run loop on the **main thread**,
+  which conflicts with `#[tokio::main]` owning it.
+
+## Decision
+
+Introduce an extensible daemon under [`src/daemon/`](../../src/daemon/): a
+long-lived process that hosts pluggable **services** behind a Unix-domain control
+socket, with an optional macOS menu-bar shell. The browser bridge is the first
+service migrated onto it (see [ADR-0036](adr-0036.md)); a trivial in-tree `echo`
+service exercises the framework in tests.
+
+### The `DaemonService` abstraction
+
+A service implements one trait ([`src/daemon/service.rs`](../../src/daemon/service.rs)):
+
+```rust
+#[async_trait]
+pub trait DaemonService: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn handle(&self, op: &str, payload: Value) -> Result<Value>;
+    fn menu(&self) -> MenuSnapshot;                 // cheap snapshot for the tray
+    async fn menu_action(&self, action_id: &str) -> Result<()>;
+    async fn status(&self) -> ServiceStatus;        // structured, for `daemon status`
+    async fn shutdown(&self);
+}
+```
+
+`MenuSnapshot { title, items: Vec<MenuItem> }` where a `MenuItem` is a
+`Label(String)`, a `Separator`, or an `Action(MenuAction { id, label, enabled })`.
+`ServiceStatus { name, healthy, summary, detail: Value }` is the structured shape
+`daemon status` aggregates.
+
+The `ServiceRegistry` ([`registry.rs`](../../src/daemon/registry.rs)) holds the
+services and routes by the request envelope's `service` field; it also iterates
+them for `status`, menu snapshots, and shutdown.
+
+### Unix-domain control socket, NDJSON framing
+
+Operator/tray traffic flows over a Unix-domain socket framed as
+newline-delimited JSON (`tokio_util::codec::LinesCodec`). The wire types
+([`protocol.rs`](../../src/daemon/protocol.rs)):
+
+```rust
+struct DaemonEnvelope { service: Option<String>, op: String, payload: Value }
+struct DaemonReply    { ok: bool, payload: Value, error: Option<String> }
+```
+
+A `service` of `None` or the reserved name `"daemon"` targets **built-in ops**:
+`ping` → `{ "pong": true }`, `status` → `StatusReport { services: [...] }`,
+`shutdown` → `{ "stopping": true }`. Any other `service` is dispatched to the
+matching registered service's `handle`.
+
+This control channel is **not** a network trust boundary: it is a Unix socket
+created `0600` inside a `0700` directory, so access is gated by local-user
+filesystem permission. A loopback **TCP** control plane was rejected for this
+channel precisely because it would re-introduce a network trust surface —
+reachable by every local process, and by any browser page the operator visits via
+CSRF / DNS-rebinding — that the bridge already has to defend against
+([ADR-0036](adr-0036.md)); a Unix socket sidesteps that whole threat class with
+filesystem permissions alone. It deliberately does not carry the bridge's bearer
+token — the bridge keeps its own ADR-0036 authentication on its own loopback TCP
+planes.
+
+### Paths, permissions, single-instance
+
+The runtime directory is resolved via `dirs::data_dir()` —
+`~/Library/Application Support/omni-dev/` on macOS,
+`~/.local/share/omni-dev/` on Linux ([`paths.rs`](../../src/daemon/paths.rs)).
+This **deliberately diverges** from the `~/.omni-dev` config-file directory: the
+socket and token are volatile runtime state, not user configuration. Defaults:
+
+- control socket → `<runtime_dir>/daemon.sock`
+- bridge token file → `<runtime_dir>/bridge.token`
+
+The directory is created/tightened to `0700`, the token file to `0600`, and the
+socket path is length-checked against the 104-byte `sockaddr_un` limit before
+binding.
+
+Single-instance supervision ([`single_instance.rs`](../../src/daemon/single_instance.rs))
+needs no lockfile: the **exclusive socket bind is the lock**. On `EADDRINUSE` the
+daemon probes the existing socket with a `ping`; a live answer means another
+daemon is running (fail), no answer means a stale socket left by a crash (warn,
+unlink, rebind).
+
+### Lifecycle: the `run` / launcher split
+
+The framework resolves "what literally launches the daemon" with a
+foreground/launcher split that mirrors the bridge's existing `serve` (server) vs
+`request` (thin client) shape:
+
+| Command | Role | Blocks? |
+|---|---|---|
+| `omni-dev daemon run` | **Becomes** the daemon: binds the socket (the bind is the single-instance lock), starts every registered service, serves until `SIGTERM`/`SIGINT` (Ctrl-C off-Unix) or a `shutdown` op. This is what a launcher / launchd execs. | yes |
+| `omni-dev daemon start` | Launcher: on macOS installs + loads a launchd LaunchAgent; elsewhere spawns `daemon run` detached. Polls `ping` until the socket answers. | no |
+| `omni-dev daemon stop` | Thin client: sends the built-in `shutdown` op; on macOS also unloads the LaunchAgent so it does not auto-restart. | no |
+| `omni-dev daemon restart` | `stop` (wait until down) then `start` (wait until ready). | no |
+| `omni-dev daemon status` | Thin client: requests the aggregated `StatusReport` and prints a per-service table (`--json` for machines). | no |
+
+Graceful shutdown ([`lifecycle.rs`](../../src/daemon/lifecycle.rs),
+[`server.rs`](../../src/daemon/server.rs)) installs `SIGTERM`/`SIGINT` handlers
+that cancel a shared `tokio_util::sync::CancellationToken`; the accept loop
+selects on it, then each service's `shutdown().await` runs and the socket file is
+removed.
+
+On macOS, `daemon start` installs a LaunchAgent labelled
+`com.github.rust-works.omni-dev.daemon` with `RunAtLoad` (start at login) and
+`KeepAlive.SuccessfulExit = false` (restart on abnormal exit, but a clean
+shutdown stays down) ([`launchd.rs`](../../src/daemon/launchd.rs)).
+
+### macOS menu bar — feature-gated, main-thread run loop
+
+The tray ([`tray.rs`](../../src/daemon/tray.rs)) is compiled only under
+`cfg(all(target_os = "macos", feature = "menu-bar"))`. The `menu-bar` Cargo
+feature is **off by default** and pulls in macOS-only `tray-icon`, `tao`, and
+`arboard` (clipboard). Headless `daemon run` (non-macOS, feature off, or
+`--no-menu`) is a plain async path and is what launchd/CI use.
+
+Because a native menu bar requires the platform run loop on the main thread, the
+tray path does **not** use the `#[tokio::main]` macro: it builds a multi-thread
+`tokio::runtime::Runtime`, spawns the socket server and services onto it, and
+hands the main thread to the `tao` event loop, which rebuilds the menu from
+`registry → menu()` snapshots ~1 Hz and routes clicks to `menu_action`. Clipboard
+menu actions (copy key/snippet/request command) are handled in the tray via
+`arboard`.
+
+## Consequences
+
+- One supervised host owns single-instance locking, signal handling, graceful
+  shutdown, status aggregation, and the macOS menu bar **once**; a new capability
+  becomes a long-lived service by implementing a single trait and registering it,
+  rather than re-deriving a foreground-process harness.
+- The trust boundaries stay cleanly separated: the operator/tray control plane is
+  a `0600` Unix socket gated by filesystem permission, while each service keeps
+  its own network authentication. The browser bridge's ADR-0036 model — loopback
+  TCP planes, bearer auth on both, default-closed, server-side `validate_outbound_url`
+  — is **untouched**; the daemon supervises it, it does not proxy or relax it.
+- The bridge's session token, previously visible only on the foreground `serve`
+  stdout, is now also persisted to a `0600` token file under the runtime
+  directory so thin clients (`browser bridge request` / `harvest`) can discover it
+  with no foreground process. This is the only change to the bridge's externally
+  observable surface (recorded as an amendment in [ADR-0036](adr-0036.md)).
+- `omni-dev browser bridge serve` is **preserved unchanged** as a standalone
+  foreground path; daemon hosting is additive, not a replacement, and no CLI
+  surface was removed or deprecated.
+- New dependencies are confined to the optional, macOS-only `menu-bar` feature
+  (`tray-icon`, `tao`, `arboard`); default and non-macOS builds are unaffected.
+  `tokio` (`UnixListener`), `tokio-util` (`CancellationToken` + `LinesCodec`), and
+  `async-trait` were already in the tree.
+- The runtime directory deliberately differs from the `~/.omni-dev` config
+  directory; operators looking for the socket or token file should look under the
+  platform data directory (`~/Library/Application Support/omni-dev/` on macOS).
+- The daemon is the framework the issue tracker's "extensible daemon" work calls
+  for; the browser bridge is its first migrated service, and the in-tree `echo`
+  service plus the routing/single-instance/lifecycle unit tests guard the
+  framework independently of any one service.
+
+See [ADR-0036](adr-0036.md) for the bridge's own security model and
+[docs/browser-bridge.md](../browser-bridge.md) for the operator-facing guide,
+including the "Running under the daemon" section.

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -18,16 +18,17 @@ add-on — both planes are authenticated and default-closed. See
 
 1. [How it works](#how-it-works)
 2. [Quick start](#quick-start)
-3. [Talking to the control plane](#talking-to-the-control-plane)
-4. [The `request` thin client](#the-request-thin-client)
-5. [Routing to a specific tab](#routing-to-a-specific-tab)
-6. [Security model](#security-model)
-7. [Flags](#flags)
-8. [Random ports](#random-ports)
-9. [Worked example: downloading Grafana / Loki logs](#worked-example-downloading-grafana--loki-logs)
-10. [Harvesting your own data (best-effort)](#harvesting-your-own-data-best-effort)
-11. [WebSocket wire protocol](#websocket-wire-protocol)
-12. [Caveats](#caveats)
+3. [Running under the daemon](#running-under-the-daemon)
+4. [Talking to the control plane](#talking-to-the-control-plane)
+5. [The `request` thin client](#the-request-thin-client)
+6. [Routing to a specific tab](#routing-to-a-specific-tab)
+7. [Security model](#security-model)
+8. [Flags](#flags)
+9. [Random ports](#random-ports)
+10. [Worked example: downloading Grafana / Loki logs](#worked-example-downloading-grafana--loki-logs)
+11. [Harvesting your own data (best-effort)](#harvesting-your-own-data-best-effort)
+12. [WebSocket wire protocol](#websocket-wire-protocol)
+13. [Caveats](#caveats)
 
 ## How it works
 
@@ -72,6 +73,76 @@ the HTTP response.**
    ```
 
 The bridge works only while the tab is open and the snippet is running.
+
+## Running under the daemon
+
+`serve` is the simplest way to run the bridge — one foreground process you start
+and stop by hand. The bridge can **also** be hosted by the long-lived omni-dev
+daemon ([ADR-0039](adrs/adr-0039.md)), which keeps it running across terminals,
+supervises its lifecycle, and (on macOS) gives it a menu-bar presence. Both ways
+run the *same* bridge core on the *same* loopback-TCP planes with the *same*
+[security model](#security-model) — `serve` is not deprecated, and which one you
+use is invisible to the `request` / `harvest` thin clients.
+
+| Command | What it does |
+|---|---|
+| `omni-dev daemon run` | **Becomes** the daemon in the foreground: binds the control socket (which doubles as the single-instance lock), starts the bridge on its planes, and blocks until `SIGTERM`/`SIGINT` or `daemon stop`. This is what a launcher execs. |
+| `omni-dev daemon start` | Launches the daemon in the background and returns once it is ready. On macOS it installs + loads a launchd LaunchAgent (auto-starts at login); elsewhere it spawns `daemon run` detached. |
+| `omni-dev daemon stop` | Stops the daemon (and, on macOS, unloads the LaunchAgent so it does not auto-restart). |
+| `omni-dev daemon restart` | `stop` then `start`. |
+| `omni-dev daemon status` | Reports the daemon and each hosted service (`--json` for machines). |
+
+`daemon run` accepts the bridge's port/scope flags as `--bridge-ws-port`,
+`--bridge-control-port`, `--bridge-allow-origin`, and `--bridge-token-file`
+(plus `--socket <PATH>` to override the control-socket location and `--no-menu`
+to stay headless on a macOS menu-bar build).
+
+### Token discovery (no foreground stdout)
+
+A standalone `serve` prints the session token to stdout; a backgrounded daemon
+has none. So the daemon **persists the resolved token to a `0600` file** —
+`bridge.token` under the per-user runtime directory (`dirs::data_dir()`:
+`~/Library/Application Support/omni-dev/` on macOS, `~/.local/share/omni-dev/` on
+Linux; this is *not* the `~/.omni-dev` config directory). The thin clients fall
+back to that file automatically, so under the daemon you usually need neither
+`OMNI_BRIDGE_TOKEN` nor `--token-file`:
+
+```bash
+omni-dev daemon start
+omni-dev browser bridge request --url /loki/api/v1/labels   # token discovered from the file
+```
+
+The token is still **generated** (never taken from argv), still compared in
+constant time, and the file is still required to be `0600` — see the
+[security model](#security-model). It is removed when the bridge shuts down.
+
+### Checking on it
+
+```bash
+omni-dev daemon status
+# daemon: running
+#   browser-bridge   ok         1 tab(s), 0 pending (control :9998, ws :9999)
+```
+
+Before any tab connects the line reads `no tab connected (control :9998, ws
+:9999)`; `omni-dev daemon status --json` emits the structured per-service report.
+The `GET /__bridge/status` endpoint is unchanged and still feeds this view.
+
+### Menu bar (macOS, `menu-bar` feature)
+
+Built with `--features menu-bar` on macOS, the daemon adds a **Browser Bridge**
+menu showing the connection line (`Connected — <origins> — N pending` /
+`No tab connected`) and the session key, with actions:
+
+- **Copy bridge key** — the raw session token, to paste into `OMNI_BRIDGE_TOKEN`.
+- **Copy console snippet** — the ready-to-paste DevTools snippet.
+- **Copy request command** — a complete `OMNI_BRIDGE_TOKEN='…' omni-dev browser
+  bridge request …` line.
+- **Disconnect tab `<id>`** — one entry per connected tab.
+- **Restart bridge** — stop and relaunch the planes with the same token.
+
+The menu is compiled out on non-macOS builds and when the `menu-bar` feature is
+off; those builds (and `daemon run --no-menu`) are headless.
 
 ## Talking to the control plane
 


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for the omni-dev daemon framework — a long-lived supervised process that hosts pluggable services over a Unix-domain control socket, with an optional macOS menu-bar shell. The browser bridge is the first service migrated onto the daemon.

The documentation covers the architectural rationale (ADR-0039), the security model amendment for daemon-hosted bridge operation (ADR-0036 amendment), operator guidance for running the bridge under the daemon, and CLAUDE.md orientation for AI-assisted development on the daemon subsystem.

No source code is changed in this PR — it is a documentation phase of issue #987.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Relates to #987

## Changes Made

**New ADR:**
- Added `docs/adrs/adr-0039.md` — complete architectural decision record for the extensible omni-dev daemon: the `DaemonService` trait abstraction, Unix-domain control socket with NDJSON framing (`DaemonEnvelope` / `DaemonReply`), paths and permissions (`dirs::data_dir()`, `0700` directory, `0600` socket/token), single-instance supervision via exclusive socket bind, the `run`/launcher lifecycle split, graceful shutdown via `CancellationToken`, and the feature-gated macOS menu-bar path
- Updated `docs/adrs/README.md` to include ADR-0039 in the index table

**ADR Amendment:**
- Amended `docs/adrs/adr-0036.md` to record the browser bridge daemon integration: confirms trust boundaries are unchanged (loopback TCP planes, bearer auth, default-closed, `validate_outbound_url`), documents the new `0600` `bridge.token` file as the only externally observable delta enabling thin-client token discovery without a foreground process, and confirms `serve` is unchanged

**Operator Guide:**
- Added "Running under the daemon" section to `docs/browser-bridge.md` (section 3, renumbering subsequent sections): command reference table (`daemon run` / `start` / `stop` / `restart` / `status`), token discovery explanation (fallback to `bridge.token` file under runtime directory), status-checking examples, and macOS menu-bar actions (copy bridge key, copy console snippet, copy request command, disconnect tab, restart bridge)

**CLAUDE.md:**
- Added "Daemon" section covering architecture overview, the key source files and their responsibilities (`service.rs`, `registry.rs`, `protocol.rs`, `server.rs`, `single_instance.rs`, `lifecycle.rs`, `paths.rs`, `launchd.rs`, `tray.rs`, `services/bridge.rs`, CLI modules), and a note that changes to the daemon CLI surface require the `update-snapshots` skill

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Verified all cross-references between ADR-0036, ADR-0039, and `docs/browser-bridge.md` are consistent and accurate
- [x] Confirmed `docs/adrs/README.md` index entry matches ADR-0039 title, status, and date
- [x] Reviewed CLAUDE.md daemon section for accuracy against existing source structure
- [x] Backward compatibility verified — `serve` mode is explicitly documented as unchanged

### Test Commands

```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The key review concern is **accuracy of the security narrative**: ADR-0039 and the ADR-0036 amendment both assert that the daemon does not weaken the browser bridge's trust boundaries, and `docs/browser-bridge.md` repeats this for operators. Reviewers familiar with the daemon implementation should verify the documentation correctly reflects the actual isolation guarantees (separate Unix-socket control plane vs. loopback TCP bridge planes, `0600` token file semantics, etc.).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

This PR is documentation-only; no runtime code is changed.

## Security Considerations

- [x] No security implications

The documentation accurately describes the existing security model. Key points documented (not changed by this PR):
- The Unix-domain control socket is `0600` inside a `0700` directory — access gated by filesystem permission, not a network token
- The daemon does not proxy bridge traffic; each service retains its own authentication on its own network planes
- The `bridge.token` file is `0600`, generated (never taken from argv), and compared in constant time
- The ADR explicitly records why a loopback TCP control plane was rejected for the daemon's operator channel (CSRF/DNS-rebinding risk)

## Breaking Changes

None. This is a documentation-only PR. `omni-dev browser bridge serve` remains fully supported and unchanged; daemon hosting is additive.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional services can be documented as they are migrated onto the daemon using the same pattern established by ADR-0039 and the browser bridge operator guide

**Known Limitations:**
- The `menu-bar` Cargo feature is off by default; the menu-bar documentation in `docs/browser-bridge.md` applies only to macOS builds compiled with `--features menu-bar`

**Alternatives Considered:**
- Keeping the daemon design entirely in CLAUDE.md only — rejected in favour of a first-class ADR so the architectural rationale is discoverable alongside ADR-0036 and the rest of the decision log