### PR TITLE
feat(atlassian): document --set-field semantics and add option value validation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -728,6 +728,10 @@ omni-dev atlassian jira create body.json --format adf --project PROJ --summary "
 omni-dev atlassian jira create issue.md --set-field "Story Points=5" \
   --set-field "Sprint=customfield_10020"
 
+# Values may contain spaces, parentheses, and '=' — only shell quoting is needed
+omni-dev atlassian jira create issue.md \
+  --set-field "Work Type=Product Features (Planned)"
+
 # Target a specific instance (overrides ATLASSIAN_INSTANCE_URL / settings.json)
 omni-dev atlassian jira create issue.md --instance https://other.atlassian.net
 
@@ -746,10 +750,36 @@ ignored: it never routes requests. The target instance comes from `--instance`
 (when given), otherwise from auth config (`ATLASSIAN_INSTANCE_URL` env /
 `settings.json`), never from the document.
 
-Prints the created issue key (e.g., `PROJ-124`) to stdout. `--set-field`
-values are parsed as YAML scalars (numbers, bools) when possible, falling
-back to strings; entries override the frontmatter `custom_fields:` map for
-the same name.
+Prints the created issue key (e.g., `PROJ-124`) to stdout.
+
+`--set-field "NAME=VALUE"` semantics:
+
+- **Splitting.** The argument is split on the **first** `=` only. `NAME` is
+  everything before it (surrounding whitespace trimmed); `VALUE` is everything
+  after, kept verbatim — spaces, parentheses, and further `=` are all literal,
+  so the only quoting needed is your shell's.
+- **Value typing.** `VALUE` is parsed as a YAML scalar (number, bool) when
+  possible, otherwise a string. The shape actually sent then follows the
+  field's schema: option/select fields send `{"value": "…"}`, number fields
+  send a JSON number, array-of-option fields take a YAML list, and rich-text
+  (ADF) fields take JFM markdown. So `--set-field "Story Points=5"` sends the
+  number `5` for a numeric field, whereas an option field receives the string
+  `"5"` wrapped as `{"value": "5"}`.
+- **Field resolution.** `NAME` resolves against the create screen for the
+  target project + issue type. A `customfield_<digits>` id is matched first;
+  otherwise the **display name** is matched exactly. The field **must be on the
+  create screen** — an unknown name fails up front with the list of accepted
+  fields (it is never silently dropped), and an ambiguous display name lists
+  the matching ids.
+- **Option validation.** For option fields whose allowed values are known, a
+  value outside that set is rejected before the request with a clear,
+  field-named error. Fields that do not enumerate their values are sent as-is
+  and validated by JIRA (its error is surfaced verbatim).
+- **Precedence.** A `--set-field` entry overrides the frontmatter
+  `custom_fields:` entry of the same name.
+
+Run [`jira project create-meta`](#jira-projects) to see which fields a
+project + issue type accepts, their types, and allowed values.
 
 #### JIRA: Transitions
 

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -192,6 +192,15 @@ pub struct EditMetaField {
 
     /// Schema describing the field's wire type.
     pub schema: EditMetaSchema,
+
+    /// Permitted option `value`s for option-like fields (`select`,
+    /// `radiobuttons`, multi-select), taken from the meta `allowedValues`.
+    /// Empty when the field does not enumerate values (free text, numbers,
+    /// user pickers, cascading selects) — in which case `--set-field` values
+    /// pass through for the API to validate. Used to reject an out-of-range
+    /// option before the request; see
+    /// [`crate::atlassian::custom_fields`].
+    pub allowed_values: Vec<String>,
 }
 
 /// Schema type information for an editable field.
@@ -1065,6 +1074,20 @@ struct JiraEditMetaField {
     name: Option<String>,
     #[serde(default)]
     schema: Option<JiraEditMetaSchemaRaw>,
+    #[serde(rename = "allowedValues", default)]
+    allowed_values: Vec<JiraAllowedValueRaw>,
+}
+
+impl JiraEditMetaField {
+    /// Flattens the raw `allowedValues` to their display `value`s (falling back
+    /// to `name`) for option validation. Cascading `children` are ignored —
+    /// `--set-field` targets only the top-level option.
+    fn allowed_value_strings(&self) -> Vec<String> {
+        self.allowed_values
+            .iter()
+            .filter_map(|v| v.value.clone().or_else(|| v.name.clone()))
+            .collect()
+    }
 }
 
 #[derive(Deserialize)]
@@ -2847,7 +2870,11 @@ mod tests {
                                         "type": "option",
                                         "custom": "com.atlassian.jira.plugin.system.customfieldtypes:select",
                                         "customId": 10001
-                                    }
+                                    },
+                                    "allowedValues": [
+                                        {"value": "Planned", "id": "10100"},
+                                        {"value": "Unplanned", "id": "10101"}
+                                    ]
                                 }
                             }
                         }]
