### PR TITLE
chore(cargo): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Description

Bumps the transitive dependency `quinn-proto` from 0.11.14 to 0.11.15 to resolve the high-severity security advisory [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185).

The advisory, published on 2026-06-22, describes a remote memory exhaustion vulnerability in `quinn-proto` caused by unbounded out-of-order stream reassembly. An attacker could exploit this to exhaust server memory remotely. The fix is a patch-level lockfile-only bump — no `Cargo.toml` manifest or source changes are required.

This change was needed because the Security Audit CI job began failing after the advisory was published.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [x] Dependency update

## Related Issue

Resolves RUSTSEC-2026-0185 — remote memory exhaustion in `quinn-proto` via unbounded out-of-order stream reassembly.

## Changes Made

**Dependency Update:**
- Bumped `quinn-proto` from `0.11.14` to `0.11.15` in `Cargo.lock` (checksum updated accordingly)
- No changes to `Cargo.toml` — this is a transitive lockfile-only patch

**Documentation:**
- No documentation changes required

**Testing:**
- No new tests required; existing test suite validates the updated dependency

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (not applicable — dependency-only change)
- [ ] Integration tests updated/added (not applicable)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Backward compatibility verified — patch-level bump with no API changes

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Security audit (should now pass with the bumped lockfile)
cargo audit
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — this PR directly addresses a high-severity memory exhaustion CVE

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable — Cargo.lock only)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable — lockfile bump)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement (describe below)

This PR resolves **RUSTSEC-2026-0185**, a high-severity vulnerability in `quinn-proto` ≤ 0.11.14 where unbounded buffering of out-of-order QUIC stream data could allow a remote attacker to exhaust server memory. Upgrading to 0.11.15 applies the upstream fix that bounds this reassembly buffer.

## Breaking Changes

None. This is a patch-level transitive dependency update. The public API of `quinn-proto` is unchanged between 0.11.14 and 0.11.15.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Applying a `[patch]` override in `Cargo.toml` — not necessary since the upstream crate released 0.11.15 promptly after the advisory.
- Pinning to a specific patched version in `Cargo.toml` — not needed; a lockfile bump is sufficient and least invasive.