### PR TITLE
fix(mcp): serialise resources env tests on canonical AUTH_ENV_MUTEX

### DIFF
--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -595,11 +595,19 @@ mod tests {
     //
     // These tests exercise the JIRA/Confluence branches by pointing
     // `ATLASSIAN_*` env vars at a wiremock server and checking the
-    // full handler path. `ENV_MUTEX` serialises env-var access — the
-    // stdlib warns that process-env access races across threads, and
-    // `create_client` reads these vars internally.
-
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // full handler path. `create_client` reads these vars internally, so
+    // env-var access must be serialised across threads.
+    //
+    // Route through the crate-wide `AUTH_ENV_MUTEX` rather than a local
+    // mutex: it is the *one* canonical lock for every test that mutates the
+    // Atlassian credential env vars. Independent mutexes over the same
+    // process-global vars provide no mutual exclusion and caused a flaky env
+    // race (issues #950, #1075).
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 
     struct EnvGuard {
         keys: Vec<&'static str>,
@@ -653,7 +661,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         let _env = EnvGuard::set(&[
             ("ATLASSIAN_INSTANCE_URL", server.uri()),
             ("ATLASSIAN_EMAIL", "test@example.com".to_string()),
@@ -708,7 +716,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         let _env = EnvGuard::set(&[
             ("ATLASSIAN_INSTANCE_URL", server.uri()),
             ("ATLASSIAN_EMAIL", "test@example.com".to_string()),
@@ -743,7 +751,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         let _env = EnvGuard::set(&[
             ("ATLASSIAN_INSTANCE_URL", server.uri()),
             ("ATLASSIAN_EMAIL", "test@example.com".to_string()),
@@ -804,7 +812,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         let _env = EnvGuard::set(&[
             ("ATLASSIAN_INSTANCE_URL", server.uri()),
             ("ATLASSIAN_EMAIL", "test@example.com".to_string()),
@@ -849,7 +857,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         let _env = EnvGuard::set(&[
             ("ATLASSIAN_INSTANCE_URL", server.uri()),
             ("ATLASSIAN_EMAIL", "test@example.com".to_string()),
@@ -872,7 +880,7 @@ mod tests {
         // No ATLASSIAN_* env vars set → create_client() fails in the JIRA
         // branch of read_resource, exercising the "Failed to load Atlassian
         // credentials" context wrap.
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         // Scrub any stray vars the surrounding process may have set so
         // create_client() definitively fails.
         for key in [
@@ -900,7 +908,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn read_resource_confluence_without_credentials_errors() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = env_lock();
         for key in [
             "ATLASSIAN_INSTANCE_URL",
             "ATLASSIAN_EMAIL",


### PR DESCRIPTION
## Description

`src/mcp/jira_tools.rs::jira_project_create_meta_handler_returns_success`
flaked under the parallel test runner (#1075). The earlier approach on this
branch deleted the test; chasing the resulting coverage gap surfaced the
**actual root cause**, which deletion only masked.

## Root cause

[`src/mcp/resources.rs`](../blob/main/src/mcp/resources.rs) guarded its
`ATLASSIAN_*`-mutating tests with a **local** `ENV_MUTEX`, independent of the
crate-wide `AUTH_ENV_MUTEX` that every other Atlassian-env test serialises on
(`confluence_tools.rs`, `cli/atlassian/confluence/mod.rs`,
`cli/atlassian/jira/user.rs`, `test_support.rs::AtlassianEnvGuard`).

Independent mutexes over the same process-global env provide **no** mutual
exclusion. So the `resources.rs` tests raced the jira handler test: one would
repoint the shared `ATLASSIAN_INSTANCE_URL` at its own wiremock server (or
`remove_var` the credentials on drop) while the handler test's
`create_client()` was resolving them — so the client targeted the wrong
server (or returned `CredentialsNotFound`), and the test's `.unwrap()`
panicked. This is the exact failure mode `test_support.rs` documents from
issue #950; `resources.rs` was the lone holdout still using a private mutex.

## Fix

- **`src/mcp/resources.rs`** — replace the stray `ENV_MUTEX` with an
  `env_lock()` helper routing through the canonical `AUTH_ENV_MUTEX`,
  mirroring `confluence_tools.rs` / `jira/user.rs`. *This is the actual fix.*
- The flaky test is **kept as-is** (no coverage lost — the prior deletion is
  reverted), and is now race-free.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- 20/20 parallel `cargo test --features mcp --lib 'mcp::'` runs green.
- **Counterfactual (proves causation):** reverting *only* the `resources.rs`
  change while keeping the test reproduces the flake (7 failures on run 9/12);
  restoring the fix → clean again.
- `cargo fmt --check` and `cargo clippy --features mcp --lib` clean.

## Related Issue
Fixes #1075