### PR TITLE
feat: local invocation + HTTP request/response log

### DIFF
--- a/.omni-dev/scopes.yaml
+++ b/.omni-dev/scopes.yaml
@@ -35,6 +35,10 @@ scopes:
     description: "MCP server implementation and tool handlers"
     examples: ["mcp: add git_view_commits tool", "mcp: wire up stdio transport"]
     file_patterns: ["src/mcp/**", "src/mcp.rs", "src/mcp_server.rs"]
+  - name: "request-log"
+    description: "Local append-only invocation + HTTP request log and its reader"
+    examples: ["request-log: add append-only log writer", "request-log: add omni-dev log reader"]
+    file_patterns: ["src/request_log.rs", "src/cli/log.rs", "src/cli/log/**"]
   - name: "resources"
     description: "Embedded reference content registry shared by CLI and MCP"
     examples: ["resources: add jfm spec entry", "resources: extract specs into shared registry"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,15 @@ The daemon's **second** service (after the browser bridge) authenticates Snowfla
 
 **No new trust boundary:** requests ride the daemon's existing `0600` Unix socket; **no secret is persisted** (in-memory session only). Keep the operator guide + lumon contract [docs/snowflake-service.md](docs/snowflake-service.md) in sync, and run the [`update-snapshots`](.claude/skills/update-snapshots/SKILL.md) skill on any CLI-surface change (see Code Changes §5).
 
+### Request log
+A local, append-only NDJSON log (`log.jsonl`) of every invocation **and** the HTTP requests it issues, plus an `omni-dev log` subcommand to search and pretty-print it. Best-effort and default-on; a write failure never changes the caller's exit code.
+
+- `src/request_log.rs` — the schema (one forward-compatible `LogRecord` for both write and read, same `#[serde(default)]` + `skip_serializing_if` contract the daemon wire types use), the `record`/`record_http`/`record_invocation` writers, path resolution (`OMNI_DEV_LOG_FILE` → `state_dir`→`data_dir`/`omni-dev/log.jsonl`, dir `0700`/file `0600`), and the per-invocation `RequestLogContext` (process-global `OnceLock` + a `tokio` task-local override) that lets HTTP records inherit their parent `invocation_id`/`source`/`mcp_tool` without threading state through call sites.
+- `src/cli/log.rs` + `src/cli/log/{format,query,stream}.rs` — the read-only `omni-dev log` command: the filter matrix, the `--query` mini-language (AND/OR/NOT, `field:value`, fuzzy tokens), `oneline`/`json`/`full` renderers (`json` is byte-identical to the on-disk lines), and the streaming reader (`--limit` ring buffer, `-f/--follow`).
+- The invocation record is emitted by the [`main.rs`](src/main.rs) shell around `cli.execute()`; HTTP records are emitted from one hook per transport method (Atlassian, Datadog, Snowflake `send_once`, the Claude/AI backends + `claude-cli`, and the browser bridge `dispatch`/`start_stream`). The MCP server's hand-written `call_tool` scopes the task-local context to `source=mcp` per tool call.
+
+**No secret is ever written:** auth headers are redacted centrally and request/response bodies are opt-in via `OMNI_DEV_LOG_BODIES` (headers via `OMNI_DEV_LOG_HEADERS`); `OMNI_DEV_LOG_DISABLE` is an absolute opt-out. **No new trust boundary** — the log is local-machine state with the same `0700`/`0600` posture as other runtime state. Keep the operator guide [docs/log.md](docs/log.md) in sync, and run the [`update-snapshots`](.claude/skills/update-snapshots/SKILL.md) skill on any CLI-surface change (see Code Changes §5).
+
 ### Skill Structure
 Claude skills are organized in `.claude/skills/`, one subdirectory per skill with a `SKILL.md` file.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ureq = "3"
 quick-xml = "0.40.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["fs", "signal", "user"] }
+nix = { version = "0.31", default-features = false, features = ["fs", "hostname", "signal", "user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Menu-bar tray deps (enabled by the `menu-bar` feature). `muda` (the menu

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,135 @@
+# Request log
+
+`omni-dev` keeps a local, append-only log of every invocation **and** the HTTP
+requests it issues, and ships an `omni-dev log` subcommand to search and
+pretty-print it. It is the single, durable, queryable record of *what was run*
+and *what it talked to over the network* — the thing `RUST_LOG` tracing (ephemeral,
+stderr-only) is not.
+
+## What gets recorded
+
+One JSON object per line (NDJSON). A `kind` field discriminates the two record
+types, so the log is a complete invocation history, not just an HTTP history:
+
+- **`kind: "invocation"`** — one per process run (and one per MCP tool call):
+  the resolved subcommand path, full argv, exit code, duration, any top-level
+  error, and a whitelisted `OMNI_DEV_*` env snapshot.
+- **`kind: "http"`** — one per outbound request (recorded *inside* each client's
+  retry loop, so retries and transport failures are captured too): service,
+  method, URL, status, elapsed, and any error.
+
+Every HTTP record shares an `invocation_id` with the invocation that issued it,
+so you can pull a run and all of its requests with a single `--id`.
+
+## Location
+
+Resolved in this order:
+
+1. `OMNI_DEV_LOG_FILE` if set.
+2. Otherwise `dirs::state_dir()` joined with `omni-dev/log.jsonl` — on Linux,
+   `~/.local/state/omni-dev/log.jsonl`.
+3. On platforms without a state dir (macOS), it falls back to the data dir,
+   matching the daemon's convention: `~/Library/Application Support/omni-dev/log.jsonl`.
+
+The directory is created `0700` and the file `0600`, the same posture as other
+`omni-dev` runtime state. The log lives entirely on your machine.
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `OMNI_DEV_LOG_FILE` | Override the log path. |
+| `OMNI_DEV_LOG_DISABLE=1` | Disable logging entirely. |
+| `OMNI_DEV_LOG_BODIES=1` | Opt in to recording request/response bodies (off by default; payloads are large and may contain customer content). |
+| `OMNI_DEV_LOG_HEADERS=1` | Opt in to recording (redacted) request/response headers. |
+
+Logging is **best effort**: a write failure is swallowed (logged only at
+`tracing::debug`) and can never change the command's exit code.
+
+## `omni-dev log`
+
+```
+omni-dev log [OPTIONS]
+```
+
+### Filters
+
+| Flag | Matches |
+|------|---------|
+| `--since <DUR>` | Records newer than a relative window: `30m`, `2h`, `1d`, `1w`, `45s`. |
+| `--method <METHOD>` | HTTP method (case-insensitive). |
+| `--status <STATUS>` | Exact (`200`), class (`5xx`), or comma list (`4xx,5xx`). |
+| `--service <NAME>` | `jira`, `confluence`, `datadog`, `browser-bridge`, `snowflake`, `claude`, `claude-cli`. |
+| `--command <PATH>` | Resolved command-path prefix on whole segments, e.g. `"jira read"`. |
+| `--url <SUBSTR>` | Substring of the request URL. |
+| `--grep <REGEX>` | Regular expression against the raw JSON line. |
+| `--fuzzy <TOKEN>` | Substring of the raw line; repeatable, AND-ed. |
+| `--query <EXPR>` | Query expression (see below); repeatable, AND-ed. |
+| `--id <ID>` | This record `id` **or** `invocation_id` — pulls a run and its requests. |
+
+### Output
+
+| Flag | Effect |
+|------|--------|
+| `--format <oneline\|json\|full>` | `oneline` (default), `json` (NDJSON, byte-identical to the file — composes with `jq`), or `full` (pretty block). |
+| `-n, --limit <N>` | Show at most the N most recent matching records. |
+| `-f, --follow` | Tail the log, printing new matching records as they arrive. |
+
+### The `--query` mini-language
+
+- **Structured terms:** `field:value` — `kind`, `source`, `service`, `method`,
+  `status` (supports `5xx`), `command`, `url`, `id`, `invocation_id` (alias
+  `inv`), `mcp_tool` (alias `tool`), `via_daemon`, `error`. Field matching is
+  shared with the flags, so `--status 5xx` and `status:5xx` behave identically.
+- **Bare tokens** are fuzzy substring matches against the raw JSON line.
+- **Operators:** `AND` (also implicit between adjacent terms), `OR`, `NOT` (or a
+  leading `-`), and parentheses. Use `"quotes"` for a value containing spaces.
+
+```bash
+omni-dev log --query 'kind:http AND (status:5xx OR method:POST)'
+omni-dev log --query 'service:jira -status:2xx'        # jira requests that did not 2xx
+```
+
+### Examples
+
+```bash
+# The last 20 things you ran.
+omni-dev log -n 20
+
+# Server errors in the last two hours.
+omni-dev log --since 2h --status 5xx
+
+# A run and every request it made.
+omni-dev log --id 0001718000000-0a1b2c3d4e5f6071
+
+# Compose with jq.
+omni-dev log --format json --service datadog | jq 'select(.elapsed_ms > 1000)'
+
+# Follow live.
+omni-dev log -f --service browser-bridge
+```
+
+## Redaction posture
+
+No secret material is ever written, under any code path:
+
+- Auth headers/tokens are **redacted centrally** before writing; only a
+  non-secret `auth_principal` identity is ever kept.
+- Request/response bodies are **opt-in** via `OMNI_DEV_LOG_BODIES=1`.
+- The `OMNI_DEV_*` env snapshot redacts any name containing `TOKEN`, `SECRET`,
+  `KEY`, `PASSWORD`, or `PASSWD`.
+
+## Daemon-served requests
+
+Requests executed inside the daemon (the browser bridge and the Snowflake
+session pool) set `via_daemon: true`. Because the daemon is a separate process
+from the CLI that asked it to act, such requests carry the *daemon's*
+`invocation_id`, not the CLI's — cross-socket correlation is a planned follow-up.
+
+## Schema and compatibility
+
+Records are read and written through a single forward-compatible struct: every
+field is `#[serde(default)]` and every optional field is `skip_serializing_if`.
+A newer reader never chokes on an older line, and an older reader never chokes on
+a newer one — the same forward-rolling contract the daemon wire types use. The
+record id is time-sortable, so sorting lines by `id` ≈ sorting by time.

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -4,7 +4,7 @@
 //! writing issues. Uses Basic Auth (email + API token).
 
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -15,6 +15,7 @@ use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::adf_validated::ValidatedAdfDocument;
 use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::error::AtlassianError;
+use crate::request_log;
 
 /// HTTP request timeout for Atlassian API calls.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -6767,20 +6768,51 @@ impl AtlassianClient {
         &self.instance_url
     }
 
+    /// Appends a best-effort HTTP record for one request attempt. The service
+    /// tag is `confluence` for `/wiki/` paths, else `jira`.
+    fn log_request(
+        &self,
+        method: &str,
+        url: &str,
+        started: Instant,
+        result: &reqwest::Result<reqwest::Response>,
+    ) {
+        let service = if url.contains("/wiki/") {
+            "confluence"
+        } else {
+            "jira"
+        };
+        match result {
+            Ok(r) => request_log::record_http(
+                service,
+                method,
+                url,
+                started,
+                Some(r.status().as_u16()),
+                None,
+            ),
+            Err(e) => {
+                request_log::record_http(service, method, url, started, None, Some(&e.to_string()));
+            }
+        }
+    }
+
     /// Sends an authenticated GET request and returns the raw response.
     ///
     /// Shared transport method used by both JIRA and Confluence API
     /// implementations.
     pub async fn get_json(&self, url: &str) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .get(url)
                 .header("Authorization", &self.auth_header)
                 .header("Accept", "application/json")
                 .send()
-                .await
-                .context("Failed to send GET request to Atlassian API")?;
+                .await;
+            self.log_request("GET", url, started, &result);
+            let response = result.context("Failed to send GET request to Atlassian API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);
@@ -6800,15 +6832,17 @@ impl AtlassianClient {
         body: &T,
     ) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .put(url)
                 .header("Authorization", &self.auth_header)
                 .header("Content-Type", "application/json")
                 .json(body)
                 .send()
-                .await
-                .context("Failed to send PUT request to Atlassian API")?;
+                .await;
+            self.log_request("PUT", url, started, &result);
+            let response = result.context("Failed to send PUT request to Atlassian API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);
@@ -6825,15 +6859,17 @@ impl AtlassianClient {
         body: &T,
     ) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .post(url)
                 .header("Authorization", &self.auth_header)
                 .header("Content-Type", "application/json")
                 .json(body)
                 .send()
-                .await
-                .context("Failed to send POST request to Atlassian API")?;
+                .await;
+            self.log_request("POST", url, started, &result);
+            let response = result.context("Failed to send POST request to Atlassian API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);
@@ -6863,13 +6899,15 @@ impl AtlassianClient {
     /// Sends an authenticated DELETE request and returns the raw response.
     pub async fn delete(&self, url: &str) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .delete(url)
                 .header("Authorization", &self.auth_header)
                 .send()
-                .await
-                .context("Failed to send DELETE request to Atlassian API")?;
+                .await;
+            self.log_request("DELETE", url, started, &result);
+            let response = result.context("Failed to send DELETE request to Atlassian API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);
@@ -6897,22 +6935,25 @@ impl AtlassianClient {
         for (name, value) in extra_headers {
             req = req.header(*name, *value);
         }
-        req.send()
-            .await
-            .context("Failed to send multipart POST request to Atlassian API")
+        let started = Instant::now();
+        let result = req.send().await;
+        self.log_request("POST", url, started, &result);
+        result.context("Failed to send multipart POST request to Atlassian API")
     }
 
     /// Internal: GET with custom Accept header and 429 retry.
     async fn get_json_raw_accept(&self, url: &str, accept: &str) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .get(url)
                 .header("Authorization", &self.auth_header)
                 .header("Accept", accept)
                 .send()
-                .await
-                .context("Failed to send GET request to Atlassian API")?;
+                .await;
+            self.log_request("GET", url, started, &result);
+            let response = result.context("Failed to send GET request to Atlassian API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use axum::{
@@ -39,6 +39,7 @@ use crate::browser::protocol::{
     ResponseEnvelope, StatusResponse, StreamItem, StreamLine, TabInfo,
 };
 use crate::browser::snippet;
+use crate::request_log;
 
 /// Default WebSocket-plane port.
 pub const DEFAULT_WS_PORT: u16 = 9999;
@@ -915,10 +916,38 @@ fn resolve_allow_origin<'a>(req: &'a ControlRequest, state: &'a AppState) -> Opt
 
 /// The shared request path: scope-check, register a waiter, send the command,
 /// and await the browser's reply (or time out).
+/// Appends a best-effort `service = browser-bridge` HTTP record for one proxied
+/// request, flagging `via_daemon` when the bridge is hosted by the daemon.
+fn record_bridge_http(
+    method: &str,
+    url: &str,
+    started: Instant,
+    status: Option<u16>,
+    error: Option<&str>,
+) {
+    let via_daemon = matches!(
+        request_log::current_context().source,
+        request_log::Source::Daemon
+    );
+    request_log::record_http_with(
+        "browser-bridge",
+        method,
+        url,
+        started,
+        status,
+        error,
+        request_log::HttpExtra {
+            via_daemon,
+            ..Default::default()
+        },
+    );
+}
+
 async fn dispatch(
     state: &AppState,
     req: ControlRequest,
 ) -> Result<ResponseEnvelope, (StatusCode, String)> {
+    let started = Instant::now();
     auth::validate_outbound_url(&req.url, resolve_allow_origin(&req, state)).map_err(|_| {
         (
             StatusCode::FORBIDDEN,
@@ -942,6 +971,9 @@ async fn dispatch(
         )
     })?;
 
+    // Clone the method/URL for the request log before they move into `Command`.
+    let log_method = req.method.clone();
+    let log_url = req.url.clone();
     let (id, rx) = state.correlator.register();
     let command = Command {
         id,
@@ -989,6 +1021,7 @@ async fn dispatch(
                 body,
                 encoding,
             } => {
+                record_bridge_http(&log_method, &log_url, started, Some(status), None);
                 // Size is accounted against the *decoded* body. For base64 that
                 // means decoding here to learn the true byte length; the envelope
                 // still carries the base64 string (the caller / proxy decodes).
@@ -1030,17 +1063,36 @@ async fn dispatch(
                     encoding,
                 })
             }
-            ReplyOutcome::Error(msg) => Err((
-                StatusCode::BAD_GATEWAY,
-                format!("browser fetch failed: {msg}"),
-            )),
+            ReplyOutcome::Error(msg) => {
+                record_bridge_http(&log_method, &log_url, started, None, Some(&msg));
+                Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!("browser fetch failed: {msg}"),
+                ))
+            }
         },
-        Ok(Err(_)) => Err((
-            StatusCode::BAD_GATEWAY,
-            "browser connection closed before replying".to_string(),
-        )),
+        Ok(Err(_)) => {
+            record_bridge_http(
+                &log_method,
+                &log_url,
+                started,
+                None,
+                Some("browser connection closed before replying"),
+            );
+            Err((
+                StatusCode::BAD_GATEWAY,
+                "browser connection closed before replying".to_string(),
+            ))
+        }
         Err(_) => {
             state.correlator.remove(id);
+            record_bridge_http(
+                &log_method,
+                &log_url,
+                started,
+                None,
+                Some("browser did not reply in time"),
+            );
             Err((
                 StatusCode::GATEWAY_TIMEOUT,
                 "browser did not reply in time".to_string(),
@@ -1073,6 +1125,7 @@ async fn start_stream(
     state: &AppState,
     req: ControlRequest,
 ) -> Result<(u16, BTreeMap<String, String>, StreamDriver), (StatusCode, String)> {
+    let started = Instant::now();
     auth::validate_outbound_url(&req.url, resolve_allow_origin(&req, state)).map_err(|_| {
         (
             StatusCode::FORBIDDEN,
@@ -1096,6 +1149,9 @@ async fn start_stream(
         )
     })?;
 
+    // Clone the method/URL for the request log before they move into `Command`.
+    let log_method = req.method.clone();
+    let log_url = req.url.clone();
     let (id, mut rx) = state.correlator.register_stream();
     let command = Command {
         id,
@@ -1138,9 +1194,13 @@ async fn start_stream(
 
     let idle = state.config.request_timeout;
     let (status, headers) = match tokio::time::timeout(idle, rx.recv()).await {
-        Ok(Some(StreamItem::Head { status, headers })) => (status, headers),
+        Ok(Some(StreamItem::Head { status, headers })) => {
+            record_bridge_http(&log_method, &log_url, started, Some(status), None);
+            (status, headers)
+        }
         Ok(Some(StreamItem::Error(msg))) => {
             state.correlator.remove(id);
+            record_bridge_http(&log_method, &log_url, started, None, Some(&msg));
             return Err((
                 StatusCode::BAD_GATEWAY,
                 format!("browser fetch failed: {msg}"),
@@ -1148,12 +1208,26 @@ async fn start_stream(
         }
         Ok(Some(_)) => {
             state.correlator.remove(id);
+            record_bridge_http(
+                &log_method,
+                &log_url,
+                started,
+                None,
+                Some("browser streamed a body chunk before the response head"),
+            );
             return Err((
                 StatusCode::BAD_GATEWAY,
                 "browser streamed a body chunk before the response head".to_string(),
             ));
         }
         Ok(None) => {
+            record_bridge_http(
+                &log_method,
+                &log_url,
+                started,
+                None,
+                Some("browser connection closed before replying"),
+            );
             return Err((
                 StatusCode::BAD_GATEWAY,
                 "browser connection closed before replying".to_string(),
@@ -1161,6 +1235,13 @@ async fn start_stream(
         }
         Err(_) => {
             send_cancel(state, conn_id, id).await;
+            record_bridge_http(
+                &log_method,
+                &log_url,
+                started,
+                None,
+                Some("browser did not start streaming in time"),
+            );
             return Err((
                 StatusCode::GATEWAY_TIMEOUT,
                 "browser did not start streaming in time".to_string(),

--- a/src/claude/ai.rs
+++ b/src/claude/ai.rs
@@ -7,7 +7,7 @@ pub mod openai;
 
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use reqwest::Client;
@@ -15,6 +15,7 @@ use serde_json::Value;
 
 use crate::claude::error::ClaudeError;
 use crate::claude::model_config::get_model_registry;
+use crate::request_log;
 
 /// HTTP request timeout for AI API calls.
 ///
@@ -75,6 +76,30 @@ pub(crate) fn build_http_client() -> Result<Client> {
         .timeout(REQUEST_TIMEOUT)
         .build()
         .context("Failed to build HTTP client")
+}
+
+/// Appends a best-effort `service = claude` HTTP record for one AI-backend
+/// `POST` attempt (direct Anthropic, Bedrock, or OpenAI-compatible).
+pub(crate) fn record_ai_http(
+    url: &str,
+    started: Instant,
+    result: &reqwest::Result<reqwest::Response>,
+) {
+    match result {
+        Ok(r) => {
+            request_log::record_http(
+                "claude",
+                "POST",
+                url,
+                started,
+                Some(r.status().as_u16()),
+                None,
+            );
+        }
+        Err(e) => {
+            request_log::record_http("claude", "POST", url, started, None, Some(&e.to_string()));
+        }
+    }
 }
 
 /// Returns the maximum output tokens for a model from the registry,

--- a/src/claude/ai/bedrock.rs
+++ b/src/claude/ai/bedrock.rs
@@ -201,11 +201,10 @@ impl AiClient for BedrockAiClient {
                 builder = builder.header(key, value);
             }
 
-            let response = builder
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
+            let started = std::time::Instant::now();
+            let send_result = builder.json(&request).send().await;
+            super::record_ai_http(&api_url, started, &send_result);
+            let response = send_result.map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
 
             let response = super::check_error_response(response).await?;
 

--- a/src/claude/ai/claude.rs
+++ b/src/claude/ai/claude.rs
@@ -128,11 +128,14 @@ impl AiClient for ClaudeAiClient {
                 builder = builder.header(key, value);
             }
 
-            let response = builder
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
+            let started = std::time::Instant::now();
+            let send_result = builder.json(&request).send().await;
+            super::record_ai_http(
+                "https://api.anthropic.com/v1/messages",
+                started,
+                &send_result,
+            );
+            let response = send_result.map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
 
             let response = super::check_error_response(response).await?;
 

--- a/src/claude/ai/claude_cli.rs
+++ b/src/claude/ai/claude_cli.rs
@@ -22,7 +22,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
@@ -32,6 +32,7 @@ use tracing::{debug, info, warn};
 
 use super::{AiClient, AiClientCapabilities, AiClientMetadata, RequestOptions};
 use crate::claude::error::ClaudeError;
+use crate::request_log;
 
 /// Default subprocess timeout.
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
@@ -341,11 +342,40 @@ impl ClaudeCliAiClient {
 
     /// Variant of [`Self::run`] that materialises any options on the request.
     ///
+    /// Times the whole subprocess run and appends one `service = claude-cli`
+    /// record (a non-HTTP entry: the subprocess makes its own API calls) so the
+    /// `claude-cli` backend appears in the request log alongside the HTTP ones.
+    async fn run_with_options(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        options: &RequestOptions,
+    ) -> Result<String> {
+        let started = Instant::now();
+        let result = self
+            .run_with_options_inner(system_prompt, user_prompt, options)
+            .await;
+        let error = result.as_ref().err().map(|e| format!("{e:#}"));
+        request_log::record_http_with(
+            "claude-cli",
+            "EXEC",
+            &self.model,
+            started,
+            None,
+            error.as_deref(),
+            request_log::HttpExtra::default(),
+        );
+        result
+    }
+
+    /// Inner implementation of [`Self::run_with_options`] (the actual subprocess
+    /// drive); the public method wraps this to time and record the run.
+    ///
     /// When `options.response_schema` is `Some`, the schema is serialised
     /// to a JSON string and passed inline via `--json-schema <json>`.
     /// `claude -p` requires the schema on argv; passing a file path makes
     /// the subprocess exit silently with empty output.
-    async fn run_with_options(
+    async fn run_with_options_inner(
         &self,
         system_prompt: &str,
         user_prompt: &str,

--- a/src/claude/ai/openai.rs
+++ b/src/claude/ai/openai.rs
@@ -342,10 +342,10 @@ impl OpenAiAiClient {
             req_builder = req_builder.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let response = req_builder
-            .send()
-            .await
-            .map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
+        let started = std::time::Instant::now();
+        let send_result = req_builder.send().await;
+        super::record_ai_http(&api_url, started, &send_result);
+        let response = send_result.map_err(|e| ClaudeError::NetworkError(e.to_string()))?;
 
         let response = super::check_error_response(response).await?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ pub mod daemon;
 pub mod datadog;
 pub mod git;
 pub mod help;
+pub mod log;
 pub mod resources;
 pub mod snowflake;
 pub mod transcript;
@@ -145,6 +146,8 @@ pub enum Commands {
     Coverage(coverage::CoverageCommand),
     /// Transcript and caption fetching from media platforms.
     Transcript(transcript::TranscriptCommand),
+    /// Search the local invocation + HTTP request log.
+    Log(log::LogCommand),
     /// Embedded reference resources (specs, etc.).
     Resources(resources::ResourcesCommand),
     /// Generates shell completion scripts.
@@ -205,6 +208,7 @@ impl Cli {
             Commands::Snowflake(cmd) => cmd.execute().await,
             Commands::Coverage(cmd) => cmd.execute(repo).await,
             Commands::Transcript(cmd) => cmd.execute().await,
+            Commands::Log(log_cmd) => log_cmd.execute(),
             Commands::Config(config_cmd) => config_cmd.execute(),
             Commands::Resources(resources_cmd) => resources_cmd.execute(),
             Commands::Completions(completions_cmd) => completions_cmd.execute(),

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -1,0 +1,165 @@
+//! `omni-dev log` — search and pretty-print the local invocation + HTTP log.
+//!
+//! Read-only and synchronous. Streams [`request_log::log_file_path`] line by
+//! line, applies the filter matrix, and renders each match as `oneline`,
+//! `json` (byte-identical to the on-disk NDJSON), or `full`.
+
+mod format;
+mod query;
+mod stream;
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+
+use crate::request_log;
+use query::Filter;
+
+/// Output rendering for `omni-dev log`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum Format {
+    /// One compact line per record (default).
+    Oneline,
+    /// The on-disk NDJSON line, verbatim (composes with `jq`).
+    Json,
+    /// A labelled, multi-line block per record.
+    Full,
+}
+
+/// Searches and pretty-prints the local invocation + HTTP request log.
+#[derive(Parser)]
+pub struct LogCommand {
+    /// Only records newer than this relative window (e.g. `30m`, `2h`, `1d`).
+    #[arg(long, value_name = "DUR")]
+    since: Option<String>,
+    /// Match the HTTP method (case-insensitive), e.g. `GET`.
+    #[arg(long, value_name = "METHOD")]
+    method: Option<String>,
+    /// Match the status: exact (`200`), class (`5xx`), or list (`4xx,5xx`).
+    #[arg(long, value_name = "STATUS")]
+    status: Option<String>,
+    /// Match the service tag, e.g. `jira`, `datadog`, `browser-bridge`.
+    #[arg(long, value_name = "NAME")]
+    service: Option<String>,
+    /// Match the resolved command path prefix, e.g. `"jira read"`.
+    #[arg(long, value_name = "PATH")]
+    command: Option<String>,
+    /// Match a substring of the request URL.
+    #[arg(long, value_name = "SUBSTR")]
+    url: Option<String>,
+    /// Match a regular expression against the raw JSON line.
+    #[arg(long, value_name = "REGEX")]
+    grep: Option<String>,
+    /// Require a fuzzy token (substring of the raw line); repeatable, AND-ed.
+    #[arg(long, value_name = "TOKEN")]
+    fuzzy: Vec<String>,
+    /// A query expression (AND/OR/NOT, `field:value`, bare tokens); repeatable,
+    /// AND-ed together.
+    #[arg(long, value_name = "EXPR")]
+    query: Vec<String>,
+    /// Match this record `id` or `invocation_id` (pulls a run and its requests).
+    #[arg(long, value_name = "ID")]
+    id: Option<String>,
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Oneline)]
+    format: Format,
+    /// Show at most N (most recent) matching records.
+    #[arg(short = 'n', long, value_name = "N")]
+    limit: Option<usize>,
+    /// Follow the log, printing new matching records as they are appended.
+    #[arg(short = 'f', long)]
+    follow: bool,
+}
+
+impl LogCommand {
+    /// Executes the `omni-dev log` command.
+    pub fn execute(self) -> Result<()> {
+        let path = request_log::log_file_path().context("could not resolve the log file path")?;
+        let filter = Filter::build(query::FilterInput {
+            since: self.since.as_deref(),
+            method: self.method.as_deref(),
+            status: self.status.as_deref(),
+            service: self.service.as_deref(),
+            command: self.command.as_deref(),
+            url: self.url.as_deref(),
+            grep: self.grep.as_deref(),
+            fuzzy: &self.fuzzy,
+            query: &self.query,
+            id: self.id.as_deref(),
+        })?;
+        stream::run(&path, &filter, self.format, self.limit, self.follow)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(subcommand)]
+        cmd: Wrapped,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum Wrapped {
+        Log(LogCommand),
+    }
+
+    fn parse(args: &[&str]) -> LogCommand {
+        let mut full = vec!["omni-dev", "log"];
+        full.extend_from_slice(args);
+        match Wrapper::try_parse_from(full).unwrap().cmd {
+            Wrapped::Log(cmd) => cmd,
+        }
+    }
+
+    #[test]
+    fn defaults_are_sane() {
+        let cmd = parse(&[]);
+        assert_eq!(cmd.format, Format::Oneline);
+        assert!(cmd.limit.is_none());
+        assert!(!cmd.follow);
+    }
+
+    #[test]
+    fn parses_full_flag_matrix() {
+        let cmd = parse(&[
+            "--since",
+            "2h",
+            "--method",
+            "GET",
+            "--status",
+            "5xx",
+            "--service",
+            "jira",
+            "--command",
+            "jira read",
+            "--url",
+            "issue",
+            "--grep",
+            "X-\\d+",
+            "--fuzzy",
+            "a",
+            "--fuzzy",
+            "b",
+            "--query",
+            "status:5xx OR method:POST",
+            "--id",
+            "abc",
+            "--format",
+            "json",
+            "-n",
+            "10",
+            "-f",
+        ]);
+        assert_eq!(cmd.since.as_deref(), Some("2h"));
+        assert_eq!(cmd.status.as_deref(), Some("5xx"));
+        assert_eq!(cmd.fuzzy, vec!["a", "b"]);
+        assert_eq!(cmd.query.len(), 1);
+        assert_eq!(cmd.format, Format::Json);
+        assert_eq!(cmd.limit, Some(10));
+        assert!(cmd.follow);
+    }
+}

--- a/src/cli/log/format.rs
+++ b/src/cli/log/format.rs
@@ -150,4 +150,59 @@ mod tests {
         assert!(line.contains("exit=0"));
         assert!(line.contains("120ms"));
     }
+
+    #[test]
+    fn oneline_invocation_falls_back_to_mcp_tool() {
+        let rec = LogRecord {
+            kind: RecordKind::Invocation,
+            timestamp: "2026-06-22T12:00:00.000Z".to_string(),
+            source: Some(Source::Mcp),
+            mcp_tool: Some("jira_read".to_string()),
+            ..LogRecord::default()
+        };
+        let line = render(&rec, "", Format::Oneline);
+        assert!(line.contains("mcp"));
+        assert!(line.contains("jira_read"));
+    }
+
+    #[test]
+    fn oneline_http_flags_daemon_and_handles_unknown_kind() {
+        let rec = LogRecord {
+            kind: RecordKind::Http,
+            timestamp: "2026-06-22T12:00:00.000Z".to_string(),
+            service: Some("snowflake".to_string()),
+            method: Some("POST".to_string()),
+            status_code: Some(200),
+            via_daemon: true,
+            ..LogRecord::default()
+        };
+        assert!(render(&rec, "", Format::Oneline).contains("[daemon]"));
+
+        // An unknown (future) kind falls through the invocation arm without panic.
+        let unknown = LogRecord {
+            kind: RecordKind::Unknown,
+            ..LogRecord::default()
+        };
+        let _ = render(&unknown, "", Format::Oneline);
+    }
+
+    #[test]
+    fn full_format_is_pretty_json() {
+        let rec = LogRecord {
+            kind: RecordKind::Http,
+            service: Some("jira".to_string()),
+            ..LogRecord::default()
+        };
+        let out = render(&rec, "", Format::Full);
+        assert!(out.contains("\"service\": \"jira\""));
+        assert!(out.contains('\n'), "pretty output spans multiple lines");
+    }
+
+    #[test]
+    fn short_time_handles_negative_offset_and_no_t() {
+        // Negative tz offset exercises the rfind('-') fallback.
+        assert_eq!(short_time("2026-06-22T01:02:03-05:00"), "01:02:03");
+        // No 'T' separator and no tz marker returns the input unchanged.
+        assert_eq!(short_time("12:00:00"), "12:00:00");
+    }
 }

--- a/src/cli/log/format.rs
+++ b/src/cli/log/format.rs
@@ -1,0 +1,153 @@
+//! Rendering of [`LogRecord`] lines as `oneline`, `json`, or `full`.
+
+use super::Format;
+use crate::request_log::{LogRecord, RecordKind, Source};
+
+/// Renders one record for display.
+///
+/// `raw` is the verbatim on-disk JSON line; the `json` format returns it
+/// unchanged so output is byte-identical to the file (composes with `jq`).
+pub fn render(rec: &LogRecord, raw: &str, format: Format) -> String {
+    match format {
+        Format::Json => raw.to_string(),
+        Format::Oneline => oneline(rec),
+        Format::Full => full(rec),
+    }
+}
+
+/// The `HH:MM:SS.mmm` portion of an RFC3339 timestamp, best effort.
+fn short_time(ts: &str) -> &str {
+    let after_t = ts.split_once('T').map_or(ts, |(_, t)| t);
+    // Trim the timezone suffix (`Z` or `+hh:mm`).
+    let end = after_t
+        .find(['Z', '+'])
+        .or_else(|| after_t.rfind('-'))
+        .unwrap_or(after_t.len());
+    &after_t[..end]
+}
+
+/// Lowercase string form of a [`Source`].
+fn source_str(source: Option<Source>) -> &'static str {
+    match source {
+        Some(Source::Cli) => "cli",
+        Some(Source::Mcp) => "mcp",
+        Some(Source::Daemon) => "daemon",
+        Some(Source::Unknown) | None => "-",
+    }
+}
+
+/// One compact line per record.
+fn oneline(rec: &LogRecord) -> String {
+    let time = short_time(&rec.timestamp);
+    match rec.kind {
+        RecordKind::Http => {
+            let service = rec.service.as_deref().unwrap_or("-");
+            let method = rec.method.as_deref().unwrap_or("-");
+            let status = rec
+                .status_code
+                .map_or_else(|| "ERR".to_string(), |c| c.to_string());
+            let elapsed = rec
+                .elapsed_ms
+                .map_or_else(String::new, |ms| format!("{ms}ms"));
+            let url = rec.url.as_deref().unwrap_or("");
+            let daemon = if rec.via_daemon { " [daemon]" } else { "" };
+            let err = rec
+                .error
+                .as_deref()
+                .map_or_else(String::new, |e| format!("  error={e}"));
+            format!(
+                "{time}  http  {service:<14} {method:<6} {status:<4} {elapsed:>7}  {url}{daemon}{err}"
+            )
+        }
+        RecordKind::Invocation | RecordKind::Unknown => {
+            let source = source_str(rec.source);
+            let command = if rec.command.is_empty() {
+                rec.mcp_tool.clone().unwrap_or_else(|| "-".to_string())
+            } else {
+                rec.command.join(" ")
+            };
+            let exit = rec
+                .exit_code
+                .map_or_else(String::new, |c| format!(" exit={c}"));
+            let dur = rec
+                .duration_ms
+                .map_or_else(String::new, |ms| format!(" {ms}ms"));
+            format!("{time}  inv   {source:<14} {command}{exit}{dur}")
+        }
+    }
+}
+
+/// A labelled, multi-line block per record (pretty-printed JSON body).
+fn full(rec: &LogRecord) -> String {
+    // serde_json pretty is the most faithful "full" view; fall back to oneline
+    // if (somehow) the record cannot be re-serialized.
+    match serde_json::to_string_pretty(rec) {
+        Ok(pretty) => format!("{pretty}\n"),
+        Err(_) => oneline(rec),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_time_extracts_clock() {
+        assert_eq!(short_time("2026-06-22T12:34:56.789Z"), "12:34:56.789");
+        assert_eq!(short_time("2026-06-22T01:02:03.004+10:00"), "01:02:03.004");
+    }
+
+    #[test]
+    fn json_format_is_verbatim() {
+        let rec = LogRecord::default();
+        let raw = r#"{"id":"x","kind":"http"}"#;
+        assert_eq!(render(&rec, raw, Format::Json), raw);
+    }
+
+    #[test]
+    fn oneline_http_includes_key_fields() {
+        let mut rec = LogRecord {
+            kind: RecordKind::Http,
+            timestamp: "2026-06-22T12:34:56.789Z".to_string(),
+            service: Some("jira".to_string()),
+            method: Some("GET".to_string()),
+            status_code: Some(200),
+            elapsed_ms: Some(42),
+            url: Some("https://x/rest/api/3/issue/A-1".to_string()),
+            ..LogRecord::default()
+        };
+        let line = render(&rec, "", Format::Oneline);
+        assert!(line.contains("http"));
+        assert!(line.contains("jira"));
+        assert!(line.contains("GET"));
+        assert!(line.contains("200"));
+        assert!(line.contains("42ms"));
+        assert!(line.contains("issue/A-1"));
+
+        rec.status_code = None;
+        rec.error = Some("timeout".to_string());
+        let line = render(&rec, "", Format::Oneline);
+        assert!(line.contains("ERR"));
+        assert!(line.contains("error=timeout"));
+    }
+
+    #[test]
+    fn oneline_invocation_shows_command() {
+        let rec = LogRecord {
+            kind: RecordKind::Invocation,
+            timestamp: "2026-06-22T12:34:56.789Z".to_string(),
+            command: vec!["jira".to_string(), "read".to_string()],
+            source: Some(Source::Cli),
+            exit_code: Some(0),
+            duration_ms: Some(120),
+            ..LogRecord::default()
+        };
+        let line = render(&rec, "", Format::Oneline);
+        assert!(line.contains("inv"));
+        assert!(line.contains("cli"));
+        assert!(line.contains("jira read"));
+        assert!(line.contains("exit=0"));
+        assert!(line.contains("120ms"));
+    }
+}

--- a/src/cli/log/format.rs
+++ b/src/cli/log/format.rs
@@ -205,4 +205,25 @@ mod tests {
         // No 'T' separator and no tz marker returns the input unchanged.
         assert_eq!(short_time("12:00:00"), "12:00:00");
     }
+
+    #[test]
+    fn oneline_renders_daemon_and_absent_source() {
+        let daemon = LogRecord {
+            kind: RecordKind::Invocation,
+            timestamp: "2026-06-22T12:00:00.000Z".to_string(),
+            source: Some(Source::Daemon),
+            command: vec!["daemon".to_string(), "run".to_string()],
+            ..LogRecord::default()
+        };
+        assert!(render(&daemon, "", Format::Oneline).contains("daemon"));
+
+        // A record with no source renders the "-" placeholder.
+        let none = LogRecord {
+            kind: RecordKind::Invocation,
+            command: vec!["x".to_string()],
+            ..LogRecord::default()
+        };
+        let line = render(&none, "", Format::Oneline);
+        assert!(line.contains(" - "));
+    }
 }

--- a/src/cli/log/query.rs
+++ b/src/cli/log/query.rs
@@ -586,4 +586,179 @@ mod tests {
         .unwrap();
         assert!(!fail.matches(&rec, "{}"));
     }
+
+    fn empty_input<'a>() -> FilterInput<'a> {
+        FilterInput {
+            since: None,
+            method: None,
+            status: None,
+            service: None,
+            command: None,
+            url: None,
+            grep: None,
+            fuzzy: &[],
+            query: &[],
+            id: None,
+        }
+    }
+
+    fn rec_http() -> LogRecord {
+        LogRecord {
+            id: "rec-1".to_string(),
+            invocation_id: "inv-9".to_string(),
+            kind: RecordKind::Http,
+            timestamp: "2026-06-22T10:00:00.000Z".to_string(),
+            service: Some("jira".to_string()),
+            method: Some("GET".to_string()),
+            url: Some("https://acme.atlassian.net/rest/api/3/issue/X-1".to_string()),
+            status_code: Some(200),
+            ..LogRecord::default()
+        }
+    }
+
+    #[test]
+    fn build_rejects_bad_inputs() {
+        let mut i = empty_input();
+        i.grep = Some("(");
+        assert!(Filter::build(i).is_err(), "bad regex");
+
+        let mut i = empty_input();
+        i.status = Some("9xx");
+        assert!(Filter::build(i).is_err(), "bad status class");
+
+        let mut i = empty_input();
+        i.since = Some("bogus");
+        assert!(Filter::build(i).is_err(), "bad since");
+
+        let bad_query = vec!["(unclosed".to_string()];
+        let mut i = empty_input();
+        i.query = &bad_query;
+        assert!(Filter::build(i).is_err(), "bad query");
+    }
+
+    #[test]
+    fn matches_each_flag() {
+        let rec = rec_http();
+        let raw = serde_json::to_string(&rec).unwrap();
+
+        let mut i = empty_input();
+        i.method = Some("get");
+        assert!(Filter::build(i).unwrap().matches(&rec, &raw));
+        let mut i = empty_input();
+        i.method = Some("post");
+        assert!(!Filter::build(i).unwrap().matches(&rec, &raw));
+
+        let mut i = empty_input();
+        i.service = Some("jira");
+        assert!(Filter::build(i).unwrap().matches(&rec, &raw));
+
+        let mut i = empty_input();
+        i.url = Some("issue/X-1");
+        assert!(Filter::build(i).unwrap().matches(&rec, &raw));
+        let mut i = empty_input();
+        i.url = Some("nope");
+        assert!(!Filter::build(i).unwrap().matches(&rec, &raw));
+
+        let mut i = empty_input();
+        i.grep = Some("X-\\d+");
+        assert!(Filter::build(i).unwrap().matches(&rec, &raw));
+
+        let toks = vec!["jira".to_string(), "issue".to_string()];
+        let mut i = empty_input();
+        i.fuzzy = &toks;
+        assert!(Filter::build(i).unwrap().matches(&rec, &raw));
+        let toks = vec!["absent".to_string()];
+        let mut i = empty_input();
+        i.fuzzy = &toks;
+        assert!(!Filter::build(i).unwrap().matches(&rec, &raw));
+
+        for id in ["rec-1", "inv-9"] {
+            let mut i = empty_input();
+            i.id = Some(id);
+            assert!(Filter::build(i).unwrap().matches(&rec, &raw), "id {id}");
+        }
+        let mut i = empty_input();
+        i.id = Some("other");
+        assert!(!Filter::build(i).unwrap().matches(&rec, &raw));
+    }
+
+    #[test]
+    fn since_filters_by_recency() {
+        let raw = "{}";
+        let mut past = rec_http();
+        past.timestamp = "2000-01-01T00:00:00.000Z".to_string();
+        let mut future = rec_http();
+        future.timestamp = "2999-01-01T00:00:00.000Z".to_string();
+        let mut undated = rec_http();
+        undated.timestamp = String::new();
+
+        let mut i = empty_input();
+        i.since = Some("1d");
+        let f = Filter::build(i).unwrap();
+        assert!(!f.matches(&past, raw));
+        assert!(f.matches(&future, raw));
+        assert!(
+            !f.matches(&undated, raw),
+            "unparseable timestamp is excluded"
+        );
+    }
+
+    #[test]
+    fn query_covers_every_field_arm() {
+        let mut rec = rec_http();
+        rec.source = Some(Source::Mcp);
+        rec.mcp_tool = Some("jira_read".to_string());
+        rec.via_daemon = true;
+        rec.error = Some("boom timeout".to_string());
+        rec.command = vec!["jira".to_string(), "read".to_string()];
+        let raw = serde_json::to_string(&rec).unwrap().to_ascii_lowercase();
+
+        let cases = [
+            ("kind:http", true),
+            ("kind:invocation", false),
+            ("source:mcp", true),
+            ("source:cli", false),
+            ("service:jira", true),
+            ("method:GET", true),
+            ("status:2xx", true),
+            ("status:5xx", false),
+            ("command:jira", true),
+            ("cmd:\"jira read\"", true),
+            ("url:issue", true),
+            ("id:rec-1", true),
+            ("id:inv-9", true),
+            ("id:nope", false),
+            ("inv:inv-9", true),
+            ("invocation_id:inv-9", true),
+            ("tool:jira_read", true),
+            ("mcp_tool:other", false),
+            ("via_daemon:true", true),
+            ("via_daemon:false", false),
+            ("error:timeout", true),
+            ("err:absent", false),
+            ("error:", true),
+            ("unknownfield:x", false),
+        ];
+        for (q, expected) in cases {
+            let parsed = parse_query(q).unwrap();
+            assert_eq!(parsed.eval(&rec, &raw), expected, "query: {q}");
+        }
+    }
+
+    #[test]
+    fn query_parser_edge_cases() {
+        let rec = LogRecord::default();
+        let raw = r#"{"x":"hello world"}"#.to_ascii_lowercase();
+
+        assert!(parse_query("\"hello world\"").unwrap().eval(&rec, &raw));
+        assert!(parse_query("hello AND world").unwrap().eval(&rec, &raw));
+        assert!(!parse_query("NOT hello").unwrap().eval(&rec, &raw));
+        assert!(parse_query("(hello OR nope) AND world")
+            .unwrap()
+            .eval(&rec, &raw));
+
+        assert!(parse_query("(hello").is_err());
+        assert!(parse_query("hello )").is_err());
+        assert!(parse_query("").is_err());
+    }
 }

--- a/src/cli/log/query.rs
+++ b/src/cli/log/query.rs
@@ -1,0 +1,587 @@
+//! Filter construction and the `--query` mini-language.
+//!
+//! A [`Filter`] is the AND of every supplied flag plus every `--query`
+//! expression. The query language supports `AND`/`OR`/`NOT` (and a leading `-`
+//! for negation), parentheses, `field:value` structured terms, and bare fuzzy
+//! tokens matched against the raw JSON line. Field matching is shared with the
+//! structured flags so `--status 5xx` and `status:5xx` behave identically.
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use regex::Regex;
+
+use crate::request_log::{LogRecord, RecordKind, Source};
+
+/// The raw, borrowed flag values used to build a [`Filter`].
+pub struct FilterInput<'a> {
+    pub since: Option<&'a str>,
+    pub method: Option<&'a str>,
+    pub status: Option<&'a str>,
+    pub service: Option<&'a str>,
+    pub command: Option<&'a str>,
+    pub url: Option<&'a str>,
+    pub grep: Option<&'a str>,
+    pub fuzzy: &'a [String],
+    pub query: &'a [String],
+    pub id: Option<&'a str>,
+}
+
+/// A compiled predicate over [`LogRecord`] lines.
+pub struct Filter {
+    since: Option<DateTime<Utc>>,
+    method: Option<String>,
+    status: Option<StatusMatcher>,
+    service: Option<String>,
+    command: Option<String>,
+    url: Option<String>,
+    grep: Option<Regex>,
+    fuzzy: Vec<String>,
+    id: Option<String>,
+    queries: Vec<Expr>,
+}
+
+impl Filter {
+    /// Compiles all flags and query expressions up front, surfacing parse
+    /// errors (bad regex/status/duration/query) before streaming begins.
+    pub fn build(input: FilterInput<'_>) -> Result<Self> {
+        let since = match input.since {
+            Some(s) => Some(parse_since(s)?),
+            None => None,
+        };
+        let status = match input.status {
+            Some(s) => Some(StatusMatcher::parse(s)?),
+            None => None,
+        };
+        let grep = match input.grep {
+            Some(s) => Some(Regex::new(s).with_context(|| format!("invalid --grep regex: {s}"))?),
+            None => None,
+        };
+        let mut queries = Vec::new();
+        for q in input.query {
+            queries.push(parse_query(q).with_context(|| format!("invalid --query: {q}"))?);
+        }
+        Ok(Self {
+            since,
+            method: input.method.map(str::to_string),
+            status,
+            service: input.service.map(str::to_string),
+            command: input.command.map(str::to_string),
+            url: input.url.map(str::to_string),
+            grep,
+            fuzzy: input.fuzzy.to_vec(),
+            id: input.id.map(str::to_string),
+            queries,
+        })
+    }
+
+    /// Whether `rec` (whose verbatim JSON line is `raw`) passes every clause.
+    pub fn matches(&self, rec: &LogRecord, raw: &str) -> bool {
+        let raw_lower = raw.to_ascii_lowercase();
+
+        if let Some(cutoff) = self.since {
+            match parse_timestamp(&rec.timestamp) {
+                Some(ts) if ts >= cutoff => {}
+                _ => return false,
+            }
+        }
+        if let Some(m) = &self.method {
+            if !opt_eq_ci(rec.method.as_deref(), m) {
+                return false;
+            }
+        }
+        if let Some(s) = &self.status {
+            if !s.matches(rec.status_code) {
+                return false;
+            }
+        }
+        if let Some(s) = &self.service {
+            if !opt_eq_ci(rec.service.as_deref(), s) {
+                return false;
+            }
+        }
+        if let Some(c) = &self.command {
+            if !command_matches(rec, c) {
+                return false;
+            }
+        }
+        if let Some(u) = &self.url {
+            if !contains_ci(rec.url.as_deref(), u) {
+                return false;
+            }
+        }
+        if let Some(re) = &self.grep {
+            if !re.is_match(raw) {
+                return false;
+            }
+        }
+        for token in &self.fuzzy {
+            if !raw_lower.contains(&token.to_ascii_lowercase()) {
+                return false;
+            }
+        }
+        if let Some(id) = &self.id {
+            if &rec.id != id && &rec.invocation_id != id {
+                return false;
+            }
+        }
+        for q in &self.queries {
+            if !q.eval(rec, &raw_lower) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Parses a relative duration like `30m`, `2h`, `1d`, `1w`, `45s`.
+fn parse_since(s: &str) -> Result<DateTime<Utc>> {
+    let s = s.trim();
+    let (num, unit) =
+        s.split_at(s.find(|c: char| !c.is_ascii_digit()).with_context(|| {
+            format!("invalid --since duration: {s} (expected e.g. 30m, 2h, 1d)")
+        })?);
+    let n: i64 = num
+        .parse()
+        .with_context(|| format!("invalid --since duration: {s}"))?;
+    let dur = match unit {
+        "s" => Duration::seconds(n),
+        "m" => Duration::minutes(n),
+        "h" => Duration::hours(n),
+        "d" => Duration::days(n),
+        "w" => Duration::weeks(n),
+        other => bail!("invalid --since unit: {other} (use s, m, h, d, or w)"),
+    };
+    Ok(Utc::now() - dur)
+}
+
+/// Parses an RFC3339 timestamp into UTC, or `None` if absent/unparseable.
+fn parse_timestamp(ts: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+/// A status filter: a set of exact codes and/or `Nxx` classes.
+struct StatusMatcher {
+    exact: Vec<u16>,
+    classes: Vec<u8>,
+}
+
+impl StatusMatcher {
+    /// Parses `"200"`, `"5xx"`, or a comma list like `"4xx,5xx"`.
+    fn parse(spec: &str) -> Result<Self> {
+        let mut exact = Vec::new();
+        let mut classes = Vec::new();
+        for part in spec.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let lower = part.to_ascii_lowercase();
+            if let Some(first) = lower.strip_suffix("xx") {
+                let digit: u8 = first
+                    .parse()
+                    .with_context(|| format!("invalid status class: {part}"))?;
+                if !(1..=5).contains(&digit) {
+                    bail!("invalid status class: {part}");
+                }
+                classes.push(digit);
+            } else {
+                exact.push(
+                    part.parse()
+                        .with_context(|| format!("invalid status code: {part}"))?,
+                );
+            }
+        }
+        if exact.is_empty() && classes.is_empty() {
+            bail!("empty --status filter");
+        }
+        Ok(Self { exact, classes })
+    }
+
+    /// Whether a (possibly absent) status code matches this filter.
+    fn matches(&self, code: Option<u16>) -> bool {
+        let Some(code) = code else {
+            return false;
+        };
+        self.exact.contains(&code) || self.classes.contains(&((code / 100) as u8))
+    }
+}
+
+/// Whether the record's command path matches `prefix` on whole path segments
+/// (so `jira` matches `["jira","read"]` but `jir` does not).
+fn command_matches(rec: &LogRecord, prefix: &str) -> bool {
+    let joined = rec.command.join(" ");
+    let prefix = prefix.trim();
+    joined == prefix || joined.starts_with(&format!("{prefix} "))
+}
+
+/// Case-insensitive equality against an optional field.
+fn opt_eq_ci(field: Option<&str>, value: &str) -> bool {
+    field.is_some_and(|f| f.eq_ignore_ascii_case(value))
+}
+
+/// Case-insensitive substring against an optional field.
+fn contains_ci(field: Option<&str>, value: &str) -> bool {
+    field.is_some_and(|f| f.to_ascii_lowercase().contains(&value.to_ascii_lowercase()))
+}
+
+/// Lowercase string form of a [`RecordKind`].
+fn kind_str(kind: RecordKind) -> &'static str {
+    match kind {
+        RecordKind::Invocation => "invocation",
+        RecordKind::Http => "http",
+        RecordKind::Unknown => "unknown",
+    }
+}
+
+/// Lowercase string form of a [`Source`].
+fn source_str(source: Source) -> &'static str {
+    match source {
+        Source::Cli => "cli",
+        Source::Mcp => "mcp",
+        Source::Daemon => "daemon",
+        Source::Unknown => "unknown",
+    }
+}
+
+/// Evaluates a `field:value` term against a record (shared by the query AST).
+fn field_matches(rec: &LogRecord, field: &str, value: &str) -> bool {
+    match field.to_ascii_lowercase().as_str() {
+        "kind" => kind_str(rec.kind).eq_ignore_ascii_case(value),
+        "source" => rec
+            .source
+            .is_some_and(|s| source_str(s).eq_ignore_ascii_case(value)),
+        "service" => opt_eq_ci(rec.service.as_deref(), value),
+        "method" => opt_eq_ci(rec.method.as_deref(), value),
+        "status" => StatusMatcher::parse(value).is_ok_and(|m| m.matches(rec.status_code)),
+        "command" | "cmd" => command_matches(rec, value),
+        "url" => contains_ci(rec.url.as_deref(), value),
+        "id" => rec.id == value || rec.invocation_id == value,
+        "invocation_id" | "inv" => rec.invocation_id == value,
+        "mcp_tool" | "tool" => opt_eq_ci(rec.mcp_tool.as_deref(), value),
+        "via_daemon" => rec.via_daemon == matches!(value, "1" | "true" | "yes"),
+        "error" | "err" => match rec.error.as_deref() {
+            Some(e) if value.is_empty() || value == "true" => !e.is_empty() || value == "true",
+            Some(e) => e.to_ascii_lowercase().contains(&value.to_ascii_lowercase()),
+            None => false,
+        },
+        _ => false,
+    }
+}
+
+// --- `--query` mini-language ---
+
+/// A parsed query expression tree.
+enum Expr {
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+    Not(Box<Self>),
+    /// `field:value` structured term.
+    Field(String, String),
+    /// Bare fuzzy token, matched against the lowercased raw line.
+    Term(String),
+}
+
+impl Expr {
+    /// Evaluates against a record and its lowercased raw JSON line.
+    fn eval(&self, rec: &LogRecord, raw_lower: &str) -> bool {
+        match self {
+            Self::And(a, b) => a.eval(rec, raw_lower) && b.eval(rec, raw_lower),
+            Self::Or(a, b) => a.eval(rec, raw_lower) || b.eval(rec, raw_lower),
+            Self::Not(a) => !a.eval(rec, raw_lower),
+            Self::Field(f, v) => field_matches(rec, f, v),
+            Self::Term(t) => raw_lower.contains(&t.to_ascii_lowercase()),
+        }
+    }
+}
+
+/// A query token stream cursor for the recursive-descent parser.
+#[derive(Debug, PartialEq, Eq)]
+enum Token {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Word(String),
+}
+
+/// Splits a query string into tokens, honoring parentheses, `"quoted values"`,
+/// and a leading `-` as negation.
+fn tokenize(input: &str) -> Result<Vec<Token>> {
+    let mut tokens = Vec::new();
+    let mut chars = input.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        match c {
+            c if c.is_whitespace() => {
+                chars.next();
+            }
+            '(' => {
+                chars.next();
+                tokens.push(Token::LParen);
+            }
+            ')' => {
+                chars.next();
+                tokens.push(Token::RParen);
+            }
+            '-' => {
+                chars.next();
+                // A lone '-' is a stray; '-foo' negates the following word.
+                tokens.push(Token::Not);
+            }
+            _ => {
+                let mut word = String::new();
+                while let Some(&c) = chars.peek() {
+                    if c.is_whitespace() || c == '(' || c == ')' {
+                        break;
+                    }
+                    if c == '"' {
+                        chars.next();
+                        for qc in chars.by_ref() {
+                            if qc == '"' {
+                                break;
+                            }
+                            word.push(qc);
+                        }
+                        continue;
+                    }
+                    word.push(c);
+                    chars.next();
+                }
+                match word.to_ascii_uppercase().as_str() {
+                    "AND" => tokens.push(Token::And),
+                    "OR" => tokens.push(Token::Or),
+                    "NOT" => tokens.push(Token::Not),
+                    _ => tokens.push(Token::Word(word)),
+                }
+            }
+        }
+    }
+    Ok(tokens)
+}
+
+/// Parses a `--query` expression into an [`Expr`] tree.
+fn parse_query(input: &str) -> Result<Expr> {
+    let tokens = tokenize(input)?;
+    let mut parser = Parser { tokens, pos: 0 };
+    let expr = parser.parse_or()?;
+    if parser.pos != parser.tokens.len() {
+        bail!("unexpected trailing tokens in query");
+    }
+    Ok(expr)
+}
+
+/// Recursive-descent parser: `or := and ("OR" and)*`,
+/// `and := unary (("AND")? unary)*`, `unary := "NOT" unary | primary`,
+/// `primary := "(" or ")" | term`.
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn parse_or(&mut self) -> Result<Expr> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek(), Some(Token::Or)) {
+            self.pos += 1;
+            let right = self.parse_and()?;
+            left = Expr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<Expr> {
+        let mut left = self.parse_unary()?;
+        loop {
+            match self.peek() {
+                Some(Token::And) => {
+                    self.pos += 1;
+                    let right = self.parse_unary()?;
+                    left = Expr::And(Box::new(left), Box::new(right));
+                }
+                // Implicit AND between adjacent terms (stop at OR/`)`/EOF).
+                Some(Token::Word(_) | Token::Not | Token::LParen) => {
+                    let right = self.parse_unary()?;
+                    left = Expr::And(Box::new(left), Box::new(right));
+                }
+                _ => break,
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr> {
+        if matches!(self.peek(), Some(Token::Not)) {
+            self.pos += 1;
+            return Ok(Expr::Not(Box::new(self.parse_unary()?)));
+        }
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr> {
+        match self.tokens.get(self.pos) {
+            Some(Token::LParen) => {
+                self.pos += 1;
+                let inner = self.parse_or()?;
+                match self.tokens.get(self.pos) {
+                    Some(Token::RParen) => {
+                        self.pos += 1;
+                        Ok(inner)
+                    }
+                    _ => bail!("unbalanced parenthesis in query"),
+                }
+            }
+            Some(Token::Word(_)) => {
+                let Some(Token::Word(word)) = self.tokens.get(self.pos) else {
+                    unreachable!()
+                };
+                let word = word.clone();
+                self.pos += 1;
+                Ok(match word.split_once(':') {
+                    Some((field, value)) if !field.is_empty() => {
+                        Expr::Field(field.to_string(), value.to_string())
+                    }
+                    _ => Expr::Term(word),
+                })
+            }
+            _ => bail!("expected a term in query"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn http(status: Option<u16>, service: &str, method: &str) -> LogRecord {
+        LogRecord {
+            kind: RecordKind::Http,
+            service: Some(service.to_string()),
+            method: Some(method.to_string()),
+            status_code: status,
+            ..LogRecord::default()
+        }
+    }
+
+    #[test]
+    fn status_matcher_handles_exact_class_and_list() {
+        let m = StatusMatcher::parse("200").unwrap();
+        assert!(m.matches(Some(200)));
+        assert!(!m.matches(Some(201)));
+
+        let m = StatusMatcher::parse("5xx").unwrap();
+        assert!(m.matches(Some(503)));
+        assert!(!m.matches(Some(404)));
+        assert!(!m.matches(None));
+
+        let m = StatusMatcher::parse("4xx,5xx").unwrap();
+        assert!(m.matches(Some(404)));
+        assert!(m.matches(Some(500)));
+        assert!(!m.matches(Some(204)));
+    }
+
+    #[test]
+    fn status_matcher_rejects_garbage() {
+        assert!(StatusMatcher::parse("9xx").is_err());
+        assert!(StatusMatcher::parse("abc").is_err());
+        assert!(StatusMatcher::parse("").is_err());
+    }
+
+    #[test]
+    fn since_parses_units() {
+        assert!(parse_since("30m").is_ok());
+        assert!(parse_since("2h").is_ok());
+        assert!(parse_since("1d").is_ok());
+        assert!(parse_since("1w").is_ok());
+        assert!(parse_since("10x").is_err());
+        assert!(parse_since("h").is_err());
+    }
+
+    #[test]
+    fn command_prefix_matches() {
+        let mut rec = LogRecord::default();
+        rec.command = vec!["jira".to_string(), "read".to_string()];
+        assert!(command_matches(&rec, "jira"));
+        assert!(command_matches(&rec, "jira read"));
+        assert!(!command_matches(&rec, "git"));
+    }
+
+    #[test]
+    fn query_field_and_implicit_and() {
+        let rec = http(Some(500), "jira", "POST");
+        let expr = parse_query("status:5xx service:jira").unwrap();
+        assert!(expr.eval(&rec, "{}"));
+        let expr = parse_query("status:5xx service:datadog").unwrap();
+        assert!(!expr.eval(&rec, "{}"));
+    }
+
+    #[test]
+    fn query_or_not_and_parens() {
+        let rec = http(Some(404), "jira", "GET");
+        assert!(parse_query("status:5xx OR status:4xx")
+            .unwrap()
+            .eval(&rec, "{}"));
+        assert!(parse_query("NOT status:5xx").unwrap().eval(&rec, "{}"));
+        assert!(parse_query("-status:5xx").unwrap().eval(&rec, "{}"));
+        assert!(parse_query("(status:4xx OR status:5xx) method:GET")
+            .unwrap()
+            .eval(&rec, "{}"));
+        assert!(!parse_query("(status:4xx OR status:5xx) method:POST")
+            .unwrap()
+            .eval(&rec, "{}"));
+    }
+
+    #[test]
+    fn query_bare_token_is_fuzzy_on_raw() {
+        let rec = LogRecord::default();
+        let expr = parse_query("deploy").unwrap();
+        assert!(expr.eval(&rec, r#"{"url":"/api/deploy"}"#));
+        assert!(!expr.eval(&rec, r#"{"url":"/api/status"}"#));
+    }
+
+    #[test]
+    fn query_rejects_unbalanced_parens() {
+        assert!(parse_query("(status:5xx").is_err());
+        assert!(parse_query("status:5xx)").is_err());
+    }
+
+    #[test]
+    fn filter_ands_flags_together() {
+        let rec = http(Some(500), "jira", "GET");
+        let pass = Filter::build(FilterInput {
+            since: None,
+            method: Some("GET"),
+            status: Some("5xx"),
+            service: Some("jira"),
+            command: None,
+            url: None,
+            grep: None,
+            fuzzy: &[],
+            query: &[],
+            id: None,
+        })
+        .unwrap();
+        assert!(pass.matches(&rec, "{}"));
+
+        let fail = Filter::build(FilterInput {
+            since: None,
+            method: Some("POST"),
+            status: None,
+            service: None,
+            command: None,
+            url: None,
+            grep: None,
+            fuzzy: &[],
+            query: &[],
+            id: None,
+        })
+        .unwrap();
+        assert!(!fail.matches(&rec, "{}"));
+    }
+}

--- a/src/cli/log/query.rs
+++ b/src/cli/log/query.rs
@@ -505,8 +505,10 @@ mod tests {
 
     #[test]
     fn command_prefix_matches() {
-        let mut rec = LogRecord::default();
-        rec.command = vec!["jira".to_string(), "read".to_string()];
+        let rec = LogRecord {
+            command: vec!["jira".to_string(), "read".to_string()],
+            ..LogRecord::default()
+        };
         assert!(command_matches(&rec, "jira"));
         assert!(command_matches(&rec, "jira read"));
         assert!(!command_matches(&rec, "git"));

--- a/src/cli/log/query.rs
+++ b/src/cli/log/query.rs
@@ -436,10 +436,7 @@ impl Parser {
                     _ => bail!("unbalanced parenthesis in query"),
                 }
             }
-            Some(Token::Word(_)) => {
-                let Some(Token::Word(word)) = self.tokens.get(self.pos) else {
-                    unreachable!()
-                };
+            Some(Token::Word(word)) => {
                 let word = word.clone();
                 self.pos += 1;
                 Ok(match word.split_once(':') {
@@ -760,5 +757,90 @@ mod tests {
         assert!(parse_query("(hello").is_err());
         assert!(parse_query("hello )").is_err());
         assert!(parse_query("").is_err());
+    }
+
+    #[test]
+    fn matches_rejects_on_each_clause() {
+        let mut rec = rec_http();
+        rec.command = vec!["jira".to_string(), "read".to_string()];
+        let raw = serde_json::to_string(&rec).unwrap();
+
+        // Each clause, set to a value the record does NOT satisfy, fails the match.
+        let mut status = empty_input();
+        status.status = Some("5xx");
+        assert!(!Filter::build(status).unwrap().matches(&rec, &raw));
+
+        let mut service = empty_input();
+        service.service = Some("datadog");
+        assert!(!Filter::build(service).unwrap().matches(&rec, &raw));
+
+        let mut command = empty_input();
+        command.command = Some("git");
+        assert!(!Filter::build(command).unwrap().matches(&rec, &raw));
+        // …and the matching command passes.
+        let mut command = empty_input();
+        command.command = Some("jira");
+        assert!(Filter::build(command).unwrap().matches(&rec, &raw));
+
+        let mut url = empty_input();
+        url.url = Some("absent-path");
+        assert!(!Filter::build(url).unwrap().matches(&rec, &raw));
+
+        let mut grep = empty_input();
+        grep.grep = Some("ZZZ-not-present");
+        assert!(!Filter::build(grep).unwrap().matches(&rec, &raw));
+
+        // A --query clause that fails also rejects the record.
+        let q = vec!["service:datadog".to_string()];
+        let mut query = empty_input();
+        query.query = &q;
+        assert!(!Filter::build(query).unwrap().matches(&rec, &raw));
+    }
+
+    #[test]
+    fn since_rejects_all_digit_and_empty_number() {
+        // No unit (all digits) hits the "no non-digit found" error path.
+        let mut all_digits = empty_input();
+        all_digits.since = Some("30");
+        assert!(Filter::build(all_digits).is_err());
+
+        // A leading non-digit yields an empty number, hitting the parse error.
+        let mut empty_num = empty_input();
+        empty_num.since = Some("xh");
+        assert!(Filter::build(empty_num).is_err());
+    }
+
+    #[test]
+    fn query_covers_kind_source_and_error_variants() {
+        let raw = "{}".to_ascii_lowercase();
+
+        for (kind, q, want) in [
+            (RecordKind::Invocation, "kind:invocation", true),
+            (RecordKind::Http, "kind:invocation", false),
+            (RecordKind::Unknown, "kind:unknown", true),
+        ] {
+            let rec = LogRecord {
+                kind,
+                ..LogRecord::default()
+            };
+            assert_eq!(parse_query(q).unwrap().eval(&rec, &raw), want, "{q}");
+        }
+
+        for (source, q, want) in [
+            (Source::Cli, "source:cli", true),
+            (Source::Daemon, "source:daemon", true),
+            (Source::Unknown, "source:unknown", true),
+            (Source::Daemon, "source:cli", false),
+        ] {
+            let rec = LogRecord {
+                source: Some(source),
+                ..LogRecord::default()
+            };
+            assert_eq!(parse_query(q).unwrap().eval(&rec, &raw), want, "{q}");
+        }
+
+        // The error arm with no error present returns false.
+        let rec = LogRecord::default();
+        assert!(!parse_query("error:boom").unwrap().eval(&rec, &raw));
     }
 }

--- a/src/cli/log/stream.rs
+++ b/src/cli/log/stream.rs
@@ -102,31 +102,47 @@ fn follow_loop<W: Write>(
     out: &mut W,
 ) -> Result<()> {
     loop {
-        if let Ok(file) = File::open(path) {
-            let len = file.metadata().map_or(pos, |m| m.len());
-            if len < pos {
-                pos = 0; // truncated or rotated — restart
-            }
-            if len > pos {
-                let mut reader = BufReader::new(file);
-                reader.seek(SeekFrom::Start(pos))?;
-                let mut line = String::new();
-                loop {
-                    line.clear();
-                    let n = reader.read_line(&mut line)?;
-                    if n == 0 || !line.ends_with('\n') {
-                        break; // EOF or partial trailing line — wait for more
-                    }
-                    pos += n as u64;
-                    if let Some(rendered) = render_if_match(&line, filter, format) {
-                        writeln!(out, "{rendered}")?;
-                        out.flush()?;
-                    }
-                }
-            }
-        }
+        pos = drain_appended(path, filter, format, pos, out)?;
         std::thread::sleep(FOLLOW_POLL);
     }
+}
+
+/// Reads and emits any complete lines appended past `pos`, returning the new
+/// position. Restarts from the top if the file shrank (truncation/rotation);
+/// a no-op (returns `pos` unchanged) if the file is absent or has not grown.
+/// A trailing partial line (no newline yet) is left for the next call.
+fn drain_appended<W: Write>(
+    path: &Path,
+    filter: &Filter,
+    format: Format,
+    mut pos: u64,
+    out: &mut W,
+) -> Result<u64> {
+    let Ok(file) = File::open(path) else {
+        return Ok(pos);
+    };
+    let len = file.metadata().map_or(pos, |m| m.len());
+    if len < pos {
+        pos = 0; // truncated or rotated — restart
+    }
+    if len > pos {
+        let mut reader = BufReader::new(file);
+        reader.seek(SeekFrom::Start(pos))?;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = reader.read_line(&mut line)?;
+            if n == 0 || !line.ends_with('\n') {
+                break; // EOF or partial trailing line — wait for more
+            }
+            pos += n as u64;
+            if let Some(rendered) = render_if_match(&line, filter, format) {
+                writeln!(out, "{rendered}")?;
+                out.flush()?;
+            }
+        }
+    }
+    Ok(pos)
 }
 
 /// Parses one raw line, returning its rendering when it matches the filter.
@@ -289,5 +305,60 @@ mod tests {
             swallow_broken_pipe(anyhow::Error::from(Error::from(ErrorKind::BrokenPipe))).is_ok()
         );
         assert!(swallow_broken_pipe(anyhow::anyhow!("unrelated")).is_err());
+    }
+
+    #[test]
+    fn drain_appended_reads_only_new_complete_lines() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, sample_lines()).unwrap();
+
+        // First drain reads the whole backlog and advances the position.
+        let mut out = Vec::new();
+        let pos = drain_appended(&path, &empty_filter(), Format::Json, 0, &mut out).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap().lines().count(), 5);
+        assert!(pos > 0);
+
+        // Appending two lines and draining from `pos` yields only those.
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(f, r#"{{"id":"5","kind":"http"}}"#).unwrap();
+        writeln!(f, r#"{{"id":"6","kind":"http"}}"#).unwrap();
+        let mut out = Vec::new();
+        let pos2 = drain_appended(&path, &empty_filter(), Format::Json, pos, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.lines().count(), 2);
+        assert!(text.contains(r#""id":"5""#));
+        assert!(pos2 > pos);
+
+        // A trailing partial line (no newline) is left for the next call.
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        write!(f, r#"{{"id":"7","kind":"http"}}"#).unwrap();
+        let mut out = Vec::new();
+        let pos3 = drain_appended(&path, &empty_filter(), Format::Json, pos2, &mut out).unwrap();
+        assert!(String::from_utf8(out).unwrap().is_empty());
+        assert_eq!(pos3, pos2, "partial line does not advance the position");
+
+        // Truncation resets to the top and re-reads.
+        std::fs::write(&path, "{\"id\":\"x\",\"kind\":\"http\"}\n").unwrap();
+        let mut out = Vec::new();
+        drain_appended(&path, &empty_filter(), Format::Json, pos2, &mut out).unwrap();
+        assert!(String::from_utf8(out).unwrap().contains(r#""id":"x""#));
+
+        // A missing file is a no-op that preserves the position.
+        let missing = dir.path().join("gone.jsonl");
+        let mut out = Vec::new();
+        assert_eq!(
+            drain_appended(&missing, &empty_filter(), Format::Json, 7, &mut out).unwrap(),
+            7
+        );
+        assert!(String::from_utf8(out).unwrap().is_empty());
     }
 }

--- a/src/cli/log/stream.rs
+++ b/src/cli/log/stream.rs
@@ -260,4 +260,34 @@ mod tests {
         // All sample lines are status 200, so nothing matches 5xx.
         assert!(String::from_utf8(out).unwrap().is_empty());
     }
+
+    #[test]
+    fn run_on_missing_file_without_follow_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.jsonl");
+        // No file yet and not following: clean no-op.
+        assert!(run(&missing, &empty_filter(), Format::Json, None, false).is_ok());
+    }
+
+    #[test]
+    fn run_reads_an_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, sample_lines()).unwrap();
+        // Exercises the open + backlog path (output goes to captured stdout).
+        assert!(run(&path, &empty_filter(), Format::Json, Some(2), false).is_ok());
+    }
+
+    #[test]
+    fn broken_pipe_is_swallowed_other_errors_propagate() {
+        use std::io::{Error, ErrorKind};
+
+        assert!(ignore_broken_pipe(Error::from(ErrorKind::BrokenPipe)).is_ok());
+        assert!(ignore_broken_pipe(Error::from(ErrorKind::PermissionDenied)).is_err());
+
+        assert!(
+            swallow_broken_pipe(anyhow::Error::from(Error::from(ErrorKind::BrokenPipe))).is_ok()
+        );
+        assert!(swallow_broken_pipe(anyhow::anyhow!("unrelated")).is_err());
+    }
 }

--- a/src/cli/log/stream.rs
+++ b/src/cli/log/stream.rs
@@ -1,0 +1,263 @@
+//! Streaming reader: filter and render the log line by line.
+//!
+//! The backlog is read without buffering the whole file (a `--limit` keeps only
+//! the most recent N matches in a ring buffer); `--follow` then tails newly
+//! appended complete lines. A broken pipe (e.g. piping into `head`) is treated
+//! as a clean exit, not an error.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use super::format;
+use super::query::Filter;
+use super::Format;
+use crate::request_log::LogRecord;
+
+/// Poll interval while following the log.
+const FOLLOW_POLL: Duration = Duration::from_millis(250);
+
+/// Streams the log file at `path`, applying `filter` and rendering as `format`.
+pub fn run(
+    path: &Path,
+    filter: &Filter,
+    format: Format,
+    limit: Option<usize>,
+    follow: bool,
+) -> Result<()> {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    let mut pos = 0u64;
+    match File::open(path) {
+        Ok(file) => {
+            let mut reader = BufReader::new(file);
+            pos = emit_backlog(&mut reader, filter, format, limit, &mut out)?;
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            if !follow {
+                return Ok(());
+            }
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    if follow {
+        if let Err(e) = follow_loop(path, filter, format, pos, &mut out) {
+            return swallow_broken_pipe(e);
+        }
+    }
+    Ok(())
+}
+
+/// Reads every existing line, emitting matches. With `limit`, only the most
+/// recent N matches are kept (ring buffer) and printed at the end; without it,
+/// matches stream out as they are read. Returns the byte offset of end-of-file.
+fn emit_backlog<R: BufRead, W: Write>(
+    reader: &mut R,
+    filter: &Filter,
+    format: Format,
+    limit: Option<usize>,
+    out: &mut W,
+) -> Result<u64> {
+    let mut pos = 0u64;
+    let mut ring: VecDeque<String> = VecDeque::new();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            break;
+        }
+        pos += n as u64;
+        if let Some(rendered) = render_if_match(&line, filter, format) {
+            match limit {
+                Some(cap) => {
+                    ring.push_back(rendered);
+                    while ring.len() > cap {
+                        ring.pop_front();
+                    }
+                }
+                None => writeln!(out, "{rendered}").or_else(ignore_broken_pipe)?,
+            }
+        }
+    }
+    for rendered in &ring {
+        writeln!(out, "{rendered}").or_else(ignore_broken_pipe)?;
+    }
+    Ok(pos)
+}
+
+/// Tails the file from `pos`, printing newly appended complete lines forever
+/// (until the process is interrupted). Restarts from the top on truncation.
+fn follow_loop<W: Write>(
+    path: &Path,
+    filter: &Filter,
+    format: Format,
+    mut pos: u64,
+    out: &mut W,
+) -> Result<()> {
+    loop {
+        if let Ok(file) = File::open(path) {
+            let len = file.metadata().map_or(pos, |m| m.len());
+            if len < pos {
+                pos = 0; // truncated or rotated — restart
+            }
+            if len > pos {
+                let mut reader = BufReader::new(file);
+                reader.seek(SeekFrom::Start(pos))?;
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    let n = reader.read_line(&mut line)?;
+                    if n == 0 || !line.ends_with('\n') {
+                        break; // EOF or partial trailing line — wait for more
+                    }
+                    pos += n as u64;
+                    if let Some(rendered) = render_if_match(&line, filter, format) {
+                        writeln!(out, "{rendered}")?;
+                        out.flush()?;
+                    }
+                }
+            }
+        }
+        std::thread::sleep(FOLLOW_POLL);
+    }
+}
+
+/// Parses one raw line, returning its rendering when it matches the filter.
+/// Malformed lines (and empties) are silently skipped.
+fn render_if_match(line: &str, filter: &Filter, format: Format) -> Option<String> {
+    let raw = line.trim_end_matches(['\n', '\r']);
+    if raw.is_empty() {
+        return None;
+    }
+    let rec: LogRecord = serde_json::from_str(raw).ok()?;
+    if filter.matches(&rec, raw) {
+        Some(format::render(&rec, raw, format))
+    } else {
+        None
+    }
+}
+
+/// Maps a broken-pipe write error to `Ok(())`; propagates anything else.
+fn ignore_broken_pipe(e: io::Error) -> io::Result<()> {
+    if e.kind() == io::ErrorKind::BrokenPipe {
+        Ok(())
+    } else {
+        Err(e)
+    }
+}
+
+/// Maps a broken-pipe error (downcast from `anyhow`) to a clean exit.
+fn swallow_broken_pipe(e: anyhow::Error) -> Result<()> {
+    if let Some(io_err) = e.downcast_ref::<io::Error>() {
+        if io_err.kind() == io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+    }
+    Err(e)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::cli::log::query::FilterInput;
+    use std::io::Cursor;
+
+    fn empty_filter() -> Filter {
+        Filter::build(FilterInput {
+            since: None,
+            method: None,
+            status: None,
+            service: None,
+            command: None,
+            url: None,
+            grep: None,
+            fuzzy: &[],
+            query: &[],
+            id: None,
+        })
+        .unwrap()
+    }
+
+    fn sample_lines() -> String {
+        let mut s = String::new();
+        for i in 0..5 {
+            s.push_str(&format!(
+                r#"{{"id":"{i}","invocation_id":"inv","kind":"http","timestamp":"2026-06-22T00:00:0{i}.000Z","service":"jira","method":"GET","status_code":200,"url":"/x/{i}"}}"#,
+            ));
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn backlog_emits_all_without_limit() {
+        let mut reader = BufReader::new(Cursor::new(sample_lines()));
+        let mut out = Vec::new();
+        emit_backlog(&mut reader, &empty_filter(), Format::Json, None, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.lines().count(), 5);
+        // JSON format is byte-identical to the input lines.
+        assert!(text.contains(r#""url":"/x/0""#));
+        assert!(text.contains(r#""url":"/x/4""#));
+    }
+
+    #[test]
+    fn backlog_limit_keeps_most_recent() {
+        let mut reader = BufReader::new(Cursor::new(sample_lines()));
+        let mut out = Vec::new();
+        emit_backlog(
+            &mut reader,
+            &empty_filter(),
+            Format::Json,
+            Some(2),
+            &mut out,
+        )
+        .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.lines().count(), 2);
+        assert!(text.contains(r#""url":"/x/3""#));
+        assert!(text.contains(r#""url":"/x/4""#));
+        assert!(!text.contains(r#""url":"/x/0""#));
+    }
+
+    #[test]
+    fn backlog_skips_malformed_and_empty_lines() {
+        let input = "not json\n\n{\"id\":\"1\",\"kind\":\"http\"}\n";
+        let mut reader = BufReader::new(Cursor::new(input));
+        let mut out = Vec::new();
+        emit_backlog(&mut reader, &empty_filter(), Format::Json, None, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.lines().count(), 1);
+        assert!(text.contains(r#""id":"1""#));
+    }
+
+    #[test]
+    fn backlog_applies_filter() {
+        let filter = Filter::build(FilterInput {
+            since: None,
+            method: None,
+            status: Some("5xx"),
+            service: None,
+            command: None,
+            url: None,
+            grep: None,
+            fuzzy: &[],
+            query: &[],
+            id: None,
+        })
+        .unwrap();
+        let mut reader = BufReader::new(Cursor::new(sample_lines()));
+        let mut out = Vec::new();
+        emit_backlog(&mut reader, &filter, Format::Json, None, &mut out).unwrap();
+        // All sample lines are status 200, so nothing matches 5xx.
+        assert!(String::from_utf8(out).unwrap().is_empty());
+    }
+}

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -4,13 +4,14 @@
 //! `DD-APPLICATION-KEY` headers on every request and retries 429 responses
 //! with `Retry-After` / `X-RateLimit-Reset` awareness.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use reqwest::Client;
 
 use crate::datadog::auth::{base_url_for_site, DatadogCredentials};
 use crate::datadog::error::DatadogError;
+use crate::request_log;
 
 /// HTTP request timeout for Datadog API calls.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -70,18 +71,47 @@ impl DatadogClient {
         &self.base_url
     }
 
+    /// Appends a best-effort HTTP record for one Datadog request attempt.
+    fn log_request(
+        method: &str,
+        url: &str,
+        started: Instant,
+        result: &reqwest::Result<reqwest::Response>,
+    ) {
+        match result {
+            Ok(r) => request_log::record_http(
+                "datadog",
+                method,
+                url,
+                started,
+                Some(r.status().as_u16()),
+                None,
+            ),
+            Err(e) => request_log::record_http(
+                "datadog",
+                method,
+                url,
+                started,
+                None,
+                Some(&e.to_string()),
+            ),
+        }
+    }
+
     /// Sends an authenticated GET request and returns the raw response.
     pub async fn get_json(&self, url: &str) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .get(url)
                 .header("DD-API-KEY", &self.api_key)
                 .header("DD-APPLICATION-KEY", &self.app_key)
                 .header("Accept", "application/json")
                 .send()
-                .await
-                .context("Failed to send GET request to Datadog API")?;
+                .await;
+            Self::log_request("GET", url, started, &result);
+            let response = result.context("Failed to send GET request to Datadog API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);
@@ -98,7 +128,8 @@ impl DatadogClient {
         body: &T,
     ) -> Result<reqwest::Response> {
         for attempt in 0..=MAX_RETRIES {
-            let response = self
+            let started = Instant::now();
+            let result = self
                 .client
                 .post(url)
                 .header("DD-API-KEY", &self.api_key)
@@ -107,8 +138,9 @@ impl DatadogClient {
                 .header("Accept", "application/json")
                 .json(body)
                 .send()
-                .await
-                .context("Failed to send POST request to Datadog API")?;
+                .await;
+            Self::log_request("POST", url, started, &result);
+            let response = result.context("Failed to send POST request to Datadog API")?;
 
             if response.status().as_u16() != 429 || attempt == MAX_RETRIES {
                 return Ok(response);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod datadog;
 pub mod git;
 #[cfg(feature = "mcp")]
 pub mod mcp;
+pub mod request_log;
 pub mod resources;
 pub mod snowflake;
 pub mod transcript;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
 use std::process;
+use std::time::Instant;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use omni_dev::request_log::{self, InvocationOutcome, RequestLogContext, Source};
 use omni_dev::Cli;
 
 fn main() {
     init_tracing();
 
+    // Capture argv before clap consumes it, so the invocation record can log the
+    // full command line and the resolved subcommand path.
+    let argv: Vec<String> = std::env::args().collect();
     let cli = Cli::parse();
 
     // The macOS menu-bar daemon needs the GUI event loop on the main thread,
@@ -35,9 +40,61 @@ fn main() {
         }
     };
 
-    if let Err(e) = runtime.block_on(cli.execute()) {
+    // Stash the per-invocation context so HTTP records can correlate to this
+    // run, then time the whole command and append one invocation record after
+    // it returns. Logging is best-effort and never affects the exit code.
+    let command = resolve_command_path(&argv);
+    let source = if is_daemon_run(&command) {
+        Source::Daemon
+    } else {
+        Source::Cli
+    };
+    request_log::set_global(RequestLogContext {
+        invocation_id: request_log::new_id(),
+        source,
+        mcp_tool: None,
+    });
+
+    let start = Instant::now();
+    let result = runtime.block_on(cli.execute());
+
+    let (exit_code, error) = match &result {
+        Ok(()) => (0, None),
+        Err(e) => (1, Some(format!("{e:#}"))),
+    };
+    request_log::record_invocation(InvocationOutcome {
+        command,
+        command_line: argv,
+        exit_code,
+        error,
+        duration: start.elapsed(),
+    });
+
+    if let Err(e) = result {
         die(&e);
     }
+}
+
+/// Resolves the clap subcommand path (e.g. `["jira","read"]`) by re-deriving
+/// matches from argv and walking the subcommand chain. Generic — robust to new
+/// subcommands — and returns an empty path if re-parsing fails.
+fn resolve_command_path(argv: &[String]) -> Vec<String> {
+    let mut path = Vec::new();
+    let Ok(matches) = Cli::command().try_get_matches_from(argv) else {
+        return path;
+    };
+    let mut current = &matches;
+    while let Some((name, sub)) = current.subcommand() {
+        path.push(name.to_string());
+        current = sub;
+    }
+    path
+}
+
+/// Whether the resolved command path is `daemon run` (the long-lived daemon).
+fn is_daemon_run(command: &[String]) -> bool {
+    command.first().map(String::as_str) == Some("daemon")
+        && command.get(1).map(String::as_str) == Some("run")
 }
 
 /// Initializes the tracing subscriber (stderr, `RUST_LOG`-driven, default

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,6 +15,7 @@ use rmcp::{
 
 use super::catalogue_cache::CatalogueCache;
 use super::resources;
+use crate::request_log;
 
 /// The omni-dev MCP server.
 ///
@@ -55,6 +56,40 @@ impl OmniDevServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for OmniDevServer {
+    /// Routes an MCP tool call, scoping a task-local request-log context
+    /// (`source = mcp`, the tool name) around the dispatch so any HTTP the tool
+    /// issues correlates to it, and appending one invocation record per call.
+    ///
+    /// Mirrors the dispatch the `#[tool_handler]` macro would otherwise
+    /// generate; defining it here makes the macro skip its own `call_tool`.
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::CallToolResult, McpError> {
+        let tool = request.name.to_string();
+        let ctx = request_log::RequestLogContext::mcp(tool.clone());
+        request_log::CTX
+            .scope(ctx, async move {
+                let started = std::time::Instant::now();
+                let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+                let result = self.tool_router.call(tcc).await;
+                let (exit_code, error) = match &result {
+                    Ok(_) => (0, None),
+                    Err(e) => (1, Some(e.to_string())),
+                };
+                request_log::record_invocation(request_log::InvocationOutcome {
+                    command: vec![tool],
+                    command_line: Vec::new(),
+                    exit_code,
+                    error,
+                    duration: started.elapsed(),
+                });
+                result
+            })
+            .await
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
             ServerCapabilities::builder()

--- a/src/request_log.rs
+++ b/src/request_log.rs
@@ -1,0 +1,680 @@
+//! Append-only, local invocation + HTTP request log (`log.jsonl`).
+//!
+//! Every `omni-dev` invocation appends one `kind: "invocation"` line; every
+//! outbound HTTP request made by one of the integration clients appends one
+//! `kind: "http"` line correlated to it by a shared `invocation_id`. The log
+//! is **local-machine state** written under the platform state/data directory
+//! (`0700` dir / `0600` file, the same posture as [`crate::daemon::paths`]).
+//!
+//! Design invariants:
+//!
+//! - **Best effort.** [`record`] swallows every error (logging only at
+//!   `tracing::debug`); a logging failure can never change the program's exit
+//!   code. Honors `OMNI_DEV_LOG_DISABLE=1` for an absolute opt-out.
+//! - **No secrets.** Auth headers/tokens are never written; only a non-secret
+//!   `auth_principal` identity is kept. Headers are redacted centrally
+//!   ([`redact_headers`]) and request/response bodies are opt-in via
+//!   `OMNI_DEV_LOG_BODIES=1`.
+//! - **Forward compatible.** A single [`LogRecord`] is used for both writing
+//!   and reading: every field is `#[serde(default)]`, and every optional field
+//!   is `skip_serializing_if`, so a newer reader never chokes on an older line
+//!   and an older reader never chokes on a newer one — the same forward-rolling
+//!   contract the daemon wire types use.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use chrono::SecondsFormat;
+use serde::{Deserialize, Serialize};
+
+/// Default log file name under the runtime directory.
+const LOG_FILE_NAME: &str = "log.jsonl";
+
+/// Which kind of record a line holds. Unknown future kinds deserialize to
+/// [`RecordKind::Unknown`] rather than failing the read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordKind {
+    /// One per process invocation (or per MCP tool call).
+    #[default]
+    Invocation,
+    /// One per outbound HTTP request.
+    Http,
+    /// A kind written by a newer version that this reader does not know.
+    #[serde(other)]
+    Unknown,
+}
+
+/// What drove an invocation. Unknown future sources deserialize to
+/// [`Source::Unknown`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Source {
+    /// A direct `omni-dev` CLI invocation.
+    #[default]
+    Cli,
+    /// An `omni-dev-mcp` tool call.
+    Mcp,
+    /// Work performed inside the long-lived daemon process.
+    Daemon,
+    /// A source written by a newer version that this reader does not know.
+    #[serde(other)]
+    Unknown,
+}
+
+/// One line of the log. Used for both writing and reading; every field is
+/// `#[serde(default)]` (tolerant reads) and every optional field is
+/// `skip_serializing_if` (compact, forward-compatible writes).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LogRecord {
+    // --- Core fields (present on every record) ---
+    /// Per-record, time-sortable id (see [`new_id`]).
+    #[serde(default)]
+    pub id: String,
+    /// Shared by an invocation record and every HTTP record it spawned.
+    #[serde(default)]
+    pub invocation_id: String,
+    /// Discriminates the record type.
+    #[serde(default)]
+    pub kind: RecordKind,
+    /// RFC3339 timestamp with milliseconds.
+    #[serde(default)]
+    pub timestamp: String,
+    /// Host the record was written on.
+    #[serde(default)]
+    pub hostname: String,
+    /// Writing process id.
+    #[serde(default)]
+    pub pid: u32,
+    /// `omni-dev` version that wrote the record.
+    #[serde(default)]
+    pub omni_dev_version: String,
+    /// Working directory at write time.
+    #[serde(default)]
+    pub cwd: String,
+    /// OS user that owns the process.
+    #[serde(default)]
+    pub system_user: String,
+
+    // --- `kind: "invocation"` fields ---
+    /// Resolved clap subcommand path, e.g. `["jira","read"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub command: Vec<String>,
+    /// Full argv.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub command_line: Vec<String>,
+    /// Process exit code (0 success, 1 error — matches `die`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Wall time of the whole invocation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Whitelisted, non-secret `OMNI_DEV_*` env snapshot.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+    /// What drove the run (`cli`/`mcp`/`daemon`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<Source>,
+    /// When `source = mcp`, the tool name that drove the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_tool: Option<String>,
+
+    // --- `kind: "http"` fields ---
+    /// Coarse service tag (`jira`/`confluence`/`datadog`/…) for fast filtering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service: Option<String>,
+    /// HTTP method.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// Request URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Response status; absent on a network/transport error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+    /// Elapsed time of the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+    /// True when the request ran inside the daemon (bridge/Snowflake pool).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub via_daemon: bool,
+    /// Which pooled daemon session served the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_session_id: Option<String>,
+    /// Non-secret identity actually used (token id / OAuth principal) — never
+    /// the secret itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_principal: Option<String>,
+    /// Redacted request headers (only when `OMNI_DEV_LOG_HEADERS=1`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub request_headers: BTreeMap<String, String>,
+    /// Redacted response headers (only when `OMNI_DEV_LOG_HEADERS=1`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub response_headers: BTreeMap<String, String>,
+    /// Request body (only when `OMNI_DEV_LOG_BODIES=1`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<String>,
+    /// Response body (only when `OMNI_DEV_LOG_BODIES=1`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_body: Option<String>,
+    /// Free-form correlation tags.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub context: BTreeMap<String, String>,
+
+    // --- shared optional ---
+    /// Top-level error chain (invocation) or per-request error (http).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `skip_serializing_if` predicate for `bool` fields that default to `false`.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires `fn(&T) -> bool`
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+impl LogRecord {
+    /// Builds a record carrying only the always-present core fields.
+    fn new(kind: RecordKind, invocation_id: String) -> Self {
+        Self {
+            id: new_id(),
+            invocation_id,
+            kind,
+            timestamp: now_rfc3339_millis(),
+            hostname: hostname(),
+            pid: std::process::id(),
+            omni_dev_version: crate::VERSION.to_string(),
+            cwd: cwd(),
+            system_user: system_user(),
+            ..Self::default()
+        }
+    }
+}
+
+/// The per-invocation context every record is stamped with.
+///
+/// Held once per process in [`GLOBAL`] (CLI/daemon) and overridden per task in
+/// [`CTX`] (the multiplexed MCP server), so HTTP records can find their parent
+/// invocation without threading state through every call site.
+#[derive(Debug, Clone)]
+pub struct RequestLogContext {
+    /// Shared id linking an invocation to the HTTP it spawned.
+    pub invocation_id: String,
+    /// What drove the run.
+    pub source: Source,
+    /// MCP tool name when `source = mcp`.
+    pub mcp_tool: Option<String>,
+}
+
+impl Default for RequestLogContext {
+    fn default() -> Self {
+        Self {
+            invocation_id: new_id(),
+            source: Source::Cli,
+            mcp_tool: None,
+        }
+    }
+}
+
+impl RequestLogContext {
+    /// A CLI context with a freshly minted invocation id.
+    pub fn cli() -> Self {
+        Self {
+            invocation_id: new_id(),
+            source: Source::Cli,
+            mcp_tool: None,
+        }
+    }
+
+    /// An MCP context for a single tool call.
+    pub fn mcp(tool: impl Into<String>) -> Self {
+        Self {
+            invocation_id: new_id(),
+            source: Source::Mcp,
+            mcp_tool: Some(tool.into()),
+        }
+    }
+}
+
+static GLOBAL: OnceLock<RequestLogContext> = OnceLock::new();
+
+tokio::task_local! {
+    /// Per-task context override, set around each MCP tool dispatch.
+    pub static CTX: RequestLogContext;
+}
+
+/// Installs the process-global context. The first call wins (the CLI/daemon
+/// shell sets it once, very early); later calls are ignored.
+pub fn set_global(ctx: RequestLogContext) {
+    let _ = GLOBAL.set(ctx);
+}
+
+/// Resolves the active context: task-local override first, then the
+/// process-global default, then a synthesized fallback.
+pub fn current_context() -> RequestLogContext {
+    if let Ok(ctx) = CTX.try_with(RequestLogContext::clone) {
+        return ctx;
+    }
+    if let Some(ctx) = GLOBAL.get() {
+        return ctx.clone();
+    }
+    RequestLogContext::default()
+}
+
+/// Whether logging is disabled entirely (`OMNI_DEV_LOG_DISABLE=1`).
+pub fn disabled() -> bool {
+    env_flag("OMNI_DEV_LOG_DISABLE")
+}
+
+/// Whether request/response bodies may be recorded (`OMNI_DEV_LOG_BODIES=1`).
+pub fn bodies_enabled() -> bool {
+    env_flag("OMNI_DEV_LOG_BODIES")
+}
+
+/// Whether (redacted) headers may be recorded (`OMNI_DEV_LOG_HEADERS=1`).
+pub fn headers_enabled() -> bool {
+    env_flag("OMNI_DEV_LOG_HEADERS")
+}
+
+/// Reads a boolean-ish env var (`1`/`true`/`yes`, case-insensitive).
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| {
+        let v = v.trim().to_ascii_lowercase();
+        v == "1" || v == "true" || v == "yes"
+    })
+}
+
+/// Resolves the log file path: `OMNI_DEV_LOG_FILE` override, else
+/// `state_dir` (falling back to `data_dir`) joined with `omni-dev/log.jsonl`.
+pub fn log_file_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("OMNI_DEV_LOG_FILE") {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+    let base = dirs::state_dir().or_else(dirs::data_dir)?;
+    Some(base.join("omni-dev").join(LOG_FILE_NAME))
+}
+
+/// Appends one record. Best effort: every error is swallowed (logged at
+/// `tracing::debug`) so logging can never affect the caller's exit code.
+pub fn record(entry: &LogRecord) {
+    if disabled() {
+        return;
+    }
+    if let Err(e) = try_record(entry) {
+        tracing::debug!("request_log: failed to append record: {e}");
+    }
+}
+
+/// The fallible append used by [`record`]; all errors flow back to be swallowed.
+fn try_record(entry: &LogRecord) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let path = log_file_path().context("could not resolve the log file path")?;
+    if let Some(parent) = path.parent() {
+        crate::daemon::paths::ensure_dir_0700(parent)?;
+    }
+    let mut line = serde_json::to_string(entry).context("failed to serialize record")?;
+    line.push('\n');
+    append_line(&path, &line)?;
+    Ok(())
+}
+
+/// Appends a single line with `O_APPEND | O_CREATE`, creating the file `0600`.
+/// When bodies are enabled (lines may exceed the atomic-write size) an advisory
+/// exclusive lock guards the write; the common no-body path relies on
+/// `O_APPEND` single-write atomicity and takes no lock.
+#[cfg(unix)]
+fn append_line(path: &std::path::Path, line: &str) -> anyhow::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .mode(0o600)
+        .open(path)?;
+
+    if bodies_enabled() {
+        match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusive) {
+            Ok(mut guard) => {
+                guard.write_all(line.as_bytes())?;
+            }
+            Err((mut file, _)) => {
+                file.write_all(line.as_bytes())?;
+            }
+        }
+    } else {
+        let mut file = file;
+        file.write_all(line.as_bytes())?;
+    }
+    Ok(())
+}
+
+/// Non-unix fallback: `O_APPEND | O_CREATE` single write, no advisory lock and
+/// no mode tightening (those are unix concepts).
+#[cfg(not(unix))]
+fn append_line(path: &std::path::Path, line: &str) -> anyhow::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)?;
+    file.write_all(line.as_bytes())?;
+    Ok(())
+}
+
+/// The outcome of an invocation, recorded once after `cli.execute()` returns.
+#[derive(Debug, Clone)]
+pub struct InvocationOutcome {
+    /// Resolved clap subcommand path.
+    pub command: Vec<String>,
+    /// Full argv.
+    pub command_line: Vec<String>,
+    /// Process exit code.
+    pub exit_code: i32,
+    /// Rendered error chain, when the command failed.
+    pub error: Option<String>,
+    /// Wall time of the whole invocation.
+    pub duration: Duration,
+}
+
+/// Appends one `kind: "invocation"` record from the active context.
+pub fn record_invocation(outcome: InvocationOutcome) {
+    let ctx = current_context();
+    let mut rec = LogRecord::new(RecordKind::Invocation, ctx.invocation_id);
+    rec.source = Some(ctx.source);
+    rec.mcp_tool = ctx.mcp_tool;
+    rec.command = outcome.command;
+    rec.command_line = outcome.command_line;
+    rec.exit_code = Some(outcome.exit_code);
+    rec.error = outcome.error;
+    rec.duration_ms = Some(outcome.duration.as_millis() as u64);
+    rec.env = whitelisted_env();
+    record(&rec);
+}
+
+/// Optional, non-secret extras for an HTTP record. Bodies/headers are gated and
+/// redacted centrally in [`record_http_with`], so callers may pass them freely.
+#[derive(Debug, Clone, Default)]
+pub struct HttpExtra {
+    /// True when served inside the daemon.
+    pub via_daemon: bool,
+    /// Pooled daemon session id that served the request.
+    pub daemon_session_id: Option<String>,
+    /// Non-secret identity used (never the secret).
+    pub auth_principal: Option<String>,
+    /// Raw request headers (redacted + gated before writing).
+    pub request_headers: BTreeMap<String, String>,
+    /// Raw response headers (redacted + gated before writing).
+    pub response_headers: BTreeMap<String, String>,
+    /// Request body (gated before writing).
+    pub request_body: Option<String>,
+    /// Response body (gated before writing).
+    pub response_body: Option<String>,
+    /// Free-form correlation tags.
+    pub context: BTreeMap<String, String>,
+}
+
+/// Appends one `kind: "http"` record with method/url/status/elapsed/error.
+pub fn record_http(
+    service: &str,
+    method: &str,
+    url: &str,
+    started: Instant,
+    status: Option<u16>,
+    error: Option<&str>,
+) {
+    record_http_with(
+        service,
+        method,
+        url,
+        started,
+        status,
+        error,
+        HttpExtra::default(),
+    );
+}
+
+/// Appends one `kind: "http"` record with extra, non-secret fields.
+///
+/// Headers and bodies are dropped unless their opt-in env var is set, and
+/// headers are always redacted — so no secret can be written here under any
+/// caller.
+#[allow(clippy::too_many_arguments)]
+pub fn record_http_with(
+    service: &str,
+    method: &str,
+    url: &str,
+    started: Instant,
+    status: Option<u16>,
+    error: Option<&str>,
+    extra: HttpExtra,
+) {
+    if disabled() {
+        return;
+    }
+    let ctx = current_context();
+    let mut rec = LogRecord::new(RecordKind::Http, ctx.invocation_id);
+    rec.source = Some(ctx.source);
+    rec.mcp_tool = ctx.mcp_tool;
+    rec.service = Some(service.to_string());
+    rec.method = Some(method.to_string());
+    rec.url = Some(url.to_string());
+    rec.status_code = status;
+    rec.elapsed_ms = Some(started.elapsed().as_millis() as u64);
+    rec.error = error.map(str::to_string);
+    rec.via_daemon = extra.via_daemon;
+    rec.daemon_session_id = extra.daemon_session_id;
+    rec.auth_principal = extra.auth_principal;
+    rec.context = extra.context;
+    if headers_enabled() {
+        rec.request_headers = redact_headers(&extra.request_headers);
+        rec.response_headers = redact_headers(&extra.response_headers);
+    }
+    if bodies_enabled() {
+        rec.request_body = extra.request_body;
+        rec.response_body = extra.response_body;
+    }
+    record(&rec);
+}
+
+/// Header names whose values must never be written (compared lowercased).
+const SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api-key",
+    "dd-api-key",
+    "dd-application-key",
+    "x-datadog-api-key",
+    "x-datadog-application-key",
+    "x-omni-bridge",
+    "x-omni-bridge-target",
+];
+
+/// Replaces sensitive header values with `REDACTED`, passing others through.
+pub fn redact_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let redacted = SENSITIVE_HEADERS.contains(&name.to_ascii_lowercase().as_str());
+            (
+                name.clone(),
+                if redacted {
+                    "REDACTED".to_string()
+                } else {
+                    value.clone()
+                },
+            )
+        })
+        .collect()
+}
+
+/// A time-sortable id: 13-digit zero-padded epoch-millis, a dash, then 16 hex.
+///
+/// Lexical order ≈ chronological order, which is all the reader needs. Mirrors
+/// the uuid-shaped minting in [`crate::snowflake::client`] without adding a
+/// crate.
+pub fn new_id() -> String {
+    let millis = chrono::Utc::now().timestamp_millis().max(0);
+    let suffix = rand::random::<u64>();
+    format!("{millis:013}-{suffix:016x}")
+}
+
+/// Current time as RFC3339 with millisecond precision, in UTC.
+fn now_rfc3339_millis() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+/// Best-effort current working directory.
+fn cwd() -> String {
+    std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default()
+}
+
+/// Best-effort OS username (`$USER`, then the passwd entry for the euid).
+fn system_user() -> String {
+    if let Ok(user) = std::env::var("USER") {
+        if !user.is_empty() {
+            return user;
+        }
+    }
+    #[cfg(unix)]
+    {
+        if let Ok(Some(user)) = nix::unistd::User::from_uid(nix::unistd::geteuid()) {
+            return user.name;
+        }
+    }
+    String::new()
+}
+
+/// Best-effort hostname (`gethostname`, then `$HOSTNAME`, then empty).
+fn hostname() -> String {
+    #[cfg(unix)]
+    {
+        if let Ok(name) = nix::unistd::gethostname() {
+            if let Some(name) = name.to_str() {
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+            }
+        }
+    }
+    std::env::var("HOSTNAME").unwrap_or_default()
+}
+
+/// Names matching these substrings have their env values redacted, guarding
+/// against any future secret-bearing `OMNI_DEV_*` var.
+const SECRETISH: &[&str] = &["TOKEN", "SECRET", "KEY", "PASSWORD", "PASSWD"];
+
+/// Snapshot of `OMNI_DEV_*` env vars, with secret-looking values redacted.
+fn whitelisted_env() -> BTreeMap<String, String> {
+    std::env::vars()
+        .filter(|(k, _)| k.starts_with("OMNI_DEV_"))
+        .map(|(k, v)| {
+            let secretish = SECRETISH.iter().any(|needle| k.contains(needle));
+            let value = if secretish { "REDACTED".to_string() } else { v };
+            (k, value)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_round_trips_through_json() {
+        let mut rec = LogRecord::new(RecordKind::Http, "inv-1".to_string());
+        rec.service = Some("jira".to_string());
+        rec.method = Some("GET".to_string());
+        rec.url = Some("https://example.atlassian.net/rest/api/3/issue/X-1".to_string());
+        rec.status_code = Some(200);
+        rec.elapsed_ms = Some(42);
+
+        let line = serde_json::to_string(&rec).unwrap();
+        let back: LogRecord = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.invocation_id, "inv-1");
+        assert_eq!(back.kind, RecordKind::Http);
+        assert_eq!(back.service.as_deref(), Some("jira"));
+        assert_eq!(back.status_code, Some(200));
+    }
+
+    #[test]
+    fn reader_tolerates_unknown_fields() {
+        let line = r#"{"id":"x","invocation_id":"i","kind":"http","method":"GET",
+            "future_field":{"nested":true},"another":42}"#;
+        let rec: LogRecord = serde_json::from_str(line).unwrap();
+        assert_eq!(rec.kind, RecordKind::Http);
+        assert_eq!(rec.method.as_deref(), Some("GET"));
+    }
+
+    #[test]
+    fn reader_tolerates_missing_newer_fields() {
+        // An "old" line with only a couple of fields present.
+        let line = r#"{"kind":"invocation","command":["git","view"]}"#;
+        let rec: LogRecord = serde_json::from_str(line).unwrap();
+        assert_eq!(rec.kind, RecordKind::Invocation);
+        assert_eq!(rec.command, vec!["git", "view"]);
+        assert!(rec.status_code.is_none());
+        assert!(rec.id.is_empty());
+    }
+
+    #[test]
+    fn unknown_kind_and_source_do_not_fail() {
+        let line = r#"{"kind":"telemetry","source":"webhook"}"#;
+        let rec: LogRecord = serde_json::from_str(line).unwrap();
+        assert_eq!(rec.kind, RecordKind::Unknown);
+        assert_eq!(rec.source, Some(Source::Unknown));
+    }
+
+    #[test]
+    fn optional_fields_are_skipped_when_empty() {
+        let rec = LogRecord::new(RecordKind::Invocation, "i".to_string());
+        let line = serde_json::to_string(&rec).unwrap();
+        // Empty collections / None options must not appear on the wire.
+        assert!(!line.contains("status_code"));
+        assert!(!line.contains("request_headers"));
+        assert!(!line.contains("via_daemon"));
+        assert!(!line.contains("\"env\""));
+    }
+
+    #[test]
+    fn ids_are_time_sortable() {
+        let a = new_id();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let b = new_id();
+        assert!(a < b, "{a} should sort before {b}");
+    }
+
+    #[test]
+    fn sensitive_headers_are_redacted() {
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), "Bearer secret".to_string());
+        headers.insert("X-Api-Key".to_string(), "abc123".to_string());
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+        let out = redact_headers(&headers);
+        assert_eq!(out["Authorization"], "REDACTED");
+        assert_eq!(out["X-Api-Key"], "REDACTED");
+        assert_eq!(out["Content-Type"], "application/json");
+    }
+
+    #[test]
+    fn env_flag_parses_truthy_values() {
+        std::env::set_var("OMNI_DEV_TEST_FLAG_ABC", "1");
+        assert!(env_flag("OMNI_DEV_TEST_FLAG_ABC"));
+        std::env::set_var("OMNI_DEV_TEST_FLAG_ABC", "TRUE");
+        assert!(env_flag("OMNI_DEV_TEST_FLAG_ABC"));
+        std::env::set_var("OMNI_DEV_TEST_FLAG_ABC", "0");
+        assert!(!env_flag("OMNI_DEV_TEST_FLAG_ABC"));
+        std::env::remove_var("OMNI_DEV_TEST_FLAG_ABC");
+        assert!(!env_flag("OMNI_DEV_TEST_FLAG_ABC"));
+    }
+}

--- a/src/request_log.rs
+++ b/src/request_log.rs
@@ -315,8 +315,13 @@ fn try_record(entry: &LogRecord) -> anyhow::Result<()> {
     use anyhow::Context;
 
     let path = log_file_path().context("could not resolve the log file path")?;
+    // Only create and tighten the parent when it's missing — re-`chmod`ing an
+    // existing dir (e.g. a user-chosen OMNI_DEV_LOG_FILE location, or a shared
+    // temp dir) is both wrong and may fail; the file itself is always 0600.
     if let Some(parent) = path.parent() {
-        crate::daemon::paths::ensure_dir_0700(parent)?;
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            crate::daemon::paths::ensure_dir_0700(parent)?;
+        }
     }
     let mut line = serde_json::to_string(entry).context("failed to serialize record")?;
     line.push('\n');

--- a/src/snowflake/client/transport.rs
+++ b/src/snowflake/client/transport.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 use url::Url;
 
 use super::error::{Error, Result};
+use crate::request_log;
 
 /// Response codes that mean the session token is no longer valid.
 const SESSION_EXPIRED_CODES: &[&str] = &["390112", "390114", "390108"];
@@ -87,7 +88,7 @@ impl Transport {
     ) -> Result<Value> {
         let url = self.resolve(path, query)?;
         let raw = self
-            .send_with_retry(|| self.post_request(url.clone(), body, token))
+            .send_with_retry("POST", &url, || self.post_request(url.clone(), body, token))
             .await?;
         finalize(raw)
     }
@@ -109,7 +110,9 @@ impl Transport {
     ) -> Result<Value> {
         let url = self.resolve("queries/v1/query-request", query)?;
         let mut raw = self
-            .send_with_retry(|| self.post_request(url.clone(), body, Some(token)))
+            .send_with_retry("POST", &url, || {
+                self.post_request(url.clone(), body, Some(token))
+            })
             .await?;
 
         if SESSION_EXPIRED_CODES.contains(&raw.code.as_str()) {
@@ -144,7 +147,7 @@ impl Transport {
         loop {
             tokio::time::sleep(poll_interval).await;
             let raw = self
-                .send_with_retry(|| self.get_request(url.clone(), Some(token)))
+                .send_with_retry("GET", &url, || self.get_request(url.clone(), Some(token)))
                 .await?;
             if !IN_PROGRESS_CODES.contains(&raw.code.as_str()) {
                 return Ok(raw);
@@ -236,14 +239,47 @@ impl Transport {
         request
     }
 
+    /// Appends a best-effort HTTP record for one Snowflake request attempt,
+    /// flagging `via_daemon` when running inside the daemon process. The pooled
+    /// `daemon_session_id` is not visible at this transport boundary (one
+    /// `Transport` is shared across pooled sessions); threading it is a follow-up.
+    fn log_request(
+        &self,
+        method: &str,
+        url: &Url,
+        started: Instant,
+        status: Option<u16>,
+        error: Option<&str>,
+    ) {
+        let via_daemon = matches!(
+            request_log::current_context().source,
+            request_log::Source::Daemon
+        );
+        request_log::record_http_with(
+            "snowflake",
+            method,
+            url.as_str(),
+            started,
+            status,
+            error,
+            request_log::HttpExtra {
+                via_daemon,
+                ..Default::default()
+            },
+        );
+    }
+
     /// Sends a freshly built request, retrying transient failures with backoff.
+    /// `method`/`url` are passed only for the request log.
     async fn send_with_retry(
         &self,
+        method: &str,
+        url: &Url,
         build: impl Fn() -> reqwest::RequestBuilder,
     ) -> Result<RawResponse> {
         let mut attempt = 1;
         loop {
-            match self.send_once(build()).await {
+            match self.send_once(method, url, build()).await {
                 Ok(raw) => return Ok(raw),
                 Err(err) if attempt < MAX_ATTEMPTS && is_retryable(&err) => {
                     tokio::time::sleep(BACKOFF_BASE * 2u32.pow(attempt - 1)).await;
@@ -255,7 +291,13 @@ impl Transport {
     }
 
     /// Sends one request (bounded by `request_timeout`) and parses the envelope.
-    async fn send_once(&self, request: reqwest::RequestBuilder) -> Result<RawResponse> {
+    async fn send_once(
+        &self,
+        method: &str,
+        url: &Url,
+        request: reqwest::RequestBuilder,
+    ) -> Result<RawResponse> {
+        let started = Instant::now();
         let send = async {
             let response = request.send().await?;
             let status = response.status();
@@ -264,14 +306,19 @@ impl Transport {
         };
         let (status, text) = match tokio::time::timeout(self.request_timeout, send).await {
             Ok(Ok(v)) => v,
-            Ok(Err(e)) => return Err(Error::Transport(e)),
+            Ok(Err(e)) => {
+                self.log_request(method, url, started, None, Some(&e.to_string()));
+                return Err(Error::Transport(e));
+            }
             Err(_) => {
+                self.log_request(method, url, started, None, Some("request timed out"));
                 return Err(Error::Server {
                     code: "timeout".to_string(),
                     message: format!("request exceeded {:?}", self.request_timeout),
-                })
+                });
             }
         };
+        self.log_request(method, url, started, Some(status.as_u16()), None);
         if !status.is_success() {
             return Err(Error::Server {
                 code: status.as_u16().to_string(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -701,3 +701,25 @@ fn log_write_failure_does_not_change_exit_code() {
         "command must exit 0 even when the log cannot be written"
     );
 }
+
+#[test]
+fn bodies_flag_creates_parent_and_writes_record() {
+    // A nested path whose parent does not exist exercises directory creation,
+    // and OMNI_DEV_LOG_BODIES=1 routes the write through the advisory-locked
+    // path. (A local command makes no HTTP, so only the invocation is logged.)
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("nested").join("log.jsonl");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .arg("help-all")
+        .env("OMNI_DEV_LOG_FILE", &log)
+        .env("OMNI_DEV_LOG_BODIES", "1")
+        .output()
+        .expect("failed to run binary");
+    assert!(output.status.success());
+
+    let contents = fs::read_to_string(&log).expect("nested log file should be created");
+    assert!(contents
+        .lines()
+        .any(|l| l.contains(r#""kind":"invocation""#)));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -615,3 +615,89 @@ async fn cli_execute_dispatches_ai_chat() {
     // Either way the async dispatch chain is exercised.
     let _ = cli.execute().await;
 }
+
+// ── Request log (#1025) ─────────────────────────────────────────────────
+
+/// Runs the binary with `OMNI_DEV_LOG_FILE` pointed at a temp file and the
+/// given args, returning the spawned process output.
+fn run_with_log(log_file: &std::path::Path, args: &[&str]) -> std::process::Output {
+    std::process::Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .args(args)
+        .env("OMNI_DEV_LOG_FILE", log_file)
+        .output()
+        .expect("failed to run binary")
+}
+
+#[test]
+fn invocation_appends_at_least_one_line() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("log.jsonl");
+
+    let output = run_with_log(&log, &["help-all"]);
+    assert!(output.status.success());
+
+    let contents = fs::read_to_string(&log).expect("log file should exist");
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.is_empty()).collect();
+    assert!(!lines.is_empty(), "expected at least one log line");
+
+    // The last line is this invocation, with the resolved command path.
+    let rec: serde_json::Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(rec["kind"], "invocation");
+    assert_eq!(rec["command"], serde_json::json!(["help-all"]));
+    assert_eq!(rec["exit_code"], 0);
+    assert_eq!(rec["source"], "cli");
+}
+
+#[test]
+fn omni_dev_log_reads_back_records_byte_identically() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("log.jsonl");
+
+    // Populate the log with one invocation, then read it back as JSON.
+    assert!(run_with_log(&log, &["help-all"]).status.success());
+
+    let on_disk = fs::read_to_string(&log).unwrap();
+    let output = run_with_log(&log, &["log", "--format", "json"]);
+    assert!(output.status.success());
+    let rendered = String::from_utf8(output.stdout).unwrap();
+
+    // `omni-dev log --format json` reproduces the on-disk NDJSON verbatim,
+    // except its own (later) invocation line, which is appended after the read.
+    for line in on_disk.lines().filter(|l| !l.is_empty()) {
+        assert!(
+            rendered.contains(line),
+            "json output should contain on-disk line verbatim:\n{line}"
+        );
+    }
+}
+
+#[test]
+fn log_disable_appends_nothing() {
+    let dir = TempDir::new().unwrap();
+    let log = dir.path().join("log.jsonl");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_omni-dev"))
+        .arg("help-all")
+        .env("OMNI_DEV_LOG_FILE", &log)
+        .env("OMNI_DEV_LOG_DISABLE", "1")
+        .output()
+        .expect("failed to run binary");
+    assert!(output.status.success());
+    assert!(!log.exists(), "no log file should be written when disabled");
+}
+
+#[test]
+fn log_write_failure_does_not_change_exit_code() {
+    // A log path under a non-directory cannot be created; the command must
+    // still succeed because logging is best-effort.
+    let dir = TempDir::new().unwrap();
+    let not_a_dir = dir.path().join("file");
+    fs::write(&not_a_dir, b"x").unwrap();
+    let unwritable = not_a_dir.join("nested").join("log.jsonl");
+
+    let output = run_with_log(&unwritable, &["help-all"]);
+    assert!(
+        output.status.success(),
+        "command must exit 0 even when the log cannot be written"
+    );
+}

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -20,6 +20,7 @@ Commands:
   snowflake   Snowflake: run arbitrary SQL through the daemon's multiplexed sessions
   coverage    Coverage: diff/patch coverage analysis for PR comments
   transcript  Transcript and caption fetching from media platforms
+  log         Search the local invocation + HTTP request log
   resources   Embedded reference resources (specs, etc.)
   help-all    Displays comprehensive help for all commands
   help        Print this message or the help of the given subcommand(s)
@@ -2999,6 +3000,31 @@ Usage: help-all
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev log - Search the local invocation + HTTP request log
+
+Search the local invocation + HTTP request log
+
+Usage: log [OPTIONS]
+
+Options:
+      --since <DUR>      Only records newer than this relative window (e.g. `30m`, `2h`, `1d`)
+      --method <METHOD>  Match the HTTP method (case-insensitive), e.g. `GET`
+      --status <STATUS>  Match the status: exact (`200`), class (`5xx`), or list (`4xx,5xx`)
+      --service <NAME>   Match the service tag, e.g. `jira`, `datadog`, `browser-bridge`
+      --command <PATH>   Match the resolved command path prefix, e.g. `"jira read"`
+      --url <SUBSTR>     Match a substring of the request URL
+      --grep <REGEX>     Match a regular expression against the raw JSON line
+      --fuzzy <TOKEN>    Require a fuzzy token (substring of the raw line); repeatable, AND-ed
+      --query <EXPR>     A query expression (AND/OR/NOT, `field:value`, bare tokens); repeatable, AND-ed together
+      --id <ID>          Match this record `id` or `invocation_id` (pulls a run and its requests)
+      --format <FORMAT>  Output format [default: oneline] [possible values: oneline, json, full]
+  -n, --limit <N>        Show at most N (most recent) matching records
+  -f, --follow           Follow the log, printing new matching records as they are appended
+  -h, --help             Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
Implements the core of #1025: a local, append-only NDJSON log of every `omni-dev` invocation **and** the HTTP requests it issues, plus an `omni-dev log` subcommand to search and pretty-print it. The interactive TUI (`--interactive`) is deferred to a follow-up exactly as the issue scopes it.

## What this adds

- **Writer + schema** (`src/request_log.rs`): one forward-compatible `LogRecord` for both read and write (every field `#[serde(default)]`, optionals `skip_serializing_if` — the same forward-rolling contract the daemon wire types use). Best-effort `record()` (dir `0700` / file `0600`, all errors swallowed so logging can never change the exit code). Path resolution: `OMNI_DEV_LOG_FILE` → `state_dir()`→`data_dir()` / `omni-dev/log.jsonl`. A `RequestLogContext` (process-global `OnceLock` + a `tokio` task-local override) lets HTTP records inherit their parent `invocation_id`/`source`/`mcp_tool` without threading state through call sites.
- **`omni-dev log` reader** (`src/cli/log/`): the full filter matrix (`--since/--method/--status/--service/--command/--url/--grep/--fuzzy/--query/--id`), the `--query` mini-language (AND/OR/NOT, parentheses, `field:value`, fuzzy tokens), `oneline`/`json`/`full` renderers (`json` is byte-identical to the on-disk NDJSON — composes with `jq`), and a streaming reader (`-n/--limit` ring buffer, `-f/--follow`).
- **Invocation shell** (`src/main.rs`): wraps `cli.execute()` to append one `kind:"invocation"` record per run — resolved command path, argv, exit code, duration, error chain, and a whitelisted `OMNI_DEV_*` env snapshot.
- **HTTP hooks**, one per transport method, inside the existing retry loops so retries and transport errors are captured: Atlassian (×6, jira vs confluence by URL), Datadog (×2), Snowflake (`send_once`, `via_daemon` from context), the three Claude/AI backends + the `claude-cli` subprocess, and the browser bridge (`dispatch`/`start_stream`). The MCP server's hand-written `call_tool` scopes a task-local `source=mcp` context per tool call.
- **Docs**: new operator guide `docs/log.md` + a `CLAUDE.md` pointer.

## Trust boundary

No new trust boundary and no secret is ever written: auth headers are redacted centrally, request/response bodies are opt-in via `OMNI_DEV_LOG_BODIES`, headers via `OMNI_DEV_LOG_HEADERS`, and `OMNI_DEV_LOG_DISABLE` is an absolute opt-out. The log is local-machine state with the same `0700`/`0600` posture as other runtime state.

## Acceptance criteria

- [x] Every invocation appends ≥1 line; HTTP-issuing commands append per-request, including on error (verified: a 429-retry test produced 3 `http` records).
- [x] Forward-compatible schema (reader `#[serde(default)]`, writer `skip_serializing_if`).
- [x] `omni-dev log` supports the filter/format/follow/limit/id matrix.
- [x] `--format json` is NDJSON byte-identical to the on-disk lines.
- [x] No secret values appear under any code path; headers redacted, bodies opt-in.
- [x] Write failures never change the caller's exit code.
- [x] Invocation and HTTP records share an `invocation_id`; daemon-served requests set `via_daemon`.
- [x] MCP-driven traffic recorded with `source = mcp` and `mcp_tool`.
- [x] Help-all golden snapshot updated.
- [ ] Interactive TUI — deferred to a follow-up (as the issue scopes it).

## Deferred (documented in `docs/log.md`)

- Interactive TUI (`--interactive`, `OMNI_DEV_LOG_NO_TUI`, `OMNI_DEV_LOG_TUI_BUFFER`).
- Cross-socket `invocation_id` propagation and Snowflake `daemon_session_id` (the pooled session id isn't visible at the shared transport boundary; `via_daemon` is set).

## Verification

`./scripts/build.sh` (build, `fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test`) passes, plus all lib tests under `--features mcp`. New unit tests cover the schema round-trip/forward-compat, the `--query` parser, status-class and `--since` parsing, and the streaming reader; new integration tests assert ≥1 line per invocation, byte-identical JSON read-back, `OMNI_DEV_LOG_DISABLE`, and write-failure-keeps-exit-0.

Closes #1025