### PR TITLE
fix(atlassian): enrich ADF validation errors with source location and offending text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **JFM→ADF validation failures now point at the source line, column, and offending text** ([#1087](https://github.com/rust-works/omni-dev/issues/1087)): when a JFM body converts to ADF that violates the content model — most commonly bold-wrapping-inline-code (`` **`/api/v1/example`** ``, which maps to a text node carrying both `strong` and `code`, a combination ADF forbids) — the write was aborted with only an opaque ADF index path (e.g. `at /38/4/0/1`), leaving the author to count siblings under an unrendered tree to find the culprit in a large document. The [`AdfValidationError`](src/atlassian/adf_validated.rs) is now enriched: it resolves the index path against the produced ADF tree to name the **offending run's text** (`in text: "/api/v1/example"`) and, when the JFM source is available, reports the **1-based `line:column`** of that run in the original markdown (columns counted in characters, so multi-byte text lines up with an editor cursor). Every validation error gains the text excerpt via [`ValidatedAdfDocument::try_new`](src/atlassian/adf_validated.rs); the JFM-sourced paths additionally gain `line:column` through a new shared [`markdown_to_validated_adf`](src/atlassian/adf_validated.rs) helper (and `try_new_with_source` / `validate_with_source` variants) now used by the MCP `jira`/`confluence` create/write/comment tools, the matching CLI commands and their `--dry-run` / `convert to-adf` preflights, and custom-field rich-text sections. This is the diagnostics improvement from #1087 option 2; silently splitting the `strong`+`code` marks (option 1) remains a separate follow-up.
+
 ## [0.31.0] - 2026-06-30
 
 ### Added

--- a/src/atlassian/adf_validated.rs
+++ b/src/atlassian/adf_validated.rs
@@ -825,6 +825,38 @@ mod tests {
         let loc = locate_in_source("hello\nworld foo", "foo").unwrap();
         assert_eq!(loc, SourceLocation { line: 2, column: 7 });
         assert!(locate_in_source("no match here", "absent").is_none());
+        // A needle that is only whitespace trims to empty and locates nothing.
+        assert!(locate_in_source("some text", "   ").is_none());
+    }
+
+    #[test]
+    fn collect_text_stops_at_the_excerpt_budget() {
+        // A block node whose *own* text already fills the budget, plus a child:
+        // gathering the child enters `gather_text` with a full buffer (the
+        // entry guard), and the post-child loop guard also fires — so the
+        // trailing child text is never appended.
+        let long = "a".repeat(EXCERPT_MAX_CHARS + 5);
+        let mut node = AdfNode::paragraph(vec![AdfNode::text("SHOULD_NOT_APPEAR")]);
+        node.text = Some(long);
+        let gathered = collect_text(&node);
+        assert!(gathered.chars().count() >= EXCERPT_MAX_CHARS);
+        assert!(!gathered.contains("SHOULD_NOT_APPEAR"), "got: {gathered}");
+    }
+
+    #[test]
+    fn resolve_context_returns_empty_for_off_tree_path() {
+        // A violation whose path runs off the tree resolves to no node, so no
+        // excerpt or location is attached.
+        let d = doc(vec![AdfNode::paragraph(vec![AdfNode::text("hi")])]);
+        let violation = AdfSchemaViolation::DisallowedChild {
+            child_type: "x".to_string(),
+            parent_type: "y".to_string(),
+            path: vec![9, 9],
+        };
+        assert_eq!(
+            resolve_context(&violation, &d, Some("hi")),
+            ViolationContext::default()
+        );
     }
 
     #[test]

--- a/src/atlassian/adf_validated.rs
+++ b/src/atlassian/adf_validated.rs
@@ -19,8 +19,161 @@ use std::ops::Deref;
 
 use serde::Serialize;
 
-use crate::atlassian::adf::AdfDocument;
+use crate::atlassian::adf::{AdfDocument, AdfNode};
 use crate::atlassian::adf_schema::{validate_document, AdfSchemaViolation};
+use crate::atlassian::convert::markdown_to_adf;
+
+/// A 1-based position in the original JFM markdown source.
+///
+/// Columns are counted in Unicode scalar values (chars), not bytes, so the
+/// reported column matches what an editor's cursor shows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceLocation {
+    /// 1-based line number.
+    pub line: usize,
+    /// 1-based column (counted in chars).
+    pub column: usize,
+}
+
+/// Human-facing context resolved for a single violation: the offending node's
+/// type, a short excerpt of its text (for Ctrl-F recovery), and — when the
+/// original JFM source is available — the 1-based `line:column` of that text.
+///
+/// Populated by [`AdfValidationError::enriched`]; a [`ViolationContext`] with
+/// all-`None` fields means the violation's path could not be resolved to a
+/// node carrying text (so nothing extra is printed for it).
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ViolationContext {
+    /// The offending node's `node_type` (e.g. `"text"`, `"paragraph"`).
+    node_type: Option<String>,
+    /// A short, display-truncated excerpt of the offending run's text.
+    excerpt: Option<String>,
+    /// 1-based `line:column` of the offending text in the JFM source, when a
+    /// source was supplied and the excerpt could be located in it.
+    location: Option<SourceLocation>,
+}
+
+/// Maximum number of chars shown in a violation's text excerpt before it is
+/// truncated with an ellipsis. Long enough to identify the run, short enough
+/// to keep the message on one line.
+const EXCERPT_MAX_CHARS: usize = 60;
+
+/// Resolves the [`AdfNode`] at `path` (an index path from the document root),
+/// or `None` if the path runs off the tree.
+fn node_at_path<'a>(doc: &'a AdfDocument, path: &[usize]) -> Option<&'a AdfNode> {
+    let mut children = doc.content.as_slice();
+    let mut found: Option<&AdfNode> = None;
+    for &idx in path {
+        let node = children.get(idx)?;
+        found = Some(node);
+        children = node.content.as_deref().unwrap_or(&[]);
+    }
+    found
+}
+
+/// Concatenates the text of a node and its inline descendants, stopping once
+/// [`EXCERPT_MAX_CHARS`] worth of characters have been collected. Used to give
+/// block-level violations (which have no `.text` of their own) a locator drawn
+/// from their first inline content.
+fn collect_text(node: &AdfNode) -> String {
+    let mut out = String::new();
+    gather_text(node, &mut out);
+    out
+}
+
+fn gather_text(node: &AdfNode, out: &mut String) {
+    if out.chars().count() >= EXCERPT_MAX_CHARS {
+        return;
+    }
+    if let Some(text) = &node.text {
+        out.push_str(text);
+    }
+    if let Some(children) = &node.content {
+        for child in children {
+            gather_text(child, out);
+            if out.chars().count() >= EXCERPT_MAX_CHARS {
+                return;
+            }
+        }
+    }
+}
+
+/// Truncates `s` to at most [`EXCERPT_MAX_CHARS`] chars, appending `…` when it
+/// was shortened. Operates on char boundaries so it never splits a codepoint.
+fn truncate_excerpt(s: &str) -> String {
+    if s.chars().count() <= EXCERPT_MAX_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(EXCERPT_MAX_CHARS).collect();
+    out.push('…');
+    out
+}
+
+/// Converts a byte offset in `source` to a 1-based `line:column`.
+fn offset_to_line_col(source: &str, byte_offset: usize) -> SourceLocation {
+    let mut line = 1;
+    let mut column = 1;
+    for (idx, ch) in source.char_indices() {
+        if idx >= byte_offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    SourceLocation { line, column }
+}
+
+/// Locates `needle` (an ADF text-node value) in the JFM `source` and returns
+/// its 1-based `line:column`.
+///
+/// The ADF text is the source run with inline markup stripped (e.g. a code
+/// span's backticks are gone), so it is a substring of the source and a direct
+/// search lands on the offending run. Reports the **first** occurrence; the
+/// excerpt printed alongside disambiguates when the same text repeats.
+fn locate_in_source(source: &str, needle: &str) -> Option<SourceLocation> {
+    let needle = needle.trim();
+    if needle.is_empty() {
+        return None;
+    }
+    let byte_offset = source.find(needle)?;
+    Some(offset_to_line_col(source, byte_offset))
+}
+
+/// Resolves the display context for one violation against `doc` (offending node
+/// + excerpt) and, when `source` is `Some`, its `line:column` in the source.
+fn resolve_context(
+    violation: &AdfSchemaViolation,
+    doc: &AdfDocument,
+    source: Option<&str>,
+) -> ViolationContext {
+    let Some(node) = node_at_path(doc, violation.path()) else {
+        return ViolationContext::default();
+    };
+    let node_type = Some(node.node_type.clone());
+
+    let full_text = match &node.text {
+        Some(text) => text.clone(),
+        None => collect_text(node),
+    };
+    let full_text = full_text.trim();
+    if full_text.is_empty() {
+        return ViolationContext {
+            node_type,
+            ..ViolationContext::default()
+        };
+    }
+
+    let location = source.and_then(|src| locate_in_source(src, full_text));
+    ViolationContext {
+        node_type,
+        excerpt: Some(truncate_excerpt(full_text)),
+        location,
+    }
+}
 
 /// One or more nesting violations discovered when validating an
 /// [`AdfDocument`] against the upstream content model.
@@ -32,6 +185,42 @@ use crate::atlassian::adf_schema::{validate_document, AdfSchemaViolation};
 pub struct AdfValidationError {
     /// All violations found, in document order.
     pub violations: Vec<AdfSchemaViolation>,
+    /// Resolved per-violation source context, parallel to `violations` when
+    /// present. Empty when the error was built without a document to resolve
+    /// against (e.g. a hand-constructed error in a test); populated by
+    /// [`Self::enriched`] so [`Display`](std::fmt::Display) can point at the
+    /// offending source location. See issue #1087.
+    contexts: Vec<ViolationContext>,
+}
+
+impl AdfValidationError {
+    /// Builds an error from `violations` with no resolved source context.
+    ///
+    /// Use [`Self::enriched`] to attach the offending node/excerpt/location.
+    #[must_use]
+    pub fn new(violations: Vec<AdfSchemaViolation>) -> Self {
+        Self {
+            violations,
+            contexts: Vec::new(),
+        }
+    }
+
+    /// Resolves each violation's ADF path against `doc` (capturing the
+    /// offending node type and a text excerpt) and, when `source` is `Some`,
+    /// maps that excerpt to a 1-based `line:column` in the original JFM.
+    ///
+    /// This turns an opaque ADF index path (e.g. `/38/4/0/1`) into an
+    /// actionable message that names the offending run and, for JFM-sourced
+    /// documents, where to find it (issue #1087).
+    #[must_use]
+    fn enriched(mut self, doc: &AdfDocument, source: Option<&str>) -> Self {
+        self.contexts = self
+            .violations
+            .iter()
+            .map(|v| resolve_context(v, doc, source))
+            .collect();
+        self
+    }
 }
 
 impl std::fmt::Display for AdfValidationError {
@@ -92,8 +281,22 @@ impl std::fmt::Display for AdfValidationError {
                     );
                 }
             }
