### PR TITLE
fix(daemon): implement graceful connection draining on shutdown

### DIFF
--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -3,11 +3,13 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures::{SinkExt, StreamExt};
 use serde_json::json;
 use tokio::net::UnixStream;
+use tokio::task::{JoinError, JoinSet};
 use tokio_util::codec::{Framed, LinesCodec};
 use tokio_util::sync::CancellationToken;
 
@@ -16,6 +18,12 @@ use super::paths;
 use super::protocol::{DaemonEnvelope, DaemonReply, StatusReport, DAEMON_SERVICE};
 use super::registry::ServiceRegistry;
 use super::single_instance;
+
+/// How long to wait for accepted-but-unfinished connections to drain on
+/// shutdown before aborting the stragglers. Generous enough for a normal
+/// in-flight dispatch+reply, bounded so a stuck or idle client cannot hang
+/// shutdown indefinitely (a service manager would `SIGKILL` us eventually).
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for a [`run`] invocation.
 #[derive(Debug, Clone)]
@@ -53,13 +61,16 @@ pub async fn run_with_shutdown(
 
     lifecycle::install_signal_handlers(shutdown.clone());
 
+    // Connection handlers are tracked here rather than detached, so accepted
+    // requests can be drained on shutdown instead of being abandoned (#992).
+    let mut conns: JoinSet<()> = JoinSet::new();
     loop {
         tokio::select! {
             () = shutdown.cancelled() => break,
             accepted = listener.accept() => {
                 match accepted {
                     Ok((stream, _addr)) => {
-                        tokio::spawn(handle_connection(
+                        conns.spawn(handle_connection(
                             stream,
                             registry.clone(),
                             shutdown.clone(),
@@ -68,8 +79,19 @@ pub async fn run_with_shutdown(
                     Err(e) => tracing::warn!("daemon accept error: {e}"),
                 }
             }
+            // Reap finished handlers during normal operation so the set does
+            // not grow unbounded over a long-lived daemon. The guard disables
+            // this arm when empty (an empty `JoinSet` yields `None` at once,
+            // which would otherwise busy-loop the select).
+            joined = conns.join_next(), if !conns.is_empty() => {
+                if let Some(result) = joined {
+                    note_reaped(result);
+                }
+            }
         }
     }
+
+    drain_connections(&mut conns, DRAIN_TIMEOUT).await;
 
     tracing::info!("daemon shutting down; draining services");
     registry.shutdown_all().await;
@@ -84,35 +106,73 @@ pub async fn run_with_shutdown(
     Ok(())
 }
 
+/// Logs a reaped connection task that ended by panicking; clean exits and
+/// cancellations are ignored. Shared by the accept-loop reaper and the drain so
+/// both report a crashed handler the same way.
+fn note_reaped(result: Result<(), JoinError>) {
+    if let Err(e) = result {
+        if e.is_panic() {
+            tracing::warn!("daemon connection task panicked: {e}");
+        }
+    }
+}
+
+/// Awaits outstanding connection handlers (bounded by `timeout`) so an accepted
+/// request finishes its dispatch+reply before the daemon tears down. Called once
+/// the accept loop has stopped and *before* `shutdown_all()`, since in-flight
+/// handlers may still be dispatching into live services. Stragglers past the
+/// deadline are aborted rather than allowed to hang shutdown. (`timeout` is a
+/// parameter, fixed to [`DRAIN_TIMEOUT`] in production, so tests can drive the
+/// abort path without a multi-second wait.)
+async fn drain_connections(conns: &mut JoinSet<()>, timeout: Duration) {
+    let count = conns.len();
+    if count == 0 {
+        return;
+    }
+    tracing::info!("draining {count} in-flight connection(s)");
+    let drain = async {
+        while let Some(result) = conns.join_next().await {
+            note_reaped(result);
+        }
+    };
+    if tokio::time::timeout(timeout, drain).await.is_err() {
+        tracing::warn!(
+            "timed out draining connections after {timeout:?}; aborting {} straggler(s)",
+            conns.len()
+        );
+        conns.abort_all();
+        while conns.join_next().await.is_some() {}
+    }
+}
+
 /// Serves one client connection: decode each NDJSON line, dispatch it, and
-/// write back one reply line, until the client hangs up or shutdown fires.
+/// write back one reply line, until the client hangs up or a read/write error.
+///
+/// There is deliberately no `shutdown.cancelled()` arm here: an accepted line
+/// always finishes its dispatch+reply, and shutdown is handled by the server
+/// draining these tasks (see [`drain_connections`]). `shutdown` is still
+/// threaded through for the built-in `shutdown` op (see [`handle_builtin`]).
 async fn handle_connection(
     stream: UnixStream,
     registry: Arc<ServiceRegistry>,
     shutdown: CancellationToken,
 ) {
     let mut framed = Framed::new(stream, LinesCodec::new());
-    loop {
-        tokio::select! {
-            () = shutdown.cancelled() => break,
-            line = framed.next() => {
-                let Some(line) = line else { break };
-                let reply = match line {
-                    Ok(line) => dispatch_line(&line, &registry, &shutdown).await,
-                    Err(e) => DaemonReply::err(format!("read error: {e}")),
-                };
-                let encoded = match serde_json::to_string(&reply) {
-                    Ok(encoded) => encoded,
-                    Err(e) => {
-                        tracing::warn!("failed to encode daemon reply: {e}");
-                        break;
-                    }
-                };
-                if let Err(e) = framed.send(encoded).await {
-                    tracing::debug!("daemon client write failed: {e}");
-                    break;
-                }
+    while let Some(line) = framed.next().await {
+        let reply = match line {
+            Ok(line) => dispatch_line(&line, &registry, &shutdown).await,
+            Err(e) => DaemonReply::err(format!("read error: {e}")),
+        };
+        let encoded = match serde_json::to_string(&reply) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                tracing::warn!("failed to encode daemon reply: {e}");
+                break;
             }
+        };
+        if let Err(e) = framed.send(encoded).await {
+            tracing::debug!("daemon client write failed: {e}");
+            break;
         }
     }
 }
@@ -179,4 +239,52 @@ pub fn resolve_socket(socket: Option<PathBuf>) -> Result<PathBuf> {
 // The daemon-server tests that bind a socket (and thus mutate the process-global
 // umask via `bind_or_reclaim`) live in `tests/daemon_socket.rs`, isolated in
 // their own process so the umask write cannot race the library's other parallel
-// unit tests. See #1017.
+// unit tests. See #1017. The tests below are socket-free: they exercise the
+// connection-draining logic directly, with no `bind`, so they stay here.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn drain_connections_returns_immediately_when_empty() {
+        let mut conns: JoinSet<()> = JoinSet::new();
+        drain_connections(&mut conns, Duration::from_secs(5)).await;
+        assert!(conns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_connections_awaits_completed_tasks() {
+        let mut conns: JoinSet<()> = JoinSet::new();
+        conns.spawn(async {});
+        drain_connections(&mut conns, Duration::from_secs(5)).await;
+        // Every tracked handler was joined.
+        assert!(conns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_connections_times_out_and_aborts_stragglers() {
+        let mut conns: JoinSet<()> = JoinSet::new();
+        // A task that never finishes on its own forces the timeout + abort path;
+        // the only way `drain_connections` can return is by aborting it.
+        conns.spawn(std::future::pending::<()>());
+        drain_connections(&mut conns, Duration::from_millis(50)).await;
+        assert!(
+            conns.is_empty(),
+            "straggler should have been aborted and joined"
+        );
+    }
+
+    #[tokio::test]
+    async fn note_reaped_ignores_success_and_logs_panic() {
+        // A clean exit is a no-op.
+        note_reaped(Ok(()));
+        // A panicked handler yields a `JoinError` with `is_panic()`, which
+        // `note_reaped` logs (and must not propagate).
+        let mut js: JoinSet<()> = JoinSet::new();
+        js.spawn(async { panic!("boom") });
+        let result = js.join_next().await.unwrap();
+        assert!(result.is_err());
+        note_reaped(result);
+    }
+}

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -20,15 +20,20 @@
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Result;
+use async_trait::async_trait;
 use serde_json::{json, Value};
+use tokio::sync::Notify;
 
 use omni_dev::daemon::client::DaemonClient;
 use omni_dev::daemon::protocol::DaemonEnvelope;
 use omni_dev::daemon::registry::ServiceRegistry;
 use omni_dev::daemon::server::{run, DaemonOptions};
+use omni_dev::daemon::service::{DaemonService, MenuSnapshot, ServiceStatus};
 use omni_dev::daemon::services::echo::EchoService;
 use omni_dev::daemon::single_instance::{bind_or_reclaim, bind_private};
 use tempfile::TempDir;
@@ -154,4 +159,160 @@ async fn stale_socket_is_reclaimed() {
     std::fs::write(&socket, b"stale").unwrap();
     let listener = bind_or_reclaim(&socket).await.unwrap();
     drop(listener);
+}
+
+/// A service whose `slow` op blocks until released, then echoes. It signals when
+/// its handler has *started* (so the test can guarantee the request is genuinely
+/// in-flight before shutting down) and records when it has *completed*, standing
+/// in for in-flight work that must be drained rather than abandoned on shutdown.
+struct SlowService {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+    completed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl DaemonService for SlowService {
+    fn name(&self) -> &'static str {
+        "slow"
+    }
+    async fn handle(&self, op: &str, payload: Value) -> Result<Value> {
+        match op {
+            "slow" => {
+                self.started.notify_one();
+                self.release.notified().await;
+                self.completed.store(true, Ordering::SeqCst);
+                Ok(payload)
+            }
+            other => anyhow::bail!("unknown slow op: {other}"),
+        }
+    }
+    fn menu(&self) -> MenuSnapshot {
+        MenuSnapshot::default()
+    }
+    async fn menu_action(&self, _action_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn status(&self) -> ServiceStatus {
+        ServiceStatus {
+            name: self.name().to_string(),
+            healthy: true,
+            summary: "ready".to_string(),
+            detail: Value::Null,
+        }
+    }
+    async fn shutdown(&self) {}
+}
+
+/// An accepted request still mid-`handle()` when shutdown fires must be drained,
+/// not abandoned: `run()` waits for it to finish before returning (#992).
+#[tokio::test]
+async fn in_flight_request_is_drained_on_shutdown() {
+    let dir = tempdir_0700();
+    let socket = dir.path().join("d.sock");
+
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let completed = Arc::new(AtomicBool::new(false));
+
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(SlowService {
+        started: started.clone(),
+        release: release.clone(),
+        completed: completed.clone(),
+    }));
+    let opts = DaemonOptions {
+        socket_path: socket.clone(),
+    };
+    let mut server = tokio::spawn(run(registry, opts));
+
+    // Wait for the socket to accept.
+    let client = DaemonClient::new(&socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Fire a slow request and wait until it is genuinely in `handle()`.
+    let slow = tokio::spawn({
+        let socket = socket.clone();
+        async move {
+            DaemonClient::new(&socket)
+                .request(DaemonEnvelope::service("slow", "slow", json!({ "v": 1 })))
+                .await
+        }
+    });
+    started.notified().await;
+
+    // Ask the daemon to shut down while that request is mid-`handle()`.
+    DaemonClient::new(&socket).shutdown().await.ok();
+
+    // `run()` must not return while the request is still in flight: it is
+    // draining, not abandoning it. Pre-fix, the handler was a detached task and
+    // `run()` returned at once, so this `timeout` would observe it already done.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut server)
+            .await
+            .is_err(),
+        "run() returned before the in-flight request was drained"
+    );
+    assert!(!completed.load(Ordering::SeqCst));
+
+    // Release the handler: the drain completes, the reply is delivered, and only
+    // then does the server stop.
+    release.notify_one();
+    let reply = slow.await.unwrap().unwrap();
+    assert!(reply.ok);
+    assert_eq!(reply.payload, json!({ "v": 1 }));
+    assert!(completed.load(Ordering::SeqCst));
+    tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("server should stop after draining")
+        .expect("server task should not panic")
+        .expect("run() should return Ok");
+}
+
+/// A line that is not valid UTF-8 fails the `LinesCodec` decode; the connection
+/// handler must answer with a `read error` reply rather than drop the client
+/// silently.
+#[tokio::test]
+async fn invalid_utf8_line_yields_read_error_reply() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    let dir = tempdir_0700();
+    let socket = dir.path().join("d.sock");
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(EchoService));
+    let opts = DaemonOptions {
+        socket_path: socket.clone(),
+    };
+    let server = tokio::spawn(run(registry, opts));
+
+    let client = DaemonClient::new(&socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Raw connection so we can send bytes the JSON client never would.
+    let mut stream = UnixStream::connect(&socket).await.unwrap();
+    let mut line = String::new();
+    {
+        stream.write_all(b"\xff\xff\n").await.unwrap();
+        let mut reader = BufReader::new(&mut stream);
+        reader.read_line(&mut line).await.unwrap();
+    }
+    let reply: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(reply["ok"], json!(false));
+    assert!(reply["error"].as_str().unwrap().contains("read error"));
+
+    // Drop the raw connection before shutdown so the drain does not wait on it.
+    drop(stream);
+    client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server).await;
 }


### PR DESCRIPTION
## Description

Prior to this change, the daemon used `tokio::spawn` to detach connection handlers, meaning any in-flight requests could be abandoned mid-dispatch when a shutdown signal arrived. The server would tear down immediately after the accept loop exited, leaving connected clients without a reply.

This PR fixes issue #992 by tracking all accepted connection handlers in a `JoinSet` instead of detaching them. On shutdown, the server now waits (up to 5 seconds) for all in-flight requests to finish their dispatch+reply cycle before proceeding with `shutdown_all()` and socket cleanup. Stragglers past the deadline are aborted to prevent shutdown from hanging indefinitely.

The fix also simplifies `handle_connection()`: the `shutdown.cancelled()` select arm is removed because accepted requests should always complete, and the graceful-shutdown contract is now entirely managed by the draining mechanism rather than interrupt logic inside each handler.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue

Fixes #992

## Changes Made

**Core Changes:**
- Replaced `tokio::spawn` detached task spawning with a `JoinSet<()>` (`conns`) to track all accepted connection handlers in `run_with_shutdown()`
- Added reaping of finished handlers inside the main `select!` loop (`joined = conns.join_next(), if !conns.is_empty()`) to prevent unbounded growth in long-lived daemons
- Added `drain_connections()` async function that awaits all outstanding handlers bounded by `DRAIN_TIMEOUT` (5 seconds); logs and aborts stragglers if the deadline is exceeded
- Added `DRAIN_TIMEOUT` constant (`Duration::from_secs(5)`) with explanatory doc comment
- Simplified `handle_connection()` by removing the `shutdown.cancelled()` select arm; the function now uses a plain `while let Some(line) = framed.next().await` loop, relying on the server's draining mechanism for graceful shutdown
- Updated doc comment on `handle_connection()` to explain the deliberate absence of a shutdown cancellation arm

**Testing:**
- Added `SlowService` test helper that implements `DaemonService` with a `slow` op that blocks until released via `Arc<Notify>`, and records completion via `Arc<AtomicBool>`
- Added `in_flight_request_is_drained_on_shutdown` integration test that:
  1. Registers `SlowService` and spins up a real daemon on a temp socket
  2. Fires a `slow` request and waits until it is genuinely in-flight inside `handle()`
  3. Sends a shutdown command to the daemon
  4. Asserts that `run()` has NOT returned (i.e. the drain is blocking, not abandoning the request)
  5. Releases the slow handler and verifies the reply is delivered correctly
  6. Asserts that `run()` returns cleanly after draining

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (`in_flight_request_is_drained_on_shutdown`)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (normal daemon operation with connection draining)
- [x] Tested error/edge cases (panic in connection task is logged, not propagated; straggler timeout aborts cleanly)
- [x] Backward compatibility verified (no change to daemon protocol or API surface)

### Test Commands
```bash
# Core test suite
cargo test

# Run the specific new drain test
cargo test in_flight_request_is_drained_on_shutdown

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `JoinSet` replaces detached spawning; draining happens before `shutdown_all()` so live services are still available to in-flight handlers
- [x] Error handling — panicking connection tasks are logged but do not propagate; timeout stragglers are aborted and joined before continuing shutdown
- [x] Performance impact — `join_next()` reaping inside the select loop prevents unbounded `JoinSet` growth; the shutdown drain is time-bounded at 5 seconds

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] Potential performance impact (describe below)

During normal operation, the `join_next()` reap arm in the select loop adds negligible overhead — it only fires when a handler task actually completes. On shutdown, the drain adds up to `DRAIN_TIMEOUT` (5 seconds) of latency, but only when requests are genuinely in-flight at shutdown time. The timeout is intentionally generous for a typical dispatch+reply round-trip while still bounding the worst case for a stuck or idle client.

## Security Considerations

- [x] No security implications

## Breaking Changes

None. The daemon protocol, socket API, and all external interfaces are unchanged. This is an internal implementation change to how connection handler tasks are managed.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- `DRAIN_TIMEOUT` is a compile-time constant; a future improvement could make it configurable via `DaemonOptions` for environments with stricter shutdown SLAs.

**Known Limitations:**
- The 5-second drain timeout means a single long-running or stuck handler can delay full daemon shutdown by up to 5 seconds. This is intentional and preferred over the previous behaviour of abandoning requests entirely.

**Alternatives Considered:**
- Keeping `tokio::spawn` and adding a `Barrier` or `Semaphore` to track in-flight count: more complex and error-prone than `JoinSet`, which owns the task lifecycle directly.
- Propagating the cancellation token into `handle_connection()` and waiting for it to yield: this still races between the cancellation check and the dispatch, so a request could be interrupted partway through.