### PR TITLE
docs(atlassian): add preservation guidance for localId attributes in Confluence operations

### DIFF
--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -34,8 +34,21 @@ pub enum ConfluenceSubcommands {
     /// Manages comments on a Confluence page.
     Comment(comment::CommentCommand),
     /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON (mirrors the `confluence_read` MCP tool).
+    ///
+    /// The output carries `localId` attributes (and inline-comment anchor
+    /// spans) that anchor inline comments and other stateful nodes. Preserve
+    /// them verbatim when editing so a later `write` does not drop those
+    /// comments.
     Read(read::ReadCommand),
     /// Pushes content to a Confluence page (mirrors the `confluence_write` MCP tool).
+    ///
+    /// This fully replaces the page body, so it can silently lose data. Inline
+    /// comments (and task-item state) are anchored to the page through the
+    /// `localId` attributes that `read` emits; if the body you push omits them,
+    /// Confluence drops the inline comments tied to those anchors. Edit the JFM
+    /// produced by `read` and keep its `localId`s intact — do not hand-author a
+    /// fresh body or push content produced with local IDs stripped (see
+    /// `atlassian convert from-adf --strip-local-ids`).
     Write(write::WriteCommand),
     /// Interactive fetch-edit-push cycle for a Confluence page.
     Edit(edit::EditCommand),

--- a/src/cli/atlassian/convert.rs
+++ b/src/cli/atlassian/convert.rs
@@ -84,7 +84,9 @@ pub struct FromAdfCommand {
     /// Input file (reads from stdin if omitted or "-").
     pub file: Option<String>,
 
-    /// Omit localId attributes from output for readability.
+    /// Omit localId attributes from output. For reading only — do NOT write
+    /// stripped output back to Confluence, as localIds anchor inline comments
+    /// and dropping them makes Confluence lose those comments.
     #[arg(long)]
     pub strip_local_ids: bool,
 }

--- a/src/mcp/atlassian_tools.rs
+++ b/src/mcp/atlassian_tools.rs
@@ -32,7 +32,9 @@ pub struct AtlassianConvertParams {
     #[serde(default)]
     pub compact: Option<bool>,
     /// When `direction = from-adf`, strip `localId` attributes from output
-    /// for better readability.
+    /// for better readability. For reading only — do NOT write stripped output
+    /// back to Confluence, as `localId`s anchor inline comments and dropping
+    /// them makes Confluence lose those comments.
     #[serde(default)]
     pub strip_local_ids: Option<bool>,
 }

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -122,6 +122,10 @@ pub struct ConfluenceWriteParams {
     /// NOT Confluence wiki markup. Use `##` not `h2.`, triple-backtick fences
     /// not `{code}`, backtick inline code not `{{...}}`. Full reference:
     /// MCP resource `omni-dev://specs/jfm`.
+    ///
+    /// Preserve the `localId` attributes (and inline-comment anchor spans) from
+    /// the original `confluence_read` output: they anchor inline comments and
+    /// stateful nodes, and dropping them makes Confluence lose those comments.
     pub content: String,
     /// Format of `content`: `"jfm"` (default markdown) or `"adf"` (raw ADF JSON).
     #[serde(default)]
@@ -1157,7 +1161,10 @@ impl OmniDevServer {
     #[tool(
         description = "Fetch a Confluence page by numeric ID (e.g. \"12345678\"). Returns JFM markdown by \
                        default — AI-friendly GitHub-style markdown, the form to read/edit then feed back to \
-                       `confluence_write`/`confluence_create`. Pass format=\"adf\" for the raw ADF JSON \
+                       `confluence_write`/`confluence_create`. That output carries `localId` attributes \
+                       (and inline-comment anchor spans) that anchor inline comments and other stateful \
+                       nodes — preserve them verbatim when editing so a later `confluence_write` does not \
+                       drop those comments. Pass format=\"adf\" for the raw ADF JSON \
                        (the on-the-wire document model) only when you need exact node structure. \
                        When `output_file` is set, the content is written to that path and the tool returns \
                        a short YAML summary (path/bytes/format) — useful for large pages. \
@@ -1222,6 +1229,12 @@ impl OmniDevServer {
         description = "Overwrite an EXISTING Confluence page's body (identified by `id`) from JFM \
                        markdown (default) or raw ADF JSON. This fully replaces the body — to create a \
                        brand-new page instead, use `confluence_create`. \
+                       DATA LOSS: inline comments (and task-item state) are anchored to the page through \
+                       the `localId` attributes that `confluence_read` emits; if the body you send omits \
+                       them, Confluence drops the inline comments tied to those anchors. Edit the JFM \
+                       returned by `confluence_read` and keep its `localId`s intact — do not hand-author a \
+                       fresh body or send content produced with local IDs stripped (`atlassian_convert` \
+                       with `strip_local_ids`). \
                        JFM is GitHub-style markdown, NOT Confluence wiki markup — see resource \
                        `omni-dev://specs/jfm` for syntax. \
                        Set `dry_run: true` first when uncertain about required fields or \

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -953,7 +953,7 @@ Arguments:
   [FILE]  Input file (reads from stdin if omitted or "-")
 
 Options:
-      --strip-local-ids  Omit localId attributes from output for readability
+      --strip-local-ids  Omit localId attributes from output. For reading only — do NOT write stripped output back to Confluence, as localIds anchor inline comments and dropping them makes Confluence lose those comments
   -h, --help             Print help
 
 


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation warnings across the CLI and MCP tool layer to help users (and AI assistants) understand the critical importance of preserving `localId` attributes when editing and writing Confluence pages.

**The problem being addressed**: Confluence uses `localId` attributes embedded in ADF content to anchor inline comments and track stateful nodes (e.g. task-item state). When a user reads a Confluence page, edits the content, and then writes it back without preserving these `localId` values, Confluence silently drops the inline comments tied to those anchors — a data-loss scenario with no error message to warn the user.

This PR surfaces that risk prominently in the help text and tool descriptions so that users know:
- `confluence read` / `confluence_read` output carries `localId` attributes that must be preserved
- `confluence write` / `confluence_write` will silently drop inline comments if `localId`s are omitted
- `atlassian convert from-adf --strip-local-ids` / `atlassian_convert` with `strip_local_ids` is for **read-only inspection only** and must never be used before writing content back to Confluence

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

No linked issue — this is a proactive documentation improvement to prevent silent data loss for Confluence users.

## Changes Made

**CLI Documentation (`src/cli/atlassian/confluence/mod.rs`):**
- Extended `Read` subcommand doc comment to note that output carries `localId` attributes and inline-comment anchor spans that must be preserved verbatim when editing
- Extended `Write` subcommand doc comment with an explicit warning that pushing content without `localId`s causes Confluence to silently drop inline comments; instructs users to edit JFM from `read` and keep its `localId`s intact, not to hand-author fresh bodies or push stripped content

**CLI Documentation (`src/cli/atlassian/convert.rs`):**
- Rewrote `--strip-local-ids` flag description to clarify it is for **reading/inspection only** and must not be used before writing content back to Confluence, because stripping `localId`s will cause Confluence to lose the inline comments anchored to them

**MCP Tool Documentation (`src/mcp/atlassian_tools.rs`):**
- Updated `strip_local_ids` field documentation in `AtlassianConvertParams` with the same read-only warning

**MCP Tool Documentation (`src/mcp/confluence_tools.rs`):**
- Updated `confluence_read` tool description to highlight that the returned content carries `localId` attributes and anchor spans that must be preserved verbatim in any subsequent `confluence_write`
- Updated `confluence_write` tool description with an explicit `DATA LOSS` warning: explains that inline comments are anchored via `localId`s from `confluence_read` output, and that omitting them causes Confluence to silently drop those comments; warns against hand-authoring fresh bodies or using content produced with `strip_local_ids`
- Updated `ConfluenceWriteParams.content` field doc comment with the same preservation guidance

**Test Snapshot (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated integration test help output snapshot to reflect the expanded `--strip-local-ids` flag description

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no new behavior to test)
- [x] Integration tests updated/added (snapshot `integration_test__help_all_output.snap` updated to match new help text)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (verified help output matches updated snapshot)
- [ ] Tested error/edge cases (not applicable — documentation change only)
- [ ] Cross-platform testing (not applicable)
- [x] Backward compatibility verified (purely additive doc changes; no behavior change)

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Verify help text snapshot matches updated documentation
cargo test integration_test__help_all_output
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [x] User experience — verify that the warning language is clear, appropriately alarming (it describes a silent data-loss risk), and consistent across CLI and MCP tool descriptions
- [x] Backward compatibility — confirm this is purely additive (expanded help text only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only change)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications (documentation change only; the underlying behavior is unchanged)

## Breaking Changes

None. This PR only updates help text and doc comments. No APIs, CLI interfaces, or runtime behavior were changed.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Why this matters for AI assistants**: The `confluence_read` and `confluence_write` MCP tools are commonly used by AI agents to read, modify, and push Confluence pages. Without explicit warnings in the tool descriptions, an AI assistant might plausibly hand-author new content or strip `localId`s to reduce noise — unknowingly causing permanent loss of inline comments on the page. The `DATA LOSS` label in `confluence_write`'s description is intentional to signal the severity.

**Known Limitations**: This only adds documentation warnings. A future improvement could make the tooling actively detect and warn when a user attempts to write content that is missing `localId`s that were present in the last-read version of the page.

**Alternatives Considered**: Adding a runtime validation/warning in `confluence_write` when `localId`s appear to be missing was considered but deferred — that change would require more significant code changes and heuristics to avoid false positives.