### PR TITLE
fix(atlassian): strip code marks from headings in JFM→ADF conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`jira dev` auto-discovery for Bitbucket Server** ([#924](https://github.com/rust-works/omni-dev/issues/924)): provider auto-discovery now queries the DevStatus detail endpoint with the instance-type identifier (e.g. `applicationType=stash`) reported by the summary's `byInstanceType` map, rather than the human-readable display name (`Bitbucket Server`). Previously, any provider whose display name differed from its identifier — Bitbucket Server being the canonical case — was missed, returning empty results.
+- **Inline `code` in JFM headings no longer fails the ADF mark validator** ([#1005](https://github.com/rust-works/omni-dev/issues/1005)): A heading authored with backticks — e.g. `` ### `GET /api/services/example` `` — previously produced a `heading` node carrying a `code` mark, which ADF's heading content model forbids, so the document was rejected at write time with an opaque JSONPath-only error. The JFM→ADF converter now strips the `code` mark from heading content (keeping the text as plain — the safe lossy direction, since Atlassian renders no inline-code styling on headings) and emits a warning naming the affected heading. The validator remains the safety net for any other path that produces a code-marked heading.
 
 ## [0.29.0] - 2026-06-12
 

--- a/docs/specs/jfm.md
+++ b/docs/specs/jfm.md
@@ -176,6 +176,15 @@ ADF v1.
 | `breakout`        | Trailing block attr: `{breakout=wide breakoutWidth=N}`  |
 | `border`          | On media/table cells: `border-color=#hex border-size=N` |
 
+> **Inline `code` in headings.** ADF's `heading` content model forbids the
+> `code` mark (a heading styles its own text, and Atlassian renders no
+> inline-code styling on headings). A heading authored with backticks —
+> e.g. `` ### `GET /api/services/example` `` — has its `code` mark stripped
+> during JFM→ADF conversion, keeping the text as plain, and a warning is
+> emitted naming the heading. The conversion is intentionally lossy in the
+> safe direction: without stripping, the document would be rejected by the
+> mark validator at write time (issue #1005).
+
 ### Unsupported Node Handling
 
 ADF nodes that cannot be represented in markdown are serialized as fenced
@@ -306,12 +315,12 @@ As of `SCHEMA_VERSION 52.9.5-2026-05-10`, the validator covers:
 - Per-term quantifiers and content-term sequences (e.g. empty `bulletList`,
   two-`media` `mediaSingle`, or a `layoutSection` with one column are all
   reported as `AdfSchemaViolation::Arity`).
-
-Out of scope and not enforced:
-
-- Mark whitelists (which marks may apply to which nodes).
-- Attribute-value schemas (allowed values for `panel.type`, `status.color`,
-  etc.).
+- Per-context mark allow-lists (which marks may apply to which nodes — e.g.
+  `code` is rejected on `heading`) and per-mark attribute schemas, reported as
+  `AdfSchemaViolation::DisallowedMark` / `InvalidMarkAttr`.
+- Node attribute-value schemas (allowed values for `panel.panelType`,
+  `status.color`, `heading.level`, etc.), reported as
+  `AdfSchemaViolation::MissingAttr` / `InvalidAttr`.
 
 ## Generic Directive System
 

--- a/src/atlassian/convert.rs
+++ b/src/atlassian/convert.rs
@@ -160,7 +160,18 @@ impl<'a> MarkdownParser<'a> {
         self.advance();
         // Collect indented continuation lines produced by hardBreaks (issue #433).
         self.collect_hardbreak_continuations(&mut full_text);
-        let inline_nodes = parse_inline(&full_text);
+        let mut inline_nodes = parse_inline(&full_text);
+        // ADF's `heading` content model forbids the `code` mark, but
+        // JFM/CommonMark parses inline-code spans inside `#`-headings. Strip
+        // them here (keeping the text as plain) so we don't build a document
+        // the validator only rejects at write time (issue #1005).
+        if strip_heading_code_marks(&mut inline_nodes) > 0 {
+            warn!(
+                "Stripped inline `code` from heading (ADF forbids code marks on \
+                 headings; kept the text as plain): {}",
+                full_text.trim()
+            );
+        }
 
         #[allow(clippy::cast_possible_truncation)]
         Some(AdfNode::heading(level as u8, inline_nodes))
@@ -2172,6 +2183,34 @@ fn add_mark(node: &mut AdfNode, mark: AdfMark) {
     } else {
         node.marks = Some(vec![mark]);
     }
+}
+
+/// Removes `code` marks from heading inline content, returning the count
+/// removed.
+///
+/// ADF's `heading` content model forbids the `code` mark (a heading styles
+/// its own text), but JFM/CommonMark parses inline-code spans inside
+/// `#`-headings. Stripping here keeps the text as plain — a lossy but safe
+/// direction, since Atlassian renders no inline-code styling on headings —
+/// rather than building a document the validator only rejects at write time
+/// (issue #1005). Recurses into `content` to be robust to future inline
+/// containers; today heading inline content is flat text nodes.
+fn strip_heading_code_marks(nodes: &mut [AdfNode]) -> usize {
+    let mut removed = 0;
+    for node in nodes.iter_mut() {
+        if let Some(marks) = node.marks.as_mut() {
+            let before = marks.len();
+            marks.retain(|m| m.mark_type != "code");
+            removed += before - marks.len();
+            if marks.is_empty() {
+                node.marks = None;
+            }
+        }
+        if let Some(children) = node.content.as_mut() {
+            removed += strip_heading_code_marks(children);
+        }
+    }
+    removed
 }
 
 /// Prepends a mark before existing marks to preserve outside-in ordering.
@@ -4964,6 +5003,64 @@ mod tests {
             let attrs = doc.content[0].attrs.as_ref().unwrap();
             assert_eq!(attrs["level"], level as u64);
         }
+    }
+
+    // ── issue #1005: inline `code` is not permitted on headings ─────
+
+    #[test]
+    fn heading_inline_code_mark_stripped() {
+        // `### `GET /api`` parses an inline-code span; ADF forbids the `code`
+        // mark on headings, so it is stripped and the text kept as plain.
+        let doc = markdown_to_adf("### `GET /api`").unwrap();
+        let heading = &doc.content[0];
+        assert_eq!(heading.node_type, "heading");
+        let content = heading.content.as_ref().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0].text.as_deref(), Some("GET /api"));
+        assert!(
+            content[0].marks.is_none(),
+            "expected no marks, got: {:?}",
+            content[0].marks
+        );
+    }
+
+    #[test]
+    fn heading_code_strip_preserves_sibling_strong() {
+        // `### **`x`**` → text `x` carrying `strong`; only `code` is removed.
+        let doc = markdown_to_adf("### **`x`**").unwrap();
+        let content = doc.content[0].content.as_ref().unwrap();
+        let marks = content[0].marks.as_ref().unwrap();
+        assert!(marks.iter().any(|m| m.mark_type == "strong"));
+        assert!(!marks.iter().any(|m| m.mark_type == "code"));
+    }
+
+    #[test]
+    fn heading_code_strip_preserves_link() {
+        // `### [`x`](url)` → text `x` carrying `link`; only `code` is removed.
+        let doc = markdown_to_adf("### [`x`](https://e.com)").unwrap();
+        let content = doc.content[0].content.as_ref().unwrap();
+        let marks = content[0].marks.as_ref().unwrap();
+        assert!(marks.iter().any(|m| m.mark_type == "link"));
+        assert!(!marks.iter().any(|m| m.mark_type == "code"));
+    }
+
+    #[test]
+    fn heading_with_code_now_passes_validation() {
+        // End-to-end guard: the converted document no longer trips the ADF
+        // mark validator that previously rejected it at write time.
+        let doc = markdown_to_adf("### `GET /api`").unwrap();
+        let violations = crate::atlassian::adf_schema::validate_document(&doc);
+        assert!(violations.is_empty(), "got: {violations:?}");
+    }
+
+    #[test]
+    fn paragraph_inline_code_mark_preserved() {
+        // Regression guard: the strip is heading-only — paragraph inline code
+        // keeps its `code` mark.
+        let doc = markdown_to_adf("`x`").unwrap();
+        let content = doc.content[0].content.as_ref().unwrap();
+        let marks = content[0].marks.as_ref().unwrap();
+        assert!(marks.iter().any(|m| m.mark_type == "code"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a JFM→ADF conversion bug where inline `code` spans inside Markdown headings (e.g. `` ### `GET /api` ``) produced ADF documents that failed validation at write time. ADF's `heading` content model forbids the `code` mark, but JFM/CommonMark parses inline-code spans inside `#`-headings without complaint, so the mismatch was only caught by the ADF mark validator — with an opaque JSONPath-only error message that gave users no actionable information.

The fix proactively strips `code` marks from heading inline content during JFM→ADF conversion, keeping the text as plain. This is a deliberate lossy-but-safe transformation: Atlassian itself renders no inline-code styling on headings, so no visual fidelity is lost. A `warn!` log is emitted naming the affected heading text so authors are informed. The ADF schema validator remains as the safety net for any other path that might produce a code-marked heading.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Fixes #1005

## Changes Made

**Core Changes:**
- Added `strip_heading_code_marks()` function in `src/atlassian/convert.rs` that recursively removes `code` marks from ADF inline nodes, returning the count of marks removed
- Integrated stripping into the heading parsing path in `MarkdownParser` — called immediately after `parse_inline()` so the problematic mark never reaches the built `AdfNode::heading`
- Emits a `warn!` log naming the heading text whenever one or more `code` marks are stripped, giving authors a clear signal without failing the conversion

**Documentation:**
- Added a callout block to `docs/specs/jfm.md` under the extension table describing the inline-`code`-in-headings behaviour, the safe-lossy stripping strategy, and the reason (ADF forbids the mark; issue #1005)
- Updated the JFM spec's validator coverage section to reflect that per-context mark allow-lists (including `code` rejected on `heading`) and per-mark attribute schemas are now enforced, replacing the previous "Out of scope" note
- Added CHANGELOG entry describing the fix with full context for end users

**Testing:**
- `heading_inline_code_mark_stripped`: verifies that `` ### `GET /api` `` produces a heading with plain text and no marks
- `heading_code_strip_preserves_sibling_strong`: verifies that `### **\`x\`**` retains `strong` while removing only `code`
- `heading_code_strip_preserves_link`: verifies that `` ### [`x`](url) `` retains `link` while removing only `code`
- `heading_with_code_now_passes_validation`: end-to-end guard confirming the converted document produces zero ADF schema violations
- `paragraph_inline_code_mark_preserved`: regression guard confirming that `` `x` `` in a paragraph still carries its `code` mark (stripping is heading-only)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (5 new unit/integration tests in `src/atlassian/convert.rs`)
- [x] Integration tests updated/added (`heading_with_code_now_passes_validation` runs the full validator end-to-end)

**Manual Testing:**
- [x] Tested happy path scenarios (heading with backtick-quoted endpoint name converts cleanly)
- [x] Tested error/edge cases (mixed marks — strong + code, link + code — only code is removed)
- [x] Backward compatibility verified (paragraph inline code is unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new heading-code tests
cargo test heading_inline_code
cargo test heading_code_strip
cargo test heading_with_code_now
cargo test paragraph_inline_code_mark

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the `warn!` log is the only user-visible signal; confirm wording is actionable
- [x] Backward compatibility — `strip_heading_code_marks` must not affect non-heading nodes (covered by regression test)

The core logic is in `src/atlassian/convert.rs` at two locations:
1. The new `strip_heading_code_marks()` free function (~28 lines, starting at line 2185)
2. Its call site inside `MarkdownParser`'s heading handler (~10 lines, around line 163)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the strip pass iterates heading inline nodes only (typically 1–5 nodes), adding negligible overhead to heading parsing

## Security Considerations

- [x] No security implications — this is a purely structural document transformation with no external input handling or data exposure

## Breaking Changes

None. The conversion previously produced invalid ADF documents that were rejected at write time. The new behaviour produces valid documents with a lossy-but-safe transformation and a warning log. No API or output format contracts change for callers that were succeeding before.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The stripping is intentionally lossy: code-styled text in a heading becomes plain text. There is no ADF-compliant way to preserve the code appearance in a heading, so this is the only correct direction.

**Alternatives Considered:**
- Failing the conversion with a descriptive error instead of stripping — rejected because it would break existing documents with backtick headings that authors cannot easily fix
- Wrapping the code-spanned text in a `codeBlock` — not applicable since `codeBlock` is a block-level node and cannot appear inside a heading