### PR TITLE
fix(daemon): mask bridge session token in the tray menu label

### DIFF
--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -132,7 +132,9 @@ The `GET /__bridge/status` endpoint is unchanged and still feeds this view.
 
 Built with `--features menu-bar` on macOS, the daemon adds a **Browser Bridge**
 menu showing the connection line (`Connected — <origins> — N pending` /
-`No tab connected`) and the session key, with actions:
+`No tab connected`) and a **masked** session key (`Key: ••••<last 4 chars>`, so
+the full token never appears in the menu bar, screenshots, or screen shares),
+with actions:
 
 - **Copy bridge key** — the raw session token, to paste into `OMNI_BRIDGE_TOKEN`.
 - **Copy console snippet** — the ready-to-paste DevTools snippet.

--- a/src/daemon/services/bridge.rs
+++ b/src/daemon/services/bridge.rs
@@ -22,6 +22,11 @@ use crate::daemon::service::{DaemonService, MenuAction, MenuItem, MenuSnapshot, 
 /// The browser-bridge service name (the control-socket routing key).
 pub const SERVICE_NAME: &str = "browser-bridge";
 
+/// Number of trailing characters revealed in the tray's masked `Key:` label.
+/// The full token never appears in the menu bar — it stays behind the "Copy
+/// bridge key" action — so this only has to disambiguate *which* key is live.
+const TOKEN_LABEL_VISIBLE_CHARS: usize = 4;
+
 /// Hosts a [`BridgeServer`] under the daemon, persisting its session token for
 /// thin-client discovery and allowing in-place restart.
 pub struct BridgeService {
@@ -80,6 +85,24 @@ fn write_token(path: &Path, token: &str) -> Result<()> {
         .with_context(|| format!("failed to write token file {}", path.display()))?;
     paths::set_file_0600(path)?;
     Ok(())
+}
+
+/// Renders the tray's `Key:` label, revealing only the last
+/// [`TOKEN_LABEL_VISIBLE_CHARS`] characters of `token`. A visible full token is
+/// redundant exposure to shoulder-surfing, screen-sharing, and screenshots
+/// (#997); the complete value stays behind the "Copy bridge key" action. Tokens
+/// too short to keep most of their entropy hidden are masked outright.
+fn masked_key_label(token: &str) -> String {
+    let len = token.chars().count();
+    if len > TOKEN_LABEL_VISIBLE_CHARS * 2 {
+        let tail: String = token
+            .chars()
+            .skip(len - TOKEN_LABEL_VISIBLE_CHARS)
+            .collect();
+        format!("Key: \u{2022}\u{2022}\u{2022}\u{2022}{tail}")
+    } else {
+        "Key: \u{2022}\u{2022}\u{2022}\u{2022}".to_string()
+    }
 }
 
 /// A one-line summary for `daemon status` / the tray.
@@ -194,7 +217,7 @@ impl DaemonService for BridgeService {
                 };
                 let mut items = vec![
                     MenuItem::Label(line),
-                    MenuItem::Label(format!("Key: {}", self.token)),
+                    MenuItem::Label(masked_key_label(&self.token)),
                     MenuItem::Separator,
                 ];
                 items.push(MenuItem::Action(MenuAction {
@@ -368,11 +391,26 @@ mod tests {
         let menu = svc.menu();
         assert_eq!(menu.title, "Browser Bridge");
         assert!(matches!(menu.items.first(), Some(MenuItem::Label(_))));
-        // The key is shown as a label and is copyable.
-        assert!(menu.items.iter().any(|i| matches!(
-            i,
-            MenuItem::Label(text) if text.starts_with("Key: ")
-        )));
+        // The key label is masked: the full token never reaches the menu bar,
+        // only its last few characters (#997). The full value stays copyable.
+        let token = svc.token.as_str();
+        let key_label = menu
+            .items
+            .iter()
+            .find_map(|i| match i {
+                MenuItem::Label(text) if text.starts_with("Key: ") => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("menu has a masked Key label");
+        assert!(
+            !key_label.contains(token),
+            "full token leaked into tray label: {key_label}"
+        );
+        let tail: String = token
+            .chars()
+            .skip(token.chars().count() - TOKEN_LABEL_VISIBLE_CHARS)
+            .collect();
+        assert!(key_label.ends_with(&tail));
         assert!(menu.items.iter().any(|i| matches!(
             i,
             MenuItem::Action(a) if a.id == "copy-key"
@@ -386,6 +424,24 @@ mod tests {
             MenuItem::Action(a) if a.id == "restart-bridge"
         )));
         svc.shutdown().await;
+    }
+
+    #[test]
+    fn masked_key_label_hides_all_but_the_tail() {
+        // A long token reveals only its last four characters behind the mask.
+        assert_eq!(
+            masked_key_label("abcdefghijklmnop"),
+            "Key: \u{2022}\u{2022}\u{2022}\u{2022}mnop"
+        );
+        // A token too short to keep most of its entropy hidden is fully masked.
+        assert_eq!(
+            masked_key_label("secret"),
+            "Key: \u{2022}\u{2022}\u{2022}\u{2022}"
+        );
+        assert_eq!(
+            masked_key_label(""),
+            "Key: \u{2022}\u{2022}\u{2022}\u{2022}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

The daemon's macOS tray menu was rendering the full bridge session token as a plaintext `Key: <token>` label. This exposed the token to shoulder-surfing, screen-sharing, and screenshots — unnecessary risk since the token's real value is already accessible via the dedicated "Copy bridge key" action.

This PR fixes the exposure by replacing the full-token label with a masked variant (`Key: ••••<last 4 chars>`), revealing only enough of the tail to disambiguate which key is currently live. Tokens too short to safely reveal even 4 characters are masked outright (`Key: ••••`). The full token value remains accessible exclusively through the existing copy action.

Closes #997.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Fixes #997

## Changes Made

**Core Changes:**
- Added `TOKEN_LABEL_VISIBLE_CHARS: usize = 4` constant in `src/daemon/services/bridge.rs` to control how many trailing token characters are revealed in the tray label
- Added `masked_key_label(token: &str) -> String` function that renders `Key: ••••<last 4 chars>` for sufficiently long tokens, and `Key: ••••` for short or empty tokens
- Changed `BridgeService::menu()` to call `masked_key_label(&self.token)` instead of formatting the raw token into the label

**Documentation:**
- Updated `docs/browser-bridge.md` to describe the tray menu's masked key display (`Key: ••••<last 4 chars>`) and explicitly note the full token never appears in the menu bar, screenshots, or screen shares

**Testing:**
- Updated existing `menu()` integration test to assert the full token does not appear in the `Key:` label and that the label ends with the correct tail characters
- Added new unit test `masked_key_label_hides_all_but_the_tail` covering: long tokens (reveals last 4 chars), short tokens (fully masked), and empty string (fully masked)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

### Test Commands
```bash
# Core test suite
cargo test

# Run bridge-service-specific tests
cargo test -p omni-dev daemon::services::bridge

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications
- [x] User experience

The masking threshold (`TOKEN_LABEL_VISIBLE_CHARS * 2 = 8`) determines when a tail is shown vs. full masking — reviewers should confirm this boundary is conservative enough to avoid leaking meaningful entropy for short tokens.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement (describe below)

The bridge session token was previously rendered verbatim in the macOS menu bar, making it trivially readable in screen shares, screenshots, and over-the-shoulder observation. This change ensures the tray UI never exposes the full token — only the trailing 4 characters are shown to indicate which session is active. The full token remains available only via the explicit "Copy bridge key" action, which requires deliberate user interaction.

## Breaking Changes

None. The "Copy bridge key" action continues to copy the full raw token. Only the visible menu bar label changes.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The number of revealed trailing characters (`TOKEN_LABEL_VISIBLE_CHARS = 4`) is hardcoded. If token formats change significantly in the future, this constant may need revisiting.

**Alternatives Considered:**
- Removing the `Key:` label entirely — rejected because the tail characters provide useful disambiguation when a user has restarted the bridge and wants to confirm which session is active without copying to the clipboard.
- Using a hash/fingerprint of the token — rejected as unnecessarily complex for a tray label whose only job is identification, not verification.