### PR TITLE
fix(daemon): bind daemon socket owner-private from birth to close permission window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ureq = "3"
 quick-xml = "0.40.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal", "user"] }
+nix = { version = "0.31", default-features = false, features = ["fs", "signal", "user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Menu-bar tray deps (enabled by the `menu-bar` feature). `muda` (the menu

--- a/docs/adrs/adr-0039.md
+++ b/docs/adrs/adr-0039.md
@@ -105,7 +105,11 @@ socket and token are volatile runtime state, not user configuration. Defaults:
 
 The directory is created/tightened to `0700`, the token file to `0600`, and the
 socket path is length-checked against the 104-byte `sockaddr_un` limit before
-binding.
+binding. The socket itself is bound owner-private (`0600`) *from birth*: the bind
+runs under a `0o177` umask so the inode is never created group/world-accessible,
+rather than relying on a post-bind `chmod` (which would leave a brief
+group/world-readable window) or on the `0700` parent. A redundant `set_file_0600`
+follows as defense-in-depth (issue #995).
 
 Single-instance supervision ([`single_instance.rs`](../../src/daemon/single_instance.rs))
 needs no lockfile: the **exclusive socket bind is the lock**. On `EADDRINUSE` the

--- a/src/daemon/single_instance.rs
+++ b/src/daemon/single_instance.rs
@@ -4,6 +4,12 @@
 //! occupied. We then [`ping`](super::client::DaemonClient::ping) it: a live
 //! daemon answers (so we refuse to start a second), while a stale socket left
 //! by a crashed daemon does not (so we reclaim it and rebind).
+//!
+//! The socket is bound owner-private (`0600`) *from birth*: [`bind_private`]
+//! tightens the process umask across the `bind` so the inode is never created
+//! group/world-accessible. This closes the window a post-bind `chmod` would
+//! leave open, so the file mode no longer depends on the parent directory
+//! already being `0700`. See issue #995.
 
 use std::io::ErrorKind;
 use std::path::Path;
@@ -17,7 +23,7 @@ use super::paths;
 /// Binds the control socket, reclaiming a stale socket from a crashed daemon
 /// but refusing to displace a live one.
 pub async fn bind_or_reclaim(path: &Path) -> Result<UnixListener> {
-    match UnixListener::bind(path) {
+    match bind_private(path) {
         Ok(listener) => {
             paths::set_file_0600(path)?;
             Ok(listener)
@@ -35,7 +41,7 @@ pub async fn bind_or_reclaim(path: &Path) -> Result<UnixListener> {
             );
             std::fs::remove_file(path)
                 .with_context(|| format!("failed to remove stale socket {}", path.display()))?;
-            let listener = UnixListener::bind(path)
+            let listener = bind_private(path)
                 .with_context(|| format!("failed to bind daemon socket {}", path.display()))?;
             paths::set_file_0600(path)?;
             Ok(listener)
@@ -43,5 +49,61 @@ pub async fn bind_or_reclaim(path: &Path) -> Result<UnixListener> {
         Err(e) => {
             Err(e).with_context(|| format!("failed to bind daemon socket {}", path.display()))
         }
+    }
+}
+
+/// Binds a Unix socket owner-private (`0600`) by masking off the group/world
+/// permission bits while the inode is created, so there is never a window in
+/// which the control socket — over which privileged service ops run — is
+/// group/world-accessible. Returns the raw `io::Error` so callers can still
+/// match `AddrInUse`.
+///
+/// The umask is process-global, so [`UmaskGuard`] restores the prior value the
+/// instant `bind` returns. The guarded span is fully synchronous (no `.await`),
+/// so no other task on this worker thread can observe the tightened umask;
+/// genuinely-parallel OS threads creating files in the same instant are the only
+/// residual exposure, which is acceptable for a one-shot startup bind.
+fn bind_private(path: &Path) -> std::io::Result<UnixListener> {
+    #[cfg(unix)]
+    let _umask = UmaskGuard::set(nix::sys::stat::Mode::from_bits_truncate(0o177));
+    UnixListener::bind(path)
+}
+
+/// Sets the process umask for the lifetime of the guard, restoring the previous
+/// value on drop.
+#[cfg(unix)]
+struct UmaskGuard(nix::sys::stat::Mode);
+
+#[cfg(unix)]
+impl UmaskGuard {
+    fn set(mask: nix::sys::stat::Mode) -> Self {
+        Self(nix::sys::stat::umask(mask))
+    }
+}
+
+#[cfg(unix)]
+impl Drop for UmaskGuard {
+    fn drop(&mut self) {
+        nix::sys::stat::umask(self.0);
+    }
+}
+
+#[cfg(all(test, unix))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// `bind_private` alone — with no follow-up `chmod` — must yield a `0600`
+    /// socket, proving the umask closes the window rather than a post-bind
+    /// `set_file_0600`. Needs a Tokio runtime to register the listener fd.
+    #[tokio::test]
+    async fn bind_private_creates_an_owner_only_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("d.sock");
+        let listener = bind_private(&socket).unwrap();
+        let mode = std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "socket mode was {mode:o}, expected 600");
+        drop(listener);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a security vulnerability (issue #995) in the daemon control socket creation. Previously, the socket was bound using `UnixListener::bind()` and then `chmod`'d to `0600` in a separate operation. This left a brief window between socket creation and the permission tightening during which the socket could be group/world-readable — a race condition that is security-critical since the socket is used for privileged daemon operations.

The fix ensures the socket inode is created with owner-only permissions (`0600`) **from birth** by tightening the process umask to `0o177` for the duration of the `bind` call. An RAII `UmaskGuard` safely restores the original umask immediately after binding, keeping the guarded span fully synchronous with no exposure across async task boundaries. The existing `set_file_0600` call is retained as defense-in-depth.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement
- [x] Dependency update

## Related Issue

Fixes #995

## Changes Made

**Core Changes:**
- Added `bind_private()` function in `src/daemon/single_instance.rs` that tightens the process umask to `0o177` during `UnixListener::bind()`, ensuring the socket is never created with group/world-accessible permissions
- Implemented `UmaskGuard` RAII struct (Unix-only) that calls `nix::sys::stat::umask()` on construction and restores the prior value on `drop`, safely scoping the umask change to the bind operation
- Replaced both `UnixListener::bind(path)` calls in `bind_or_reclaim()` with `bind_private(path)` to apply the security fix to all socket creation paths
- Added `"fs"` feature to the `nix` dependency in `Cargo.toml` to enable `nix::sys::stat::umask` and `nix::sys::stat::Mode`

**Documentation:**
- Updated `docs/adrs/adr-0039.md` to document that the socket is bound owner-private from birth via a `0o177` umask, explaining why this is preferred over a post-bind `chmod` and why the parent directory `0700` mode is not sufficient on its own
- Added module-level doc comment to `single_instance.rs` referencing `bind_private` and explaining the security model for issue #995

**Testing:**
- Added `bind_private_creates_an_owner_only_socket` async test (Unix-only) that creates a socket via `bind_private()` without any subsequent `set_file_0600` call and asserts the socket mode is exactly `0600`, proving the umask approach closes the race window independently of the defense-in-depth `chmod`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`bind_private_creates_an_owner_only_socket`)
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (daemon starts, socket created with correct permissions)
- [x] Backward compatibility verified (no functional change to daemon socket API)

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific new socket permission test
cargo test bind_private_creates_an_owner_only_socket

# Verify socket mode after daemon start (Unix)
stat -c "%a" <socket_path>  # expected: 600

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications
- [x] Architecture changes

The key security concern is the race window between socket creation and permission tightening. Reviewers should verify:
- `bind_private()` in `src/daemon/single_instance.rs`: the `UmaskGuard` is created before `UnixListener::bind()` and is held until `bind` returns, with no `.await` points in between
- `UmaskGuard::drop()` unconditionally restores the previous umask, even if `bind` panics
- The umask change is scoped to the synchronous bind operation only — no other async tasks on the same worker thread will observe the tightened umask between task switch points

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact
- [x] No performance impact

The umask set/restore is two syscalls around the bind operation, which is negligible at daemon startup time (one-shot operation).

## Security Considerations
- [x] Security improvement (describe below)

This change eliminates a TOCTOU (time-of-check/time-of-use) race between socket creation and permission tightening. The socket is now born with `0600` permissions through the `0o177` umask, so no process can ever observe a more permissive mode on the control socket. The retained `set_file_0600` call provides defense-in-depth.

The only residual exposure is genuinely-parallel OS threads in other processes that happen to be creating files at the exact moment of the bind — this is acceptable for a one-shot startup operation in a daemon context.

## Breaking Changes

None. This is a purely internal implementation change. The socket path, API, and daemon behaviour are unchanged.

## Deployment Notes
- [x] No special deployment requirements

No migration, environment variable changes, or configuration updates are needed. The fix takes effect automatically on the next daemon startup.

## Additional Notes

**Alternatives Considered:**
- **Post-bind `chmod` only** (previous approach): Rejected because it leaves a race window between socket creation and permission tightening where another process could connect to the socket.
- **Relying on parent directory `0700`**: Rejected as defense-in-depth alone is insufficient; the socket itself should have tight permissions independent of its parent directory mode.
- **`O_CLOEXEC`-style socket options**: No equivalent POSIX mechanism exists for setting socket file permissions atomically at bind time without umask manipulation.