### PR TITLE
chore(daemon): warn on duplicate service registrations and correct stale tray docs

### DIFF
--- a/src/daemon/registry.rs
+++ b/src/daemon/registry.rs
@@ -20,10 +20,16 @@ impl ServiceRegistry {
         Self::default()
     }
 
-    /// Adds a service. Later lookups match by [`DaemonService::name`]; the
-    /// caller is responsible for not registering two services with the same
-    /// name (the first registered wins on lookup).
+    /// Adds a service. Lookups match by [`DaemonService::name`] and the first
+    /// registration wins; a second service sharing a name would be dead code
+    /// for routing and would double-count in status/menu iteration, so it is
+    /// rejected with a warning rather than silently kept.
     pub fn register(&mut self, service: Arc<dyn DaemonService>) {
+        let name = service.name();
+        if self.services.iter().any(|s| s.name() == name) {
+            tracing::warn!("ignoring duplicate registration of daemon service `{name}`");
+            return;
+        }
         self.services.push(service);
     }
 
@@ -96,5 +102,15 @@ mod tests {
         // Aggregation iterates every registered service.
         assert_eq!(registry.statuses().await.len(), 1);
         registry.shutdown_all().await;
+    }
+
+    #[test]
+    fn duplicate_registration_is_ignored() {
+        let mut registry = ServiceRegistry::new();
+        registry.register(Arc::new(EchoService));
+        registry.register(Arc::new(EchoService));
+        // The second registration shares `echo`'s name, so it is dropped: the
+        // first wins on lookup and iteration is not double-counted.
+        assert_eq!(registry.services().len(), 1);
     }
 }

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -6,8 +6,9 @@
 //! hands the main thread to the `tao` event loop. Each registered service
 //! contributes a submenu built from its [`MenuSnapshot`]; clicks are routed
 //! back to [`DaemonService::menu_action`](crate::daemon::service::DaemonService::menu_action)
-//! (or, for "Copy console snippet", fulfilled locally via the clipboard). A
-//! "Quit" item cancels the shared shutdown token and drains the daemon.
+//! (or, for the `copy-*` clipboard actions, fulfilled locally via the
+//! clipboard). A "Quit" item cancels the shared shutdown token and drains the
+//! daemon.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -273,8 +274,10 @@ fn event_loop(
     Ok(())
 }
 
-/// Routes a clicked menu id back to its service: "copy-snippet" is fulfilled via
-/// the clipboard; everything else goes to the service's `menu_action`.
+/// Routes a clicked menu id back to its service: the `copy-*` actions
+/// (`copy-key`/`copy-snippet`/`copy-request`) each read a string field from a
+/// service op and copy it to the clipboard; everything else goes to the
+/// service's `menu_action`.
 fn handle_action(
     handle: &Handle,
     registry: &ServiceRegistry,


### PR DESCRIPTION
## Description

This PR delivers two small but important daemon cleanups tracked under #998:

1. **Duplicate service registration guard** (`src/daemon/registry.rs`): `ServiceRegistry::register` previously pushed services unconditionally. If two services shared the same `name()`, the second was dead code for routing (`.find()` always returns the first match) yet still double-counted during status/menu/shutdown iteration—a latent correctness bug. The fix enforces the documented first-wins contract at the point of registration: a duplicate name now emits a `tracing::warn!` and is dropped immediately, making the inconsistency visible rather than silent.

2. **Stale tray comment update** (`src/daemon/tray.rs`): The module-level doc and the `handle_action` function doc both referred only to `"Copy console snippet"` being handled locally via the clipboard. The actual code already handles all three `copy-*` variants (`copy-key`, `copy-snippet`, `copy-request`) uniformly. Both comments are updated to reflect that reality.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Relates to #998

## Changes Made

**Core Changes:**
- `src/daemon/registry.rs`: Added duplicate-name guard in `ServiceRegistry::register`; emits `tracing::warn!` and returns early when a service with the same name is already registered, preventing silent double-counting in status/menu/shutdown loops.

**Documentation:**
- `src/daemon/tray.rs`: Updated module-level doc to reference all `copy-*` clipboard actions instead of only `"Copy console snippet"`.
- `src/daemon/tray.rs`: Updated `handle_action` doc comment to enumerate `copy-key`, `copy-snippet`, and `copy-request` explicitly.

**Testing:**
- `src/daemon/registry.rs`: Added `duplicate_registration_is_ignored` unit test that registers `EchoService` twice and asserts `registry.services().len() == 1`, verifying the first-wins contract and the drop behaviour.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`duplicate_registration_is_ignored`)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases (duplicate registration path exercised by unit test)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run only the new registry test
cargo test duplicate_registration_is_ignored

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the warning-and-drop strategy in `ServiceRegistry::register` (tracing warn vs. panic vs. silent keep)
- [x] Backward compatibility — first-wins semantics were already the de-facto behaviour; this makes them explicit and observable

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Panicking on duplicate registration was considered but rejected: a warning-and-drop is more robust in production and the first-wins behaviour is already relied upon implicitly throughout the codebase.
- Returning a `Result` from `register` was considered but would require callers to change; a logged warning with a silent drop is sufficient since duplicates are a programming error that should be caught during development via log inspection.