### PR TITLE
fix(daemon): surface launchctl bootout spawn failures

### DIFF
--- a/src/daemon/launchd.rs
+++ b/src/daemon/launchd.rs
@@ -80,9 +80,7 @@ pub fn install_and_load(socket: &Path) -> Result<()> {
 
     let domain = gui_domain();
     // Bootout any prior instance first so bootstrap does not fail as already loaded.
-    let _ = Command::new("launchctl")
-        .args(["bootout", &format!("{domain}/{LAUNCHD_LABEL}")])
-        .output();
+    bootout(&domain);
     // `launchctl bootout` is asynchronous: it returns before launchd finishes
     // tearing the job down. Bootstrapping into that window races the teardown
     // and fails with EIO ("Bootstrap failed: 5: Input/output error") — the
@@ -133,9 +131,25 @@ fn wait_until_unloaded(domain: &str) {
 /// Boots out the agent (SIGTERM-ing a running daemon) so it stops and no longer
 /// auto-starts. Best-effort: a not-loaded agent is not an error.
 pub fn unload() -> Result<()> {
-    let domain = gui_domain();
-    let _ = Command::new("launchctl")
-        .args(["bootout", &format!("{domain}/{LAUNCHD_LABEL}")])
-        .output();
+    bootout(&gui_domain());
     Ok(())
+}
+
+/// Runs `launchctl bootout <domain>/<label>`, the teardown that `start` (to
+/// clear a prior instance before bootstrap) and `stop`/`restart` (to disable
+/// auto-start) both rely on.
+///
+/// A non-zero exit is ignored on purpose: "already not loaded" is the common,
+/// benign case. A *spawn* failure (e.g. `launchctl` missing or the GUI domain
+/// unreachable) means the teardown silently did nothing, so it is logged rather
+/// than discarded — otherwise `stop`/`restart` would claim to have disabled
+/// auto-start when they had not. See issue #996.
+fn bootout(domain: &str) {
+    let target = format!("{domain}/{LAUNCHD_LABEL}");
+    if let Err(e) = Command::new("launchctl")
+        .args(["bootout", &target])
+        .output()
+    {
+        tracing::warn!("failed to run `launchctl bootout {target}`: {e}");
+    }
 }


### PR DESCRIPTION
## Description

Prior to this fix, both call sites that invoked `launchctl bootout` in `src/daemon/launchd.rs` used `let _ = Command::new("launchctl")...output()`, which silently discarded spawn errors as well as non-zero exit codes. If `launchctl` is missing from the system or the GUI domain is unreachable, the bootout teardown would silently do nothing — yet `unload()` would still return `Ok(())`. This meant the `stop` and `restart` commands would claim to have disabled auto-start when they may not have actually done so.

This PR consolidates both `launchctl bootout` call sites into a single `bootout` helper function that:
- Still ignores non-zero exit codes (the "already not loaded" case is intentionally benign)
- Logs a `tracing::warn!` message when the `launchctl` process itself fails to spawn, surfacing real problems rather than silently swallowing them

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Related Issue
Fixes #996

## Changes Made

**Core Changes:**
- Extracted a new `bootout(domain: &str)` private helper function in `src/daemon/launchd.rs` that wraps `launchctl bootout <domain>/<label>`
- Replaced the inline `let _ = Command::new("launchctl")...output()` call in `install_and_load` with `bootout(&domain)`
- Replaced the inline `let _ = Command::new("launchctl")...output()` call in `unload` with `bootout(&gui_domain())`
- Spawn failures now emit `tracing::warn!("failed to run `launchctl bootout {target}`: {e}")` instead of being silently discarded

**Documentation:**
- Added doc comment to `bootout` explaining the design intent: non-zero exit is deliberate, spawn failure is the case requiring visibility (references issue #996)

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Tested happy path scenarios (agent loads and unloads normally)
- [x] Tested error/edge cases (unloading when agent is not currently loaded remains silent/benign)
- [x] Backward compatibility verified (behavior is unchanged when `launchctl` is present and functioning)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — specifically that non-zero `launchctl` exit codes remain ignored (correct) while spawn errors are now surfaced via `tracing::warn!`
- [x] Backward compatibility — the public-facing behavior of `unload()`, `install_and_load()`, `stop`, and `restart` is unchanged for the common case

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

No breaking changes. The `unload()` function signature and return type are unchanged. The only behavioral difference is that a previously silent spawn failure will now emit a warning-level log entry.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Propagating spawn errors as `Err` from `unload()` — rejected because the call sites in `stop`/`restart` would then fail loudly on systems where `launchctl` is temporarily unavailable, which is a worse user experience than a logged warning. Surfacing via `tracing::warn!` strikes the right balance.