### PR TITLE
docs(mcp): audit MCP description quality and add STYLE-0029 checklist (refs #1072)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -26,7 +26,7 @@ which tags apply to the changes and search this file for those tags. Each rule h
 | After creating commits (before push / PR)        | `commits`                                |
 | Suppressing a lint or considering `unsafe`       | `code-style`, `unsafe`                   |
 | Writing or updating an ADR                       | `adrs`                                   |
-| Adding an MCP tool, resource, or param struct    | `api-design`, `module-organization`, `testing` |
+| Adding an MCP tool, resource, or param struct    | `api-design`, `module-organization`, `testing`, `documentation` |
 | Adding or modifying a docs/plan/ file            | `documentation`, `adrs`                  |
 | Reading env vars, or testing env-dependent code  | `testing`, `module-organization`         |
 | Reviewing code for style compliance              | All tags relevant to the changed code    |
@@ -43,7 +43,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0028`) and include:
+Assign the next sequential ID (currently next is `STYLE-0030`) and include:
 
 1. A **Tags** line immediately after the heading — a comma-separated list of category labels
    from the tag vocabulary below.
@@ -1470,3 +1470,76 @@ and `set_var`/`remove_var` are `unsafe` in Rust 2024. Injecting the resolved
 value removes the shared hazard entirely: env-dependent tests become pure,
 order-independent, lock-free, and fully parallel. A fresh bespoke env lock
 added *after* #821 (`datadog/*`) is exactly the regression this rule prevents.
+
+## STYLE-0029: MCP tool & parameter description checklist
+
+**Tags:** `documentation`, `api-design`
+
+### Situation
+
+Writing or revising any `#[tool(description = "…")]` text or any doc comment on
+a `*Params` struct field under `src/mcp/`. These strings are the **only** thing
+an AI agent reads to decide how to call a tool: field doc comments flow through
+`schemars::JsonSchema` into each field's JSON-schema `description`, and
+`description = "…"` sets the tool-level text. [STYLE-0026](#style-0026-mcp-tool-and-resource-authoring-conventions)
+covers the *wiring* (struct shape, router, tests); this rule covers the *prose
+quality* the agent actually reads.
+
+### Guidance
+
+Every tool description and parameter doc comment must satisfy this checklist.
+The reference exemplars are [`LinkCreateParams`](../src/mcp/jira_tools.rs)
+(`inward`/`outward` with the concrete `Blocks` example) and the
+[`git_*` tool descriptions](../src/mcp/git_tools.rs).
+
+**Tool-level `description`:**
+
+1. **One-line "what it does"** as the first sentence — a single, skimmable
+   summary an agent reads before the params.
+2. **CLI cross-reference, both directions.** The tool description names its
+   equivalent subcommand: ``Mirrors `omni-dev <subcommand>`.`` The clap
+   subcommand's doc comment carries the reverse, ending with
+   ``(mirrors the `<tool_name>` MCP tool)`` (see
+   [src/cli/atlassian/jira/link.rs](../src/cli/atlassian/jira/link.rs)). The
+   two must stay in lock-step. A tool with no CLI equivalent (e.g.
+   `atlassian_convert`'s `system_prompt` override) says so explicitly.
+3. **"When to use vs `<sibling>`"** wherever two tools overlap or could be
+   confused (e.g. updating a body via `jira_write` vs setting hierarchy via
+   `jira_link_parent`; `jira_link_create` vs `jira_link_parent`). One sentence
+   pointing at the sibling and when to prefer it.
+4. **A concrete example in the tool text**, not only on fields — a real key
+   (`PROJ-123`), a real enum value, or a one-line call shape. Surface the
+   single most error-prone value at the tool level the agent skims first.
+5. **Mutating/destructive affordances.** State any `dry_run`, `confirm`, or
+   preflight behaviour and its default (e.g. "Set `dry_run = true` to return
+   the would-be request without sending it"; "Requires `confirm: true`").
+
+**Per-parameter doc comment:**
+
+6. **A concrete example value** — ``e.g. `PROJ-123` ``, ``e.g. `2025-01-31` ``,
+   ``e.g. `Blocks` ``.
+7. **Allowed values for enums / closed sets** spelled out
+   (``one of `future`, `active`, `closed` ``) — don't make the agent guess.
+8. **Expected wire format** — JFM markdown vs ADF JSON, `YYYY-MM-DD`, JIRA
+   duration (`2h 30m`), Atlassian `accountId` vs display name, JQL/CQL.
+9. **Directional / order-dependent semantics spelled out** — never "source" /
+   "target" alone. Name which end is which, with an example: *"Source (inward)
+   issue — for `Blocks`, the issue doing the blocking."* This is the #1054
+   regression this rule exists to prevent.
+10. **Required vs optional.** Optional fields use `#[serde(default)]` +
+    `Option<T>` (per STYLE-0026) and the doc comment states the default
+    behaviour when the field is omitted.
+
+Keep [docs/mcp.md](mcp.md)'s tool catalog in sync when a tool's purpose or CLI
+mapping changes, and run the [`update-snapshots`](../.claude/skills/update-snapshots/SKILL.md)
+skill whenever the reverse-reference edits change CLI `--help` text.
+
+### Motivation
+
+An agent's success rate is bounded by how unambiguous these strings are. A
+vague description produces wrong-but-silent calls — an inverted `Blocks`
+dependency (#1054), a display name where an `accountId` was required, a body
+update where a parent link was meant — each costing a recovery round-trip or
+quietly corrupting data. #1049 fixed one tool (`jira_link_create`) to this bar;
+this checklist generalises it so the whole `src/mcp/` surface meets the same
+standard rather than drifting tool-by-tool.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -72,6 +72,14 @@ Read tools accept an optional `output_file` parameter (see [Cross-cutting
 parameters](#cross-cutting-parameters)). Destructive tools require an
 explicit `confirm: true`.
 
+Every tool's `description` and parameter doc comments follow the checklist in
+[STYLE-0029](STYLE_GUIDE.md#style-0029-mcp-tool--parameter-description-checklist):
+a one-line summary, concrete example values, allowed enum values, the expected
+wire format, directional semantics where order matters, and a `Mirrors
+\`omni-dev <subcommand>\`` cross-reference. Each equivalent CLI subcommand
+carries the reverse reference (`mirrors the \`<tool>\` MCP tool`) in its
+`--help`, so the two surfaces stay discoverable from each other.
+
 ### Git (5 tools)
 
 | Tool | Purpose | CLI equivalent |
@@ -132,7 +140,7 @@ project listing and create-screen introspection, and changelog history.
 | `confluence_label_remove` | Remove a label from a page. Requires `confirm: true` |
 | `confluence_user_search` | Resolve a display name or email to an Atlassian `accountId` |
 | `confluence_compare` | Structural diff between two versions of a page. `detail`: `summary`, `outline` (default), or `full`. Returns drill-in cursors. See [user guide](user-guide.md#confluence-comparing-pages) |
-| `confluence_compare_section` | Drill into a single section delta via a cursor returned from `confluence_compare`. `format`: `unified`, `side-by-side`, `markdown-inline` |
+| `confluence_compare_section` | Drill into a single section delta via a cursor returned from `confluence_compare`. `format`: `unified`, `side_by_side`, `markdown_inline` |
 
 ### Atlassian — shared (2 tools)
 

--- a/src/cli/ai/claude/skills/mod.rs
+++ b/src/cli/ai/claude/skills/mod.rs
@@ -28,11 +28,11 @@ pub struct SkillsCommand {
 /// Skills subcommands.
 #[derive(Subcommand)]
 pub enum SkillsSubcommands {
-    /// Syncs skills from a source repository into one or more targets.
+    /// Syncs skills from a source repository into one or more targets (mirrors the `claude_skills_sync` MCP tool).
     Sync(sync::SyncCommand),
-    /// Removes skill symlinks and managed exclude block previously created by `sync`.
+    /// Removes skill symlinks and managed exclude block previously created by `sync` (mirrors the `claude_skills_clean` MCP tool).
     Clean(clean::CleanCommand),
-    /// Reports residue left by `sync` — symlinks and managed exclude-block entries.
+    /// Reports residue left by `sync` — symlinks and managed exclude-block entries (mirrors the `claude_skills_status` MCP tool).
     Status(status::StatusCommand),
 }
 

--- a/src/cli/atlassian/auth.rs
+++ b/src/cli/atlassian/auth.rs
@@ -21,7 +21,7 @@ pub struct AuthCommand {
 pub enum AuthSubcommands {
     /// Configures Atlassian Cloud credentials interactively.
     Login(LoginCommand),
-    /// Shows the current authentication status.
+    /// Shows the current authentication status (mirrors the `atlassian_auth_status` MCP tool).
     Status(StatusCommand),
 }
 

--- a/src/cli/atlassian/confluence/attachment.rs
+++ b/src/cli/atlassian/confluence/attachment.rs
@@ -23,13 +23,13 @@ pub struct AttachmentCommand {
 /// Attachment subcommands.
 #[derive(Subcommand)]
 pub enum AttachmentSubcommands {
-    /// Uploads a file as an attachment to a Confluence page.
+    /// Uploads a file as an attachment to a Confluence page (mirrors the `confluence_attachment_upload` MCP tool).
     Upload(UploadCommand),
-    /// Lists attachments on a Confluence page.
+    /// Lists attachments on a Confluence page (mirrors the `confluence_attachment_list` MCP tool).
     List(ListCommand),
-    /// Downloads an attachment binary by ID.
+    /// Downloads an attachment binary by ID (mirrors the `confluence_attachment_download` MCP tool).
     Download(DownloadCommand),
-    /// Deletes an attachment by ID.
+    /// Deletes an attachment by ID (mirrors the `confluence_attachment_delete` MCP tool).
     Delete(DeleteCommand),
 }
 

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -24,13 +24,13 @@ pub struct CommentCommand {
 /// Comment subcommands.
 #[derive(Subcommand)]
 pub enum CommentSubcommands {
-    /// Lists comments on a Confluence page.
+    /// Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool).
     List(ListCommand),
-    /// Adds a footer comment to a Confluence page.
+    /// Adds a footer comment to a Confluence page (mirrors the `confluence_comment_add` MCP tool).
     Add(AddCommand),
-    /// Adds an inline (anchored) comment to a Confluence page.
+    /// Adds an inline (anchored) comment to a Confluence page (mirrors the `confluence_comment_add_inline` MCP tool).
     AddInline(AddInlineCommand),
-    /// Lists the replies of a comment.
+    /// Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool).
     Replies(RepliesCommand),
 }
 

--- a/src/cli/atlassian/confluence/compare.rs
+++ b/src/cli/atlassian/confluence/compare.rs
@@ -132,9 +132,9 @@ pub struct CompareCommandGroup {
 /// Subcommands inside the compare group.
 #[derive(Subcommand)]
 pub enum CompareSubcommands {
-    /// Diff two versions of a Confluence page.
+    /// Diff two versions of a Confluence page (mirrors the `confluence_compare` MCP tool).
     Run(CompareCommand),
-    /// Drill in to a section diff using a cursor from a prior `run`.
+    /// Drill in to a section diff using a cursor from a prior `run` (mirrors the `confluence_compare_section` MCP tool).
     Section(CompareSectionCommand),
 }
 

--- a/src/cli/atlassian/confluence/label.rs
+++ b/src/cli/atlassian/confluence/label.rs
@@ -21,11 +21,11 @@ pub struct LabelCommand {
 /// Label subcommands.
 #[derive(Subcommand)]
 pub enum LabelSubcommands {
-    /// Lists labels on a Confluence page.
+    /// Lists labels on a Confluence page (mirrors the `confluence_label_list` MCP tool).
     List(ListCommand),
-    /// Adds labels to a Confluence page.
+    /// Adds labels to a Confluence page (mirrors the `confluence_label_add` MCP tool).
     Add(AddCommand),
-    /// Removes labels from a Confluence page.
+    /// Removes labels from a Confluence page (mirrors the `confluence_label_remove` MCP tool).
     Remove(RemoveCommand),
 }
 

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -33,29 +33,29 @@ pub struct ConfluenceCommand {
 pub enum ConfluenceSubcommands {
     /// Manages comments on a Confluence page.
     Comment(comment::CommentCommand),
-    /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON.
+    /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON (mirrors the `confluence_read` MCP tool).
     Read(read::ReadCommand),
-    /// Pushes content to a Confluence page.
+    /// Pushes content to a Confluence page (mirrors the `confluence_write` MCP tool).
     Write(write::WriteCommand),
     /// Interactive fetch-edit-push cycle for a Confluence page.
     Edit(edit::EditCommand),
-    /// Searches Confluence pages using CQL.
+    /// Searches Confluence pages using CQL (mirrors the `confluence_search` MCP tool).
     Search(search::SearchCommand),
-    /// Creates a new Confluence page.
+    /// Creates a new Confluence page (mirrors the `confluence_create` MCP tool).
     Create(create::CreateCommand),
-    /// Deletes a Confluence page.
+    /// Deletes a Confluence page (mirrors the `confluence_delete` MCP tool).
     Delete(delete::DeleteCommand),
-    /// Moves or reparents a Confluence page (same-space only).
+    /// Moves or reparents a Confluence page (same-space only) (mirrors the `confluence_move` MCP tool).
     Move(move_page::MoveCommand),
     /// Manages labels on Confluence pages.
     Label(label::LabelCommand),
     /// Manages attachments on Confluence pages.
     Attachment(attachment::AttachmentCommand),
-    /// Recursively downloads a Confluence page tree.
+    /// Recursively downloads a Confluence page tree (mirrors the `confluence_download` MCP tool).
     Download(download::DownloadCommand),
-    /// Lists child pages of a Confluence page or top-level pages in a space.
+    /// Lists child pages of a Confluence page or top-level pages in a space (mirrors the `confluence_children` MCP tool).
     Children(children::ChildrenCommand),
-    /// Lists version history (metadata) for a Confluence page.
+    /// Lists version history (metadata) for a Confluence page (mirrors the `confluence_history` MCP tool).
     History(history::HistoryCommand),
     /// Compares two versions of a Confluence page (structural diff).
     Compare(compare::CompareCommandGroup),

--- a/src/cli/atlassian/confluence/space.rs
+++ b/src/cli/atlassian/confluence/space.rs
@@ -18,9 +18,9 @@ pub struct SpaceCommand {
 /// Space subcommands.
 #[derive(Subcommand)]
 pub enum SpaceSubcommands {
-    /// Lists Confluence spaces.
+    /// Lists Confluence spaces (mirrors the `confluence_space_list` MCP tool).
     List(ListCommand),
-    /// Enumerates pages within a Confluence space.
+    /// Enumerates pages within a Confluence space (mirrors the `confluence_space_pages` MCP tool).
     Pages(PagesCommand),
 }
 

--- a/src/cli/atlassian/confluence/user.rs
+++ b/src/cli/atlassian/confluence/user.rs
@@ -18,7 +18,7 @@ pub struct UserCommand {
 /// Confluence user subcommands.
 #[derive(Subcommand)]
 pub enum UserSubcommands {
-    /// Searches Confluence users by display name or email.
+    /// Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool).
     Search(UserSearchCommand),
 }
 

--- a/src/cli/atlassian/convert.rs
+++ b/src/cli/atlassian/convert.rs
@@ -21,10 +21,10 @@ pub struct ConvertCommand {
 /// Conversion subcommands.
 #[derive(Subcommand)]
 pub enum ConvertSubcommands {
-    /// Converts JFM markdown to ADF JSON.
+    /// Converts JFM markdown to ADF JSON (mirrors the `atlassian_convert` MCP tool).
     #[command(name = "to-adf")]
     ToAdf(ToAdfCommand),
-    /// Converts ADF JSON to JFM markdown.
+    /// Converts ADF JSON to JFM markdown (mirrors the `atlassian_convert` MCP tool).
     #[command(name = "from-adf")]
     FromAdf(FromAdfCommand),
 }

--- a/src/cli/atlassian/jira/attachment.rs
+++ b/src/cli/atlassian/jira/attachment.rs
@@ -29,9 +29,9 @@ pub struct AttachmentCommand {
 /// Attachment subcommands.
 #[derive(Subcommand)]
 pub enum AttachmentSubcommands {
-    /// Downloads all attachments (or filtered by pattern).
+    /// Downloads all attachments (or filtered by pattern) (mirrors the `jira_attachment_download` MCP tool).
     Download(DownloadCommand),
-    /// Downloads only image attachments.
+    /// Downloads only image attachments (mirrors the `jira_attachment_images` MCP tool).
     Images(ImagesCommand),
 }
 

--- a/src/cli/atlassian/jira/board.rs
+++ b/src/cli/atlassian/jira/board.rs
@@ -18,9 +18,9 @@ pub struct BoardCommand {
 /// Board subcommands.
 #[derive(Subcommand)]
 pub enum BoardSubcommands {
-    /// Lists agile boards.
+    /// Lists agile boards (mirrors the `jira_board_list` MCP tool).
     List(ListCommand),
-    /// Lists issues on a board.
+    /// Lists issues on a board (mirrors the `jira_board_issues` MCP tool).
     Issues(IssuesCommand),
 }
 

--- a/src/cli/atlassian/jira/comment.rs
+++ b/src/cli/atlassian/jira/comment.rs
@@ -22,11 +22,11 @@ pub struct CommentCommand {
 /// Comment subcommands.
 #[derive(Subcommand)]
 pub enum CommentSubcommands {
-    /// Lists comments on a JIRA issue.
+    /// Lists comments on a JIRA issue (mirrors the `jira_comment` MCP tool with `action: list`).
     List(ListCommand),
-    /// Adds a comment to a JIRA issue.
+    /// Adds a comment to a JIRA issue (mirrors the `jira_comment` MCP tool with `action: add`).
     Add(AddCommand),
-    /// Edits an existing comment on a JIRA issue.
+    /// Edits an existing comment on a JIRA issue (mirrors the `jira_comment_edit` MCP tool).
     Edit(EditCommand),
 }
 

--- a/src/cli/atlassian/jira/field.rs
+++ b/src/cli/atlassian/jira/field.rs
@@ -18,9 +18,9 @@ pub struct FieldCommand {
 /// Field subcommands.
 #[derive(Subcommand)]
 pub enum FieldSubcommands {
-    /// Lists all field definitions.
+    /// Lists all field definitions (mirrors the `jira_field_list` MCP tool).
     List(ListCommand),
-    /// Shows options for a custom field.
+    /// Shows options for a custom field (mirrors the `jira_field_options` MCP tool).
     Options(OptionsCommand),
 }
 

--- a/src/cli/atlassian/jira/mod.rs
+++ b/src/cli/atlassian/jira/mod.rs
@@ -35,23 +35,23 @@ pub struct JiraCommand {
 /// JIRA subcommands.
 #[derive(Subcommand)]
 pub enum JiraSubcommands {
-    /// Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON.
+    /// Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON (mirrors the `jira_read` MCP tool).
     Read(read::ReadCommand),
-    /// Pushes content to a JIRA issue.
+    /// Pushes content to a JIRA issue (mirrors the `jira_write` MCP tool).
     Write(write::WriteCommand),
     /// Interactive fetch-edit-push cycle for a JIRA issue.
     Edit(edit::EditCommand),
-    /// Searches JIRA issues using JQL.
+    /// Searches JIRA issues using JQL (mirrors the `jira_search` MCP tool).
     Search(search::SearchCommand),
-    /// Creates a new JIRA issue.
+    /// Creates a new JIRA issue (mirrors the `jira_create` MCP tool).
     Create(create::CreateCommand),
     /// Lists or executes workflow transitions on a JIRA issue.
     Transition(transition::TransitionCommand),
     /// Manages comments on a JIRA issue.
     Comment(comment::CommentCommand),
-    /// Deletes a JIRA issue.
+    /// Deletes a JIRA issue (mirrors the `jira_delete` MCP tool).
     Delete(delete::DeleteCommand),
-    /// Shows development status (linked PRs, branches, repositories) for a JIRA issue.
+    /// Shows development status (linked PRs, branches, repositories) for a JIRA issue (mirrors the `jira_dev` MCP tool).
     Dev(dev::DevCommand),
     /// Lists JIRA projects.
     Project(project::ProjectCommand),
@@ -63,7 +63,7 @@ pub enum JiraSubcommands {
     Sprint(sprint::SprintCommand),
     /// Manages JIRA issue links.
     Link(link::LinkCommand),
-    /// Shows change history for JIRA issues.
+    /// Shows change history for JIRA issues (mirrors the `jira_changelog` MCP tool).
     Changelog(changelog::ChangelogCommand),
     /// Downloads JIRA issue attachments.
     Attachment(attachment::AttachmentCommand),

--- a/src/cli/atlassian/jira/project.rs
+++ b/src/cli/atlassian/jira/project.rs
@@ -18,9 +18,9 @@ pub struct ProjectCommand {
 /// Project subcommands.
 #[derive(Subcommand)]
 pub enum ProjectSubcommands {
-    /// Lists all accessible JIRA projects.
+    /// Lists all accessible JIRA projects (mirrors the `jira_project_list` MCP tool).
     List(ListCommand),
-    /// Shows the create-screen fields for a project + issue type.
+    /// Shows the create-screen fields for a project + issue type (mirrors the `jira_project_create_meta` MCP tool).
     CreateMeta(CreateMetaCommand),
 }
 

--- a/src/cli/atlassian/jira/sprint.rs
+++ b/src/cli/atlassian/jira/sprint.rs
@@ -18,15 +18,15 @@ pub struct SprintCommand {
 /// Sprint subcommands.
 #[derive(Subcommand)]
 pub enum SprintSubcommands {
-    /// Lists sprints for a board.
+    /// Lists sprints for a board (mirrors the `jira_sprint_list` MCP tool).
     List(ListCommand),
-    /// Lists issues in a sprint.
+    /// Lists issues in a sprint (mirrors the `jira_sprint_issues` MCP tool).
     Issues(IssuesCommand),
-    /// Adds issues to a sprint.
+    /// Adds issues to a sprint (mirrors the `jira_sprint_add` MCP tool).
     Add(AddCommand),
-    /// Creates a new sprint.
+    /// Creates a new sprint (mirrors the `jira_sprint_create` MCP tool).
     Create(CreateCommand),
-    /// Updates an existing sprint.
+    /// Updates an existing sprint (mirrors the `jira_sprint_update` MCP tool).
     Update(UpdateCommand),
 }
 

--- a/src/cli/atlassian/jira/transition.rs
+++ b/src/cli/atlassian/jira/transition.rs
@@ -18,9 +18,9 @@ pub struct TransitionCommand {
 /// Transition subcommands.
 #[derive(Subcommand)]
 pub enum TransitionSubcommands {
-    /// Lists workflow transitions available from the issue's current status.
+    /// Lists workflow transitions available from the issue's current status (mirrors the `jira_transition_list` MCP tool).
     List(ListCommand),
-    /// Executes a workflow transition on a JIRA issue.
+    /// Executes a workflow transition on a JIRA issue (mirrors the `jira_transition` MCP tool).
     Execute(ExecuteCommand),
 }
 

--- a/src/cli/atlassian/jira/user.rs
+++ b/src/cli/atlassian/jira/user.rs
@@ -18,7 +18,7 @@ pub struct UserCommand {
 /// JIRA user subcommands.
 #[derive(Subcommand)]
 pub enum UserSubcommands {
-    /// Searches JIRA users by display name or email substring.
+    /// Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool).
     Search(UserSearchCommand),
 }
 

--- a/src/cli/atlassian/jira/version.rs
+++ b/src/cli/atlassian/jira/version.rs
@@ -18,9 +18,9 @@ pub struct VersionCommand {
 /// Version subcommands.
 #[derive(Subcommand)]
 pub enum VersionSubcommands {
-    /// Lists versions for a project.
+    /// Lists versions for a project (mirrors the `jira_version_list` MCP tool).
     List(ListCommand),
-    /// Creates a new project version.
+    /// Creates a new project version (mirrors the `jira_version_create` MCP tool).
     Create(CreateCommand),
 }
 

--- a/src/cli/atlassian/jira/watcher.rs
+++ b/src/cli/atlassian/jira/watcher.rs
@@ -21,11 +21,11 @@ pub struct WatcherCommand {
 /// Watcher subcommands.
 #[derive(Subcommand)]
 pub enum WatcherSubcommands {
-    /// Lists current watchers on an issue.
+    /// Lists current watchers on an issue (mirrors the `jira_watcher_list` MCP tool).
     List(ListCommand),
-    /// Adds a user as a watcher on an issue.
+    /// Adds a user as a watcher on an issue (mirrors the `jira_watcher_add` MCP tool).
     Add(AddCommand),
-    /// Removes a user from watchers on an issue.
+    /// Removes a user from watchers on an issue (mirrors the `jira_watcher_remove` MCP tool).
     Remove(RemoveCommand),
 }
 

--- a/src/cli/atlassian/jira/worklog.rs
+++ b/src/cli/atlassian/jira/worklog.rs
@@ -18,9 +18,9 @@ pub struct WorklogCommand {
 /// Worklog subcommands.
 #[derive(Subcommand)]
 pub enum WorklogSubcommands {
-    /// Lists worklogs on a JIRA issue.
+    /// Lists worklogs on a JIRA issue (mirrors the `jira_worklog_list` MCP tool).
     List(ListCommand),
-    /// Adds a worklog entry to a JIRA issue.
+    /// Adds a worklog entry to a JIRA issue (mirrors the `jira_worklog_add` MCP tool).
     Add(AddCommand),
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -32,7 +32,8 @@ pub struct ModelsCommand {
 #[derive(Subcommand)]
 pub enum ModelsSubcommands {
     /// Shows the model catalog (merged user/project layers over the
-    /// embedded `models.yaml`), annotating each entry with its source layer.
+    /// embedded `models.yaml`), annotating each entry with its source layer
+    /// (mirrors the `config_models_show` MCP tool).
     Show(ShowCommand),
 }
 

--- a/src/cli/datadog/auth.rs
+++ b/src/cli/datadog/auth.rs
@@ -24,7 +24,7 @@ pub enum AuthSubcommands {
     Login(LoginCommand),
     /// Removes Datadog API credentials from settings.json.
     Logout(LogoutCommand),
-    /// Shows the current authentication status.
+    /// Shows the current authentication status (mirrors the `datadog_auth_status` MCP tool).
     Status(StatusCommand),
 }
 

--- a/src/cli/datadog/dashboard.rs
+++ b/src/cli/datadog/dashboard.rs
@@ -21,9 +21,9 @@ pub struct DashboardCommand {
 /// Dashboard subcommands.
 #[derive(Subcommand)]
 pub enum DashboardSubcommands {
-    /// Lists dashboards, optionally filtered to shared dashboards.
+    /// Lists dashboards, optionally filtered to shared dashboards (mirrors the `datadog_dashboard_list` MCP tool).
     List(list::ListCommand),
-    /// Fetches a single dashboard definition by id.
+    /// Fetches a single dashboard definition by id (mirrors the `datadog_dashboard_get` MCP tool).
     Get(get::GetCommand),
 }
 

--- a/src/cli/datadog/downtime.rs
+++ b/src/cli/datadog/downtime.rs
@@ -20,7 +20,7 @@ pub struct DowntimeCommand {
 /// Downtime subcommands.
 #[derive(Subcommand)]
 pub enum DowntimeSubcommands {
-    /// Lists scheduled downtimes via `GET /api/v1/downtime`.
+    /// Lists scheduled downtimes via `GET /api/v1/downtime` (mirrors the `datadog_downtime_list` MCP tool).
     List(list::ListCommand),
 }
 

--- a/src/cli/datadog/events.rs
+++ b/src/cli/datadog/events.rs
@@ -20,7 +20,7 @@ pub struct EventsCommand {
 /// Events subcommands.
 #[derive(Subcommand)]
 pub enum EventsSubcommands {
-    /// Lists events via `GET /api/v2/events`.
+    /// Lists events via `GET /api/v2/events` (mirrors the `datadog_events_list` MCP tool).
     List(list::ListCommand),
 }
 

--- a/src/cli/datadog/hosts.rs
+++ b/src/cli/datadog/hosts.rs
@@ -20,7 +20,7 @@ pub struct HostsCommand {
 /// Hosts subcommands.
 #[derive(Subcommand)]
 pub enum HostsSubcommands {
-    /// Lists hosts via `GET /api/v1/hosts`.
+    /// Lists hosts via `GET /api/v1/hosts` (mirrors the `datadog_hosts_list` MCP tool).
     List(list::ListCommand),
 }
 

--- a/src/cli/datadog/logs.rs
+++ b/src/cli/datadog/logs.rs
@@ -20,7 +20,7 @@ pub struct LogsCommand {
 /// Logs subcommands.
 #[derive(Subcommand)]
 pub enum LogsSubcommands {
-    /// Searches log events via `POST /api/v2/logs/events/search`.
+    /// Searches log events via `POST /api/v2/logs/events/search` (mirrors the `datadog_logs_search` MCP tool).
     Search(search::SearchCommand),
 }
 

--- a/src/cli/datadog/metrics.rs
+++ b/src/cli/datadog/metrics.rs
@@ -19,9 +19,9 @@ pub struct MetricsCommand {
 /// Metrics subcommands.
 #[derive(Subcommand)]
 pub enum MetricsSubcommands {
-    /// Executes a point-in-time metrics timeseries query.
+    /// Executes a point-in-time metrics timeseries query (mirrors the `datadog_metrics_query` MCP tool).
     Query(query::QueryCommand),
-    /// Inspects the metric catalog (`/api/v1/metrics`).
+    /// Inspects the metric catalog (`/api/v1/metrics`) (mirrors the `datadog_metrics_catalog_list` MCP tool).
     Catalog(catalog::CatalogCommand),
 }
 

--- a/src/cli/datadog/monitor.rs
+++ b/src/cli/datadog/monitor.rs
@@ -22,11 +22,11 @@ pub struct MonitorCommand {
 /// Monitor subcommands.
 #[derive(Subcommand)]
 pub enum MonitorSubcommands {
-    /// Lists monitors with optional name / tag filters.
+    /// Lists monitors with optional name / tag filters (mirrors the `datadog_monitor_list` MCP tool).
     List(list::ListCommand),
-    /// Fetches a single monitor by id.
+    /// Fetches a single monitor by id (mirrors the `datadog_monitor_get` MCP tool).
     Get(get::GetCommand),
-    /// Searches monitors by free-text / faceted query.
+    /// Searches monitors by free-text / faceted query (mirrors the `datadog_monitor_search` MCP tool).
     Search(search::SearchCommand),
 }
 

--- a/src/cli/datadog/slo.rs
+++ b/src/cli/datadog/slo.rs
@@ -21,9 +21,9 @@ pub struct SloCommand {
 /// SLO subcommands.
 #[derive(Subcommand)]
 pub enum SloSubcommands {
-    /// Lists SLOs with optional tag filter.
+    /// Lists SLOs with optional tag filter (mirrors the `datadog_slo_list` MCP tool).
     List(list::ListCommand),
-    /// Fetches a single SLO definition by id.
+    /// Fetches a single SLO definition by id (mirrors the `datadog_slo_get` MCP tool).
     Get(get::GetCommand),
 }
 

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -90,15 +90,15 @@ pub struct MessageCommand {
 /// Message subcommands.
 #[derive(Subcommand)]
 pub enum MessageSubcommands {
-    /// Analyzes commits and outputs repository information in YAML format.
+    /// Analyzes commits and outputs repository information in YAML format (mirrors the `git_view_commits` MCP tool).
     View(ViewCommand),
     /// Amends commit messages based on a YAML configuration file.
     Amend(AmendCommand),
-    /// AI-powered commit message improvement using Claude.
+    /// AI-powered commit message improvement using Claude (mirrors the `git_twiddle_commits` MCP tool).
     Twiddle(TwiddleCommand),
-    /// Checks commit messages against guidelines without modifying them.
+    /// Checks commit messages against guidelines without modifying them (mirrors the `git_check_commits` MCP tool).
     Check(CheckCommand),
-    /// Generates a commit message from staged changes and commits them.
+    /// Generates a commit message from staged changes and commits them (mirrors the `git_staged_commit` MCP tool).
     Staged(StagedCommand),
 }
 
@@ -113,7 +113,7 @@ pub struct BranchCommand {
 /// Branch subcommands.
 #[derive(Subcommand)]
 pub enum BranchSubcommands {
-    /// Analyzes branch commits and outputs repository information in YAML format.
+    /// Analyzes branch commits and outputs repository information in YAML format (mirrors the `git_branch_info` MCP tool).
     Info(InfoCommand),
     /// Create operations.
     Create(CreateCommand),
@@ -130,7 +130,7 @@ pub struct CreateCommand {
 /// Create subcommands.
 #[derive(Subcommand)]
 pub enum CreateSubcommands {
-    /// Creates a pull request with AI-generated description.
+    /// Creates a pull request with AI-generated description (mirrors the `git_create_pr` MCP tool).
     Pr(CreatePrCommand),
 }
 

--- a/src/mcp/ai_tools.rs
+++ b/src/mcp/ai_tools.rs
@@ -14,12 +14,17 @@ use crate::cli::ai::{self, SkillsFormat};
 /// Parameters for `ai_chat`.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AiChatParams {
-    /// User message to send to the AI.
+    /// User message to send to the AI, e.g. `"Summarise this diff in one
+    /// sentence."`. Sent as a single turn; there is no conversation history.
     pub message: String,
-    /// Optional model identifier (e.g., `claude-sonnet-4-6`).
+    /// Optional model identifier (e.g., `claude-sonnet-4-6`). When omitted,
+    /// the backend's environment-configured default model is used; call
+    /// `config_models_show` to see the identifiers the CLI recognises.
     #[serde(default)]
     pub model: Option<String>,
     /// Optional system prompt; defaults to `"You are a helpful assistant."`.
+    /// MCP-only: the interactive `omni-dev ai chat` CLI has no equivalent flag,
+    /// so this override is reachable only through the tool.
     #[serde(default)]
     pub system_prompt: Option<String>,
 }
@@ -72,9 +77,12 @@ impl OmniDevServer {
     /// Single-turn AI chat. Returns the assistant's response as text.
     #[tool(
         description = "Send a single message to the configured AI (Claude/OpenAI/Ollama/Bedrock) \
-                       and return its response. Non-streaming, single-turn. On missing credentials, \
-                       returns a tool error containing the same diagnostic the CLI would print. \
-                       Mirrors `omni-dev ai chat` in one-shot form."
+                       and return its response. Non-streaming, single-turn. Optionally override the \
+                       model (`model`) and the system prompt (`system_prompt`). On missing \
+                       credentials, returns a tool error containing the same diagnostic the CLI \
+                       would print. Mirrors `omni-dev ai chat` in one-shot form — that CLI command \
+                       is interactive and has no `system_prompt` flag, so this tool is the only way \
+                       to set a custom system prompt."
     )]
     pub async fn ai_chat(
         &self,
@@ -90,9 +98,12 @@ impl OmniDevServer {
     #[tool(
         description = "Sync Claude Code skills from the current repository (the MCP server's \
                        current working directory) into target worktrees. MUTATES THE FILESYSTEM: \
-                       creates symlinks inside `.claude/skills/` and upserts a managed block in \
-                       `.git/info/exclude`. Operates relative to the server process's cwd — not \
-                       cross-project. Mirrors `omni-dev ai claude skills sync`."
+                       creates symlinks inside `.claude/skills/` (e.g. \
+                       `.claude/skills/my-skill -> ../../../.claude/skills/my-skill`) and upserts a \
+                       managed block in `.git/info/exclude`. Operates relative to the server \
+                       process's cwd — not cross-project. Use `claude_skills_clean` to reverse this \
+                       and `claude_skills_status` to inspect the result without changing anything. \
+                       Mirrors `omni-dev ai claude skills sync`."
     )]
     pub async fn claude_skills_sync(
         &self,
@@ -109,9 +120,12 @@ impl OmniDevServer {
 
     /// Cleans Claude skill residue (symlinks and managed exclude block).
     #[tool(
-        description = "Remove skill symlinks and the managed exclude block created by a prior \
-                       `claude_skills_sync`. MUTATES THE FILESYSTEM. Operates relative to the \
-                       server process's cwd. Mirrors `omni-dev ai claude skills clean`."
+        description = "Remove the skill symlinks under `.claude/skills/` and the managed exclude \
+                       block created by a prior `claude_skills_sync` — the inverse of that tool. \
+                       MUTATES THE FILESYSTEM. Real files (non-symlinks) are preserved, never \
+                       deleted. Operates relative to the server process's cwd. Use \
+                       `claude_skills_status` first if you want to see what would be removed. \
+                       Mirrors `omni-dev ai claude skills clean`."
     )]
     pub async fn claude_skills_clean(
         &self,
@@ -128,9 +142,11 @@ impl OmniDevServer {
 
     /// Reports Claude skill residue (symlinks and managed exclude block) — read-only.
     #[tool(
-        description = "Report symlinks and managed exclude-block entries left by prior \
-                       `claude_skills_sync` runs. Read-only. Operates relative to the server \
-                       process's cwd. Mirrors `omni-dev ai claude skills status`."
+        description = "Report the skill symlinks under `.claude/skills/` and the managed \
+                       exclude-block entries left by prior `claude_skills_sync` runs. READ-ONLY — \
+                       changes nothing, so it is the safe way to preview before calling \
+                       `claude_skills_sync` or `claude_skills_clean`. Operates relative to the \
+                       server process's cwd. Mirrors `omni-dev ai claude skills status`."
     )]
     pub async fn claude_skills_status(
         &self,

--- a/src/mcp/atlassian_tools.rs
+++ b/src/mcp/atlassian_tools.rs
@@ -41,9 +41,17 @@ pub struct AtlassianConvertParams {
 #[tool_router(router = atlassian_tool_router, vis = "pub")]
 impl OmniDevServer {
     /// Tool: convert between JFM markdown and ADF JSON without touching the API.
-    #[tool(description = "Convert between JFM markdown and ADF JSON. \
-                       Mirrors `omni-dev atlassian convert to-adf` / `from-adf`. \
-                       `direction` must be either \"to-adf\" or \"from-adf\".")]
+    #[tool(
+        description = "Convert between JFM (JIRA-Flavoured Markdown) and ADF (Atlassian \
+                       Document Format) JSON. Bidirectional and fully offline — performs no network \
+                       I/O and needs no Atlassian credentials. Set `direction` to \"to-adf\" to \
+                       convert JFM markdown into an ADF JSON document (e.g. `# Title` becomes \
+                       `{\"version\":1,\"type\":\"doc\",\"content\":[...]}`), or \"from-adf\" to \
+                       render an ADF JSON document back into JFM markdown. Use it to preview or \
+                       inspect the ADF a JIRA/Confluence write tool would send. Output is the \
+                       converted document (JSON for to-adf, markdown for from-adf). Mirrors \
+                       `omni-dev atlassian convert to-adf` / `from-adf`."
+    )]
     pub async fn atlassian_convert(
         &self,
         Parameters(params): Parameters<AtlassianConvertParams>,

--- a/src/mcp/config_tools.rs
+++ b/src/mcp/config_tools.rs
@@ -23,9 +23,13 @@ pub struct AtlassianAuthStatusParams {}
 impl OmniDevServer {
     /// Returns the embedded `models.yaml` describing every AI model the CLI knows about.
     #[tool(
-        description = "Return the embedded `models.yaml` listing every AI model the CLI knows \
-                       about (identifiers, token budgets, provider). Output is YAML. Mirrors \
-                       `omni-dev config models show`."
+        description = "Return the embedded `models.yaml` listing every supported AI model the CLI \
+                       knows about, with each model's identifier, token limits (input context and \
+                       max output tokens), and provider. Use this to discover the valid `model` \
+                       values accepted by `ai_chat` and the git tools. Takes no arguments. \
+                       Read-only. Output is YAML. Mirrors `omni-dev config models show \
+                       --embedded-only` (the plain `show` additionally merges user/project \
+                       overrides; this tool returns the embedded catalog only)."
     )]
     pub async fn config_models_show(
         &self,
@@ -42,7 +46,10 @@ impl OmniDevServer {
         description = "Report which Atlassian credential scopes have credentials configured. \
                        Returns boolean presence flags only — NEVER includes the email, API \
                        token, or any other secret. The instance URL (non-secret) is returned \
-                       verbatim. Read-only. Output is YAML."
+                       verbatim. Checks local configuration only; it does NOT call the Atlassian \
+                       API to validate the credentials (unlike `omni-dev atlassian auth status`, \
+                       which signs in and prints the authenticated user). Takes no arguments. \
+                       Read-only. Output is YAML."
     )]
     pub async fn atlassian_auth_status(
         &self,

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -1160,7 +1160,10 @@ pub async fn delete_attachment_result(
 impl OmniDevServer {
     /// Tool: fetch a Confluence page as JFM markdown (default) or ADF JSON.
     #[tool(
-        description = "Fetch a Confluence page by ID. Returns JFM markdown by default, or raw ADF JSON when format=\"adf\". \
+        description = "Fetch a Confluence page by numeric ID (e.g. \"12345678\"). Returns JFM markdown by \
+                       default — AI-friendly GitHub-style markdown, the form to read/edit then feed back to \
+                       `confluence_write`/`confluence_create`. Pass format=\"adf\" for the raw ADF JSON \
+                       (the on-the-wire document model) only when you need exact node structure. \
                        When `output_file` is set, the content is written to that path and the tool returns \
                        a short YAML summary (path/bytes/format) — useful for large pages. \
                        Mirrors `omni-dev atlassian confluence read`."
@@ -1178,7 +1181,11 @@ impl OmniDevServer {
 
     /// Tool: search Confluence pages by CQL.
     #[tool(
-        description = "Search Confluence pages using CQL. Returns YAML with matching page IDs, titles, and space keys. \
+        description = "Search Confluence pages using CQL (Confluence Query Language), e.g. \
+                       `space = ENG AND title ~ \"architecture\"`. Returns YAML with matching page IDs, \
+                       titles, and space keys — feed an ID into `confluence_read` for the body. \
+                       Use `confluence_children`/`confluence_space_pages` instead when you want to \
+                       enumerate a known page tree or space rather than query by text. \
                        Mirrors `omni-dev atlassian confluence search --cql`."
     )]
     pub async fn confluence_search(
@@ -1193,7 +1200,8 @@ impl OmniDevServer {
 
     /// Tool: create a new Confluence page.
     #[tool(
-        description = "Create a new Confluence page, from explicit fields or from a full JFM \
+        description = "Create a NEW Confluence page (use `confluence_write` to overwrite an existing \
+                       page identified by its ID). Builds from explicit fields or from a full JFM \
                        `document` (frontmatter + body, e.g. the output of `confluence_read`). \
                        With a `document`, `space_key`/`title`/`parent_id` come from the \
                        frontmatter and the body becomes the page body — enabling the \
@@ -1216,7 +1224,9 @@ impl OmniDevServer {
 
     /// Tool: update a Confluence page's body (and optionally title).
     #[tool(
-        description = "Overwrite a Confluence page's body from JFM markdown (default) or raw ADF JSON. \
+        description = "Overwrite an EXISTING Confluence page's body (identified by `id`) from JFM \
+                       markdown (default) or raw ADF JSON. This fully replaces the body — to create a \
+                       brand-new page instead, use `confluence_create`. \
                        JFM is GitHub-style markdown, NOT Confluence wiki markup — see resource \
                        `omni-dev://specs/jfm` for syntax. \
                        Set `dry_run: true` first when uncertain about required fields or \
@@ -1289,8 +1299,11 @@ impl OmniDevServer {
     /// Lists children of a Confluence page, or top-level pages in a space,
     /// with optional recursion.
     #[tool(
-        description = "List children of a Confluence page, or top-level pages in a space. \
-                       Supports optional recursion with a max depth. Mirrors \
+        description = "List children of a Confluence page (pass `id`, e.g. \"12345678\"), or top-level \
+                       pages in a space (pass `space`, e.g. \"ENG\") — `id` and `space` are mutually \
+                       exclusive. Supports optional recursion with a max depth, so this is the tool for \
+                       walking a page hierarchy. To enumerate EVERY page in a space (flat, with status/sort \
+                       filters and cursor pagination) use `confluence_space_pages` instead. Mirrors \
                        `omni-dev atlassian confluence children`."
     )]
     pub async fn confluence_children(
@@ -1381,7 +1394,9 @@ impl OmniDevServer {
     /// Posts an inline (anchored) comment to a Confluence page.
     #[tool(
         description = "Post a markdown comment anchored to a text selection on a \
-                       Confluence page. `anchor_text` must match the on-page text \
+                       Confluence page (an inline comment). For a page-level comment not tied \
+                       to any text, use `confluence_comment_add` instead. \
+                       `anchor_text` must match the on-page text \
                        exactly; if it appears multiple times, pass `match_index` \
                        (1-based) to pick which occurrence. Errors if the anchor \
                        does not match or `match_index` is out of range. Mirrors \
@@ -1605,7 +1620,9 @@ impl OmniDevServer {
 
     /// Enumerates pages within a Confluence space (paginated).
     #[tool(
-        description = "Enumerate pages within a Confluence space (one page per call). \
+        description = "Enumerate ALL pages within a Confluence space (flat list, one response page per \
+                       call), e.g. space \"ENG\". To walk a page hierarchy parent-by-parent instead, use \
+                       `confluence_children`. \
                        Returns summary records: `id`, `title`, `status`, `parentId`, \
                        `authorId`, `createdAt` — no page bodies. \
                        Optional filters: `status` (common values: `current`, \

--- a/src/mcp/datadog_tools.rs
+++ b/src/mcp/datadog_tools.rs
@@ -47,7 +47,8 @@ pub struct DatadogAuthStatusParams {}
 /// Parameters for the `datadog_metrics_query` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DatadogMetricsQueryParams {
-    /// Datadog query string (e.g. `avg:system.cpu.user{*}`).
+    /// Datadog metrics query string, e.g. `avg:system.cpu.user{*}` or
+    /// `sum:trace.http.request.hits{service:api}.as_rate()`. Required.
     pub query: String,
     /// Start of the query window. Accepts relative shorthand (`15m`,
     /// `1h`, `7d`), the literal `now`, an RFC 3339 timestamp with
@@ -61,13 +62,17 @@ pub struct DatadogMetricsQueryParams {
 /// Parameters for the `datadog_monitor_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogMonitorListParams {
-    /// Substring match on the monitor name.
+    /// Substring match on the monitor name, e.g. `cpu`. Optional; omit to
+    /// match all names.
     #[serde(default)]
     pub name: Option<String>,
-    /// Comma-separated `key:value` tags applied to the monitor.
+    /// Comma-separated `key:value` tags on the monitored *scope* (the
+    /// `tags` API filter), e.g. `env:prod,team:sre`. Optional.
     #[serde(default)]
     pub tags: Option<String>,
-    /// Comma-separated `key:value` tags applied via `monitor_tags`.
+    /// Comma-separated `key:value` tags on the *monitor object itself* (the
+    /// `monitor_tags` API filter), e.g. `service:api`. Distinct from `tags`
+    /// above. Optional.
     #[serde(default)]
     pub monitor_tags: Option<String>,
     /// Maximum monitors to return. `0` (or omitted) means "fetch every
@@ -79,14 +84,15 @@ pub struct DatadogMonitorListParams {
 /// Parameters for the `datadog_monitor_get` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DatadogMonitorGetParams {
-    /// Datadog monitor identifier.
+    /// Datadog monitor identifier (numeric, e.g. `12345`). Required.
     pub monitor_id: i64,
 }
 
 /// Parameters for the `datadog_monitor_search` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DatadogMonitorSearchParams {
-    /// Free-text / faceted search query (e.g. `status:alert`).
+    /// Free-text / faceted search query, e.g. `status:alert`,
+    /// `type:metric tag:team:sre`. Required.
     pub query: String,
     /// Maximum monitors to return. `0` (or omitted) means "fetch every
     /// match", capped at 10000.
@@ -97,8 +103,8 @@ pub struct DatadogMonitorSearchParams {
 /// Parameters for the `datadog_dashboard_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogDashboardListParams {
-    /// When set, restricts the response to shared (or non-shared)
-    /// dashboards depending on the boolean.
+    /// `true` returns only shared dashboards; `false` returns only
+    /// non-shared ones; omit (the default) to return all. Optional.
     #[serde(default)]
     pub filter_shared: Option<bool>,
 }
@@ -113,11 +119,11 @@ pub struct DatadogDashboardGetParams {
 /// Parameters for the `datadog_metrics_catalog_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogMetricsCatalogListParams {
-    /// Filter by host (e.g. `web-01`).
+    /// Filter by host (e.g. `web-01`). Optional; omit for all hosts.
     #[serde(default)]
     pub host: Option<String>,
-    /// Cutoff in Unix epoch seconds; only metrics ingested since this
-    /// timestamp are returned.
+    /// Cutoff in Unix epoch seconds (e.g. `1700000000`); only metrics
+    /// ingested since this timestamp are returned. Optional.
     #[serde(default)]
     pub from: Option<i64>,
 }
@@ -125,7 +131,9 @@ pub struct DatadogMetricsCatalogListParams {
 /// Parameters for the `datadog_downtime_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogDowntimeListParams {
-    /// When true, restricts results to currently-active downtimes.
+    /// When `true`, restricts results to currently-active downtimes.
+    /// Defaults to `false` (include past and future downtimes too).
+    /// Optional.
     #[serde(default)]
     pub active_only: Option<bool>,
 }
@@ -133,11 +141,11 @@ pub struct DatadogDowntimeListParams {
 /// Parameters for the `datadog_hosts_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogHostsListParams {
-    /// Datadog hosts filter (e.g. `env:prod`).
+    /// Datadog hosts filter (e.g. `env:prod`). Optional; omit for all hosts.
     #[serde(default)]
     pub filter: Option<String>,
-    /// Cutoff in Unix epoch seconds; hosts last reporting before this
-    /// are excluded.
+    /// Cutoff in Unix epoch seconds (e.g. `1700000000`); hosts last
+    /// reporting before this are excluded. Optional.
     #[serde(default)]
     pub from: Option<i64>,
     /// Maximum hosts to return. `0` (or omitted) auto-paginates up to 10000.
@@ -148,16 +156,19 @@ pub struct DatadogHostsListParams {
 /// Parameters for the `datadog_slo_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogSloListParams {
-    /// Comma-separated `key:value` tags applied to the SLO.
+    /// Comma-separated `key:value` tags applied to the SLO, e.g.
+    /// `team:sre,env:prod`. Optional.
     #[serde(default)]
     pub tags: Option<String>,
-    /// Free-text query.
+    /// Free-text query matched against SLO name/description, e.g.
+    /// `checkout latency`. Optional.
     #[serde(default)]
     pub query: Option<String>,
-    /// Comma-separated list of SLO ids.
+    /// Comma-separated list of SLO ids, e.g. `abc123,def456`. Optional.
     #[serde(default)]
     pub ids: Option<String>,
-    /// Comma-separated list of metric names referenced by the SLO.
+    /// Comma-separated list of metric names referenced by the SLO, e.g.
+    /// `aws.elb.healthy_host_count`. Optional.
     #[serde(default)]
     pub metrics_query: Option<String>,
     /// Maximum SLOs to return. `0` (or omitted) means "fetch every match",
@@ -169,26 +180,30 @@ pub struct DatadogSloListParams {
 /// Parameters for the `datadog_slo_get` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DatadogSloGetParams {
-    /// Datadog SLO identifier (string).
+    /// Datadog SLO identifier (string, e.g. `abc123def456`). Required.
     pub slo_id: String,
 }
 
 /// Parameters for the `datadog_events_list` tool.
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DatadogEventsListParams {
-    /// Datadog events query (e.g. `service:api`).
+    /// Datadog events query (e.g. `service:api`). Optional; omit to match
+    /// all events in the window.
     #[serde(default)]
     pub filter: Option<String>,
-    /// Start of the time range. Defaults to `1h`.
+    /// Start of the time range. Accepts relative shorthand (`15m`, `1h`),
+    /// `now`, RFC 3339, or Unix epoch seconds. Defaults to `1h`.
     #[serde(default)]
     pub from: Option<String>,
-    /// End of the time range. Defaults to `now`.
+    /// End of the time range, same formats as `from`. Defaults to `now`.
     #[serde(default)]
     pub to: Option<String>,
-    /// Comma-separated list of source names.
+    /// Comma-separated list of source names, e.g. `github,nagios`.
+    /// Optional.
     #[serde(default)]
     pub sources: Option<String>,
-    /// Comma-separated list of `key:value` tags.
+    /// Comma-separated list of `key:value` tags, e.g. `env:prod,team:sre`.
+    /// Optional.
     #[serde(default)]
     pub tags: Option<String>,
     /// Maximum events to return. `0` means "fetch every match across
@@ -201,7 +216,8 @@ pub struct DatadogEventsListParams {
 /// Parameters for the `datadog_logs_search` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DatadogLogsSearchParams {
-    /// Datadog logs query (e.g. `service:api status:error`).
+    /// Datadog logs query, e.g. `service:api status:error`. Required; use
+    /// `*` to match all logs.
     pub filter: String,
     /// Start of the time range. Accepts relative shorthand (`15m`,
     /// `1h`), `now`, RFC 3339, or Unix epoch seconds. Defaults to
@@ -234,7 +250,10 @@ impl OmniDevServer {
         description = "Report which Datadog credential scopes have credentials configured. \
                        Returns boolean presence flags only — NEVER includes the API key, \
                        application key, or any other secret. The site (non-secret) is \
-                       returned verbatim. Read-only. Output is YAML."
+                       returned verbatim. Read-only; takes no parameters. Unlike the CLI \
+                       `omni-dev datadog auth status`, this tool only inspects local config \
+                       presence and does NOT call Datadog's `/api/v1/validate` endpoint, so \
+                       it cannot confirm the keys are actually accepted. Output is YAML."
     )]
     pub async fn datadog_auth_status(
         &self,
@@ -246,7 +265,10 @@ impl OmniDevServer {
 
     /// Tool: execute a point-in-time Datadog metrics timeseries query.
     #[tool(
-        description = "Execute a point-in-time Datadog metrics timeseries query. \
+        description = "Execute a point-in-time Datadog metrics timeseries query \
+                       (e.g. `avg:system.cpu.user{*}` over the last `1h`). Returns the actual \
+                       data points; use `datadog_metrics_catalog_list` instead when you only \
+                       need to discover metric *names*. Read-only. \
                        Mirrors `omni-dev datadog metrics query`. Returns YAML matching \
                        the CLI `-o yaml` output (status, from_date, to_date, series)."
     )]
@@ -260,8 +282,12 @@ impl OmniDevServer {
 
     /// Tool: list Datadog monitors with optional filters.
     #[tool(
-        description = "List Datadog monitors with optional name / tags filters. \
-                       `limit` of 0 (or omitted) auto-paginates up to 10000. \
+        description = "List Datadog monitors with optional name / tags filters \
+                       (e.g. `name = \"cpu\"`, `tags = \"team:sre\"`). Returns full monitor \
+                       objects. Use `datadog_monitor_search` for free-text / faceted queries \
+                       like `status:alert`; use `datadog_monitor_get` when you already know \
+                       the numeric monitor id. `limit` of 0 (or omitted) auto-paginates up to \
+                       10000. Read-only. \
                        Mirrors `omni-dev datadog monitor list`. Output is YAML."
     )]
     pub async fn datadog_monitor_list(
@@ -273,8 +299,12 @@ impl OmniDevServer {
     }
 
     /// Tool: fetch a single Datadog monitor by id.
-    #[tool(description = "Fetch a single Datadog monitor by numeric id. \
-                       Mirrors `omni-dev datadog monitor get`. Output is YAML.")]
+    #[tool(
+        description = "Fetch a single Datadog monitor by numeric id (e.g. `12345`). \
+                       Use `datadog_monitor_list` / `datadog_monitor_search` to discover ids \
+                       first. Read-only. \
+                       Mirrors `omni-dev datadog monitor get`. Output is YAML."
+    )]
     pub async fn datadog_monitor_get(
         &self,
         Parameters(params): Parameters<DatadogMonitorGetParams>,
@@ -286,8 +316,12 @@ impl OmniDevServer {
     }
 
     /// Tool: free-text / faceted search across Datadog monitors.
-    #[tool(description = "Free-text / faceted search across Datadog monitors. \
-                       `limit` of 0 (or omitted) auto-paginates up to 10000. \
+    #[tool(description = "Free-text / faceted search across Datadog monitors \
+                       (e.g. `status:alert`, `type:metric tag:team:sre`). Prefer this over \
+                       `datadog_monitor_list` when filtering by status/facets rather than just \
+                       name/tags; the response is a search envelope (monitors + paging \
+                       metadata) rather than a plain array. `limit` of 0 (or omitted) \
+                       auto-paginates up to 10000. Read-only. \
                        Mirrors `omni-dev datadog monitor search`. Output is YAML.")]
     pub async fn datadog_monitor_search(
         &self,
@@ -299,8 +333,10 @@ impl OmniDevServer {
 
     /// Tool: list Datadog dashboards.
     #[tool(
-        description = "List Datadog dashboards. `filter_shared` (boolean, optional) \
-                       restricts to shared / non-shared dashboards. \
+        description = "List Datadog dashboards (id, title, author). `filter_shared` (boolean, \
+                       optional) restricts to shared (`true`) or non-shared (`false`) \
+                       dashboards; omit it for all. Use `datadog_dashboard_get` to fetch one \
+                       dashboard's full widget definition by id. Read-only. \
                        Mirrors `omni-dev datadog dashboard list`. Output is YAML."
     )]
     pub async fn datadog_dashboard_list(
@@ -312,9 +348,12 @@ impl OmniDevServer {
     }
 
     /// Tool: fetch a single Datadog dashboard definition by id.
-    #[tool(description = "Fetch a single Datadog dashboard by id (string). \
-                       Returns the full definition including widgets. \
-                       Mirrors `omni-dev datadog dashboard get`. Output is YAML.")]
+    #[tool(
+        description = "Fetch a single Datadog dashboard by id (string, e.g. `abc-def-ghi`). \
+                       Returns the full definition including widgets. Use \
+                       `datadog_dashboard_list` to discover ids first. Read-only. \
+                       Mirrors `omni-dev datadog dashboard get`. Output is YAML."
+    )]
     pub async fn datadog_dashboard_get(
         &self,
         Parameters(params): Parameters<DatadogDashboardGetParams>,
@@ -326,12 +365,14 @@ impl OmniDevServer {
     }
 
     /// Tool: search Datadog log events.
-    #[tool(
-        description = "Search Datadog log events. `limit` of 0 (or omitted) auto-paginates \
+    #[tool(description = "Search Datadog log events with a logs query (e.g. \
+                       `service:api status:error`) over a time range (default last `15m`). \
+                       For the event/alert stream rather than logs, use \
+                       `datadog_events_list`. `limit` of 0 (or omitted) auto-paginates \
                        across cursor pages up to 10000; any non-zero value caps the total at \
-                       that count. `sort` is `timestamp-asc` or `timestamp-desc` (default). \
-                       Mirrors `omni-dev datadog logs search`. Output is YAML."
-    )]
+                       that count (default 100). `sort` is `timestamp-asc` or `timestamp-desc` \
+                       (default). Read-only. \
+                       Mirrors `omni-dev datadog logs search`. Output is YAML.")]
     pub async fn datadog_logs_search(
         &self,
         Parameters(params): Parameters<DatadogLogsSearchParams>,
@@ -342,11 +383,14 @@ impl OmniDevServer {
 
     /// Tool: list Datadog events.
     #[tool(
-        description = "List Datadog events. `limit` of 0 (or omitted) auto-paginates across \
-                       cursor pages up to 10000; any non-zero value caps the total at that \
-                       count. `from` / `to` accept relative shorthand (`15m`, `1h`), `now`, \
-                       RFC 3339, or Unix epoch seconds. Mirrors \
-                       `omni-dev datadog events list`. Output is YAML."
+        description = "List Datadog events from the event/alert stream (e.g. deploys, \
+                       monitor alerts), optionally filtered (e.g. `service:api`) over a time \
+                       range (default last `1h`). For application log lines use \
+                       `datadog_logs_search` instead. `limit` of 0 (or omitted) auto-paginates \
+                       across cursor pages up to 10000; any non-zero value caps the total at \
+                       that count (default 100). `from` / `to` accept relative shorthand \
+                       (`15m`, `1h`), `now`, RFC 3339, or Unix epoch seconds. Read-only. \
+                       Mirrors `omni-dev datadog events list`. Output is YAML."
     )]
     pub async fn datadog_events_list(
         &self,
@@ -358,9 +402,11 @@ impl OmniDevServer {
 
     /// Tool: list Datadog SLOs.
     #[tool(
-        description = "List Datadog Service Level Objectives. `limit` of 0 (or omitted) \
-                       auto-paginates up to 10000. Mirrors `omni-dev datadog slo list`. \
-                       Output is YAML."
+        description = "List Datadog Service Level Objectives, optionally filtered by tags, \
+                       free-text `query`, explicit `ids`, or referenced `metrics_query`. Use \
+                       `datadog_slo_get` to fetch one SLO's full definition by id. `limit` of \
+                       0 (or omitted) auto-paginates up to 10000. Read-only. \
+                       Mirrors `omni-dev datadog slo list`. Output is YAML."
     )]
     pub async fn datadog_slo_list(
         &self,
@@ -371,8 +417,11 @@ impl OmniDevServer {
     }
 
     /// Tool: fetch a single SLO by id.
-    #[tool(description = "Fetch a single Datadog SLO by id (string). \
-                       Mirrors `omni-dev datadog slo get`. Output is YAML.")]
+    #[tool(
+        description = "Fetch a single Datadog SLO by id (string, e.g. `abc123def456`). \
+                       Use `datadog_slo_list` to discover ids first. Read-only. \
+                       Mirrors `omni-dev datadog slo get`. Output is YAML."
+    )]
     pub async fn datadog_slo_get(
         &self,
         Parameters(params): Parameters<DatadogSloGetParams>,
@@ -383,9 +432,10 @@ impl OmniDevServer {
 
     /// Tool: list Datadog reporting hosts.
     #[tool(
-        description = "List Datadog reporting hosts. `limit` of 0 (or omitted) \
-                       auto-paginates up to 10000. Mirrors `omni-dev datadog hosts list`. \
-                       Output is YAML."
+        description = "List Datadog reporting hosts, optionally narrowed by a hosts `filter` \
+                       (e.g. `env:prod`) and a `from` cutoff (Unix epoch seconds). `limit` of \
+                       0 (or omitted) auto-paginates up to 10000. Read-only. \
+                       Mirrors `omni-dev datadog hosts list`. Output is YAML."
     )]
     pub async fn datadog_hosts_list(
         &self,
@@ -397,9 +447,11 @@ impl OmniDevServer {
 
     /// Tool: list Datadog scheduled downtimes.
     #[tool(
-        description = "List Datadog scheduled downtimes. `active_only` (boolean, optional) \
-                       restricts to currently-active downtimes. Mirrors \
-                       `omni-dev datadog downtime list`. Output is YAML."
+        description = "List Datadog scheduled downtimes (monitor muting windows). \
+                       `active_only` (boolean, optional, default `false`) restricts to \
+                       currently-active downtimes; omit or set `false` to include past and \
+                       future ones. Read-only. \
+                       Mirrors `omni-dev datadog downtime list`. Output is YAML."
     )]
     pub async fn datadog_downtime_list(
         &self,
@@ -412,9 +464,11 @@ impl OmniDevServer {
     /// Tool: list metrics in the Datadog catalog.
     #[tool(
         description = "List metrics in the Datadog catalog (`/api/v1/metrics`). Distinct \
-                       from `datadog_metrics_query`: returns metric *names* ingested since \
-                       `from`, optionally filtered by `host`. Mirrors \
-                       `omni-dev datadog metrics catalog list`. Output is YAML."
+                       from `datadog_metrics_query`: returns metric *names* (e.g. \
+                       `system.cpu.user`) ingested since `from`, optionally filtered by \
+                       `host` — use this to discover what to query, then \
+                       `datadog_metrics_query` to fetch the actual timeseries. Read-only. \
+                       Mirrors `omni-dev datadog metrics catalog list`. Output is YAML."
     )]
     pub async fn datadog_metrics_catalog_list(
         &self,

--- a/src/mcp/git_tools.rs
+++ b/src/mcp/git_tools.rs
@@ -36,7 +36,8 @@ pub struct GitViewCommitsParams {
 /// Parameters for the `git_branch_info` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GitBranchInfoParams {
-    /// Base branch to compare against. Defaults to `main` or `master`.
+    /// Base branch to compare against, e.g. `main` or `develop`.
+    /// Defaults to `main` or `master` (whichever exists) when omitted.
     #[serde(default)]
     pub branch: Option<String>,
     /// Path to the git repository. Defaults to the current working directory.
@@ -48,6 +49,8 @@ pub struct GitBranchInfoParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GitCheckCommitsParams {
     /// Commit range to check (e.g., `HEAD~3..HEAD`, `abc123..def456`).
+    /// Required — unlike the CLI, this tool does not default to "commits ahead
+    /// of the base branch".
     pub range: String,
     /// Optional explicit path to the guidelines file. When omitted the tool
     /// falls back to `.omni-dev/commit-guidelines.md` via the standard
@@ -58,9 +61,11 @@ pub struct GitCheckCommitsParams {
     #[serde(default)]
     pub repo_path: Option<String>,
     /// When true, warnings are treated as non-zero exit conditions.
+    /// Defaults to `false` (only errors fail).
     #[serde(default)]
     pub strict: bool,
-    /// Claude model override.
+    /// Claude model override (e.g. `claude-sonnet-4-6`). Defaults to the model
+    /// from settings, then the built-in default, when omitted.
     #[serde(default)]
     pub model: Option<String>,
 }
@@ -68,10 +73,12 @@ pub struct GitCheckCommitsParams {
 /// Parameters for the `git_twiddle_commits` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GitTwiddleCommitsParams {
-    /// Commit range to twiddle. Defaults to `HEAD~5..HEAD` when omitted.
+    /// Commit range to twiddle (e.g., `HEAD~3..HEAD`, `abc123..def456`).
+    /// Defaults to `HEAD~5..HEAD` when omitted.
     #[serde(default)]
     pub range: Option<String>,
-    /// Claude model override.
+    /// Claude model override (e.g. `claude-sonnet-4-6`). Defaults to the model
+    /// from settings, then the built-in default, when omitted.
     #[serde(default)]
     pub model: Option<String>,
     /// When true, proposed amendments are returned without being applied.
@@ -92,7 +99,8 @@ pub struct GitStagedCommitParams {
     /// committed to the repository. Defaults to `false` (commit applied).
     #[serde(default)]
     pub print_only: bool,
-    /// Claude model override.
+    /// Claude model override (e.g. `claude-sonnet-4-6`). Defaults to the model
+    /// from settings, then the built-in default, when omitted.
     #[serde(default)]
     pub model: Option<String>,
     /// Path to the git repository. Defaults to the current working directory.
@@ -103,10 +111,12 @@ pub struct GitStagedCommitParams {
 /// Parameters for the `git_create_pr` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GitCreatePrParams {
-    /// Claude model override.
+    /// Claude model override (e.g. `claude-sonnet-4-6`). Defaults to the model
+    /// from settings, then the built-in default, when omitted.
     #[serde(default)]
     pub model: Option<String>,
-    /// Base branch for the PR. Defaults to the primary remote's main branch.
+    /// Base branch the PR would merge into, e.g. `main` or `develop`.
+    /// Defaults to the primary remote's main branch when omitted.
     #[serde(default)]
     pub base_branch: Option<String>,
     /// Path to the git repository. Defaults to the current working directory.
@@ -120,6 +130,9 @@ impl OmniDevServer {
     /// Tool: analyse commits in a range and return repository information as YAML.
     #[tool(
         description = "Analyze commits in a range and return repository information as YAML. \
+                       Use this when you have an explicit commit range (e.g. `HEAD~3..HEAD`); \
+                       use `git_branch_info` instead to analyze the current branch against a base \
+                       branch without computing the range yourself. \
                        Mirrors `omni-dev git commit message view`."
     )]
     pub async fn git_view_commits(
@@ -150,8 +163,11 @@ impl OmniDevServer {
 
     /// Tool: analyse branch commits and return repository info as YAML.
     #[tool(
-        description = "Analyze branch commits against a base and return repository information \
-                       as YAML. Mirrors `omni-dev git branch info`."
+        description = "Analyze the current branch's commits against a base branch and return \
+                       repository information as YAML. Use this when you want the diff against \
+                       `main`/`master` (or another base) without computing an explicit range; \
+                       use `git_view_commits` instead when you already have a range. \
+                       Mirrors `omni-dev git branch info`."
     )]
     pub async fn git_branch_info(
         &self,
@@ -172,10 +188,12 @@ impl OmniDevServer {
 
     /// Tool: validate commit messages against guidelines.
     #[tool(
-        description = "Validate commit messages in a range against commit guidelines. \
-                       Mirrors `omni-dev git commit message check`. Returns a YAML payload with \
-                       the full CheckReport, a pass/fail summary, and the exit code the CLI \
-                       would use (honouring `strict`)."
+        description = "Validate commit messages in a range against commit guidelines \
+                       (read-only — never modifies commits). Use this to report problems; use \
+                       `git_twiddle_commits` instead to rewrite the messages. `range` is required \
+                       (e.g. `HEAD~3..HEAD`). Mirrors `omni-dev git commit message check`. Returns \
+                       a YAML payload with the full CheckReport, a pass/fail summary, and the exit \
+                       code the CLI would use (honouring `strict`)."
     )]
     pub async fn git_check_commits(
         &self,
@@ -198,10 +216,13 @@ impl OmniDevServer {
 
     /// Tool: AI-powered commit message improvement.
     #[tool(
-        description = "Generate improved commit messages for a range and (by default) apply \
-                       them. Mirrors `omni-dev git commit message twiddle --auto-apply`. Set \
-                       `dry_run = true` to return the proposed amendments as YAML without \
-                       applying them. The editor is never started from this tool."
+        description = "Generate improved commit messages for a range (e.g. `HEAD~3..HEAD`) and \
+                       (by default) apply them. Mutating: rewrites commit messages unless \
+                       `dry_run = true`. Use this to fix messages; use `git_check_commits` instead \
+                       to only report problems without modifying anything. Mirrors \
+                       `omni-dev git commit message twiddle --auto-apply`. Set `dry_run = true` to \
+                       return the proposed amendments as YAML without applying them. The editor is \
+                       never started from this tool."
     )]
     pub async fn git_twiddle_commits(
         &self,

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -145,11 +145,13 @@ pub struct BulkIssueSpec {
 /// existing JIRA key.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct BulkLinkSpec {
-    /// Link type name (e.g., `Blocks`).
+    /// Link type name (e.g., `Blocks`; list options with `jira_link_types`).
     pub link_type: String,
-    /// Source (inward) issue — a batch alias or an existing key.
+    /// Source (inward) issue — e.g. for `Blocks`, the issue doing the blocking.
+    /// May be a batch alias minted earlier in this call or an existing key.
     pub inward: String,
-    /// Target (outward) issue — a batch alias or an existing key.
+    /// Target (outward) issue — e.g. for `Blocks`, the issue being blocked.
+    /// May be a batch alias minted earlier in this call or an existing key.
     pub outward: String,
 }
 
@@ -1023,10 +1025,12 @@ async fn run_jira_user_search(client: &AtlassianClient, query: &str, limit: u32)
 impl OmniDevServer {
     /// Tool: fetch a JIRA issue as JFM markdown or raw ADF JSON.
     #[tool(
-        description = "Fetch a JIRA issue. Returns JFM markdown (default, AI-friendly) \
-                       or raw ADF JSON when `format = \"adf\"`. When `output_file` is set, \
-                       the content is written to that path and the tool returns a short \
-                       YAML summary (path/bytes/format) — useful for large issues."
+        description = "Fetch a JIRA issue by key (e.g. `PROJ-123`). Returns JFM markdown \
+                       (default, AI-friendly GitHub-style markdown — see resource \
+                       `omni-dev://specs/jfm`) or the raw ADF description JSON when \
+                       `format = \"adf\"`. When `output_file` is set, the content is written \
+                       to that path and the tool returns a short YAML summary \
+                       (path/bytes/format) — useful for large issues."
     )]
     pub async fn jira_read(
         &self,
@@ -1047,7 +1051,11 @@ impl OmniDevServer {
     }
 
     /// Tool: search JIRA issues by JQL.
-    #[tool(description = "Search JIRA issues using a JQL query. Returns matching issues as YAML.")]
+    #[tool(description = "Search JIRA issues using a JQL query (e.g. \
+                       `project = PROJ AND status = Open ORDER BY created DESC`; dates are \
+                       `YYYY-MM-DD`). Returns matching issues as YAML. `limit` defaults to 20; \
+                       pass `0` for unlimited. To list issues on a board or sprint instead, use \
+                       `jira_board_issues` / `jira_sprint_issues`.")]
     pub async fn jira_search(
         &self,
         Parameters(params): Parameters<JiraSearchParams>,
@@ -1081,7 +1089,8 @@ impl OmniDevServer {
                        resolves the input and returns the request that would be sent (method, path, \
                        body) without creating the issue (mirrors the CLI's \
                        `omni-dev atlassian jira create --dry-run`). Returns the new issue key and \
-                       self URL as YAML."
+                       self URL as YAML. Creates a single issue; to create several issues at once \
+                       (and optionally link them, e.g. epic decomposition) use `jira_bulk_create`."
     )]
     pub async fn jira_create(
         &self,
@@ -1130,7 +1139,8 @@ impl OmniDevServer {
     /// Tool: update a JIRA issue's description, assignee, reporter, or
     /// arbitrary fields.
     #[tool(
-        description = "Update a JIRA issue. `content` updates the description (JFM markdown by \
+        description = "Update a JIRA issue by key (e.g. `PROJ-123`). `content` updates the \
+                       description (JFM markdown by \
                        default, or raw ADF JSON when `format = \"adf\"`); omit it to leave the \
                        description unchanged. JFM is GitHub-style markdown — see resource \
                        `omni-dev://specs/jfm` for syntax. To set the parent for hierarchy \
@@ -1221,8 +1231,11 @@ impl OmniDevServer {
 
     /// Tool: list or add comments on a JIRA issue.
     #[tool(
-        description = "Manage JIRA issue comments. `action = \"list\"` returns comments as YAML; \
-                       `action = \"add\"` posts the given `body` (JFM markdown)."
+        description = "Manage JIRA issue comments on `key` (e.g. `PROJ-123`). \
+                       `action = \"list\"` returns comments as YAML; `action = \"add\"` posts the \
+                       given `body` (JFM markdown — GitHub-style, see resource \
+                       `omni-dev://specs/jfm`). To change the text of an existing comment use \
+                       `jira_comment_edit` (it needs the comment id from the `list` output)."
     )]
     pub async fn jira_comment(
         &self,
@@ -1244,8 +1257,11 @@ impl OmniDevServer {
 
     /// Tool: edit an existing JIRA comment.
     #[tool(
-        description = "Edit an existing JIRA comment. `body` is JFM markdown (see resource \
-                       `omni-dev://specs/jfm`) and replaces the current comment text. Optional \
+        description = "Edit an existing JIRA comment (identified by `key` + `comment_id`; get \
+                       the id from `jira_comment` with `action = \"list\"`). To add a new comment \
+                       or list comments use `jira_comment` instead. `body` is JFM markdown (see \
+                       resource `omni-dev://specs/jfm`) and replaces the current comment text. \
+                       Optional \
                        `visibility = {type: \"group\"|\"role\", value: <name>}` updates the \
                        restriction. JIRA enforces stricter permissions on edit than on add (often \
                        only the original author can edit) — when JIRA refuses, its error message \
@@ -1270,8 +1286,8 @@ impl OmniDevServer {
 
     /// Tool: fetch development status (PRs, branches, repositories) for an issue.
     #[tool(
-        description = "Fetch development status for a JIRA issue: linked pull requests, \
-                       branches, and repositories as YAML."
+        description = "Fetch development status for a JIRA issue by key (e.g. `PROJ-123`): \
+                       linked pull requests, branches, and repositories as YAML. Read-only."
     )]
     pub async fn jira_dev(
         &self,

--- a/src/mcp/jira_tools.rs
+++ b/src/mcp/jira_tools.rs
@@ -482,7 +482,8 @@ pub struct WatcherListParams {
 pub struct WatcherMutateParams {
     /// JIRA issue key (e.g., `PROJ-123`).
     pub key: String,
-    /// Atlassian account ID of the user.
+    /// Atlassian `accountId` of the user (not a display name or email). Use
+    /// `jira_user_search` to resolve a name or email to an `accountId`.
     pub account_id: String,
 }
 
@@ -495,7 +496,8 @@ pub struct WatcherMutateParams {
 pub struct WatcherRemoveParams {
     /// JIRA issue key (e.g., `PROJ-123`).
     pub key: String,
-    /// Atlassian account ID of the user.
+    /// Atlassian `accountId` of the user (not a display name or email). Use
+    /// `jira_user_search` to resolve a name or email to an `accountId`.
     pub account_id: String,
     /// Must be set to `true` — destructive guard.
     pub confirm: bool,
@@ -1194,7 +1196,8 @@ impl OmniDevServer {
 
     /// Tool: add a watcher to an issue.
     #[tool(
-        description = "Add a user (by Atlassian account ID) as a watcher on a JIRA issue. \
+        description = "Add a user (by Atlassian `accountId`, not a name or email — resolve one \
+                       with `jira_user_search`) as a watcher on a JIRA issue. \
                        Returns YAML `{status: ok}`. Mirrors `omni-dev atlassian jira watcher add`."
     )]
     pub async fn jira_watcher_add(
@@ -1212,7 +1215,8 @@ impl OmniDevServer {
 
     /// Tool: remove a watcher from an issue.
     #[tool(
-        description = "Remove a user (by Atlassian account ID) from the watchers of a JIRA \
+        description = "Remove a user (by Atlassian `accountId`, not a name or email — resolve \
+                       one with `jira_user_search`) from the watchers of a JIRA \
                        issue. Destructive operation: callers must explicitly pass \
                        `confirm: true` for the removal to proceed; otherwise the tool \
                        refuses with an error. Returns YAML `{status: ok}`. Mirrors \

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -193,9 +193,9 @@ Manages Claude Code skills across repositories and worktrees
 Usage: skills <COMMAND>
 
 Commands:
-  sync    Syncs skills from a source repository into one or more targets
-  clean   Removes skill symlinks and managed exclude block previously created by `sync`
-  status  Reports residue left by `sync` — symlinks and managed exclude-block entries
+  sync    Syncs skills from a source repository into one or more targets (mirrors the `claude_skills_sync` MCP tool)
+  clean   Removes skill symlinks and managed exclude block previously created by `sync` (mirrors the `claude_skills_clean` MCP tool)
+  status  Reports residue left by `sync` — symlinks and managed exclude-block entries (mirrors the `claude_skills_status` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -204,9 +204,9 @@ Options:
 
 ================================================================================
 
-omni-dev ai claude skills clean - Removes skill symlinks and managed exclude block previously created by `sync`
+omni-dev ai claude skills clean - Removes skill symlinks and managed exclude block previously created by `sync` (mirrors the `claude_skills_clean` MCP tool)
 
-Removes skill symlinks and managed exclude block previously created by `sync`
+Removes skill symlinks and managed exclude block previously created by `sync` (mirrors the `claude_skills_clean` MCP tool)
 
 Usage: clean [OPTIONS]
 
@@ -220,9 +220,9 @@ Options:
 
 ================================================================================
 
-omni-dev ai claude skills status - Reports residue left by `sync` — symlinks and managed exclude-block entries
+omni-dev ai claude skills status - Reports residue left by `sync` — symlinks and managed exclude-block entries (mirrors the `claude_skills_status` MCP tool)
 
-Reports residue left by `sync` — symlinks and managed exclude-block entries
+Reports residue left by `sync` — symlinks and managed exclude-block entries (mirrors the `claude_skills_status` MCP tool)
 
 Usage: status [OPTIONS]
 
@@ -235,9 +235,9 @@ Options:
 
 ================================================================================
 
-omni-dev ai claude skills sync - Syncs skills from a source repository into one or more targets
+omni-dev ai claude skills sync - Syncs skills from a source repository into one or more targets (mirrors the `claude_skills_sync` MCP tool)
 
-Syncs skills from a source repository into one or more targets
+Syncs skills from a source repository into one or more targets (mirrors the `claude_skills_sync` MCP tool)
 
 Usage: sync [OPTIONS]
 
@@ -279,7 +279,7 @@ Usage: auth <COMMAND>
 
 Commands:
   login   Configures Atlassian Cloud credentials interactively
-  status  Shows the current authentication status
+  status  Shows the current authentication status (mirrors the `atlassian_auth_status` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -300,9 +300,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian auth status - Shows the current authentication status
+omni-dev atlassian auth status - Shows the current authentication status (mirrors the `atlassian_auth_status` MCP tool)
 
-Shows the current authentication status
+Shows the current authentication status (mirrors the `atlassian_auth_status` MCP tool)
 
 Usage: status
 
@@ -320,18 +320,18 @@ Usage: confluence <COMMAND>
 
 Commands:
   comment     Manages comments on a Confluence page
-  read        Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
-  write       Pushes content to a Confluence page
+  read        Fetches a Confluence page and outputs it as JFM markdown or ADF JSON (mirrors the `confluence_read` MCP tool)
+  write       Pushes content to a Confluence page (mirrors the `confluence_write` MCP tool)
   edit        Interactive fetch-edit-push cycle for a Confluence page
-  search      Searches Confluence pages using CQL
-  create      Creates a new Confluence page
-  delete      Deletes a Confluence page
-  move        Moves or reparents a Confluence page (same-space only)
+  search      Searches Confluence pages using CQL (mirrors the `confluence_search` MCP tool)
+  create      Creates a new Confluence page (mirrors the `confluence_create` MCP tool)
+  delete      Deletes a Confluence page (mirrors the `confluence_delete` MCP tool)
+  move        Moves or reparents a Confluence page (same-space only) (mirrors the `confluence_move` MCP tool)
   label       Manages labels on Confluence pages
   attachment  Manages attachments on Confluence pages
-  download    Recursively downloads a Confluence page tree
-  children    Lists child pages of a Confluence page or top-level pages in a space
-  history     Lists version history (metadata) for a Confluence page
+  download    Recursively downloads a Confluence page tree (mirrors the `confluence_download` MCP tool)
+  children    Lists child pages of a Confluence page or top-level pages in a space (mirrors the `confluence_children` MCP tool)
+  history     Lists version history (metadata) for a Confluence page (mirrors the `confluence_history` MCP tool)
   compare     Compares two versions of a Confluence page (structural diff)
   user        Confluence user operations
   space       Confluence space operations
@@ -350,10 +350,10 @@ Manages attachments on Confluence pages
 Usage: attachment <COMMAND>
 
 Commands:
-  upload    Uploads a file as an attachment to a Confluence page
-  list      Lists attachments on a Confluence page
-  download  Downloads an attachment binary by ID
-  delete    Deletes an attachment by ID
+  upload    Uploads a file as an attachment to a Confluence page (mirrors the `confluence_attachment_upload` MCP tool)
+  list      Lists attachments on a Confluence page (mirrors the `confluence_attachment_list` MCP tool)
+  download  Downloads an attachment binary by ID (mirrors the `confluence_attachment_download` MCP tool)
+  delete    Deletes an attachment by ID (mirrors the `confluence_attachment_delete` MCP tool)
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -362,9 +362,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence attachment delete - Deletes an attachment by ID
+omni-dev atlassian confluence attachment delete - Deletes an attachment by ID (mirrors the `confluence_attachment_delete` MCP tool)
 
-Deletes an attachment by ID
+Deletes an attachment by ID (mirrors the `confluence_attachment_delete` MCP tool)
 
 Usage: delete [OPTIONS] <ATTACHMENT_ID>
 
@@ -379,9 +379,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence attachment download - Downloads an attachment binary by ID
+omni-dev atlassian confluence attachment download - Downloads an attachment binary by ID (mirrors the `confluence_attachment_download` MCP tool)
 
-Downloads an attachment binary by ID
+Downloads an attachment binary by ID (mirrors the `confluence_attachment_download` MCP tool)
 
 Usage: download [OPTIONS] <ATTACHMENT_ID>
 
@@ -395,9 +395,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence attachment list - Lists attachments on a Confluence page
+omni-dev atlassian confluence attachment list - Lists attachments on a Confluence page (mirrors the `confluence_attachment_list` MCP tool)
 
-Lists attachments on a Confluence page
+Lists attachments on a Confluence page (mirrors the `confluence_attachment_list` MCP tool)
 
 Usage: list [OPTIONS] <PAGE_ID>
 
@@ -413,9 +413,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence attachment upload - Uploads a file as an attachment to a Confluence page
+omni-dev atlassian confluence attachment upload - Uploads a file as an attachment to a Confluence page (mirrors the `confluence_attachment_upload` MCP tool)
 
-Uploads a file as an attachment to a Confluence page
+Uploads a file as an attachment to a Confluence page (mirrors the `confluence_attachment_upload` MCP tool)
 
 Usage: upload [OPTIONS] <PAGE_ID> <FILE>
 
@@ -432,9 +432,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence children - Lists child pages of a Confluence page or top-level pages in a space
+omni-dev atlassian confluence children - Lists child pages of a Confluence page or top-level pages in a space (mirrors the `confluence_children` MCP tool)
 
-Lists child pages of a Confluence page or top-level pages in a space
+Lists child pages of a Confluence page or top-level pages in a space (mirrors the `confluence_children` MCP tool)
 
 Usage: children [OPTIONS] [ID]
 
@@ -458,10 +458,10 @@ Manages comments on a Confluence page
 Usage: comment <COMMAND>
 
 Commands:
-  list        Lists comments on a Confluence page
-  add         Adds a footer comment to a Confluence page
-  add-inline  Adds an inline (anchored) comment to a Confluence page
-  replies     Lists the replies of a comment
+  list        Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool)
+  add         Adds a footer comment to a Confluence page (mirrors the `confluence_comment_add` MCP tool)
+  add-inline  Adds an inline (anchored) comment to a Confluence page (mirrors the `confluence_comment_add_inline` MCP tool)
+  replies     Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool)
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -470,9 +470,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence comment add - Adds a footer comment to a Confluence page
+omni-dev atlassian confluence comment add - Adds a footer comment to a Confluence page (mirrors the `confluence_comment_add` MCP tool)
 
-Adds a footer comment to a Confluence page
+Adds a footer comment to a Confluence page (mirrors the `confluence_comment_add` MCP tool)
 
 Usage: add [OPTIONS] <ID> [FILE]
 
@@ -487,9 +487,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence comment add-inline - Adds an inline (anchored) comment to a Confluence page
+omni-dev atlassian confluence comment add-inline - Adds an inline (anchored) comment to a Confluence page (mirrors the `confluence_comment_add_inline` MCP tool)
 
-Adds an inline (anchored) comment to a Confluence page
+Adds an inline (anchored) comment to a Confluence page (mirrors the `confluence_comment_add_inline` MCP tool)
 
 Usage: add-inline [OPTIONS] --anchor-text <ANCHOR_TEXT> <ID> [FILE]
 
@@ -506,9 +506,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence comment list - Lists comments on a Confluence page
+omni-dev atlassian confluence comment list - Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool)
 
-Lists comments on a Confluence page
+Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool)
 
 Usage: list [OPTIONS] <ID>
 
@@ -524,9 +524,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence comment replies - Lists the replies of a comment
+omni-dev atlassian confluence comment replies - Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool)
 
-Lists the replies of a comment
+Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool)
 
 Usage: replies [OPTIONS] --kind <KIND> <ID>
 
@@ -549,8 +549,8 @@ Compares two versions of a Confluence page (structural diff)
 Usage: compare <COMMAND>
 
 Commands:
-  run      Diff two versions of a Confluence page
-  section  Drill in to a section diff using a cursor from a prior `run`
+  run      Diff two versions of a Confluence page (mirrors the `confluence_compare` MCP tool)
+  section  Drill in to a section diff using a cursor from a prior `run` (mirrors the `confluence_compare_section` MCP tool)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -559,9 +559,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence compare run - Diff two versions of a Confluence page
+omni-dev atlassian confluence compare run - Diff two versions of a Confluence page (mirrors the `confluence_compare` MCP tool)
 
-Diff two versions of a Confluence page
+Diff two versions of a Confluence page (mirrors the `confluence_compare` MCP tool)
 
 Usage: run [OPTIONS] <ID>
 
@@ -593,9 +593,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence compare section - Drill in to a section diff using a cursor from a prior `run`
+omni-dev atlassian confluence compare section - Drill in to a section diff using a cursor from a prior `run` (mirrors the `confluence_compare_section` MCP tool)
 
-Drill in to a section diff using a cursor from a prior `run`
+Drill in to a section diff using a cursor from a prior `run` (mirrors the `confluence_compare_section` MCP tool)
 
 Usage: section [OPTIONS] --cursor <CURSOR>
 
@@ -607,9 +607,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence create - Creates a new Confluence page
+omni-dev atlassian confluence create - Creates a new Confluence page (mirrors the `confluence_create` MCP tool)
 
-Creates a new Confluence page
+Creates a new Confluence page (mirrors the `confluence_create` MCP tool)
 
 Usage: create [OPTIONS] [FILE]
 
@@ -627,9 +627,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence delete - Deletes a Confluence page
+omni-dev atlassian confluence delete - Deletes a Confluence page (mirrors the `confluence_delete` MCP tool)
 
-Deletes a Confluence page
+Deletes a Confluence page (mirrors the `confluence_delete` MCP tool)
 
 Usage: delete [OPTIONS] <ID>
 
@@ -645,9 +645,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence download - Recursively downloads a Confluence page tree
+omni-dev atlassian confluence download - Recursively downloads a Confluence page tree (mirrors the `confluence_download` MCP tool)
 
-Recursively downloads a Confluence page tree
+Recursively downloads a Confluence page tree (mirrors the `confluence_download` MCP tool)
 
 Usage: download [OPTIONS] <ID|--space <SPACE>>
 
@@ -684,9 +684,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence history - Lists version history (metadata) for a Confluence page
+omni-dev atlassian confluence history - Lists version history (metadata) for a Confluence page (mirrors the `confluence_history` MCP tool)
 
-Lists version history (metadata) for a Confluence page
+Lists version history (metadata) for a Confluence page (mirrors the `confluence_history` MCP tool)
 
 Usage: history [OPTIONS] <ID>
 
@@ -709,9 +709,9 @@ Manages labels on Confluence pages
 Usage: label <COMMAND>
 
 Commands:
-  list    Lists labels on a Confluence page
-  add     Adds labels to a Confluence page
-  remove  Removes labels from a Confluence page
+  list    Lists labels on a Confluence page (mirrors the `confluence_label_list` MCP tool)
+  add     Adds labels to a Confluence page (mirrors the `confluence_label_add` MCP tool)
+  remove  Removes labels from a Confluence page (mirrors the `confluence_label_remove` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -720,9 +720,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence label add - Adds labels to a Confluence page
+omni-dev atlassian confluence label add - Adds labels to a Confluence page (mirrors the `confluence_label_add` MCP tool)
 
-Adds labels to a Confluence page
+Adds labels to a Confluence page (mirrors the `confluence_label_add` MCP tool)
 
 Usage: add --labels <LABELS> <ID>
 
@@ -736,9 +736,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence label list - Lists labels on a Confluence page
+omni-dev atlassian confluence label list - Lists labels on a Confluence page (mirrors the `confluence_label_list` MCP tool)
 
-Lists labels on a Confluence page
+Lists labels on a Confluence page (mirrors the `confluence_label_list` MCP tool)
 
 Usage: list [OPTIONS] <ID>
 
@@ -752,9 +752,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence label remove - Removes labels from a Confluence page
+omni-dev atlassian confluence label remove - Removes labels from a Confluence page (mirrors the `confluence_label_remove` MCP tool)
 
-Removes labels from a Confluence page
+Removes labels from a Confluence page (mirrors the `confluence_label_remove` MCP tool)
 
 Usage: remove [OPTIONS] --labels <LABELS> <ID>
 
@@ -770,9 +770,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence move - Moves or reparents a Confluence page (same-space only)
+omni-dev atlassian confluence move - Moves or reparents a Confluence page (same-space only) (mirrors the `confluence_move` MCP tool)
 
-Moves or reparents a Confluence page (same-space only)
+Moves or reparents a Confluence page (same-space only) (mirrors the `confluence_move` MCP tool)
 
 Usage: move [OPTIONS] --target <TARGET> <ID>
 
@@ -787,9 +787,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence read - Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
+omni-dev atlassian confluence read - Fetches a Confluence page and outputs it as JFM markdown or ADF JSON (mirrors the `confluence_read` MCP tool)
 
-Fetches a Confluence page and outputs it as JFM markdown or ADF JSON
+Fetches a Confluence page and outputs it as JFM markdown or ADF JSON (mirrors the `confluence_read` MCP tool)
 
 Usage: read [OPTIONS] <ID>
 
@@ -804,9 +804,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence search - Searches Confluence pages using CQL
+omni-dev atlassian confluence search - Searches Confluence pages using CQL (mirrors the `confluence_search` MCP tool)
 
-Searches Confluence pages using CQL
+Searches Confluence pages using CQL (mirrors the `confluence_search` MCP tool)
 
 Usage: search [OPTIONS]
 
@@ -828,8 +828,8 @@ Confluence space operations
 Usage: space <COMMAND>
 
 Commands:
-  list   Lists Confluence spaces
-  pages  Enumerates pages within a Confluence space
+  list   Lists Confluence spaces (mirrors the `confluence_space_list` MCP tool)
+  pages  Enumerates pages within a Confluence space (mirrors the `confluence_space_pages` MCP tool)
   help   Print this message or the help of the given subcommand(s)
 
 Options:
@@ -838,9 +838,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence space list - Lists Confluence spaces
+omni-dev atlassian confluence space list - Lists Confluence spaces (mirrors the `confluence_space_list` MCP tool)
 
-Lists Confluence spaces
+Lists Confluence spaces (mirrors the `confluence_space_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -856,9 +856,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence space pages - Enumerates pages within a Confluence space
+omni-dev atlassian confluence space pages - Enumerates pages within a Confluence space (mirrors the `confluence_space_pages` MCP tool)
 
-Enumerates pages within a Confluence space
+Enumerates pages within a Confluence space (mirrors the `confluence_space_pages` MCP tool)
 
 Usage: pages [OPTIONS] <KEY>
 
@@ -883,7 +883,7 @@ Confluence user operations
 Usage: user <COMMAND>
 
 Commands:
-  search  Searches Confluence users by display name or email
+  search  Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -892,9 +892,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence user search - Searches Confluence users by display name or email
+omni-dev atlassian confluence user search - Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool)
 
-Searches Confluence users by display name or email
+Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool)
 
 Usage: search [OPTIONS] --query <QUERY>
 
@@ -907,9 +907,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian confluence write - Pushes content to a Confluence page
+omni-dev atlassian confluence write - Pushes content to a Confluence page (mirrors the `confluence_write` MCP tool)
 
-Pushes content to a Confluence page
+Pushes content to a Confluence page (mirrors the `confluence_write` MCP tool)
 
 Usage: write [OPTIONS] <ID> [FILE]
 
@@ -933,8 +933,8 @@ Converts between JFM markdown and ADF JSON
 Usage: convert <COMMAND>
 
 Commands:
-  to-adf    Converts JFM markdown to ADF JSON
-  from-adf  Converts ADF JSON to JFM markdown
+  to-adf    Converts JFM markdown to ADF JSON (mirrors the `atlassian_convert` MCP tool)
+  from-adf  Converts ADF JSON to JFM markdown (mirrors the `atlassian_convert` MCP tool)
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -943,9 +943,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian convert from-adf - Converts ADF JSON to JFM markdown
+omni-dev atlassian convert from-adf - Converts ADF JSON to JFM markdown (mirrors the `atlassian_convert` MCP tool)
 
-Converts ADF JSON to JFM markdown
+Converts ADF JSON to JFM markdown (mirrors the `atlassian_convert` MCP tool)
 
 Usage: from-adf [OPTIONS] [FILE]
 
@@ -959,9 +959,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian convert to-adf - Converts JFM markdown to ADF JSON
+omni-dev atlassian convert to-adf - Converts JFM markdown to ADF JSON (mirrors the `atlassian_convert` MCP tool)
 
-Converts JFM markdown to ADF JSON
+Converts JFM markdown to ADF JSON (mirrors the `atlassian_convert` MCP tool)
 
 Usage: to-adf [OPTIONS] [FILE]
 
@@ -983,21 +983,21 @@ JIRA issue management, search, agile boards, and more
 Usage: jira <COMMAND>
 
 Commands:
-  read        Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON
-  write       Pushes content to a JIRA issue
+  read        Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON (mirrors the `jira_read` MCP tool)
+  write       Pushes content to a JIRA issue (mirrors the `jira_write` MCP tool)
   edit        Interactive fetch-edit-push cycle for a JIRA issue
-  search      Searches JIRA issues using JQL
-  create      Creates a new JIRA issue
+  search      Searches JIRA issues using JQL (mirrors the `jira_search` MCP tool)
+  create      Creates a new JIRA issue (mirrors the `jira_create` MCP tool)
   transition  Lists or executes workflow transitions on a JIRA issue
   comment     Manages comments on a JIRA issue
-  delete      Deletes a JIRA issue
-  dev         Shows development status (linked PRs, branches, repositories) for a JIRA issue
+  delete      Deletes a JIRA issue (mirrors the `jira_delete` MCP tool)
+  dev         Shows development status (linked PRs, branches, repositories) for a JIRA issue (mirrors the `jira_dev` MCP tool)
   project     Lists JIRA projects
   field       Manages JIRA field definitions and options
   board       Manages JIRA agile boards
   sprint      Manages JIRA agile sprints
   link        Manages JIRA issue links
-  changelog   Shows change history for JIRA issues
+  changelog   Shows change history for JIRA issues (mirrors the `jira_changelog` MCP tool)
   attachment  Downloads JIRA issue attachments
   watcher     Manages watchers on a JIRA issue
   worklog     Manages worklogs (time tracking) on a JIRA issue
@@ -1018,8 +1018,8 @@ Downloads JIRA issue attachments
 Usage: attachment <COMMAND>
 
 Commands:
-  download  Downloads all attachments (or filtered by pattern)
-  images    Downloads only image attachments
+  download  Downloads all attachments (or filtered by pattern) (mirrors the `jira_attachment_download` MCP tool)
+  images    Downloads only image attachments (mirrors the `jira_attachment_images` MCP tool)
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1028,9 +1028,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira attachment download - Downloads all attachments (or filtered by pattern)
+omni-dev atlassian jira attachment download - Downloads all attachments (or filtered by pattern) (mirrors the `jira_attachment_download` MCP tool)
 
-Downloads all attachments (or filtered by pattern)
+Downloads all attachments (or filtered by pattern) (mirrors the `jira_attachment_download` MCP tool)
 
 Usage: download [OPTIONS] <KEY>
 
@@ -1045,9 +1045,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira attachment images - Downloads only image attachments
+omni-dev atlassian jira attachment images - Downloads only image attachments (mirrors the `jira_attachment_images` MCP tool)
 
-Downloads only image attachments
+Downloads only image attachments (mirrors the `jira_attachment_images` MCP tool)
 
 Usage: images [OPTIONS] <KEY>
 
@@ -1068,8 +1068,8 @@ Manages JIRA agile boards
 Usage: board <COMMAND>
 
 Commands:
-  list    Lists agile boards
-  issues  Lists issues on a board
+  list    Lists agile boards (mirrors the `jira_board_list` MCP tool)
+  issues  Lists issues on a board (mirrors the `jira_board_issues` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1078,9 +1078,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira board issues - Lists issues on a board
+omni-dev atlassian jira board issues - Lists issues on a board (mirrors the `jira_board_issues` MCP tool)
 
-Lists issues on a board
+Lists issues on a board (mirrors the `jira_board_issues` MCP tool)
 
 Usage: issues [OPTIONS] --board-id <BOARD_ID>
 
@@ -1094,9 +1094,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira board list - Lists agile boards
+omni-dev atlassian jira board list - Lists agile boards (mirrors the `jira_board_list` MCP tool)
 
-Lists agile boards
+Lists agile boards (mirrors the `jira_board_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -1110,9 +1110,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira changelog - Shows change history for JIRA issues
+omni-dev atlassian jira changelog - Shows change history for JIRA issues (mirrors the `jira_changelog` MCP tool)
 
-Shows change history for JIRA issues
+Shows change history for JIRA issues (mirrors the `jira_changelog` MCP tool)
 
 Usage: changelog [OPTIONS] <KEYS>
 
@@ -1134,9 +1134,9 @@ Manages comments on a JIRA issue
 Usage: comment <COMMAND>
 
 Commands:
-  list  Lists comments on a JIRA issue
-  add   Adds a comment to a JIRA issue
-  edit  Edits an existing comment on a JIRA issue
+  list  Lists comments on a JIRA issue (mirrors the `jira_comment` MCP tool with `action: list`)
+  add   Adds a comment to a JIRA issue (mirrors the `jira_comment` MCP tool with `action: add`)
+  edit  Edits an existing comment on a JIRA issue (mirrors the `jira_comment_edit` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1145,9 +1145,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira comment add - Adds a comment to a JIRA issue
+omni-dev atlassian jira comment add - Adds a comment to a JIRA issue (mirrors the `jira_comment` MCP tool with `action: add`)
 
-Adds a comment to a JIRA issue
+Adds a comment to a JIRA issue (mirrors the `jira_comment` MCP tool with `action: add`)
 
 Usage: add [OPTIONS] <KEY> [FILE]
 
@@ -1162,9 +1162,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira comment edit - Edits an existing comment on a JIRA issue
+omni-dev atlassian jira comment edit - Edits an existing comment on a JIRA issue (mirrors the `jira_comment_edit` MCP tool)
 
-Edits an existing comment on a JIRA issue
+Edits an existing comment on a JIRA issue (mirrors the `jira_comment_edit` MCP tool)
 
 Usage: edit [OPTIONS] <KEY> <COMMENT_ID> [FILE]
 
@@ -1186,9 +1186,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira comment list - Lists comments on a JIRA issue
+omni-dev atlassian jira comment list - Lists comments on a JIRA issue (mirrors the `jira_comment` MCP tool with `action: list`)
 
-Lists comments on a JIRA issue
+Lists comments on a JIRA issue (mirrors the `jira_comment` MCP tool with `action: list`)
 
 Usage: list [OPTIONS] <KEY>
 
@@ -1203,9 +1203,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira create - Creates a new JIRA issue
+omni-dev atlassian jira create - Creates a new JIRA issue (mirrors the `jira_create` MCP tool)
 
-Creates a new JIRA issue
+Creates a new JIRA issue (mirrors the `jira_create` MCP tool)
 
 Usage: create [OPTIONS] [FILE]
 
@@ -1240,9 +1240,9 @@ ADF INPUT (--format adf):
 
 ================================================================================
 
-omni-dev atlassian jira delete - Deletes a JIRA issue
+omni-dev atlassian jira delete - Deletes a JIRA issue (mirrors the `jira_delete` MCP tool)
 
-Deletes a JIRA issue
+Deletes a JIRA issue (mirrors the `jira_delete` MCP tool)
 
 Usage: delete [OPTIONS] <KEY>
 
@@ -1257,9 +1257,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira dev - Shows development status (linked PRs, branches, repositories) for a JIRA issue
+omni-dev atlassian jira dev - Shows development status (linked PRs, branches, repositories) for a JIRA issue (mirrors the `jira_dev` MCP tool)
 
-Shows development status (linked PRs, branches, repositories) for a JIRA issue
+Shows development status (linked PRs, branches, repositories) for a JIRA issue (mirrors the `jira_dev` MCP tool)
 
 Usage: dev [OPTIONS] <KEY>
 
@@ -1298,8 +1298,8 @@ Manages JIRA field definitions and options
 Usage: field <COMMAND>
 
 Commands:
-  list     Lists all field definitions
-  options  Shows options for a custom field
+  list     Lists all field definitions (mirrors the `jira_field_list` MCP tool)
+  options  Shows options for a custom field (mirrors the `jira_field_options` MCP tool)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1308,9 +1308,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira field list - Lists all field definitions
+omni-dev atlassian jira field list - Lists all field definitions (mirrors the `jira_field_list` MCP tool)
 
-Lists all field definitions
+Lists all field definitions (mirrors the `jira_field_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -1322,9 +1322,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira field options - Shows options for a custom field
+omni-dev atlassian jira field options - Shows options for a custom field (mirrors the `jira_field_options` MCP tool)
 
-Shows options for a custom field
+Shows options for a custom field (mirrors the `jira_field_options` MCP tool)
 
 Usage: options [OPTIONS] --field-id <FIELD_ID>
 
@@ -1470,8 +1470,8 @@ Lists JIRA projects
 Usage: project <COMMAND>
 
 Commands:
-  list         Lists all accessible JIRA projects
-  create-meta  Shows the create-screen fields for a project + issue type
+  list         Lists all accessible JIRA projects (mirrors the `jira_project_list` MCP tool)
+  create-meta  Shows the create-screen fields for a project + issue type (mirrors the `jira_project_create_meta` MCP tool)
   help         Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1480,9 +1480,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira project create-meta - Shows the create-screen fields for a project + issue type
+omni-dev atlassian jira project create-meta - Shows the create-screen fields for a project + issue type (mirrors the `jira_project_create_meta` MCP tool)
 
-Shows the create-screen fields for a project + issue type
+Shows the create-screen fields for a project + issue type (mirrors the `jira_project_create_meta` MCP tool)
 
 Usage: create-meta [OPTIONS] --project <PROJECT> --issue-type <ISSUE_TYPE>
 
@@ -1495,9 +1495,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira project list - Lists all accessible JIRA projects
+omni-dev atlassian jira project list - Lists all accessible JIRA projects (mirrors the `jira_project_list` MCP tool)
 
-Lists all accessible JIRA projects
+Lists all accessible JIRA projects (mirrors the `jira_project_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -1509,9 +1509,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira read - Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON
+omni-dev atlassian jira read - Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON (mirrors the `jira_read` MCP tool)
 
-Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON
+Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON (mirrors the `jira_read` MCP tool)
 
 Usage: read [OPTIONS] <KEY>
 
@@ -1528,9 +1528,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira search - Searches JIRA issues using JQL
+omni-dev atlassian jira search - Searches JIRA issues using JQL (mirrors the `jira_search` MCP tool)
 
-Searches JIRA issues using JQL
+Searches JIRA issues using JQL (mirrors the `jira_search` MCP tool)
 
 Usage: search [OPTIONS]
 
@@ -1553,11 +1553,11 @@ Manages JIRA agile sprints
 Usage: sprint <COMMAND>
 
 Commands:
-  list    Lists sprints for a board
-  issues  Lists issues in a sprint
-  add     Adds issues to a sprint
-  create  Creates a new sprint
-  update  Updates an existing sprint
+  list    Lists sprints for a board (mirrors the `jira_sprint_list` MCP tool)
+  issues  Lists issues in a sprint (mirrors the `jira_sprint_issues` MCP tool)
+  add     Adds issues to a sprint (mirrors the `jira_sprint_add` MCP tool)
+  create  Creates a new sprint (mirrors the `jira_sprint_create` MCP tool)
+  update  Updates an existing sprint (mirrors the `jira_sprint_update` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1566,9 +1566,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira sprint add - Adds issues to a sprint
+omni-dev atlassian jira sprint add - Adds issues to a sprint (mirrors the `jira_sprint_add` MCP tool)
 
-Adds issues to a sprint
+Adds issues to a sprint (mirrors the `jira_sprint_add` MCP tool)
 
 Usage: add --sprint-id <SPRINT_ID> --issues <ISSUES>
 
@@ -1580,9 +1580,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira sprint create - Creates a new sprint
+omni-dev atlassian jira sprint create - Creates a new sprint (mirrors the `jira_sprint_create` MCP tool)
 
-Creates a new sprint
+Creates a new sprint (mirrors the `jira_sprint_create` MCP tool)
 
 Usage: create [OPTIONS] --board-id <BOARD_ID> --name <NAME>
 
@@ -1597,9 +1597,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira sprint issues - Lists issues in a sprint
+omni-dev atlassian jira sprint issues - Lists issues in a sprint (mirrors the `jira_sprint_issues` MCP tool)
 
-Lists issues in a sprint
+Lists issues in a sprint (mirrors the `jira_sprint_issues` MCP tool)
 
 Usage: issues [OPTIONS] --sprint-id <SPRINT_ID>
 
@@ -1613,9 +1613,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira sprint list - Lists sprints for a board
+omni-dev atlassian jira sprint list - Lists sprints for a board (mirrors the `jira_sprint_list` MCP tool)
 
-Lists sprints for a board
+Lists sprints for a board (mirrors the `jira_sprint_list` MCP tool)
 
 Usage: list [OPTIONS] --board-id <BOARD_ID>
 
@@ -1629,9 +1629,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira sprint update - Updates an existing sprint
+omni-dev atlassian jira sprint update - Updates an existing sprint (mirrors the `jira_sprint_update` MCP tool)
 
-Updates an existing sprint
+Updates an existing sprint (mirrors the `jira_sprint_update` MCP tool)
 
 Usage: update [OPTIONS] --sprint-id <SPRINT_ID>
 
@@ -1654,8 +1654,8 @@ Lists or executes workflow transitions on a JIRA issue
 Usage: transition <COMMAND>
 
 Commands:
-  list     Lists workflow transitions available from the issue's current status
-  execute  Executes a workflow transition on a JIRA issue
+  list     Lists workflow transitions available from the issue's current status (mirrors the `jira_transition_list` MCP tool)
+  execute  Executes a workflow transition on a JIRA issue (mirrors the `jira_transition` MCP tool)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1664,9 +1664,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira transition execute - Executes a workflow transition on a JIRA issue
+omni-dev atlassian jira transition execute - Executes a workflow transition on a JIRA issue (mirrors the `jira_transition` MCP tool)
 
-Executes a workflow transition on a JIRA issue
+Executes a workflow transition on a JIRA issue (mirrors the `jira_transition` MCP tool)
 
 Usage: execute <KEY> <TRANSITION>
 
@@ -1680,9 +1680,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira transition list - Lists workflow transitions available from the issue's current status
+omni-dev atlassian jira transition list - Lists workflow transitions available from the issue's current status (mirrors the `jira_transition_list` MCP tool)
 
-Lists workflow transitions available from the issue's current status
+Lists workflow transitions available from the issue's current status (mirrors the `jira_transition_list` MCP tool)
 
 Usage: list [OPTIONS] <KEY>
 
@@ -1703,7 +1703,7 @@ JIRA user operations (search by name or email)
 Usage: user <COMMAND>
 
 Commands:
-  search  Searches JIRA users by display name or email substring
+  search  Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1712,9 +1712,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira user search - Searches JIRA users by display name or email substring
+omni-dev atlassian jira user search - Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool)
 
-Searches JIRA users by display name or email substring
+Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool)
 
 Usage: search [OPTIONS] --query <QUERY>
 
@@ -1734,8 +1734,8 @@ Manages JIRA project versions (release versions)
 Usage: version <COMMAND>
 
 Commands:
-  list    Lists versions for a project
-  create  Creates a new project version
+  list    Lists versions for a project (mirrors the `jira_version_list` MCP tool)
+  create  Creates a new project version (mirrors the `jira_version_create` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1744,9 +1744,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira version create - Creates a new project version
+omni-dev atlassian jira version create - Creates a new project version (mirrors the `jira_version_create` MCP tool)
 
-Creates a new project version
+Creates a new project version (mirrors the `jira_version_create` MCP tool)
 
 Usage: create [OPTIONS] --project <PROJECT> --name <NAME>
 
@@ -1763,9 +1763,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira version list - Lists versions for a project
+omni-dev atlassian jira version list - Lists versions for a project (mirrors the `jira_version_list` MCP tool)
 
-Lists versions for a project
+Lists versions for a project (mirrors the `jira_version_list` MCP tool)
 
 Usage: list [OPTIONS] --project <PROJECT>
 
@@ -1788,9 +1788,9 @@ Manages watchers on a JIRA issue
 Usage: watcher <COMMAND>
 
 Commands:
-  list    Lists current watchers on an issue
-  add     Adds a user as a watcher on an issue
-  remove  Removes a user from watchers on an issue
+  list    Lists current watchers on an issue (mirrors the `jira_watcher_list` MCP tool)
+  add     Adds a user as a watcher on an issue (mirrors the `jira_watcher_add` MCP tool)
+  remove  Removes a user from watchers on an issue (mirrors the `jira_watcher_remove` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1799,9 +1799,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira watcher add - Adds a user as a watcher on an issue
+omni-dev atlassian jira watcher add - Adds a user as a watcher on an issue (mirrors the `jira_watcher_add` MCP tool)
 
-Adds a user as a watcher on an issue
+Adds a user as a watcher on an issue (mirrors the `jira_watcher_add` MCP tool)
 
 Usage: add --user <USER> <KEY>
 
@@ -1815,9 +1815,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira watcher list - Lists current watchers on an issue
+omni-dev atlassian jira watcher list - Lists current watchers on an issue (mirrors the `jira_watcher_list` MCP tool)
 
-Lists current watchers on an issue
+Lists current watchers on an issue (mirrors the `jira_watcher_list` MCP tool)
 
 Usage: list [OPTIONS] <KEY>
 
@@ -1831,9 +1831,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira watcher remove - Removes a user from watchers on an issue
+omni-dev atlassian jira watcher remove - Removes a user from watchers on an issue (mirrors the `jira_watcher_remove` MCP tool)
 
-Removes a user from watchers on an issue
+Removes a user from watchers on an issue (mirrors the `jira_watcher_remove` MCP tool)
 
 Usage: remove [OPTIONS] --user <USER> <KEY>
 
@@ -1856,8 +1856,8 @@ Manages worklogs (time tracking) on a JIRA issue
 Usage: worklog <COMMAND>
 
 Commands:
-  list  Lists worklogs on a JIRA issue
-  add   Adds a worklog entry to a JIRA issue
+  list  Lists worklogs on a JIRA issue (mirrors the `jira_worklog_list` MCP tool)
+  add   Adds a worklog entry to a JIRA issue (mirrors the `jira_worklog_add` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -1866,9 +1866,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira worklog add - Adds a worklog entry to a JIRA issue
+omni-dev atlassian jira worklog add - Adds a worklog entry to a JIRA issue (mirrors the `jira_worklog_add` MCP tool)
 
-Adds a worklog entry to a JIRA issue
+Adds a worklog entry to a JIRA issue (mirrors the `jira_worklog_add` MCP tool)
 
 Usage: add [OPTIONS] --time-spent <TIME_SPENT> <KEY>
 
@@ -1884,9 +1884,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira worklog list - Lists worklogs on a JIRA issue
+omni-dev atlassian jira worklog list - Lists worklogs on a JIRA issue (mirrors the `jira_worklog_list` MCP tool)
 
-Lists worklogs on a JIRA issue
+Lists worklogs on a JIRA issue (mirrors the `jira_worklog_list` MCP tool)
 
 Usage: list [OPTIONS] <KEY>
 
@@ -1901,9 +1901,9 @@ Options:
 
 ================================================================================
 
-omni-dev atlassian jira write - Pushes content to a JIRA issue
+omni-dev atlassian jira write - Pushes content to a JIRA issue (mirrors the `jira_write` MCP tool)
 
-Pushes content to a JIRA issue
+Pushes content to a JIRA issue (mirrors the `jira_write` MCP tool)
 
 Usage: write [OPTIONS] <KEY> [FILE]
 
@@ -2180,7 +2180,7 @@ AI model configuration and information
 Usage: models <COMMAND>
 
 Commands:
-  show  Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer
+  show  Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer (mirrors the `config_models_show` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2189,9 +2189,9 @@ Options:
 
 ================================================================================
 
-omni-dev config models show - Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer
+omni-dev config models show - Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer (mirrors the `config_models_show` MCP tool)
 
-Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer
+Shows the model catalog (merged user/project layers over the embedded `models.yaml`), annotating each entry with its source layer (mirrors the `config_models_show` MCP tool)
 
 Usage: show [OPTIONS]
 
@@ -2394,7 +2394,7 @@ Usage: auth <COMMAND>
 Commands:
   login   Configures Datadog API credentials interactively
   logout  Removes Datadog API credentials from settings.json
-  status  Shows the current authentication status
+  status  Shows the current authentication status (mirrors the `datadog_auth_status` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2427,9 +2427,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog auth status - Shows the current authentication status
+omni-dev datadog auth status - Shows the current authentication status (mirrors the `datadog_auth_status` MCP tool)
 
-Shows the current authentication status
+Shows the current authentication status (mirrors the `datadog_auth_status` MCP tool)
 
 Usage: status
 
@@ -2446,8 +2446,8 @@ Inspects Datadog dashboards
 Usage: dashboard <COMMAND>
 
 Commands:
-  list  Lists dashboards, optionally filtered to shared dashboards
-  get   Fetches a single dashboard definition by id
+  list  Lists dashboards, optionally filtered to shared dashboards (mirrors the `datadog_dashboard_list` MCP tool)
+  get   Fetches a single dashboard definition by id (mirrors the `datadog_dashboard_get` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2456,9 +2456,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog dashboard get - Fetches a single dashboard definition by id
+omni-dev datadog dashboard get - Fetches a single dashboard definition by id (mirrors the `datadog_dashboard_get` MCP tool)
 
-Fetches a single dashboard definition by id
+Fetches a single dashboard definition by id (mirrors the `datadog_dashboard_get` MCP tool)
 
 Usage: get [OPTIONS] <ID>
 
@@ -2472,9 +2472,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog dashboard list - Lists dashboards, optionally filtered to shared dashboards
+omni-dev datadog dashboard list - Lists dashboards, optionally filtered to shared dashboards (mirrors the `datadog_dashboard_list` MCP tool)
 
-Lists dashboards, optionally filtered to shared dashboards
+Lists dashboards, optionally filtered to shared dashboards (mirrors the `datadog_dashboard_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2493,7 +2493,7 @@ Inspects Datadog scheduled downtimes
 Usage: downtime <COMMAND>
 
 Commands:
-  list  Lists scheduled downtimes via `GET /api/v1/downtime`
+  list  Lists scheduled downtimes via `GET /api/v1/downtime` (mirrors the `datadog_downtime_list` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2502,9 +2502,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog downtime list - Lists scheduled downtimes via `GET /api/v1/downtime`
+omni-dev datadog downtime list - Lists scheduled downtimes via `GET /api/v1/downtime` (mirrors the `datadog_downtime_list` MCP tool)
 
-Lists scheduled downtimes via `GET /api/v1/downtime`
+Lists scheduled downtimes via `GET /api/v1/downtime` (mirrors the `datadog_downtime_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2523,7 +2523,7 @@ Inspects the Datadog events stream
 Usage: events <COMMAND>
 
 Commands:
-  list  Lists events via `GET /api/v2/events`
+  list  Lists events via `GET /api/v2/events` (mirrors the `datadog_events_list` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2532,9 +2532,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog events list - Lists events via `GET /api/v2/events`
+omni-dev datadog events list - Lists events via `GET /api/v2/events` (mirrors the `datadog_events_list` MCP tool)
 
-Lists events via `GET /api/v2/events`
+Lists events via `GET /api/v2/events` (mirrors the `datadog_events_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2558,7 +2558,7 @@ Inspects Datadog reporting hosts
 Usage: hosts <COMMAND>
 
 Commands:
-  list  Lists hosts via `GET /api/v1/hosts`
+  list  Lists hosts via `GET /api/v1/hosts` (mirrors the `datadog_hosts_list` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2567,9 +2567,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog hosts list - Lists hosts via `GET /api/v1/hosts`
+omni-dev datadog hosts list - Lists hosts via `GET /api/v1/hosts` (mirrors the `datadog_hosts_list` MCP tool)
 
-Lists hosts via `GET /api/v1/hosts`
+Lists hosts via `GET /api/v1/hosts` (mirrors the `datadog_hosts_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2590,7 +2590,7 @@ Searches Datadog logs
 Usage: logs <COMMAND>
 
 Commands:
-  search  Searches log events via `POST /api/v2/logs/events/search`
+  search  Searches log events via `POST /api/v2/logs/events/search` (mirrors the `datadog_logs_search` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2599,9 +2599,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog logs search - Searches log events via `POST /api/v2/logs/events/search`
+omni-dev datadog logs search - Searches log events via `POST /api/v2/logs/events/search` (mirrors the `datadog_logs_search` MCP tool)
 
-Searches log events via `POST /api/v2/logs/events/search`
+Searches log events via `POST /api/v2/logs/events/search` (mirrors the `datadog_logs_search` MCP tool)
 
 Usage: search [OPTIONS] --filter <FILTER>
 
@@ -2624,8 +2624,8 @@ Queries Datadog metrics
 Usage: metrics <COMMAND>
 
 Commands:
-  query    Executes a point-in-time metrics timeseries query
-  catalog  Inspects the metric catalog (`/api/v1/metrics`)
+  query    Executes a point-in-time metrics timeseries query (mirrors the `datadog_metrics_query` MCP tool)
+  catalog  Inspects the metric catalog (`/api/v1/metrics`) (mirrors the `datadog_metrics_catalog_list` MCP tool)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2634,9 +2634,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog metrics catalog - Inspects the metric catalog (`/api/v1/metrics`)
+omni-dev datadog metrics catalog - Inspects the metric catalog (`/api/v1/metrics`) (mirrors the `datadog_metrics_catalog_list` MCP tool)
 
-Inspects the metric catalog (`/api/v1/metrics`)
+Inspects the metric catalog (`/api/v1/metrics`) (mirrors the `datadog_metrics_catalog_list` MCP tool)
 
 Usage: catalog <COMMAND>
 
@@ -2665,9 +2665,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog metrics query - Executes a point-in-time metrics timeseries query
+omni-dev datadog metrics query - Executes a point-in-time metrics timeseries query (mirrors the `datadog_metrics_query` MCP tool)
 
-Executes a point-in-time metrics timeseries query
+Executes a point-in-time metrics timeseries query (mirrors the `datadog_metrics_query` MCP tool)
 
 Usage: query [OPTIONS] --query <QUERY> --from <FROM>
 
@@ -2688,9 +2688,9 @@ Inspects Datadog monitors
 Usage: monitor <COMMAND>
 
 Commands:
-  list    Lists monitors with optional name / tag filters
-  get     Fetches a single monitor by id
-  search  Searches monitors by free-text / faceted query
+  list    Lists monitors with optional name / tag filters (mirrors the `datadog_monitor_list` MCP tool)
+  get     Fetches a single monitor by id (mirrors the `datadog_monitor_get` MCP tool)
+  search  Searches monitors by free-text / faceted query (mirrors the `datadog_monitor_search` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2699,9 +2699,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog monitor get - Fetches a single monitor by id
+omni-dev datadog monitor get - Fetches a single monitor by id (mirrors the `datadog_monitor_get` MCP tool)
 
-Fetches a single monitor by id
+Fetches a single monitor by id (mirrors the `datadog_monitor_get` MCP tool)
 
 Usage: get [OPTIONS] <ID>
 
@@ -2715,9 +2715,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog monitor list - Lists monitors with optional name / tag filters
+omni-dev datadog monitor list - Lists monitors with optional name / tag filters (mirrors the `datadog_monitor_list` MCP tool)
 
-Lists monitors with optional name / tag filters
+Lists monitors with optional name / tag filters (mirrors the `datadog_monitor_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2732,9 +2732,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog monitor search - Searches monitors by free-text / faceted query
+omni-dev datadog monitor search - Searches monitors by free-text / faceted query (mirrors the `datadog_monitor_search` MCP tool)
 
-Searches monitors by free-text / faceted query
+Searches monitors by free-text / faceted query (mirrors the `datadog_monitor_search` MCP tool)
 
 Usage: search [OPTIONS] --query <QUERY>
 
@@ -2754,8 +2754,8 @@ Inspects Datadog Service Level Objectives
 Usage: slo <COMMAND>
 
 Commands:
-  list  Lists SLOs with optional tag filter
-  get   Fetches a single SLO definition by id
+  list  Lists SLOs with optional tag filter (mirrors the `datadog_slo_list` MCP tool)
+  get   Fetches a single SLO definition by id (mirrors the `datadog_slo_get` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2764,9 +2764,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog slo get - Fetches a single SLO definition by id
+omni-dev datadog slo get - Fetches a single SLO definition by id (mirrors the `datadog_slo_get` MCP tool)
 
-Fetches a single SLO definition by id
+Fetches a single SLO definition by id (mirrors the `datadog_slo_get` MCP tool)
 
 Usage: get [OPTIONS] <ID>
 
@@ -2780,9 +2780,9 @@ Options:
 
 ================================================================================
 
-omni-dev datadog slo list - Lists SLOs with optional tag filter
+omni-dev datadog slo list - Lists SLOs with optional tag filter (mirrors the `datadog_slo_list` MCP tool)
 
-Lists SLOs with optional tag filter
+Lists SLOs with optional tag filter (mirrors the `datadog_slo_list` MCP tool)
 
 Usage: list [OPTIONS]
 
@@ -2822,7 +2822,7 @@ Branch-related operations
 Usage: branch <COMMAND>
 
 Commands:
-  info    Analyzes branch commits and outputs repository information in YAML format
+  info    Analyzes branch commits and outputs repository information in YAML format (mirrors the `git_branch_info` MCP tool)
   create  Create operations
   help    Print this message or the help of the given subcommand(s)
 
@@ -2839,7 +2839,7 @@ Create operations
 Usage: create <COMMAND>
 
 Commands:
-  pr    Creates a pull request with AI-generated description
+  pr    Creates a pull request with AI-generated description (mirrors the `git_create_pr` MCP tool)
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2848,9 +2848,9 @@ Options:
 
 ================================================================================
 
-omni-dev git branch create pr - Creates a pull request with AI-generated description
+omni-dev git branch create pr - Creates a pull request with AI-generated description (mirrors the `git_create_pr` MCP tool)
 
-Creates a pull request with AI-generated description
+Creates a pull request with AI-generated description (mirrors the `git_create_pr` MCP tool)
 
 Usage: pr [OPTIONS]
 
@@ -2869,9 +2869,9 @@ Options:
 
 ================================================================================
 
-omni-dev git branch info - Analyzes branch commits and outputs repository information in YAML format
+omni-dev git branch info - Analyzes branch commits and outputs repository information in YAML format (mirrors the `git_branch_info` MCP tool)
 
-Analyzes branch commits and outputs repository information in YAML format
+Analyzes branch commits and outputs repository information in YAML format (mirrors the `git_branch_info` MCP tool)
 
 Usage: info [BASE_BRANCH]
 
@@ -2907,11 +2907,11 @@ Commit message operations
 Usage: message <COMMAND>
 
 Commands:
-  view     Analyzes commits and outputs repository information in YAML format
+  view     Analyzes commits and outputs repository information in YAML format (mirrors the `git_view_commits` MCP tool)
   amend    Amends commit messages based on a YAML configuration file
-  twiddle  AI-powered commit message improvement using Claude
-  check    Checks commit messages against guidelines without modifying them
-  staged   Generates a commit message from staged changes and commits them
+  twiddle  AI-powered commit message improvement using Claude (mirrors the `git_twiddle_commits` MCP tool)
+  check    Checks commit messages against guidelines without modifying them (mirrors the `git_check_commits` MCP tool)
+  staged   Generates a commit message from staged changes and commits them (mirrors the `git_staged_commit` MCP tool)
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -2935,9 +2935,9 @@ Options:
 
 ================================================================================
 
-omni-dev git commit message check - Checks commit messages against guidelines without modifying them
+omni-dev git commit message check - Checks commit messages against guidelines without modifying them (mirrors the `git_check_commits` MCP tool)
 
-Checks commit messages against guidelines without modifying them
+Checks commit messages against guidelines without modifying them (mirrors the `git_check_commits` MCP tool)
 
 Usage: check [OPTIONS] [COMMIT_RANGE]
 
@@ -2963,9 +2963,9 @@ Options:
 
 ================================================================================
 
-omni-dev git commit message staged - Generates a commit message from staged changes and commits them
+omni-dev git commit message staged - Generates a commit message from staged changes and commits them (mirrors the `git_staged_commit` MCP tool)
 
-Generates a commit message from staged changes and commits them
+Generates a commit message from staged changes and commits them (mirrors the `git_staged_commit` MCP tool)
 
 Usage: staged [OPTIONS]
 
@@ -2979,9 +2979,9 @@ Options:
 
 ================================================================================
 
-omni-dev git commit message twiddle - AI-powered commit message improvement using Claude
+omni-dev git commit message twiddle - AI-powered commit message improvement using Claude (mirrors the `git_twiddle_commits` MCP tool)
 
-AI-powered commit message improvement using Claude
+AI-powered commit message improvement using Claude (mirrors the `git_twiddle_commits` MCP tool)
 
 Usage: twiddle [OPTIONS] [COMMIT_RANGE]
 
@@ -3027,9 +3027,9 @@ Options:
 
 ================================================================================
 
-omni-dev git commit message view - Analyzes commits and outputs repository information in YAML format
+omni-dev git commit message view - Analyzes commits and outputs repository information in YAML format (mirrors the `git_view_commits` MCP tool)
 
-Analyzes commits and outputs repository information in YAML format
+Analyzes commits and outputs repository information in YAML format (mirrors the `git_view_commits` MCP tool)
 
 Usage: view [COMMIT_RANGE]
 


### PR DESCRIPTION
## Description

This PR establishes a comprehensive quality standard (STYLE-0029) for MCP tool descriptions and parameter doc comments, then applies it across the entire `src/mcp/` surface. These strings are the **only** thing an AI agent reads to decide how to call a tool — vague or incomplete descriptions produce wrong-but-silent calls such as inverted link directions, display names where `accountId` is required, or the wrong body shape for a write operation.

The audit targets the root causes of known regression patterns (e.g., #1054 inverted `Blocks` direction, display-name-for-accountId) and generalises the fix from the #1049 `jira_link_create` exemplar across all tool families. The CLI ↔ MCP cross-reference pattern is also extended to every subcommand with a 1:1 MCP equivalent so both surfaces remain discoverable from each other.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Relates to #1072

## Changes Made

**Style Guide (`docs/STYLE_GUIDE.md`):**
- Added STYLE-0029: MCP tool & parameter description checklist with 10-point requirement (one-line summary, CLI cross-reference both directions, use-vs-sibling guidance, concrete example values, `dry_run`/`confirm` affordances, enum value lists, wire format specs, directional semantics, required-vs-optional)
- Added `documentation` to the task-to-tag lookup row for MCP tool/resource/param struct work
- Bumped next-ID counter from STYLE-0028 to STYLE-0030

**MCP Tool Descriptions (`src/mcp/`):**
- `ai_tools.rs`: Expanded `ai_chat`, `claude_skills_sync`, `claude_skills_clean`, `claude_skills_status` descriptions with concrete examples, sibling tool guidance, and read-only vs mutating notes; improved `AiChatParams` field docs with example message and model discovery pointer
- `atlassian_tools.rs`: Rewrote `atlassian_convert` to explain JFM (JIRA-Flavoured Markdown) vs ADF, both direction values with an example output snippet, and the offline/no-credentials nature of the tool
- `config_tools.rs`: Clarified `config_models_show` as returning the embedded catalog only (not merged user/project overrides) and linked to `ai_chat` for valid `model` values; clarified `atlassian_auth_status` as a local config check that does not call the Atlassian API
- `confluence_tools.rs`: Added concrete page ID examples, CQL example queries, create-vs-write sibling guidance, `id`-vs-`space` exclusivity, inline-vs-footer comment pointers, and `confluence_children`-vs-`confluence_space_pages` guidance
- `datadog_tools.rs`: Added `Mirrors \`omni-dev datadog ...\`` cross-references (previously missing across all Datadog tools); added concrete query examples, filter format specs, enum value lists for boolean filters, clarified `tags` vs `monitor_tags` distinction, and `datadog_logs_search`-vs-`datadog_events_list` sibling guidance
- `git_tools.rs`: Improved `git_view_commits`/`git_branch_info` sibling guidance (range-known vs base-branch comparison); clarified `git_check_commits` as read-only vs `git_twiddle_commits` as mutating; improved model param docs with discovery pointer; clarified `strict` default
- `jira_core_tools.rs`: Added issue key examples (`PROJ-123`), JFM resource reference, JQL date format (`YYYY-MM-DD`), `jira_create`-vs-`jira_bulk_create` guidance, `jira_comment`-vs-`jira_comment_edit` sibling pointers, and `jira_dev` read-only note
- `jira_tools.rs`: Fixed `account_id` param docs to explicitly state `accountId` (not display name or email) and added `jira_user_search` resolution pointer in `WatcherMutateParams`, `WatcherRemoveParams`, and both watcher tool descriptions

**CLI Cross-References (`src/cli/`):**
- Added `(mirrors the \`<tool_name>\` MCP tool)` suffix to clap `doc` strings for all 33 affected CLI subcommand variants across: `ai/claude/skills/`, `atlassian/auth`, `atlassian/confluence/` (attachment, comment, compare, label, mod, space, user, convert), `atlassian/jira/` (attachment, board, comment, field, mod, project, sprint, transition, user, version, watcher, worklog), `config`, `datadog/` (auth, dashboard, downtime, events, hosts, logs, metrics, monitor, slo), and `git`
- Updated `tests/snapshots/integration_test__help_all_output.snap` golden snapshot to reflect all help-text additions

**MCP Catalog (`docs/mcp.md`):**
- Added introductory paragraph documenting the STYLE-0029 convention and bidirectional cross-reference pattern
- Fixed `confluence_compare_section` format values from `side-by-side`/`markdown-inline` to `side_by_side`/`markdown_inline` (correct wire format the parser accepts)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Integration tests updated/added (help_all golden snapshot regenerated)
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [ ] Tested error/edge cases
- [x] Backward compatibility verified (purely additive description changes; no functional code modified)

### Test Commands
```bash
# Core test suite (includes snapshot verification)
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify help snapshot matches
cargo test integration_test__help_all_output
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience — AI agents reading these descriptions to select tools and parameters
- [x] Backward compatibility — descriptions are purely additive; no API or behavioral changes

The most important areas to review are:
- `src/mcp/datadog_tools.rs`: Largest set of changes; verify `tags` vs `monitor_tags` distinction is correctly explained and all `Mirrors` cross-references point to the correct CLI subcommand
- `src/mcp/jira_tools.rs` and `jira_core_tools.rs`: Verify `accountId` wording is consistent and the inward/outward directional semantics match what the API actually expects
- `docs/mcp.md`: Verify `side_by_side`/`markdown_inline` are the correct wire format values for `confluence_compare_section`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional MCP tools added in the future should pass STYLE-0029 as part of the `api-design` + `documentation` review checklist (now enforced by the updated task-to-tag lookup table)
- The `docs/mcp.md` tool catalog intro now documents the convention so new contributors understand the expected standard

**Known Limitations:**
- The golden snapshot update (`tests/snapshots/integration_test__help_all_output.snap`) is large (63 kB diff) but the changes are purely mechanical — every line change is the addition of `(mirrors the \`<tool_name>\` MCP tool)` to an existing help string

**Alternatives Considered:**
- Generating descriptions programmatically from a shared source of truth was considered but rejected — the descriptions intentionally differ between CLI and MCP (CLI is terse; MCP descriptions carry full agent-facing prose) so keeping them as separate strings is correct