### PR TITLE
refactor(atlassian): replace vendor-specific references with generic placeholders

### DIFF
--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -1568,7 +1568,7 @@ fn url_safe_in_bracket_content(s: &str) -> bool {
 ///
 /// The character class for the name segment must match `try_parse_emoji_shortcode`
 /// exactly (Unicode `is_alphanumeric` plus `_`, `+`, `-`).  An ASCII-only escape
-/// would leave Unicode patterns like `:Café:` or `:ZBC::Zendesk::配置:` un-escaped
+/// would leave Unicode patterns like `:Café:` or `:ZBC::Acme::配置:` un-escaped
 /// while still being detected as emoji on re-parse, splitting the text node
 /// (issue #552).
 fn escape_emoji_shortcodes(text: &str) -> String {
@@ -8372,11 +8372,11 @@ mod tests {
     }
 
     #[test]
-    fn code_block_with_exact_zendesk_shortcode_pattern_round_trips() {
-        // Issue #552: Use the exact pattern from the bug report.
+    fn code_block_with_exact_namespaced_shortcode_pattern_round_trips() {
+        // Issue #552: Use a namespaced pattern modeled on the bug report.
         let adf_json = r#"{"version":1,"type":"doc","content":[
           {"type":"codeBlock","attrs":{"language":"ruby"},"content":[
-            {"type":"text","text":"class ZBC::Zendesk::PlanType::Professional < Base"}
+            {"type":"text","text":"class ZBC::Acme::PlanType::Professional < Base"}
           ]}
         ]}"#;
         let doc: AdfDocument = serde_json::from_str(adf_json).unwrap();
@@ -8390,7 +8390,7 @@ mod tests {
         assert_eq!(content.len(), 1, "should be a single text node");
         assert_eq!(
             content[0].text.as_deref().unwrap(),
-            "class ZBC::Zendesk::PlanType::Professional < Base"
+            "class ZBC::Acme::PlanType::Professional < Base"
         );
     }
 


### PR DESCRIPTION
## Description

This PR removes vendor-specific references from code examples and tests in `src/atlassian/convert.rs`, replacing them with generic "Acme" placeholders. The changes improve the generalizability of the codebase by decoupling internal documentation and test data from specific third-party vendor names, making the code more suitable for broader use cases.

The affected area is the emoji shortcode escaping logic (issue #552), where examples and tests previously used a real vendor namespace (`ZBC::Zendesk::`) that has been replaced with a neutral placeholder (`ZBC::Acme::`). Test behavior is entirely preserved — only the example strings change.

## Type of Change

- [x] Refactoring (no functional changes)

## Related Issue

Relates to #999

## Changes Made

**Core Changes:**
- Updated doc comment example in `escape_emoji_shortcodes` to use `ZBC::Acme::配置` instead of `ZBC::Zendesk::配置`
- Renamed test function `code_block_with_exact_zendesk_shortcode_pattern_round_trips` → `code_block_with_exact_namespaced_shortcode_pattern_round_trips`
- Updated test comment to read "Use a namespaced pattern modeled on the bug report." instead of referencing the exact vendor-specific pattern
- Replaced test input string `class ZBC::Zendesk::PlanType::Professional < Base` with `class ZBC::Acme::PlanType::Professional < Base`
- Updated corresponding `assert_eq!` expectation to match the new generic test string

**Documentation:**
- Inline doc comment for `escape_emoji_shortcodes` now uses a vendor-neutral namespace example

**Testing:**
- No new tests added; existing test logic and coverage are unchanged — only test data strings updated

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable — refactor only)
- [ ] Integration tests updated/added (not applicable)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Backward compatibility verified — no functional changes

### Test Commands

```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility

The only change is to example strings in a doc comment and test data; the underlying logic of `escape_emoji_shortcodes` and its round-trip test are completely unaffected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Removing the test entirely rather than updating the example string — rejected in favour of keeping the round-trip coverage for namespaced shortcode patterns.