+            if let Some(ctx) = self.contexts.get(i) {
+                append_context(&mut out, ctx);
+            }
         }
         f.write_str(&out)
+    }
+}
+
+/// Appends the resolved source location and offending-text excerpt for one
+/// violation, each on its own indented line, when they are known.
+fn append_context(out: &mut String, ctx: &ViolationContext) {
+    if let Some(loc) = &ctx.location {
+        out.push_str(&format!("\n  at line {}, column {}", loc.line, loc.column));
+    }
+    if let Some(excerpt) = &ctx.excerpt {
+        out.push_str(&format!("\n  in text: {excerpt:?}"));
     }
 }
 
@@ -221,12 +424,52 @@ const HINTS: &[(&str, &str, &str)] = &[
 /// Returns [`AdfValidationError`] when the document violates one or more
 /// allowed-children rules in the upstream content model.
 pub fn validate(doc: &AdfDocument) -> Result<(), AdfValidationError> {
+    validate_with_source(doc, None)
+}
+
+/// Like [`validate`], but source-aware.
+///
+/// Keeps `source` (the JFM markdown `doc` was converted from, when applicable)
+/// so any violation is reported with the offending run's 1-based `line:column`.
+/// Pass `None` when there is no JFM source (e.g. ADF-format input). See issue
+/// #1087.
+///
+/// # Errors
+///
+/// Returns [`AdfValidationError`] when the document violates one or more
+/// allowed-children rules in the upstream content model.
+pub fn validate_with_source(
+    doc: &AdfDocument,
+    source: Option<&str>,
+) -> Result<(), AdfValidationError> {
     let violations = validate_document(doc);
     if violations.is_empty() {
         Ok(())
     } else {
-        Err(AdfValidationError { violations })
+        Err(AdfValidationError::new(violations).enriched(doc, source))
     }
+}
+
+/// Converts JFM markdown to a validated ADF document, keeping the source
+/// available so any validation failure can be reported with its origin.
+///
+/// On success this is equivalent to
+/// `ValidatedAdfDocument::try_new(markdown_to_adf(source)?)`. On a schema
+/// violation the returned error is enriched with the offending text excerpt
+/// and its 1-based `line:column` in `source`, so callers get an actionable
+/// message instead of a bare ADF index path (issue #1087).
+///
+/// # Errors
+///
+/// Returns an error if the document violates the ADF content model. (The
+/// markdown-to-ADF step itself is infallible in practice but its `Result` is
+/// propagated for forward compatibility.)
+pub fn markdown_to_validated_adf(source: &str) -> anyhow::Result<ValidatedAdfDocument> {
+    let doc = markdown_to_adf(source)?;
+    Ok(ValidatedAdfDocument::try_new_with_source(
+        doc,
+        Some(source),
+    )?)
 }
 
 /// An [`AdfDocument`] that has passed nesting validation against the
@@ -252,11 +495,27 @@ impl ValidatedAdfDocument {
     /// Returns [`AdfValidationError`] if `doc` contains any disallowed
     /// nesting per the schema in [`crate::atlassian::adf_schema`].
     pub fn try_new(doc: AdfDocument) -> Result<Self, AdfValidationError> {
+        Self::try_new_with_source(doc, None)
+    }
+
+    /// Like [`Self::try_new`], but keeps `source` (the JFM markdown `doc` was
+    /// converted from, when applicable) so a validation failure reports the
+    /// offending run's 1-based `line:column`. Pass `None` when there is no JFM
+    /// source (e.g. ADF-format input). See issue #1087.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AdfValidationError`] if `doc` contains any disallowed nesting
+    /// per the schema in [`crate::atlassian::adf_schema`].
+    pub fn try_new_with_source(
+        doc: AdfDocument,
+        source: Option<&str>,
+    ) -> Result<Self, AdfValidationError> {
         let violations = validate_document(&doc);
         if violations.is_empty() {
             Ok(Self(doc))
         } else {
-            Err(AdfValidationError { violations })
+            Err(AdfValidationError::new(violations).enriched(&doc, source))
         }
     }
 
@@ -437,13 +696,11 @@ mod tests {
 
     #[test]
     fn error_display_for_missing_attr_violation() {
-        let err = AdfValidationError {
-            violations: vec![AdfSchemaViolation::MissingAttr {
-                node_type: "panel".to_string(),
-                attr_name: "panelType".to_string(),
-                path: vec![0],
-            }],
-        };
+        let err = AdfValidationError::new(vec![AdfSchemaViolation::MissingAttr {
+            node_type: "panel".to_string(),
+            attr_name: "panelType".to_string(),
+            path: vec![0],
+        }]);
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF attribute"), "got: {msg}");
         assert!(msg.contains("'panelType'"), "got: {msg}");
@@ -453,18 +710,16 @@ mod tests {
     #[test]
     fn error_display_for_invalid_attr_violation() {
         use crate::atlassian::adf_attr_schema::AttrProblem;
-        let err = AdfValidationError {
-            violations: vec![AdfSchemaViolation::InvalidAttr {
-                node_type: "heading".to_string(),
-                attr_name: "level".to_string(),
-                problem: AttrProblem::OutOfRange {
-                    lo: 1,
-                    hi: 6,
-                    actual: 7,
-                },
-                path: vec![0],
-            }],
-        };
+        let err = AdfValidationError::new(vec![AdfSchemaViolation::InvalidAttr {
+            node_type: "heading".to_string(),
+            attr_name: "level".to_string(),
+            problem: AttrProblem::OutOfRange {
+                lo: 1,
+                hi: 6,
+                actual: 7,
+            },
+            path: vec![0],
+        }]);
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF attribute"), "got: {msg}");
         assert!(msg.contains("'heading.level'"), "got: {msg}");
@@ -472,14 +727,12 @@ mod tests {
 
     #[test]
     fn error_display_for_disallowed_mark_violation() {
-        let err = AdfValidationError {
-            violations: vec![AdfSchemaViolation::DisallowedMark {
-                mark_type: "code".to_string(),
-                parent_type: "heading".to_string(),
-                inline_index: Some(0),
-                path: vec![0],
-            }],
-        };
+        let err = AdfValidationError::new(vec![AdfSchemaViolation::DisallowedMark {
+            mark_type: "code".to_string(),
+            parent_type: "heading".to_string(),
+            inline_index: Some(0),
+            path: vec![0],
+        }]);
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF mark"), "got: {msg}");
         assert!(msg.contains("'code' mark"), "got: {msg}");
@@ -488,15 +741,13 @@ mod tests {
 
     #[test]
     fn error_display_for_forbidden_mark_combination() {
-        let err = AdfValidationError {
-            violations: vec![AdfSchemaViolation::ForbiddenMarkCombination {
-                mark_type: "strong".to_string(),
-                conflicts_with: "code".to_string(),
-                parent_type: "paragraph".to_string(),
-                inline_index: Some(0),
-                path: vec![0, 0],
-            }],
-        };
+        let err = AdfValidationError::new(vec![AdfSchemaViolation::ForbiddenMarkCombination {
+            mark_type: "strong".to_string(),
+            conflicts_with: "code".to_string(),
+            parent_type: "paragraph".to_string(),
+            inline_index: Some(0),
+            path: vec![0, 0],
+        }]);
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF mark combination"), "got: {msg}");
         assert!(
@@ -534,19 +785,111 @@ mod tests {
     #[test]
     fn error_display_for_invalid_mark_attr_violation() {
         use crate::atlassian::adf_attr_schema::AttrProblem;
-        let err = AdfValidationError {
-            violations: vec![AdfSchemaViolation::InvalidMarkAttr {
-                mark_type: "link".to_string(),
-                attr_name: "href".to_string(),
-                problem: AttrProblem::BadFormat {
-                    reason: "not a valid URL",
-                },
-                inline_index: Some(0),
-                path: vec![0],
-            }],
-        };
+        let err = AdfValidationError::new(vec![AdfSchemaViolation::InvalidMarkAttr {
+            mark_type: "link".to_string(),
+            attr_name: "href".to_string(),
+            problem: AttrProblem::BadFormat {
+                reason: "not a valid URL",
+            },
+            inline_index: Some(0),
+            path: vec![0],
+        }]);
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF mark"), "got: {msg}");
         assert!(msg.contains("'link' mark"), "got: {msg}");
+    }
+
+    // ── Source-location enrichment (issue #1087) ──────────────────────
+
+    #[test]
+    fn offset_to_line_col_counts_chars_not_bytes() {
+        // "éx" sits on line 3; `é` is two bytes but one column, so `x` must be
+        // reported at column 2, not 3.
+        let src = "ab\ncd\néx";
+        assert_eq!(
+            offset_to_line_col(src, 0),
+            SourceLocation { line: 1, column: 1 }
+        );
+        assert_eq!(
+            offset_to_line_col(src, 6),
+            SourceLocation { line: 3, column: 1 } // é
+        );
+        assert_eq!(
+            offset_to_line_col(src, 8),
+            SourceLocation { line: 3, column: 2 } // x
+        );
+    }
+
+    #[test]
+    fn locate_in_source_reports_first_occurrence() {
+        let loc = locate_in_source("hello\nworld foo", "foo").unwrap();
+        assert_eq!(loc, SourceLocation { line: 2, column: 7 });
+        assert!(locate_in_source("no match here", "absent").is_none());
+    }
+
+    #[test]
+    fn node_at_path_resolves_nested_and_rejects_off_tree() {
+        let d = doc(vec![AdfNode::paragraph(vec![AdfNode::text("hi")])]);
+        assert_eq!(node_at_path(&d, &[0]).unwrap().node_type, "paragraph");
+        assert_eq!(
+            node_at_path(&d, &[0, 0]).unwrap().text.as_deref(),
+            Some("hi")
+        );
+        assert!(node_at_path(&d, &[5]).is_none());
+        assert!(node_at_path(&d, &[0, 9]).is_none());
+    }
+
+    #[test]
+    fn truncate_excerpt_shortens_long_runs() {
+        assert_eq!(truncate_excerpt("abc"), "abc");
+        let long = "x".repeat(EXCERPT_MAX_CHARS + 5);
+        let t = truncate_excerpt(&long);
+        assert!(t.ends_with('…'), "got: {t}");
+        assert_eq!(t.chars().count(), EXCERPT_MAX_CHARS + 1);
+    }
+
+    #[test]
+    fn try_new_error_names_offending_text_without_source() {
+        // A strong+code text node. `try_new` has no JFM source, so the message
+        // carries the offending run's text but no line:column.
+        let text = AdfNode {
+            node_type: "text".to_string(),
+            attrs: None,
+            content: None,
+            text: Some("/api/v1/example".to_string()),
+            marks: Some(vec![
+                crate::atlassian::adf::AdfMark::strong(),
+                crate::atlassian::adf::AdfMark::code(),
+            ]),
+            local_id: None,
+            parameters: None,
+        };
+        let d = doc(vec![AdfNode::paragraph(vec![text])]);
+        let err = ValidatedAdfDocument::try_new(d).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("in text: \"/api/v1/example\""), "got: {msg}");
+        assert!(
+            !msg.contains("at line"),
+            "no source ⇒ no line:col, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn markdown_to_validated_adf_reports_line_column_and_excerpt() {
+        // Issue #1087: bold-wrapping-inline-code yields a text node carrying
+        // both `strong` and `code`, rejected by the validator. The offending
+        // run sits on line 5 of the source.
+        let src = "# Heading\n\nIntro paragraph.\n\nHere is **`/api/v1/example`** in a sentence.\n";
+        let err = markdown_to_validated_adf(src).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("/api/v1/example"), "excerpt, got: {msg}");
+        assert!(msg.contains("at line 5"), "line, got: {msg}");
+        assert!(msg.contains("column"), "column, got: {msg}");
+    }
+
+    #[test]
+    fn markdown_to_validated_adf_accepts_clean_document() {
+        let v = markdown_to_validated_adf("# Title\n\nA clean paragraph.\n").unwrap();
+        assert!(!v.content.is_empty());
     }
 }

--- a/src/atlassian/create.rs
+++ b/src/atlassian/create.rs
@@ -11,9 +11,8 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::client::{AtlassianClient, JiraCreatedIssue};
-use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::custom_fields::{merge_set_field_overrides, resolve_custom_fields};
 use crate::atlassian::document::{
     split_custom_sections, split_frontmatter, CustomFieldSection, JfmDocument, JfmFrontmatter,
@@ -134,7 +133,7 @@ pub fn resolve_jira_create(
     }
 
     let (body_md, custom_sections) = split_custom_sections(&raw_body);
-    let adf = ValidatedAdfDocument::try_new(markdown_to_adf(&body_md)?)?;
+    let adf = markdown_to_validated_adf(&body_md)?;
 
     let mut shadowed = Vec::new();
 
@@ -253,7 +252,7 @@ pub fn resolve_confluence_create(
         }
     };
 
-    let adf = ValidatedAdfDocument::try_new(markdown_to_adf(&doc.body)?)?;
+    let adf = markdown_to_validated_adf(&doc.body)?;
 
     let mut shadowed = Vec::new();
 

--- a/src/atlassian/custom_fields.rs
+++ b/src/atlassian/custom_fields.rs
@@ -12,9 +12,8 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, bail, Context, Result};
 
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::markdown_to_validated_adf;
 use crate::atlassian::client::{EditMeta, EditMetaField};
-use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::document::CustomFieldSection;
 
 #[cfg(test)]
@@ -27,7 +26,7 @@ use crate::atlassian::client::TEXTAREA_CUSTOM_TYPE as CUSTOM_TEXTAREA;
 ///   `{"value": "..."}`, textfield/number/date pass through, rich-text
 ///   fields are rejected (must use a body section instead).
 /// - **Sections** must reference rich-text fields; their markdown is
-///   converted to ADF via [`markdown_to_adf`].
+///   converted to validated ADF via [`markdown_to_validated_adf`].
 ///
 /// Field names are looked up in [`EditMeta`]; entries already formatted as
 /// `customfield_<digits>` bypass the lookup. An unknown or ambiguous name
@@ -63,13 +62,7 @@ pub fn resolve_custom_fields(
                 field.name, id
             );
         }
-        let adf = markdown_to_adf(&section.body).with_context(|| {
-            format!(
-                "Failed to convert body for custom field '{}' ({}) to ADF",
-                field.name, id
-            )
-        })?;
-        let validated = ValidatedAdfDocument::try_new(adf).with_context(|| {
+        let validated = markdown_to_validated_adf(&section.body).with_context(|| {
             format!(
                 "Custom field '{}' ({}) failed ADF nesting validation",
                 field.name, id
@@ -175,8 +168,7 @@ fn string_to_rich_text_api_value(s: &str, field_name: &str, id: &str) -> Result<
     if s.is_empty() {
         return Ok(serde_json::Value::Null);
     }
-    let adf = markdown_to_adf(s)?;
-    let validated = ValidatedAdfDocument::try_new(adf).with_context(|| {
+    let validated = markdown_to_validated_adf(s).with_context(|| {
         format!("Custom field '{field_name}' ({id}) failed ADF nesting validation")
     })?;
     serde_json::to_value(&validated).context("Failed to serialize custom field ADF document")

--- a/src/atlassian/error.rs
+++ b/src/atlassian/error.rs
@@ -229,13 +229,13 @@ mod tests {
 
     #[test]
     fn invalid_adf_nesting_display_includes_violations() {
-        let err = AtlassianError::InvalidAdfNesting(AdfValidationError {
-            violations: vec![AdfSchemaViolation::DisallowedChild {
+        let err = AtlassianError::InvalidAdfNesting(AdfValidationError::new(vec![
+            AdfSchemaViolation::DisallowedChild {
                 parent_type: "panel".to_string(),
                 child_type: "expand".to_string(),
                 path: vec![0, 0],
-            }],
-        });
+            },
+        ]));
         let msg = err.to_string();
         assert!(msg.contains("invalid ADF nesting"));
         assert!(msg.contains("`expand` cannot be a child of `panel`"));

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -4,11 +4,11 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::confluence_api::{
     CommentKind, ConfluenceApi, ConfluenceComment, InlineAnchor,
 };
-use crate::atlassian::convert::{adf_to_markdown, markdown_to_adf};
+use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::document::JfmDocument;
 use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
 use crate::cli::atlassian::helpers::{create_client, read_input};
@@ -208,20 +208,22 @@ impl RepliesCommand {
 fn parse_comment_input(file: Option<&str>, format: ContentFormat) -> Result<ValidatedAdfDocument> {
     let input = read_input(file)?;
 
-    let adf: AdfDocument = match format {
+    let validated: ValidatedAdfDocument = match format {
         ContentFormat::Jfm => {
             if input.starts_with("---\n") {
                 let doc = JfmDocument::parse(&input)?;
-                markdown_to_adf(&doc.body)?
+                markdown_to_validated_adf(&doc.body)?
             } else {
-                markdown_to_adf(&input)?
+                markdown_to_validated_adf(&input)?
             }
         }
         ContentFormat::Adf => {
-            serde_json::from_str(&input).context("Failed to parse ADF JSON input")?
+            let adf: AdfDocument =
+                serde_json::from_str(&input).context("Failed to parse ADF JSON input")?;
+            ValidatedAdfDocument::try_new(adf)?
         }
     };
-    Ok(ValidatedAdfDocument::try_new(adf)?)
+    Ok(validated)
 }
 
 /// Fetches and displays comments for a page.

--- a/src/cli/atlassian/confluence/write.rs
+++ b/src/cli/atlassian/confluence/write.rs
@@ -33,13 +33,18 @@ pub struct WriteCommand {
 impl WriteCommand {
     /// Reads input and pushes to the Confluence page.
     pub async fn execute(self) -> Result<()> {
-        let (adf, title) = prepare_write(self.file.as_deref(), &self.format)?;
+        let (adf, title, source) = prepare_write(self.file.as_deref(), &self.format)?;
 
         if self.dry_run {
-            return crate::cli::atlassian::helpers::print_dry_run(&self.id, &adf, &title);
+            return crate::cli::atlassian::helpers::print_dry_run(
+                &self.id,
+                &adf,
+                &title,
+                source.as_deref(),
+            );
         }
 
-        let validated = ValidatedAdfDocument::try_new(adf)?;
+        let validated = ValidatedAdfDocument::try_new_with_source(adf, source.as_deref())?;
         let (client, _instance_url) = create_client()?;
         let api = ConfluenceApi::new(client);
 

--- a/src/cli/atlassian/convert.rs
+++ b/src/cli/atlassian/convert.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_validated::validate;
+use crate::atlassian::adf_validated::validate_with_source;
 use crate::atlassian::convert::markdown_to_adf;
 
 /// Converts between JFM markdown and ADF JSON.
@@ -64,7 +64,7 @@ impl ToAdfCommand {
         let doc = markdown_to_adf(&input)?;
 
         if !self.no_validate {
-            validate(&doc)?;
+            validate_with_source(&doc, Some(&input))?;
         }
 
         let json = if self.compact {

--- a/src/cli/atlassian/helpers.rs
+++ b/src/cli/atlassian/helpers.rs
@@ -6,8 +6,7 @@ use std::io::{self, Read, Write};
 use anyhow::{anyhow, Context, Result};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_schema::validate_document;
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{validate_with_source, ValidatedAdfDocument};
 use crate::atlassian::api::AtlassianApi;
 use crate::atlassian::auth;
 use crate::atlassian::client::{AtlassianClient, FieldSelection};
@@ -95,7 +94,13 @@ pub async fn run_read_jira_with_fields(
 /// callers must wrap the result in [`ValidatedAdfDocument::try_new`] before
 /// sending. The dry-run path bypasses that wrapping so it can show the
 /// converted ADF *and* a violation diagnosis from [`print_dry_run`].
-pub fn prepare_write(file: Option<&str>, format: &ContentFormat) -> Result<(AdfDocument, String)> {
+/// The third tuple element is the JFM markdown body the ADF was converted from
+/// (`Some` for JFM input, `None` for ADF input), so callers can report a
+/// validation failure's 1-based `line:column` in that source (issue #1087).
+pub fn prepare_write(
+    file: Option<&str>,
+    format: &ContentFormat,
+) -> Result<(AdfDocument, String, Option<String>)> {
     let input = read_input(file)?;
 
     match format {
@@ -103,11 +108,11 @@ pub fn prepare_write(file: Option<&str>, format: &ContentFormat) -> Result<(AdfD
             let doc = JfmDocument::parse(&input)?;
             let adf = markdown_to_adf(&doc.body)?;
             let title = doc.frontmatter.title().to_string();
-            Ok((adf, title))
+            Ok((adf, title, Some(doc.body)))
         }
         ContentFormat::Adf => {
             let adf = AdfDocument::from_json_str(&input)?;
-            Ok((adf, String::new()))
+            Ok((adf, String::new(), None))
         }
     }
 }
@@ -121,7 +126,7 @@ pub fn prepare_write(file: Option<&str>, format: &ContentFormat) -> Result<(AdfD
 /// Takes a raw [`AdfDocument`] (not [`ValidatedAdfDocument`]) so callers on
 /// the dry-run path can show the ADF *and* the violation diagnosis even when
 /// the document would otherwise be rejected by [`ValidatedAdfDocument::try_new`].
-pub fn print_dry_run(id: &str, adf: &AdfDocument, title: &str) -> Result<()> {
+pub fn print_dry_run(id: &str, adf: &AdfDocument, title: &str, source: Option<&str>) -> Result<()> {
     println!("Dry run for {id}:");
     if !title.is_empty() {
         println!("  Title: {title}");
@@ -131,22 +136,25 @@ pub fn print_dry_run(id: &str, adf: &AdfDocument, title: &str) -> Result<()> {
         serde_json::to_string_pretty(adf).context("Failed to serialize ADF")?
     );
 
-    let violations = validate_document(adf);
-    if violations.is_empty() {
-        println!("\nValidation: OK");
-        Ok(())
-    } else {
-        let count = violations.len();
-        let noun = if count == 1 {
-            "violation"
-        } else {
-            "violations"
-        };
-        println!("\nValidation: {count} {noun}");
-        for v in &violations {
-            println!("  ✗ {v}");
+    match validate_with_source(adf, source) {
+        Ok(()) => {
+            println!("\nValidation: OK");
+            Ok(())
         }
-        Err(anyhow!("ADF validation failed: {count} {noun}"))
+        Err(err) => {
+            let count = err.violations.len();
+            let noun = if count == 1 {
+                "violation"
+            } else {
+                "violations"
+            };
+            println!("\nValidation: {count} {noun}");
+            // The enriched error carries per-violation ADF path, hint, and —
+            // when `source` is `Some` — the offending run's line:column and a
+            // text excerpt (issue #1087).
+            println!("{err}");
+            Err(anyhow!("ADF validation failed: {count} {noun}"))
+        }
     }
 }
 
@@ -362,7 +370,8 @@ pub async fn run_edit(id: &str, api: &dyn AtlassianApi, instance_url: &str) -> R
                         .unwrap_or_else(|e| format!("<serialization error: {e}>"));
                     tracing::trace!("ADF payload:\n{adf_json}");
                 }
-                let validated = ValidatedAdfDocument::try_new(adf)?;
+                let validated =
+                    ValidatedAdfDocument::try_new_with_source(adf, Some(&final_doc.body))?;
 
                 let title_changed = final_doc.frontmatter.title() != original_title;
                 let title_update = if title_changed {
@@ -730,11 +739,13 @@ mod tests {
         let content = "---\ntype: jira\ninstance: https://org.atlassian.net\nkey: PROJ-1\nsummary: My Title\n---\n\nHello world\n";
         fs::write(&file_path, content).unwrap();
 
-        let (adf, title) =
+        let (adf, title, source) =
             prepare_write(Some(file_path.to_str().unwrap()), &ContentFormat::Jfm).unwrap();
 
         assert_eq!(title, "My Title");
         assert!(!adf.content.is_empty());
+        // JFM input carries its body forward for line:column reporting.
+        assert!(source.is_some_and(|s| s.contains("Hello world")));
     }
 
     #[test]
@@ -744,11 +755,13 @@ mod tests {
         let adf_json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello"}]}]}"#;
         fs::write(&file_path, adf_json).unwrap();
 
-        let (adf, title) =
+        let (adf, title, source) =
             prepare_write(Some(file_path.to_str().unwrap()), &ContentFormat::Adf).unwrap();
 
         assert!(title.is_empty());
         assert_eq!(adf.content.len(), 1);
+        // ADF input has no JFM source, so there is no line:column to report.
+        assert!(source.is_none());
     }
 
     #[test]
@@ -767,11 +780,12 @@ mod tests {
         let file_path = temp_dir.path().join("null.json");
         fs::write(&file_path, "null").unwrap();
 
-        let (adf, title) =
+        let (adf, title, source) =
             prepare_write(Some(file_path.to_str().unwrap()), &ContentFormat::Adf).unwrap();
 
         assert_eq!(adf, AdfDocument::default());
         assert!(title.is_empty());
+        assert!(source.is_none());
     }
 
     #[test]
@@ -794,7 +808,7 @@ mod tests {
     #[test]
     fn print_dry_run_with_title() {
         let adf = AdfDocument::default();
-        let result = print_dry_run("PROJ-1", &adf, "My Title");
+        let result = print_dry_run("PROJ-1", &adf, "My Title", None);
         assert!(result.is_ok());
     }
 
@@ -828,7 +842,7 @@ mod tests {
         }"#;
         let adf = AdfDocument::from_json_str(adf_json).unwrap();
 
-        let result = print_dry_run("12345", &adf, "Title");
+        let result = print_dry_run("12345", &adf, "Title", None);
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         // Two `expand` children inside a `panel` produce three violations:
@@ -860,7 +874,7 @@ mod tests {
         }"#;
         let adf = AdfDocument::from_json_str(adf_json).unwrap();
 
-        let result = print_dry_run("12345", &adf, "Title");
+        let result = print_dry_run("12345", &adf, "Title", None);
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(err.contains("ADF validation failed"), "got: {err}");
@@ -869,7 +883,7 @@ mod tests {
     #[test]
     fn print_dry_run_without_title() {
         let adf = AdfDocument::default();
-        let result = print_dry_run("PROJ-1", &adf, "");
+        let result = print_dry_run("PROJ-1", &adf, "", None);
         assert!(result.is_ok());
     }
 
@@ -888,7 +902,7 @@ mod tests {
             }]
         }"#;
         let adf = AdfDocument::from_json_str(adf_json).unwrap();
-        let result = print_dry_run("12345", &adf, "Title");
+        let result = print_dry_run("12345", &adf, "Title", None);
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(
@@ -913,7 +927,7 @@ mod tests {
             }]
         }"#;
         let adf = AdfDocument::from_json_str(adf_json).unwrap();
-        let result = print_dry_run("12345", &adf, "Title");
+        let result = print_dry_run("12345", &adf, "Title", None);
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(

--- a/src/cli/atlassian/jira/comment.rs
+++ b/src/cli/atlassian/jira/comment.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::client::{AtlassianClient, JiraComment, JiraVisibility, JiraVisibilityType};
-use crate::atlassian::convert::{adf_to_markdown, markdown_to_adf};
+use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::document::JfmDocument;
 use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
 use crate::cli::atlassian::helpers::{create_client, read_input};
@@ -159,22 +159,24 @@ impl EditCommand {
 fn parse_comment_input(file: Option<&str>, format: ContentFormat) -> Result<ValidatedAdfDocument> {
     let input = read_input(file)?;
 
-    let adf: AdfDocument = match format {
+    let validated: ValidatedAdfDocument = match format {
         ContentFormat::Jfm => {
             // Try parsing as JFM document (with frontmatter) first,
             // fall back to raw markdown
             if input.starts_with("---\n") {
                 let doc = JfmDocument::parse(&input)?;
-                markdown_to_adf(&doc.body)?
+                markdown_to_validated_adf(&doc.body)?
             } else {
-                markdown_to_adf(&input)?
+                markdown_to_validated_adf(&input)?
             }
         }
         ContentFormat::Adf => {
-            serde_json::from_str(&input).context("Failed to parse ADF JSON input")?
+            let adf: AdfDocument =
+                serde_json::from_str(&input).context("Failed to parse ADF JSON input")?;
+            ValidatedAdfDocument::try_new(adf)?
         }
     };
-    Ok(ValidatedAdfDocument::try_new(adf)?)
+    Ok(validated)
 }
 
 /// Fetches and displays comments for an issue.

--- a/src/cli/atlassian/jira/write.rs
+++ b/src/cli/atlassian/jira/write.rs
@@ -18,6 +18,19 @@ use crate::cli::atlassian::helpers::{
     run_write_jira_with_resolved_fields,
 };
 
+/// The resolved write body: `(adf, title, custom-field scalars, custom-field
+/// sections, JFM source)`. The last element is the JFM markdown body the ADF
+/// was converted from, carried so a validation failure can be reported with
+/// its 1-based line:column (issue #1087). `None` for ADF-format or
+/// body-skipped paths.
+type ResolvedWriteBody = (
+    Option<AdfDocument>,
+    String,
+    std::collections::BTreeMap<String, serde_yaml::Value>,
+    Vec<CustomFieldSection>,
+    Option<String>,
+);
+
 /// Pushes content to a JIRA issue.
 #[derive(Parser)]
 pub struct WriteCommand {
@@ -112,34 +125,47 @@ impl WriteCommand {
         // (assignee/reporter/--set-field) — that combination signals a
         // "fields-only" update and should not block on stdin.
         let skip_body = self.no_content || (self.file.is_none() && other_fields_present);
-        let (body_adf, title, frontmatter_scalars, sections): (
-            Option<AdfDocument>,
-            String,
-            std::collections::BTreeMap<String, serde_yaml::Value>,
-            Vec<CustomFieldSection>,
-        ) = if skip_body {
-            (
-                None,
-                String::new(),
-                std::collections::BTreeMap::new(),
-                vec![],
-            )
-        } else if matches!(self.format, ContentFormat::Adf) {
-            let (adf, title) = prepare_write(self.file.as_deref(), &self.format)?;
-            (Some(adf), title, std::collections::BTreeMap::new(), vec![])
-        } else {
-            let input = read_input(self.file.as_deref())?;
-            let doc = JfmDocument::parse(&input)?;
-            let (body_md, sections) = doc.split_custom_sections();
-            let frontmatter_scalars = doc
-                .frontmatter
-                .jira_custom_fields()
-                .cloned()
-                .unwrap_or_default();
-            let body_adf = markdown_to_adf(&body_md)?;
-            let title = doc.frontmatter.title().to_string();
-            (Some(body_adf), title, frontmatter_scalars, sections)
-        };
+        // `body_source` is the JFM markdown body the ADF was converted from,
+        // carried alongside so a validation failure reports its 1-based
+        // line:column (issue #1087). `None` for ADF-format or body-skipped
+        // paths.
+        let (body_adf, title, frontmatter_scalars, sections, body_source): ResolvedWriteBody =
+            if skip_body {
+                (
+                    None,
+                    String::new(),
+                    std::collections::BTreeMap::new(),
+                    vec![],
+                    None,
+                )
+            } else if matches!(self.format, ContentFormat::Adf) {
+                let (adf, title, _source) = prepare_write(self.file.as_deref(), &self.format)?;
+                (
+                    Some(adf),
+                    title,
+                    std::collections::BTreeMap::new(),
+                    vec![],
+                    None,
+                )
+            } else {
+                let input = read_input(self.file.as_deref())?;
+                let doc = JfmDocument::parse(&input)?;
+                let (body_md, sections) = doc.split_custom_sections();
+                let frontmatter_scalars = doc
+                    .frontmatter
+                    .jira_custom_fields()
+                    .cloned()
+                    .unwrap_or_default();
+                let body_adf = markdown_to_adf(&body_md)?;
+                let title = doc.frontmatter.title().to_string();
+                (
+                    Some(body_adf),
+                    title,
+                    frontmatter_scalars,
+                    sections,
+                    Some(body_md),
+                )
+            };
 
         let scalars = merge_set_field_overrides(frontmatter_scalars, overrides);
 
@@ -164,7 +190,8 @@ impl WriteCommand {
             let Some(body_adf) = body_adf else {
                 unreachable!("skip_body without other fields was rejected above");
             };
-            let validated = ValidatedAdfDocument::try_new(body_adf)?;
+            let validated =
+                ValidatedAdfDocument::try_new_with_source(body_adf, body_source.as_deref())?;
             let api = JiraApi::new(client);
             return run_write(&self.key, &validated, &title, self.force, &api).await;
         }
@@ -186,7 +213,9 @@ impl WriteCommand {
             "`--set-field` of the same name",
         )?;
 
-        let validated_body = body_adf.map(ValidatedAdfDocument::try_new).transpose()?;
+        let validated_body = body_adf
+            .map(|adf| ValidatedAdfDocument::try_new_with_source(adf, body_source.as_deref()))
+            .transpose()?;
         run_write_jira_with_resolved_fields(
             &self.key,
             validated_body.as_ref(),

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -18,14 +18,13 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::api::{AtlassianApi, ContentItem};
 use crate::atlassian::client::AtlassianClient;
 use crate::atlassian::confluence_api::{
     ChildPage, CommentKind, ConfluenceApi, ConfluenceAttachmentPage, ConfluenceSpacePage,
     MovePosition, PageSummaryPage,
 };
-use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::create::{prepend_warnings, resolve_confluence_create};
 use crate::atlassian::document::{content_item_to_document, JfmDocument, JfmFrontmatter};
 use crate::cli::atlassian::confluence::download::{
@@ -578,7 +577,7 @@ fn parse_write_content(
     content: &str,
     format: ContentFormat,
 ) -> Result<(ValidatedAdfDocument, String)> {
-    let (adf, title): (AdfDocument, String) = match format {
+    let (adf, title): (ValidatedAdfDocument, String) = match format {
         ContentFormat::Jfm => {
             // JFM inputs with frontmatter are passed as-is; inputs without
             // frontmatter are treated as raw markdown. The CLI requires
@@ -586,23 +585,21 @@ fn parse_write_content(
             // separately, so we don't force it here.
             if content.starts_with("---\n") {
                 let doc = JfmDocument::parse(content)?;
-                let adf = markdown_to_adf(&doc.body)?;
                 let title = match &doc.frontmatter {
                     JfmFrontmatter::Confluence(fm) => fm.title.clone(),
                     JfmFrontmatter::Jira(fm) => fm.summary.clone(),
                 };
-                (adf, title)
+                (markdown_to_validated_adf(&doc.body)?, title)
             } else {
-                let adf = markdown_to_adf(content)?;
-                (adf, String::new())
+                (markdown_to_validated_adf(content)?, String::new())
             }
         }
-        ContentFormat::Adf => {
-            let adf = AdfDocument::from_json_str(content)?;
-            (adf, String::new())
-        }
+        ContentFormat::Adf => (
+            ValidatedAdfDocument::try_new(AdfDocument::from_json_str(content)?)?,
+            String::new(),
+        ),
     };
-    Ok((ValidatedAdfDocument::try_new(adf)?, title))
+    Ok((adf, title))
 }
 
 /// Serializes search results as YAML for the tool response body.
@@ -899,8 +896,7 @@ pub async fn list_comment_replies_yaml(
 ///
 /// The markdown `content` is converted to ADF before posting.
 pub async fn add_comment_result(api: &ConfluenceApi, id: &str, content: &str) -> Result<String> {
-    let adf: AdfDocument = markdown_to_adf(content).context("Failed to convert markdown to ADF")?;
-    let adf = ValidatedAdfDocument::try_new(adf)?;
+    let adf = markdown_to_validated_adf(content)?;
     api.add_page_comment(id, &adf).await?;
 
     let result = MutationResult {
@@ -923,8 +919,7 @@ pub async fn add_inline_comment_result(
     anchor_text: &str,
     match_index_1based: Option<usize>,
 ) -> Result<String> {
-    let adf: AdfDocument = markdown_to_adf(content).context("Failed to convert markdown to ADF")?;
-    let adf = ValidatedAdfDocument::try_new(adf)?;
+    let adf = markdown_to_validated_adf(content)?;
     let anchor = api
         .resolve_anchor(id, anchor_text, match_index_1based)
         .await?;
@@ -1816,10 +1811,9 @@ async fn run_confluence_create(params: &ConfluenceCreateParams) -> Result<String
 
     let format = parse_format(params.format.as_deref())?;
     let adf = match format {
-        ContentFormat::Jfm => markdown_to_adf(content)?,
-        ContentFormat::Adf => AdfDocument::from_json_str(content)?,
+        ContentFormat::Jfm => markdown_to_validated_adf(content)?,
+        ContentFormat::Adf => ValidatedAdfDocument::try_new(AdfDocument::from_json_str(content)?)?,
     };
-    let adf = ValidatedAdfDocument::try_new(adf)?;
 
     if params.dry_run {
         return confluence_create_dry_run_preview(

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -15,11 +15,10 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 
 use crate::atlassian::adf::AdfDocument;
-use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::client::{
     AtlassianClient, JiraCreatedIssue, JiraTransition, JiraVisibility, JiraVisibilityType,
 };
-use crate::atlassian::convert::markdown_to_adf;
 use crate::atlassian::create::{create_resolved_jira_issue, prepend_warnings, resolve_jira_create};
 use crate::atlassian::custom_fields::{
     apply_user_field_overrides, convert_textarea_string_values, resolve_custom_fields,
@@ -511,7 +510,7 @@ async fn run_jira_create(client: &AtlassianClient, params: &JiraCreateParams) ->
     let issue_type = params.issue_type.as_deref().unwrap_or("Task");
 
     let adf = match params.description.as_deref() {
-        Some(md) if !md.is_empty() => Some(ValidatedAdfDocument::try_new(markdown_to_adf(md)?)?),
+        Some(md) if !md.is_empty() => Some(markdown_to_validated_adf(md)?),
         _ => None,
     };
 
@@ -566,7 +565,7 @@ async fn create_one_issue(
 ) -> Result<JiraCreatedIssue> {
     let issue_type = spec.issue_type.as_deref().unwrap_or("Task");
     let adf = match spec.description.as_deref() {
-        Some(md) if !md.is_empty() => Some(ValidatedAdfDocument::try_new(markdown_to_adf(md)?)?),
+        Some(md) if !md.is_empty() => Some(markdown_to_validated_adf(md)?),
         _ => None,
     };
     client
@@ -774,18 +773,20 @@ async fn run_jira_write(
 ) -> Result<String> {
     let adf: Option<ValidatedAdfDocument> = match content {
         Some(c) => {
-            let raw: AdfDocument = match format {
+            let validated: ValidatedAdfDocument = match format {
                 ReadFormat::Jfm => {
                     if c.starts_with("---\n") {
                         let doc = JfmDocument::parse(c)?;
-                        markdown_to_adf(&doc.body)?
+                        markdown_to_validated_adf(&doc.body)?
                     } else {
-                        markdown_to_adf(c)?
+                        markdown_to_validated_adf(c)?
                     }
                 }
-                ReadFormat::Adf => serde_json::from_str(c).context("Failed to parse ADF JSON")?,
+                ReadFormat::Adf => ValidatedAdfDocument::try_new(
+                    serde_json::from_str(c).context("Failed to parse ADF JSON")?,
+                )?,
             };
-            Some(ValidatedAdfDocument::try_new(raw)?)
+            Some(validated)
         }
         None => None,
     };
@@ -887,7 +888,7 @@ async fn run_jira_transition(
         })?;
 
     if let Some(body) = comment.filter(|s| !s.is_empty()) {
-        let adf = ValidatedAdfDocument::try_new(markdown_to_adf(body)?)?;
+        let adf = markdown_to_validated_adf(body)?;
         client.add_comment(key, &adf).await?;
     }
 
@@ -965,7 +966,7 @@ async fn run_jira_comment(
         "add" => {
             let text =
                 body.ok_or_else(|| anyhow::anyhow!("`body` is required when action is \"add\""))?;
-            let adf = ValidatedAdfDocument::try_new(markdown_to_adf(text)?)?;
+            let adf = markdown_to_validated_adf(text)?;
             client.add_comment(key, &adf).await?;
             Ok(format!("Comment added to {key}.\n"))
         }
@@ -983,7 +984,7 @@ async fn run_jira_comment_edit(
     body: &str,
     visibility: Option<&JiraVisibilityParam>,
 ) -> Result<String> {
-    let adf = ValidatedAdfDocument::try_new(markdown_to_adf(body)?)?;
+    let adf = markdown_to_validated_adf(body)?;
     let visibility = visibility.map(parse_visibility).transpose()?;
     let updated = client
         .update_comment(key, comment_id, &adf, visibility.as_ref())

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -14,7 +14,6 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::adf_validated::{markdown_to_validated_adf, ValidatedAdfDocument};
 use crate::atlassian::client::{
     AtlassianClient, JiraCreatedIssue, JiraTransition, JiraVisibility, JiraVisibilityType,


### PR DESCRIPTION
## Description

When a JFM markdown body converts to ADF that violates the content model — most commonly bold-wrapping-inline-code (e.g. `` **`/api/v1/example`** ``, which maps to a text node carrying both `strong` and `code` marks, a combination ADF forbids) — writes were aborted with only an opaque ADF index path such as `at /38/4/0/1`. Authors had to manually count siblings in an unrendered ADF tree to locate the offending run in a large document.

This PR resolves each validation error's ADF path against the produced tree to extract the offending node's type and a text excerpt, and when the JFM source is available, maps that excerpt to a 1-based `line:column` in the original markdown. Every validation error now gains these details, turning bare opaque paths into actionable diagnostics pointing directly at the offending text and its position in the source file.

**Before:**
```
invalid ADF nesting at /38/4/0/1: 'strong' mark conflicts with 'code' mark on text node in paragraph
```

**After:**
```
invalid ADF nesting at /38/4/0/1: 'strong' mark conflicts with 'code' mark on text node in paragraph
  at line 5, column 9
  in text: "/api/v1/example"
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #1087

## Changes Made

**Core ADF Validation (`src/atlassian/adf_validated.rs`):**
- Added `SourceLocation` struct holding a 1-based `line` and `column` (counted in Unicode scalar values so multi-byte characters line up with editor cursors)
- Added `ViolationContext` struct capturing per-violation metadata: offending node type, truncated text excerpt, and optional source location
- Added `node_at_path()` to resolve ADF index paths to concrete `AdfNode` references within the document tree
- Added `collect_text()` / `gather_text()` to recursively extract inline text from block-level nodes for excerpt generation
- Added `truncate_excerpt()` to cap excerpts at 60 characters with an ellipsis
- Added `offset_to_line_col()` to convert byte offsets into 1-based `line:column` positions
- Added `locate_in_source()` to locate an ADF text value within the JFM source by substring search
- Added `resolve_context()` to orchestrate path-resolution, excerpt extraction, and source location lookup per violation
- Extended `AdfValidationError` with a `contexts` field (parallel to `violations`) and an `enriched()` method that populates it
- Updated `Display` for `AdfValidationError` to append `at line N, column M` and `in text: "…"` lines for each violation when available
- Added `validate_with_source(doc, source: Option<&str>)` as the new canonical validation entry point
- Refactored `validate()` to delegate to `validate_with_source(doc, None)`
- Added `markdown_to_validated_adf(source: &str)` convenience function that converts JFM → ADF → validated with full source tracking in one call
- Added `ValidatedAdfDocument::try_new_with_source(doc, source: Option<&str>)` variant; refactored `try_new()` to delegate to it

**CLI Commands:**
- `src/cli/atlassian/helpers.rs`: Updated `prepare_write()` to return a 3-tuple `(AdfDocument, String, Option<String>)` carrying the JFM source body; updated `print_dry_run()` to accept `source: Option<&str>` and use `validate_with_source()` so dry-run output includes enriched diagnostics; updated `run_edit()` to use `try_new_with_source()`
- `src/cli/atlassian/confluence/write.rs`: Threads the JFM source from `prepare_write()` into `try_new_with_source()` and `print_dry_run()`
- `src/cli/atlassian/confluence/comment.rs`: Updated `parse_comment_input()` to use `markdown_to_validated_adf()` for JFM paths
- `src/cli/atlassian/jira/write.rs`: Added `ResolvedWriteBody` type alias; threads `body_source` through all resolution branches and uses `try_new_with_source()` for both single-field and multi-field write paths
- `src/cli/atlassian/jira/comment.rs`: Updated `parse_comment_input()` to use `markdown_to_validated_adf()` for JFM paths
- `src/cli/atlassian/convert.rs`: Updated `to-adf` preflight validation to use `validate_with_source()` so enriched errors appear in the convert command

**Atlassian Core (`src/atlassian/`):**
- `create.rs`: Replaced two-step `markdown_to_adf()` + `ValidatedAdfDocument::try_new()` with `markdown_to_validated_adf()` in both `resolve_jira_create()` and `resolve_confluence_create()`
- `custom_fields.rs`: Replaced two-step conversion with `markdown_to_validated_adf()` in `resolve_custom_fields()` and `string_to_rich_text_api_value()`
- `error.rs`: Updated test to use `AdfValidationError::new()` constructor

**MCP Tools (`src/mcp/`):**
- `confluence_tools.rs`: Updated `parse_write_content()`, `add_comment_result()`, `add_inline_comment_result()`, and `run_confluence_create()` to use `markdown_to_validated_adf()`
- `jira_core_tools.rs`: Updated `run_jira_create()`, `create_one_issue()`, `run_jira_write()`, `run_jira_transition()`, `run_jira_comment()`, and `run_jira_comment_edit()` to use `markdown_to_validated_adf()`

**Documentation:**
- `CHANGELOG.md`: Added detailed entry under `[Unreleased]` describing the fix and linking to #1087

**Testing:**
- Added `offset_to_line_col_counts_chars_not_bytes`: verifies multi-byte characters count as one column
- Added `locate_in_source_reports_first_occurrence`: verifies substring search returns correct line:column
- Added `node_at_path_resolves_nested_and_rejects_off_tree`: verifies path resolution and out-of-bounds handling
- Added `truncate_excerpt_shortens_long_runs`: verifies 60-char truncation with ellipsis
- Added `try_new_error_names_offending_text_without_source`: verifies text excerpt appears even without JFM source, no spurious line:col
- Added `markdown_to_validated_adf_reports_line_column_and_excerpt`: end-to-end test reproducing the #1087 scenario with bold-wrapping-inline-code on line 5
- Added `markdown_to_validated_adf_accepts_clean_document`: verifies valid markdown passes through without error
- Updated existing `AdfValidationError` construction in tests to use the new `AdfValidationError::new()` constructor

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (7 new unit tests covering offset conversion, path resolution, excerpt truncation, and end-to-end source tracking)
- [x] Integration tests updated/added

**Manual Testing:**
- [x] Tested happy path scenarios (clean JFM documents pass through unchanged)
- [x] Tested error/edge cases (bold-wrapping-inline-code triggers enriched error with line:column)
- [x] Backward compatibility verified (ADF-format input paths receive excerpt without line:column, matching the `None`-source behaviour)

### Test Commands
```bash
# Core test suite
cargo test

# ADF validation specific tests
cargo test atlassian::adf_validated

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the enriched error path must not panic when a violation's ADF path runs off the tree (handled by `node_at_path` returning `Option`)
- [x] Architecture changes — `prepare_write()` signature changed from 2-tuple to 3-tuple; `print_dry_run()` gained a `source` parameter; all call sites updated
- [x] Backward compatibility — callers that pass `source: None` get the same behaviour as before (excerpt only, no line:column)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

Path resolution and text extraction run only when a validation error is actually raised, which is the failure path. The success path (valid documents) is entirely unaffected.

## Security Considerations
- [x] No security implications

The source text excerpts are derived from the document content the user submitted and are only surfaced back to that same user in error messages.

## Breaking Changes

`prepare_write()` in `src/cli/atlassian/helpers.rs` now returns `(AdfDocument, String, Option<String>)` instead of `(AdfDocument, String)`, and `print_dry_run()` now accepts an additional `source: Option<&str>` parameter. All internal call sites have been updated in this PR. These are internal APIs with no external consumers, so no migration is required for end users.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Option 1 from issue #1087 (silently splitting `strong`+`code` marks during conversion so the document is auto-healed rather than rejected) remains a separate follow-up

**Known Limitations:**
- `locate_in_source()` uses a simple substring search and reports the **first** occurrence; if the same text run appears multiple times in a document, the reported line:column points to the first match. The printed excerpt alongside disambiguates in practice.
- Column counting uses Unicode scalar values (Rust `char`), which matches most editor cursors but may differ from editors that count extended grapheme clusters.

**Alternatives Considered:**
- Auto-healing the `strong`+`code` mark combination by silently dropping one mark (issue #1087 option 1) — deferred as a separate follow-up to keep this PR focused on diagnostics