### PR TITLE
fix(claude): eliminate env data race in skills git spawns and consolidate test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ tarpaulin-report.html
 tarpaulin-report.json
 cobertura.xml
 lcov.info
+*.profraw
+*.profdata
 
 # Test temp directory
 /tmp/

--- a/src/cli/ai/claude/skills/clean.rs
+++ b/src/cli/ai/claude/skills/clean.rs
@@ -209,6 +209,7 @@ fn print_report_text(report: &CleanReport, dry_run: bool) {
 mod tests {
     use super::*;
 
+    use super::super::common::test_git::{init_repo, init_repo_with_commit, worktree_add};
     use super::super::common::{BLOCK_BEGIN, BLOCK_END};
 
     use tempfile::TempDir;
@@ -216,15 +217,6 @@ mod tests {
     fn tempdir() -> TempDir {
         std::fs::create_dir_all("tmp").ok();
         TempDir::new_in("tmp").unwrap()
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = std::process::Command::new("git")
-            .arg("init")
-            .arg(dir)
-            .output()
-            .expect("git init failed to spawn");
-        assert!(status.status.success(), "git init failed: {status:?}");
     }
 
     #[cfg(unix)]
@@ -467,32 +459,6 @@ mod tests {
         assert!(!target_skills_dir.exists());
     }
 
-    fn init_repo_with_commit(dir: &Path) {
-        init_repo(dir);
-        fs::write(dir.join("README.md"), "readme").unwrap();
-        let add = std::process::Command::new("git")
-            .args(["add", "README.md"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(add.status.success());
-        let commit = std::process::Command::new("git")
-            .args([
-                "-c",
-                "user.email=x@x",
-                "-c",
-                "user.name=x",
-                "commit",
-                "-q",
-                "-m",
-                "init",
-            ])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(commit.status.success());
-    }
-
     #[cfg(unix)]
     #[test]
     fn run_clean_propagates_remove_file_failure() {
@@ -560,13 +526,7 @@ mod tests {
         make_source_skills(src.path(), &["alpha"]);
         init_repo_with_commit(tgt_main.path());
 
-        let add_wt = std::process::Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(tgt_main.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+        worktree_add(tgt_main.path(), &linked);
 
         for root in [tgt_main.path(), linked.as_path()] {
             let skills_dir = root.join(SKILLS_SUBPATH);

--- a/src/cli/ai/claude/skills/common.rs
+++ b/src/cli/ai/claude/skills/common.rs
@@ -33,9 +33,29 @@ pub enum OutputFormat {
     Yaml,
 }
 
+/// Builds a `git` [`Command`] whose child receives an explicit, lock-synchronized
+/// copy of the current environment rather than inheriting the live process-global
+/// `environ` table at `exec` time.
+///
+/// `env_clear` flips `std` onto the path where it constructs the child's `envp`
+/// **in the parent** — `env::vars_os` snapshots the environment under `std`'s
+/// internal env lock, and the post-`fork` child execs with that captured array,
+/// never reading the global `environ`. That removes these `git` spawns from the
+/// data race against a concurrent `std::env::set_var`/`remove_var` on another
+/// thread (the cause of the intermittent skills-test failures in issue #1022):
+/// a writer mutating the global table is invisible to a child whose `envp` was
+/// already captured. The snapshot preserves the inherited environment, so
+/// production behaviour is unchanged.
+pub(super) fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    cmd.env_clear();
+    cmd.envs(std::env::vars_os());
+    cmd
+}
+
 /// Runs `git rev-parse --show-toplevel` from `path` and returns the absolute root.
 pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(path)
         .output()
@@ -57,7 +77,7 @@ pub(super) fn resolve_toplevel(path: &Path) -> Result<PathBuf> {
 /// The command may return a relative path (e.g. `.git`) when executed inside the
 /// main worktree; this helper resolves any such relative path against `path`.
 pub(super) fn resolve_git_common_dir(path: &Path) -> Result<PathBuf> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["rev-parse", "--git-common-dir"])
         .current_dir(path)
         .output()
@@ -81,7 +101,7 @@ pub(super) fn resolve_git_common_dir(path: &Path) -> Result<PathBuf> {
 
 /// Lists all worktree root paths for the repository containing `path`.
 pub(super) fn list_worktrees(path: &Path) -> Result<Vec<PathBuf>> {
-    let output = Command::new("git")
+    let output = git_command()
         .args(["worktree", "list", "--porcelain"])
         .current_dir(path)
         .output()
@@ -286,20 +306,22 @@ fn ctx_spawn_failure(command: &str, path: &Path) -> String {
     format!("Failed to run {command} in {}", path.display())
 }
 
+/// Git-repository fixtures shared by every skills command's test module.
+///
+/// All spawns route through [`git_command`] so the child gets an explicit,
+/// race-free environment — see that function for why this matters under the
+/// parallel test run (issue #1022). Centralizing these here also retires the
+/// per-module copies of `init_repo`/`init_repo_with_commit` that previously
+/// each spawned `git` directly.
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
-mod tests {
-    use super::*;
+pub(crate) mod test_git {
+    use super::git_command;
+    use std::path::Path;
 
-    use tempfile::TempDir;
-
-    fn tempdir() -> TempDir {
-        std::fs::create_dir_all("tmp").ok();
-        TempDir::new_in("tmp").unwrap()
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = Command::new("git")
+    /// `git init <dir>`; panics on a spawn failure or non-zero exit.
+    pub(crate) fn init_repo(dir: &Path) {
+        let status = git_command()
             .arg("init")
             .arg(dir)
             .output()
@@ -307,32 +329,62 @@ mod tests {
         assert!(status.status.success(), "git init failed: {status:?}");
     }
 
-    fn init_repo_with_commit(dir: &Path) {
+    /// `init_repo` plus a single committed `README.md`. Identity and signing
+    /// are pinned inline (`-c`) so the fixture neither needs ambient git user
+    /// config nor invokes the developer's commit-signing key — a throwaway test
+    /// commit must not depend on (or flake on) the host's `commit.gpgsign`.
+    pub(crate) fn init_repo_with_commit(dir: &Path) {
         init_repo(dir);
-        fs::write(dir.join("README.md"), "readme").unwrap();
-        for (k, v) in [
-            ("add", vec!["add", "README.md"]),
-            (
+        std::fs::write(dir.join("README.md"), "readme").expect("write README");
+        let add = git_command()
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .expect("git add failed to spawn");
+        assert!(add.status.success(), "git add failed: {add:?}");
+        let commit = git_command()
+            .args([
+                "-c",
+                "user.email=x@x",
+                "-c",
+                "user.name=x",
+                "-c",
+                "commit.gpgsign=false",
                 "commit",
-                vec![
-                    "-c",
-                    "user.email=x@x",
-                    "-c",
-                    "user.name=x",
-                    "commit",
-                    "-q",
-                    "-m",
-                    "init",
-                ],
-            ),
-        ] {
-            let status = Command::new("git")
-                .args(&v)
-                .current_dir(dir)
-                .output()
-                .unwrap_or_else(|_| panic!("git {k} failed to spawn"));
-            assert!(status.status.success(), "git {k} failed: {status:?}");
-        }
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(dir)
+            .output()
+            .expect("git commit failed to spawn");
+        assert!(commit.status.success(), "git commit failed: {commit:?}");
+    }
+
+    /// `git worktree add -q <linked>` run from inside `repo`.
+    pub(crate) fn worktree_add(repo: &Path, linked: &Path) {
+        let add = git_command()
+            .args(["worktree", "add", "-q"])
+            .arg(linked)
+            .current_dir(repo)
+            .output()
+            .expect("git worktree add failed to spawn");
+        assert!(add.status.success(), "git worktree add failed: {add:?}");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    use super::test_git::{init_repo, init_repo_with_commit, worktree_add};
+
+    fn tempdir() -> TempDir {
+        std::fs::create_dir_all("tmp").ok();
+        TempDir::new_in("tmp").unwrap()
     }
 
     #[test]
@@ -379,13 +431,7 @@ mod tests {
         init_repo_with_commit(main.path());
         let wt = tempdir();
         let linked = wt.path().join("linked");
-        let status = Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(main.path())
-            .output()
-            .expect("git worktree add failed");
-        assert!(status.status.success(), "git worktree add: {status:?}");
+        worktree_add(main.path(), &linked);
 
         let common = resolve_git_common_dir(&linked).unwrap();
         let main_git = fs::canonicalize(main.path().join(".git")).unwrap();
@@ -420,13 +466,7 @@ mod tests {
         init_repo_with_commit(main.path());
         let wt = tempdir();
         let linked = wt.path().join("linked");
-        let status = Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(main.path())
-            .output()
-            .expect("git worktree add failed");
-        assert!(status.status.success());
+        worktree_add(main.path(), &linked);
 
         let trees = list_worktrees(main.path()).unwrap();
         assert_eq!(trees.len(), 2);

--- a/src/cli/ai/claude/skills/mod.rs
+++ b/src/cli/ai/claude/skills/mod.rs
@@ -260,34 +260,34 @@ fn render_status_report(report: &status::StatusReport, format: OutputFormat) -> 
 }
 
 fn render_status_text(report: &status::StatusReport) -> String {
+    report
+        .targets
+        .iter()
+        .filter(|t| !(t.symlinks.is_empty() && t.exclude_entries.is_empty()))
+        .map(render_status_target)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_status_target(target: &status::TargetStatus) -> String {
     use std::fmt::Write;
     let mut out = String::new();
-    let mut first = true;
-    for target in &report.targets {
-        if target.symlinks.is_empty() && target.exclude_entries.is_empty() {
-            continue;
+    let _ = writeln!(out, "{}", target.root.display());
+    if !target.symlinks.is_empty() {
+        out.push_str("  symlinks:\n");
+        for link in &target.symlinks {
+            let _ = writeln!(
+                out,
+                "    {} -> {}",
+                link.path.display(),
+                link.points_to.display()
+            );
         }
-        if !first {
-            out.push('\n');
-        }
-        first = false;
-        let _ = writeln!(out, "{}", target.root.display());
-        if !target.symlinks.is_empty() {
-            out.push_str("  symlinks:\n");
-            for link in &target.symlinks {
-                let _ = writeln!(
-                    out,
-                    "    {} -> {}",
-                    link.path.display(),
-                    link.points_to.display()
-                );
-            }
-        }
-        if !target.exclude_entries.is_empty() {
-            let _ = writeln!(out, "  exclude block ({}):", target.exclude_file.display());
-            for entry in &target.exclude_entries {
-                let _ = writeln!(out, "    {entry}");
-            }
+    }
+    if !target.exclude_entries.is_empty() {
+        let _ = writeln!(out, "  exclude block ({}):", target.exclude_file.display());
+        for entry in &target.exclude_entries {
+            let _ = writeln!(out, "    {entry}");
         }
     }
     out
@@ -533,6 +533,12 @@ mod skills_api_tests {
                     exclude_entries: Vec::new(),
                 },
                 status::TargetStatus {
+                    root: PathBuf::from("/first"),
+                    symlinks: Vec::new(),
+                    exclude_file: PathBuf::from("/first/.git/info/exclude"),
+                    exclude_entries: vec![".claude/skills/beta/".into()],
+                },
+                status::TargetStatus {
                     root: PathBuf::from("/both"),
                     symlinks: vec![status::SymlinkInfo {
                         path: PathBuf::from("/both/.claude/skills/alpha"),
@@ -544,11 +550,17 @@ mod skills_api_tests {
             ],
         };
         let out = render_status_text(&report);
+        assert!(out.contains("/first"), "missing /first: {out}");
         assert!(out.contains("/both"), "missing /both: {out}");
         assert!(out.contains("symlinks:"), "missing symlinks: {out}");
         assert!(
             out.contains("exclude block"),
             "missing exclude block: {out}"
+        );
+        // Two rendered targets must be separated by a blank line (the join).
+        assert!(
+            out.contains("\n\n"),
+            "missing blank-line separator between targets: {out}"
         );
         assert!(
             !out.contains("/empty\n"),

--- a/src/cli/ai/claude/skills/mod.rs
+++ b/src/cli/ai/claude/skills/mod.rs
@@ -300,9 +300,10 @@ mod skills_api_tests {
 
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
 
     use tempfile::TempDir;
+
+    use super::common::test_git::{init_repo, init_repo_with_commit, worktree_add};
 
     fn tempdir() -> TempDir {
         // Anchor tmp at an absolute path so concurrent chdir-ing tests can't
@@ -310,37 +311,6 @@ mod skills_api_tests {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tmp");
         fs::create_dir_all(&root).ok();
         TempDir::new_in(&root).unwrap()
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = Command::new("git").arg("init").arg(dir).output().unwrap();
-        assert!(status.status.success());
-    }
-
-    fn init_repo_with_commit(dir: &Path) {
-        init_repo(dir);
-        fs::write(dir.join("README.md"), "readme").unwrap();
-        let add = Command::new("git")
-            .args(["add", "README.md"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(add.status.success());
-        let commit = Command::new("git")
-            .args([
-                "-c",
-                "user.email=x@x",
-                "-c",
-                "user.name=x",
-                "commit",
-                "-q",
-                "-m",
-                "init",
-            ])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(commit.status.success());
     }
 
     fn make_source_skills(root: &Path, names: &[&str]) {
@@ -360,13 +330,7 @@ mod skills_api_tests {
         let linked = wt_parent.path().join("linked");
         init_repo_with_commit(src.path());
         make_source_skills(src.path(), &["alpha"]);
-        let add_wt = Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(src.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success());
+        worktree_add(src.path(), &linked);
 
         let out = run_sync(Some(&linked), true, OutputFormat::Yaml).unwrap();
         assert!(out.contains("dry_run: false"), "missing dry_run: {out}");
@@ -405,13 +369,7 @@ mod skills_api_tests {
         init_repo_with_commit(main.path());
         let wt_parent = tempdir();
         let linked = wt_parent.path().join("linked");
-        let add_wt = Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(main.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success());
+        worktree_add(main.path(), &linked);
 
         let out = run_clean(Some(main.path()), true, OutputFormat::Yaml).unwrap();
         assert!(out.contains("actions:"), "missing actions: {out}");
@@ -455,13 +413,7 @@ mod skills_api_tests {
         let wt_parent = tempdir();
         let linked = wt_parent.path().join("linked");
         init_repo_with_commit(tgt_main.path());
-        let add_wt = Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(tgt_main.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success());
+        worktree_add(tgt_main.path(), &linked);
 
         let out = run_status(Some(tgt_main.path()), true, OutputFormat::Yaml).unwrap();
         assert!(out.contains("targets:"), "missing targets: {out}");
@@ -647,10 +599,10 @@ mod tests {
 
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
 
     use tempfile::TempDir;
 
+    use super::common::test_git::init_repo;
     use common::OutputFormat;
 
     fn tempdir() -> TempDir {
@@ -659,11 +611,6 @@ mod tests {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tmp");
         fs::create_dir_all(&root).ok();
         TempDir::new_in(&root).unwrap()
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = Command::new("git").arg("init").arg(dir).output().unwrap();
-        assert!(status.status.success());
     }
 
     #[test]

--- a/src/cli/ai/claude/skills/status.rs
+++ b/src/cli/ai/claude/skills/status.rs
@@ -188,6 +188,7 @@ fn print_report_text(report: &StatusReport) {
 mod tests {
     use super::*;
 
+    use super::super::common::test_git::{init_repo, init_repo_with_commit, worktree_add};
     use super::super::common::{BLOCK_BEGIN, BLOCK_END};
 
     use tempfile::TempDir;
@@ -195,41 +196,6 @@ mod tests {
     fn tempdir() -> TempDir {
         std::fs::create_dir_all("tmp").ok();
         TempDir::new_in("tmp").unwrap()
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = std::process::Command::new("git")
-            .arg("init")
-            .arg(dir)
-            .output()
-            .expect("git init failed to spawn");
-        assert!(status.status.success(), "git init failed: {status:?}");
-    }
-
-    fn init_repo_with_commit(dir: &Path) {
-        init_repo(dir);
-        fs::write(dir.join("README.md"), "readme").unwrap();
-        let add = std::process::Command::new("git")
-            .args(["add", "README.md"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(add.status.success());
-        let commit = std::process::Command::new("git")
-            .args([
-                "-c",
-                "user.email=x@x",
-                "-c",
-                "user.name=x",
-                "commit",
-                "-q",
-                "-m",
-                "init",
-            ])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(commit.status.success());
     }
 
     #[cfg(unix)]
@@ -367,13 +333,7 @@ mod tests {
         let linked = wt_parent.path().join("linked");
 
         init_repo_with_commit(tgt_main.path());
-        let add_wt = std::process::Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(tgt_main.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+        worktree_add(tgt_main.path(), &linked);
 
         let src = tempdir();
         let source_skill = src.path().join("alpha");

--- a/src/cli/ai/claude/skills/sync.rs
+++ b/src/cli/ai/claude/skills/sync.rs
@@ -317,6 +317,7 @@ fn print_report_text(report: &SyncReport, dry_run: bool) {
 mod tests {
     use super::*;
 
+    use super::super::common::test_git::{init_repo, init_repo_with_commit, worktree_add};
     use super::super::common::{BLOCK_BEGIN, BLOCK_END};
 
     use tempfile::TempDir;
@@ -334,15 +335,6 @@ mod tests {
             fs::create_dir_all(&skill_dir).unwrap();
             fs::write(skill_dir.join("SKILL.md"), format!("# {name}")).unwrap();
         }
-    }
-
-    fn init_repo(dir: &Path) {
-        let status = std::process::Command::new("git")
-            .arg("init")
-            .arg(dir)
-            .output()
-            .expect("git init failed to spawn");
-        assert!(status.status.success(), "git init failed: {status:?}");
     }
 
     fn make_fake_repo(dir: &Path) {
@@ -604,32 +596,6 @@ mod tests {
         cmd.execute().unwrap();
     }
 
-    fn init_repo_with_commit(dir: &Path) {
-        init_repo(dir);
-        fs::write(dir.join("README.md"), "readme").unwrap();
-        let add = std::process::Command::new("git")
-            .args(["add", "README.md"])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(add.status.success());
-        let commit = std::process::Command::new("git")
-            .args([
-                "-c",
-                "user.email=x@x",
-                "-c",
-                "user.name=x",
-                "commit",
-                "-q",
-                "-m",
-                "init",
-            ])
-            .current_dir(dir)
-            .output()
-            .unwrap();
-        assert!(commit.status.success());
-    }
-
     #[test]
     fn execute_source_defaults_to_cwd() {
         let tgt = tempdir();
@@ -787,13 +753,7 @@ mod tests {
         make_source_skills(src.path(), &["alpha"]);
         init_repo_with_commit(tgt_main.path());
 
-        let add_wt = std::process::Command::new("git")
-            .args(["worktree", "add", "-q"])
-            .arg(&linked)
-            .current_dir(tgt_main.path())
-            .output()
-            .unwrap();
-        assert!(add_wt.status.success(), "git worktree add: {add_wt:?}");
+        worktree_add(tgt_main.path(), &linked);
 
         let cmd = SyncCommand {
             source: Some(src.path().to_path_buf()),


### PR DESCRIPTION
## Description

This PR fixes intermittent test failures (issue #1022) caused by a data race between concurrent `std::env::set_var`/`remove_var` calls on one thread and `git` subprocess spawns on another thread during the parallel test run.

When spawning a child process using `Command::new("git")` without explicit environment capture, the child inherits the parent's live `environ` table at `exec` time. If another thread is mutating the environment simultaneously (e.g. via `std::env::set_var`), a data race occurs — the child may read a partially-written environment. This was the root cause of the intermittent skills test failures.

The fix introduces a `git_command()` helper in `src/cli/ai/claude/skills/common.rs` that calls `env_clear()` followed by `envs(std::env::vars_os())`. This causes `std` to snapshot the environment under its internal env lock before fork, so the child's `envp` is captured atomically and is never exposed to concurrent mutations on other threads. Production behaviour is unchanged because the full inherited environment is preserved in the snapshot.

As a secondary improvement, all per-module duplicates of `init_repo`, `init_repo_with_commit`, and `worktree_add` test helper functions have been consolidated into a new `pub(crate) mod test_git` in `common.rs`. All helpers now route through `git_command()`, so fixture spawns are also race-free. An additional `commit.gpgsign=false` flag was added to `init_repo_with_commit` so fixture commits do not depend on or fail due to the host's GPG signing configuration.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue

Fixes #1022

## Changes Made

**Core Changes:**
- Added `git_command()` in `src/cli/ai/claude/skills/common.rs` that builds a `Command::new("git")` with `env_clear()` + `envs(std::env::vars_os())` to snapshot the environment atomically, eliminating the data race against concurrent `set_var`/`remove_var` calls
- Updated `resolve_toplevel()`, `resolve_git_common_dir()`, and `list_worktrees()` in `common.rs` to use `git_command()` instead of `Command::new("git")`

**Test Infrastructure:**
- Added `pub(crate) mod test_git` in `common.rs` with three shared helpers: `init_repo()`, `init_repo_with_commit()`, and `worktree_add()`, all routed through `git_command()` for race-free environment handling
- Added `commit.gpgsign=false` to the `init_repo_with_commit` fixture to prevent failures on developer machines with global GPG signing enabled
- Removed duplicated `init_repo()` local functions from `clean.rs`, `status.rs`, `sync.rs`, and both test modules in `mod.rs`
- Removed duplicated `init_repo_with_commit()` local functions from `clean.rs`, `status.rs`, `sync.rs`, and `skills_api_tests` in `mod.rs`
- Replaced all inline `Command::new("git").args(["worktree", "add", "-q"]) ...` blocks with calls to `worktree_add()` across `clean.rs`, `status.rs`, `sync.rs`, and `mod.rs`
- Updated import statements in all affected test modules to use `super::super::common::test_git::{init_repo, init_repo_with_commit, worktree_add}`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Integration tests updated to use consolidated fixtures

**Manual Testing:**
- [x] Verified all skills tests pass under `cargo test`
- [x] Confirmed no functional change to production git operations

### Test Commands
```bash
# Core test suite
cargo test

# Run skills-specific tests
cargo test skills

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the new `git_command()` doc comment explains the rationale; reviewers should verify the env snapshot approach is correct
- [x] Backward compatibility — `envs(std::env::vars_os())` must preserve the full inherited environment for production git operations

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Switching all environment mutations to use `unsafe { std::env::set_var }` in a single-threaded context — rejected as too invasive and not the right layer to fix
- Using `Command::env()` to pass only specific variables — rejected because it would change production behaviour and require knowing which env vars `git` needs