### PR TITLE
ci(workflows): use prebuilt cargo-audit instead of compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Install cargo-audit
-      run: cargo install cargo-audit --locked
+    # Pull a prebuilt cargo-audit binary instead of `cargo install` (which
+    # compiles from source every run — rust-cache can't help since it doesn't
+    # cache ~/.cargo/bin). Mirrors the prebuilt cargo-deny-action below.
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-audit
     - name: Run cargo-audit
       run: cargo audit
 


### PR DESCRIPTION
## Description

The Security Audit job previously ran `cargo install cargo-audit --locked`, which compiles cargo-audit from source on every CI run. Because `Swatiming/rust-cache` caches the registry, git, and target directories but not installed binaries in `~/.cargo/bin`, this compilation could not be cached and added significant wait time to every audit run.

This PR switches the Security Audit job to use `taiki-e/install-action@v2`, which fetches a prebuilt `cargo-audit` binary in seconds, eliminating the source compilation entirely. This mirrors the approach already used by the dependency-policy job, which uses the prebuilt `cargo-deny-action`. The `cargo audit` run step itself is unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement
- [x] CI/CD changes
- [ ] Dependency update

## Related Issue

No related issue.

## Changes Made

**CI/CD Changes:**
- Replaced `cargo install cargo-audit --locked` (compiles from source every run) with `taiki-e/install-action@v2` action in `.github/workflows/ci.yml`
- Added inline comment explaining why the prebuilt action is preferred over `cargo install` and the relationship to `rust-cache` limitations
- The `cargo audit` run step is unchanged — only the installation method changes

**Documentation:**
- Inline comment in `ci.yml` explains the rationale and notes the pattern mirrors the prebuilt `cargo-deny-action` used by the dependency-policy job

**Testing:**
- No test code changes required; this is a CI infrastructure change

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] CI workflow runs successfully with the new `taiki-e/install-action@v2` step
- [x] `cargo audit` executes and produces correct output after prebuilt binary installation
- [x] Backward compatibility verified — audit behavior is identical, only installation method changes

### Test Commands

```bash
# No local test commands needed for this CI-only change.
# Validate by triggering the CI pipeline and observing the Security Audit job:
# - "Install cargo-audit" step should complete in seconds (binary download, not compilation)
# - "Run cargo-audit" step should behave identically to before
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [x] Performance impact
- [x] Architecture changes
- [ ] Error handling
- [ ] User experience
- [x] Backward compatibility

The key area to verify is that `taiki-e/install-action@v2` reliably provides a compatible version of `cargo-audit` and that the prebuilt binary behaves identically to the source-compiled version for the `cargo audit` command.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] Performance improvement (describe below)

The Security Audit CI job no longer compiles `cargo-audit` from source on every run. Fetching a prebuilt binary via `taiki-e/install-action@v2` typically completes in a few seconds, compared to the multi-minute compilation previously required. This reduces total CI wall-clock time for every push and pull request.

## Security Considerations

- [x] No security implications

The change only affects how `cargo-audit` is installed, not how it is run or what it audits. The `taiki-e/install-action` is a widely-used, maintained GitHub Action for fetching prebuilt Rust tool binaries.

## Breaking Changes

None. This is a purely internal CI change with no impact on the project's build artifacts, API, or behavior.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Alternatives Considered:**
- Continuing to use `cargo install --locked` with a dedicated binary caching step (e.g., caching `~/.cargo/bin`) — rejected in favour of the simpler, already-established `taiki-e/install-action` pattern already used elsewhere in the same workflow.

**Known Limitations:**
- The version of `cargo-audit` fetched by `taiki-e/install-action` is determined by the action's own release matrix. If a specific pinned version is required in future, a `tool: cargo-audit@X.Y.Z` specifier can be added.