@@ -2864,6 +2891,8 @@ mod tests {
         let field = meta.fields.get("customfield_10001").unwrap();
         assert_eq!(field.name, "Planned / Unplanned Work");
         assert_eq!(field.schema.kind, "option");
+        // allowedValues flow into EditMetaField for --set-field validation.
+        assert_eq!(field.allowed_values, vec!["Planned", "Unplanned"]);
     }
 
     #[tokio::test]
@@ -7390,6 +7419,7 @@ impl AtlassianClient {
             .fields
             .into_iter()
             .map(|(id, field)| {
+                let allowed_values = field.allowed_value_strings();
                 let schema = field.schema.map_or_else(
                     || EditMetaSchema {
                         kind: String::new(),
@@ -7405,6 +7435,7 @@ impl AtlassianClient {
                     EditMetaField {
                         name: field.name.unwrap_or_default(),
                         schema,
+                        allowed_values,
                     },
                 )
             })
@@ -7548,6 +7579,7 @@ impl AtlassianClient {
             .fields
             .into_iter()
             .map(|(id, field)| {
+                let allowed_values = field.allowed_value_strings();
                 let schema = field.schema.map_or_else(
                     || EditMetaSchema {
                         kind: String::new(),
@@ -7563,6 +7595,7 @@ impl AtlassianClient {
                     EditMetaField {
                         name: field.name.unwrap_or_default(),
                         schema,
+                        allowed_values,
                     },
                 )
             })

--- a/src/atlassian/custom_fields.rs
+++ b/src/atlassian/custom_fields.rs
@@ -46,7 +46,7 @@ pub fn resolve_custom_fields(
             out.insert(id, payload);
             continue;
         }
-        let payload = scalar_to_api_value(value, field).with_context(|| {
+        let payload = scalar_to_api_value(value, field, &id).with_context(|| {
             format!(
                 "Failed to convert custom field '{}' ({}) to API value",
                 field.name, id
@@ -223,6 +223,7 @@ pub fn convert_textarea_string_values(
 fn scalar_to_api_value(
     value: &serde_yaml::Value,
     field: &EditMetaField,
+    id: &str,
 ) -> Result<serde_json::Value> {
     let kind = field.schema.kind.as_str();
     let custom = field.schema.custom.as_deref();
@@ -231,6 +232,7 @@ fn scalar_to_api_value(
             let s = yaml_as_string(value).with_context(|| {
                 format!("expected a string for option field '{}'", field.name)
             })?;
+            validate_option_value(field, id, &s)?;
             Ok(serde_json::json!({ "value": s }))
         }
         ("array", _) => {
@@ -246,6 +248,7 @@ fn scalar_to_api_value(
                             field.name
                         )
                     })?;
+                    validate_option_value(field, id, &s)?;
                     Ok(serde_json::json!({ "value": s }))
                 })
                 .collect::<Result<_>>()?;
@@ -257,6 +260,31 @@ fn scalar_to_api_value(
             field.name
         )),
     }
+}
+
+/// Validates a supplied option string against a field's enumerated
+/// `allowedValues`, when the meta reports them.
+///
+/// Matching is exact and case-sensitive — JIRA's own contract for option
+/// `value`s. Fuzzy matching is deliberately avoided: silently coercing a
+/// value the caller did not type is worse than a clear error.
+///
+/// When the field does not enumerate values — free text, numbers, user
+/// pickers, cascading selects — `allowed_values` is empty, so the check is
+/// skipped and the API performs final validation (surfaced verbatim as an
+/// HTTP error). This turns the common "typo'd select value → opaque HTTP 400"
+/// failure into an actionable, field-named error before the request.
+fn validate_option_value(field: &EditMetaField, id: &str, value: &str) -> Result<()> {
+    if field.allowed_values.is_empty() || field.allowed_values.iter().any(|v| v == value) {
+        return Ok(());
+    }
+    bail!(
+        "Field '{}' ({}): '{}' is not an allowed option. Valid options: {}",
+        field.name,
+        id,
+        value,
+        field.allowed_values.join(", ")
+    )
 }
 
 fn yaml_as_string(value: &serde_yaml::Value) -> Result<String> {
@@ -366,9 +394,28 @@ mod tests {
                         kind: (*kind).to_string(),
                         custom: custom.map(str::to_string),
                     },
+                    allowed_values: Vec::new(),
                 },
             );
         }
+        EditMeta { fields }
+    }
+
+    /// Builds a single-field [`EditMeta`] for an option-like field that
+    /// enumerates `allowedValues`.
+    fn meta_with_allowed(id: &str, name: &str, kind: &str, allowed: &[&str]) -> EditMeta {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            id.to_string(),
+            EditMetaField {
+                name: name.to_string(),
+                schema: EditMetaSchema {
+                    kind: kind.to_string(),
+                    custom: None,
+                },
+                allowed_values: allowed.iter().map(|v| (*v).to_string()).collect(),
+            },
+        );
         EditMeta { fields }
     }
 
@@ -806,6 +853,106 @@ mod tests {
             out.get("customfield_num").unwrap(),
             &serde_json::json!({"value": "3"})
         );
+    }
+
+    #[test]
+    fn option_value_matching_allowed_values_passes() {
+        let editmeta = meta_with_allowed(
+            "customfield_21051",
+            "Work Attribution",
+            "option",
+            &["Planned", "Unplanned"],
+        );
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Work Attribution".to_string(),
+            serde_yaml::Value::String("Planned".to_string()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_21051").unwrap(),
+            &serde_json::json!({ "value": "Planned" })
+        );
+    }
+
+    #[test]
+    fn option_value_not_in_allowed_values_errors_with_field_and_options() {
+        let editmeta = meta_with_allowed(
+            "customfield_21051",
+            "Work Attribution",
+            "option",
+            &["Planned", "Unplanned"],
+        );
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Work Attribution".to_string(),
+            serde_yaml::Value::String("Plnned".to_string()),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Work Attribution"), "got: {msg}");
+        assert!(msg.contains("customfield_21051"), "got: {msg}");
+        assert!(
+            msg.contains("'Plnned' is not an allowed option"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("Planned, Unplanned"), "got: {msg}");
+    }
+
+    #[test]
+    fn option_value_matching_is_case_sensitive() {
+        // "planned" != "Planned" — JIRA's option contract is case-sensitive,
+        // and fuzzy coercion is deliberately avoided.
+        let editmeta = meta_with_allowed(
+            "customfield_21051",
+            "Work Attribution",
+            "option",
+            &["Planned"],
+        );
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Work Attribution".to_string(),
+            serde_yaml::Value::String("planned".to_string()),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        assert!(format!("{err:#}").contains("not an allowed option"));
+    }
+
+    #[test]
+    fn option_field_without_allowed_values_passes_any_value_through() {
+        // No enumerated allowedValues: skip local validation, let the API decide.
+        let editmeta = meta(&[("customfield_21051", "Work Attribution", "option", None)]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Work Attribution".to_string(),
+            serde_yaml::Value::String("Anything".to_string()),
+        );
+        let out = resolve_custom_fields(&scalars, &[], &editmeta).unwrap();
+        assert_eq!(
+            out.get("customfield_21051").unwrap(),
+            &serde_json::json!({ "value": "Anything" })
+        );
+    }
+
+    #[test]
+    fn array_option_element_not_in_allowed_values_errors() {
+        let editmeta =
+            meta_with_allowed("customfield_10004", "Teams", "array", &["backend", "auth"]);
+        let mut scalars = BTreeMap::new();
+        scalars.insert(
+            "Teams".to_string(),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("backend".to_string()),
+                serde_yaml::Value::String("frontend".to_string()),
+            ]),
+        );
+        let err = resolve_custom_fields(&scalars, &[], &editmeta).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("'frontend' is not an allowed option"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("backend, auth"), "got: {msg}");
     }
 
     #[test]

--- a/src/cli/atlassian/jira/create.rs
+++ b/src/cli/atlassian/jira/create.rs
@@ -75,10 +75,25 @@ pub struct CreateCommand {
     #[arg(long)]
     pub summary: Option<String>,
 
-    /// Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used
-    /// multiple times. Values are parsed as YAML scalars (numbers, bools)
-    /// when possible, falling back to strings. Overrides values from the
-    /// frontmatter `custom_fields:` map for the same name.
+    /// Set a custom field inline, e.g. `--set-field "Story Points=5"`.
+    /// Repeatable.
+    ///
+    /// Split on the FIRST `=`: NAME is everything before it (surrounding
+    /// spaces trimmed), VALUE everything after — spaces, parentheses, and
+    /// further `=` are kept verbatim, so only your shell's quoting is needed
+    /// (e.g. `--set-field "Work Type=Product Features (Planned)"`).
+    ///
+    /// VALUE is parsed as a YAML scalar (number, bool) when possible, else a
+    /// string; the wire type then follows the field's schema — option fields
+    /// send `{"value": ...}`, number fields send a number, and so on.
+    ///
+    /// NAME resolves against the project + issue-type create screen: a
+    /// `customfield_<digits>` id matches first, otherwise the display name.
+    /// The field must be on the create screen or the command errors listing
+    /// the accepted fields; for option fields a value outside the allowed set
+    /// is rejected up front. Run `omni-dev atlassian jira project create-meta`
+    /// to list accepted fields, their types, and allowed values. Overrides the
+    /// frontmatter `custom_fields:` entry of the same name.
     #[arg(long = "set-field", value_name = "NAME=VALUE")]
     pub set_fields: Vec<String>,
 

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -1218,7 +1218,7 @@ Options:
       --project <PROJECT>       Project key (e.g., "PROJ"). Overrides frontmatter
       --type <TYPE>             Issue type (e.g., "Task", "Bug", "Story"). Overrides frontmatter
       --summary <SUMMARY>       Issue summary/title. Overrides frontmatter
-      --set-field <NAME=VALUE>  Set a custom field inline: `--set-field "NAME=VALUE"`. Can be used multiple times. Values are parsed as YAML scalars (numbers, bools) when possible, falling back to strings. Overrides values from the frontmatter `custom_fields:` map for the same name
+      --set-field <NAME=VALUE>  Set a custom field inline, e.g. `--set-field "Story Points=5"`. Repeatable
       --dry-run                 Shows what would be sent without creating
   -h, --help                    Print help (see more with '--help')
 


### PR DESCRIPTION
## Description

This PR documents the complete semantics of `--set-field "NAME=VALUE"` for the JIRA create command and adds client-side validation for option fields. Previously, users supplying an invalid option value (e.g., a typo in a select field) would receive an opaque HTTP 400 from JIRA. Now, omni-dev validates the value against the field's `allowedValues` before sending the request, providing a clear, field-named error message.

The documentation update clarifies all aspects of `--set-field` behaviour: how the argument is split, how values are typed, how field names are resolved, and how option validation works.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #1053

## Changes Made

**Core Changes (`src/atlassian/client.rs`):**
- Added `allowed_values: Vec<String>` field to `EditMetaField` struct to carry permitted option values from the JIRA edit meta API
- Added `JiraAllowedValueRaw` deserialization struct and `#[serde(rename = "allowedValues", default)]` annotation on `JiraEditMetaField`
- Added `JiraEditMetaField::allowed_value_strings()` method that flattens raw `allowedValues` to their display `value`s (falling back to `name`), ignoring cascading `children`
- Populated `allowed_values` in both field-building paths (create meta and edit meta)
- Updated existing test to assert that `allowedValues` flow through correctly into `EditMetaField`

**Option Validation (`src/atlassian/custom_fields.rs`):**
- Added `id: &str` parameter to `scalar_to_api_value` to enable field-named error messages
- Added `validate_option_value(field, id, value)` function that rejects values not in `allowed_values` (exact, case-sensitive match) before the request; skips check when `allowed_values` is empty (free text, numbers, user pickers, cascading selects)
- Called `validate_option_value` for both single `option` fields and each element of `array` option fields

**CLI Help Text (`src/cli/atlassian/jira/create.rs`):**
- Rewrote `--set-field` argument documentation to fully describe splitting rules, value typing, field resolution, option validation, and precedence over frontmatter `custom_fields:`
- Updated `tests/snapshots/integration_test__help_all_output.snap` to match new condensed short-form help text

**Documentation (`docs/user-guide.md`):**
- Added example showing `--set-field` with a value containing spaces and parentheses
- Expanded `--set-field` section into structured bullet points covering: splitting, value typing, field resolution, option validation, and precedence
- Added reference to `jira project create-meta` command for discovering accepted fields and their allowed values

**Testing (`src/atlassian/custom_fields.rs`):**
- Added `meta_with_allowed()` test helper that builds an `EditMeta` with enumerated `allowedValues`
- Added 5 new unit tests:
  - `option_value_matching_allowed_values_passes` — valid option value is accepted
  - `option_value_not_in_allowed_values_errors_with_field_and_options` — error message names the field, the id, the bad value, and lists valid options
  - `option_value_matching_is_case_sensitive` — `"planned"` is rejected when only `"Planned"` is allowed
  - `option_field_without_allowed_values_passes_any_value_through` — no local validation when `allowedValues` is absent
  - `array_option_element_not_in_allowed_values_errors` — invalid element in a multi-select array is caught

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (5 new unit tests in `custom_fields.rs`, 1 updated client test)
- [x] Integration snapshot updated
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path: valid option value is accepted and sent as `{"value": "Planned"}`
- [x] Tested error case: typo'd option value produces clear field-named error before HTTP request
- [x] Tested case sensitivity: `"planned"` is rejected when only `"Planned"` is valid
- [x] Tested fields without `allowedValues`: any value passes through to API
- [x] Backward compatibility verified: existing usage with free-text, number, and user-picker fields is unaffected

### Test Commands
```bash
# Core test suite
cargo test

# Run atlassian-specific tests
cargo test atlassian

# Run custom fields tests specifically
cargo test custom_fields

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — `validate_option_value` error messages should be actionable and include field name, field id, the bad value, and the full list of valid options
- [x] Backward compatibility — fields without `allowedValues` (free text, numbers, user pickers, cascading selects) must continue to pass through unchanged
- [x] User experience — the new `--set-field` help text and user guide documentation accurately describes all semantics

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

The `allowed_values` check is a simple linear scan over a small slice (typical select fields have < 20 options) performed once per field before the HTTP request, which is negligible.

## Security Considerations
- [x] No security implications

This change performs client-side validation of user-supplied values against a server-provided allowlist, which can only fail safe (reject) — it does not introduce any new trust surface.

## Breaking Changes

None. All existing `--set-field` usages continue to work. Fields that previously had no `allowedValues` in the create meta will still pass through for API validation unchanged. The only new behaviour is that option fields with enumerated `allowedValues` now produce a clearer error locally instead of an opaque HTTP 400.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Fuzzy / case-insensitive suggestion ("did you mean 'Planned'?") could be added on top of the existing validation as a quality-of-life improvement without changing the strict exact-match contract
- The same `allowed_values` field could be used to drive autocompletion for `--set-field` values in shell completions

**Known Limitations:**
- Cascading select fields (parent/child option pairs) are not validated locally; only the top-level value is exposed through `allowedValues`. The child value continues to be validated by the JIRA API.
- The `allowed_values` list is populated from the create/edit meta at the time of the request; it reflects the JIRA configuration at that moment.

**Alternatives Considered:**
- Fuzzy/case-insensitive matching was deliberately rejected: silently coercing a value the user did not type is worse than a clear error, and JIRA's option contract is exact and case-sensitive.