### PR TITLE
feat(cli): implement AWS-CLI-style credential profiles for multi-tenant support

### DIFF
--- a/docs/configuration-best-practices.md
+++ b/docs/configuration-best-practices.md
@@ -6,12 +6,13 @@ real lessons learned from the project's own development.
 ## Table of Contents
 
 1. [Config Resolution Priority](#config-resolution-priority)
-2. [Ecosystem Defaults](#ecosystem-defaults)
-3. [Writing Effective Scope Definitions](#writing-effective-scope-definitions)
-4. [Writing Effective Commit Guidelines](#writing-effective-commit-guidelines)
-5. [Scope Validity vs Appropriateness](#scope-validity-vs-appropriateness)
-6. [Common Pitfalls](#common-pitfalls)
-7. [Quality Checklist](#quality-checklist)
+2. [Credential Profiles](#credential-profiles)
+3. [Ecosystem Defaults](#ecosystem-defaults)
+4. [Writing Effective Scope Definitions](#writing-effective-scope-definitions)
+5. [Writing Effective Commit Guidelines](#writing-effective-commit-guidelines)
+6. [Scope Validity vs Appropriateness](#scope-validity-vs-appropriateness)
+7. [Common Pitfalls](#common-pitfalls)
+8. [Quality Checklist](#quality-checklist)
 
 ## Config Resolution Priority
 
@@ -76,6 +77,86 @@ ecosystem defaults are still applied (see below).
   command-line arguments.
 - **Walk-up**: Automatic monorepo support — place `.omni-dev/` directories
   at package boundaries and run from within the package.
+
+## Credential Profiles
+
+Backend credentials (Atlassian, Datadog, Snowflake, Claude/AI, and the
+`claude-cli` knobs) are read as environment variables, with a fallback to the
+`env` map in `~/.omni-dev/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_API_KEY": "sk-...",
+    "DATADOG_SITE": "datadoghq.com"
+  }
+}
+```
+
+The lookup order for every such variable is **process environment first, then
+the `settings.json` `env` map** — so exported shell / CI variables always win
+and secret injection is unaffected.
+
+### Selecting a profile
+
+A **profile** is a named `env` bundle, letting one machine hold several
+credential sets (e.g. a `work` vs a `personal` Atlassian tenant) and pick one
+per invocation — the same model as the AWS CLI's `--profile`. Profiles live in a
+`profiles` map alongside the base `env`:
+
+```json
+{
+  "env": {
+    "CLAUDE_API_KEY": "sk-...",
+    "DATADOG_SITE": "datadoghq.com"
+  },
+  "profiles": {
+    "work": {
+      "env": {
+        "ATLASSIAN_INSTANCE_URL": "https://work.atlassian.net",
+        "ATLASSIAN_EMAIL": "me@work.com",
+        "ATLASSIAN_API_TOKEN": "..."
+      }
+    },
+    "personal": {
+      "env": {
+        "ATLASSIAN_INSTANCE_URL": "https://me.atlassian.net",
+        "ATLASSIAN_EMAIL": "me@personal.com",
+        "ATLASSIAN_API_TOKEN": "..."
+      }
+    }
+  }
+}
+```
+
+Select a profile two ways (the flag wins over the env var, mirroring
+`--profile` / `AWS_PROFILE`):
+
+```bash
+omni-dev --profile work atlassian jira read PROJ-1   # global --profile flag
+OMNI_DEV_PROFILE=work omni-dev datadog monitor list  # OMNI_DEV_PROFILE env var
+```
+
+### Resolution rules
+
+| Situation                                     | Lookup order for each variable               |
+|-----------------------------------------------|----------------------------------------------|
+| No profile active                             | process env, then base `env` map             |
+| `--profile work` (or `OMNI_DEV_PROFILE=work`) | process env, then the `work` profile's `env` |
+
+The layering is **isolated**: when a profile is active the base `env` map is
+**not** consulted. A key missing from the selected profile therefore fails loud
+rather than silently reusing a base credential against the wrong tenant — put
+values that every profile needs (e.g. `CLAUDE_API_KEY`) into each profile that
+needs them, not only in the base map. Process environment variables still
+override both, exactly as without a profile.
+
+- **Backward compatible.** With no `profiles` and no profile selected, behaviour
+  is byte-for-byte identical to a plain `env`-only `settings.json`.
+- **Unknown profile is a hard error.** A typo (`--profile wrok`) fails before any
+  backend call: `error: unknown profile 'wrok'; known profiles: personal, work`.
+- **Not profile-scoped:** the browser-bridge token (`OMNI_BRIDGE_TOKEN`) reads
+  the raw process environment only and ignores both the `env` map and profiles.
 
 ## Ecosystem Defaults
 

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -713,6 +713,11 @@ $ omni-dev datadog auth login
 This persists credentials to `~/.omni-dev/settings.json`, which is read by
 every invocation regardless of how the process was started.
 
+To keep several Datadog orgs on one machine and switch per invocation, put each
+org's variables in a named **profile** and select it with `--profile` /
+`OMNI_DEV_PROFILE`. See
+[Credential Profiles](configuration-best-practices.md#credential-profiles).
+
 ## See also
 
 - [User Guide](user-guide.md#datadog-integration) — short reference;

--- a/docs/snowflake-service.md
+++ b/docs/snowflake-service.md
@@ -143,6 +143,13 @@ rather than by the per-request timeout.
 { "env": { "SNOWFLAKE_ACCOUNT": "MYACCT", "SNOWFLAKE_USER": "me" } }
 ```
 
+To hold several accounts on one machine, put each account's `SNOWFLAKE_*`
+variables in a named **profile** and select it with `--profile` /
+`OMNI_DEV_PROFILE` (see
+[Credential Profiles](configuration-best-practices.md#credential-profiles)).
+Because the service pools sessions by `(account, user)`, distinct profiles
+produce distinct pools automatically.
+
 The service is **account-agnostic**: there is no hardcoded account list. Defaults
 are applied at session creation; the per-query flags issue `USE WAREHOUSE/ROLE/
 DATABASE/SCHEMA` on the reused session, so one session serves varied query

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -588,6 +588,11 @@ export ATLASSIAN_API_TOKEN=your-token
 
 Environment variables take precedence over the settings file.
 
+To keep multiple Atlassian tenants (e.g. `work` and `personal`) on one machine
+and pick one per command, store each tenant's variables in a named **profile**
+and select it with `--profile <name>` (or `OMNI_DEV_PROFILE`). See
+[Credential Profiles](configuration-best-practices.md#credential-profiles).
+
 #### Destructive Commands
 
 > **⚠️ Destructive commands require confirmation.**

--- a/src/atlassian/auth.rs
+++ b/src/atlassian/auth.rs
@@ -3,7 +3,6 @@
 //! Loads and saves Atlassian Cloud API credentials from/to the
 //! `~/.omni-dev/settings.json` file using the existing `env` map.
 
-use std::collections::HashMap;
 use std::fs;
 
 use anyhow::{Context, Result};
@@ -52,9 +51,7 @@ pub fn load_credentials() -> Result<AtlassianCredentials> {
 pub fn load_credentials_with_instance(
     instance_override: Option<&str>,
 ) -> Result<AtlassianCredentials> {
-    let settings = Settings::load().unwrap_or(Settings {
-        env: HashMap::new(),
-    });
+    let settings = Settings::load().unwrap_or_default();
 
     let instance_url = match instance_override {
         Some(url) => url.to_string(),
@@ -115,9 +112,7 @@ pub struct AuthStatus {
 /// only. Safe to call with no credentials configured (returns a scope with
 /// every flag `false`).
 pub fn status() -> AuthStatus {
-    let settings = Settings::load().unwrap_or(Settings {
-        env: HashMap::new(),
-    });
+    let settings = Settings::load().unwrap_or_default();
 
     let instance_url = settings
         .get_env_var(ATLASSIAN_INSTANCE_URL)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,16 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     pub models_yaml: Option<std::path::PathBuf>,
 
+    /// Selects a named credential/config profile from
+    /// `~/.omni-dev/settings.json` (AWS-CLI style).
+    ///
+    /// When set, the profile's `env` bundle replaces the base `env` map in the
+    /// settings-fallback chain (process env still wins); the base map is not
+    /// consulted. Overrides `OMNI_DEV_PROFILE`. An unknown name is a hard error
+    /// listing the known profiles.
+    #[arg(long, global = true, value_name = "NAME")]
+    pub profile: Option<String>,
+
     /// Run as if omni-dev was started in `<PATH>` instead of the current
     /// working directory.
     ///
@@ -198,11 +208,53 @@ impl Cli {
         if let Some(path) = &self.models_yaml {
             std::env::set_var("OMNI_DEV_MODELS_YAML", path);
         }
+
+        // The flag beats the env var: setting OMNI_DEV_PROFILE here means the
+        // settings readers (which discover the active profile from that env
+        // var) pick up the flag. When the flag is absent we leave any existing
+        // OMNI_DEV_PROFILE untouched, so the env-var path still works.
+        if let Some(profile) = &self.profile {
+            std::env::set_var(crate::utils::settings::PROFILE_ENV_VAR, profile);
+        }
+    }
+
+    /// Validates the active profile (resolved from `env`) against the settings
+    /// produced by `load_settings`. The loader is invoked only when a profile is
+    /// actually active, so a no-profile invocation reads no disk. Pure over its
+    /// inputs — unit-tested with a `MapEnv` and a constructed `Settings` rather
+    /// than the process environment and `~/.omni-dev/settings.json`.
+    fn validate_active_profile<E, F>(env: &E, load_settings: F) -> Result<()>
+    where
+        E: crate::utils::env::EnvSource,
+        F: FnOnce() -> crate::utils::settings::Settings,
+    {
+        match crate::utils::settings::active_profile_from(env) {
+            Some(name) => load_settings().validate_profile(&name),
+            None => Ok(()),
+        }
+    }
+
+    /// Thin disk boundary for [`Self::validate_active_profile`]: loads
+    /// `~/.omni-dev/settings.json`, degrading to defaults when it is absent or
+    /// unreadable rather than failing (an unreadable settings file must not block
+    /// commands that use no profile). A named function so it can be unit-tested
+    /// directly instead of as an inline closure.
+    fn load_settings_or_default() -> crate::utils::settings::Settings {
+        crate::utils::settings::Settings::load().unwrap_or_default()
     }
 
     /// Executes the CLI command.
     pub async fn execute(self) -> Result<()> {
         self.propagate_global_flags();
+
+        // Validate the selected profile once, before dispatch, so a typo fails
+        // fast rather than silently falling back to base credentials. The loader
+        // runs only when a profile is active, so a no-profile invocation pays no
+        // extra disk I/O.
+        Self::validate_active_profile(
+            &crate::utils::env::SystemEnv,
+            Self::load_settings_or_default,
+        )?;
 
         // Resolve the repo location exactly once at this boundary, then thread
         // it explicitly into each command. Nothing deeper reads the ambient CWD.
@@ -371,12 +423,13 @@ mod tests {
     const ALLOW_MCP_VAR: &str = "OMNI_DEV_CLAUDE_CLI_ALLOW_MCP";
     const MAX_BUDGET_VAR: &str = "OMNI_DEV_CLAUDE_CLI_MAX_BUDGET_USD";
     const MODELS_YAML_VAR: &str = "OMNI_DEV_MODELS_YAML";
+    const PROFILE_VAR: &str = "OMNI_DEV_PROFILE";
 
     /// Locks the shared mutex and snapshots/restores every env var
     /// `propagate_global_flags` may touch.
     struct GlobalFlagsEnvGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
-        saved: [(&'static str, Option<String>); 5],
+        saved: [(&'static str, Option<String>); 6],
     }
 
     impl GlobalFlagsEnvGuard {
@@ -390,6 +443,7 @@ mod tests {
                 ALLOW_MCP_VAR,
                 MAX_BUDGET_VAR,
                 MODELS_YAML_VAR,
+                PROFILE_VAR,
             ];
             let saved = names.map(|n| (n, std::env::var(n).ok()));
             for (n, _) in &saved {
@@ -423,6 +477,7 @@ mod tests {
         assert!(std::env::var(ALLOW_MCP_VAR).is_err());
         assert!(std::env::var(MAX_BUDGET_VAR).is_err());
         assert!(std::env::var(MODELS_YAML_VAR).is_err());
+        assert!(std::env::var(PROFILE_VAR).is_err());
     }
 
     #[test]
@@ -531,6 +586,87 @@ mod tests {
             std::env::var(MODELS_YAML_VAR).ok().as_deref(),
             Some("/tmp/custom-models.yaml")
         );
+    }
+
+    #[test]
+    fn parses_profile_flag() {
+        let cli = Cli::try_parse_from(["omni-dev", "--profile", "work", "help-all"]).unwrap();
+        assert_eq!(cli.profile.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn profile_absent_is_none() {
+        let cli = Cli::try_parse_from(["omni-dev", "help-all"]).unwrap();
+        assert!(cli.profile.is_none());
+    }
+
+    #[test]
+    fn propagate_global_flags_sets_profile() {
+        let _g = GlobalFlagsEnvGuard::new();
+        let mut cli = cli_with_defaults();
+        cli.profile = Some("work".to_string());
+        cli.propagate_global_flags();
+        assert_eq!(std::env::var(PROFILE_VAR).ok().as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn propagate_global_flags_profile_flag_beats_env_var() {
+        let _g = GlobalFlagsEnvGuard::new();
+        std::env::set_var(PROFILE_VAR, "personal");
+        let mut cli = cli_with_defaults();
+        cli.profile = Some("work".to_string());
+        cli.propagate_global_flags();
+        assert_eq!(std::env::var(PROFILE_VAR).ok().as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn propagate_global_flags_absent_profile_leaves_env_var() {
+        let _g = GlobalFlagsEnvGuard::new();
+        std::env::set_var(PROFILE_VAR, "personal");
+        cli_with_defaults().propagate_global_flags();
+        assert_eq!(std::env::var(PROFILE_VAR).ok().as_deref(), Some("personal"));
+    }
+
+    // ── validate_active_profile() seam (pure: MapEnv + injected settings loader,
+    // no process env, no disk) ──
+
+    #[test]
+    fn validate_active_profile_ok_and_skips_load_when_no_profile() {
+        use crate::test_support::env::MapEnv;
+        let env = MapEnv::new();
+        let result = Cli::validate_active_profile(&env, || panic!("must not load settings"));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_active_profile_ok_for_known_profile() {
+        use crate::test_support::env::MapEnv;
+        use crate::utils::settings::{Profile, Settings};
+        let env = MapEnv::new().with(PROFILE_VAR, "work");
+        let settings = Settings {
+            profiles: std::iter::once(("work".to_string(), Profile::default())).collect(),
+            ..Default::default()
+        };
+        assert!(Cli::validate_active_profile(&env, || settings).is_ok());
+    }
+
+    #[test]
+    fn validate_active_profile_errors_for_unknown_profile() {
+        use crate::test_support::env::MapEnv;
+        use crate::utils::settings::Settings;
+        let env = MapEnv::new().with(PROFILE_VAR, "wrok");
+        let err = Cli::validate_active_profile(&env, Settings::default)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown profile 'wrok'"));
+    }
+
+    #[test]
+    fn load_settings_or_default_never_panics() {
+        // The disk boundary must degrade to defaults rather than panic when
+        // `~/.omni-dev/settings.json` is absent or unreadable. Exercises the
+        // production loader directly, no process env or fixture required.
+        let _settings = Cli::load_settings_or_default();
     }
 
     #[test]

--- a/src/snowflake/mod.rs
+++ b/src/snowflake/mod.rs
@@ -111,9 +111,7 @@ impl SnowflakeEngineConfig {
     /// Currently infallible, but returns `Result` so the daemon registry wiring
     /// can `?` it and future validation can surface errors.
     pub fn from_env_and_settings() -> Result<Self> {
-        let settings = Settings::load().unwrap_or_else(|_| Settings {
-            env: std::collections::HashMap::new(),
-        });
+        let settings = Settings::load().unwrap_or_default();
         let pool_size = settings
             .get_env_var(ENV_POOL_SIZE)
             .and_then(|s| s.trim().parse::<usize>().ok())

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -4,24 +4,59 @@
 //! and use them as a fallback for environment variables.
 
 use std::collections::HashMap;
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-/// Settings loaded from $HOME/.omni-dev/settings.json.
+use crate::utils::env::{EnvSource, SystemEnv};
+
+/// Environment variable that selects the active profile, mirroring `AWS_PROFILE`.
+///
+/// Read from the **raw** process environment only (never through the profile
+/// fallback, which would be circular); the `--profile` flag propagates its value
+/// here in `Cli::propagate_global_flags`.
+pub const PROFILE_ENV_VAR: &str = "OMNI_DEV_PROFILE";
+
+/// A named credential/config bundle inside `settings.json` — its own `env` map,
+/// selected per invocation via `--profile` / `OMNI_DEV_PROFILE`.
 #[derive(Debug, Default, Deserialize)]
-pub struct Settings {
-    /// Environment variable overrides.
+pub struct Profile {
+    /// Environment variable overrides applied when this profile is active.
     #[serde(default)]
     pub env: HashMap<String, String>,
 }
 
-/// An [`EnvSource`](crate::utils::env::EnvSource) that reads the real process
-/// environment first and falls back to the `env` map in
-/// `$HOME/.omni-dev/settings.json` — the value form of [`get_env_var`].
+/// Settings loaded from $HOME/.omni-dev/settings.json.
+#[derive(Debug, Default, Deserialize)]
+pub struct Settings {
+    /// Environment variable overrides — the default bundle, consulted only when
+    /// **no** profile is active.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+
+    /// Named profiles. Selecting one replaces the base `env` in the fallback
+    /// chain (isolated / AWS-faithful); see [`Settings::resolve_with`].
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
+}
+
+/// Returns the active profile name from `raw` (the process environment), or
+/// `None` when `OMNI_DEV_PROFILE` is unset or empty.
+///
+/// Reads the **raw** env only, so it is pure over the injected source and never
+/// resolves through the profile fallback.
+pub fn active_profile_from<E: EnvSource>(raw: &E) -> Option<String> {
+    raw.var(PROFILE_ENV_VAR).filter(|s| !s.is_empty())
+}
+
+/// An [`EnvSource`](crate::utils::env::EnvSource) with the settings/profile
+/// fallback — the value form of [`get_env_var`].
+///
+/// Reads the real process environment first, then the active profile's `env`
+/// (or the base `env` when no profile is active) in
+/// `$HOME/.omni-dev/settings.json`.
 ///
 /// Pass `&SettingsEnv::load()` from a thin production wrapper; tests inject a
 /// pure `MapEnv` into the same `*_with(&impl EnvSource, …)` seam instead of
@@ -29,23 +64,32 @@ pub struct Settings {
 #[derive(Debug, Default)]
 pub struct SettingsEnv {
     settings: Settings,
+    active_profile: Option<String>,
 }
 
 impl SettingsEnv {
     /// Loads settings from the default location, falling back to an empty
-    /// settings map if they are absent or unreadable (env-only behaviour).
+    /// settings map if they are absent or unreadable (env-only behaviour). The
+    /// active profile is read from `OMNI_DEV_PROFILE`.
     pub fn load() -> Self {
+        Self::load_with_profile(active_profile_from(&SystemEnv).as_deref())
+    }
+
+    /// Like [`load`](Self::load) but with the active profile supplied
+    /// explicitly — for tests and embedders that select a profile without
+    /// setting `OMNI_DEV_PROFILE` in the process environment.
+    pub fn load_with_profile(profile: Option<&str>) -> Self {
         Self {
             settings: Settings::load().unwrap_or_default(),
+            active_profile: profile.map(str::to_string),
         }
     }
 }
 
-impl crate::utils::env::EnvSource for SettingsEnv {
+impl EnvSource for SettingsEnv {
     fn var(&self, key: &str) -> Option<String> {
-        env::var(key)
-            .ok()
-            .or_else(|| self.settings.env.get(key).cloned())
+        self.settings
+            .resolve_with(&SystemEnv, self.active_profile.as_deref(), key)
     }
 }
 
@@ -62,9 +106,7 @@ impl Settings {
 
         // If file doesn't exist, return default settings
         if !path.exists() {
-            return Ok(Self {
-                env: HashMap::new(),
-            });
+            return Ok(Self::default());
         }
 
         // Read and parse the settings file
@@ -82,37 +124,84 @@ impl Settings {
         Ok(home_dir.join(".omni-dev").join("settings.json"))
     }
 
-    /// Returns an environment variable with fallback to settings.
+    /// Returns an environment variable with fallback to settings, honouring the
+    /// active profile from `OMNI_DEV_PROFILE`.
     pub fn get_env_var(&self, key: &str) -> Option<String> {
-        // Try to get from actual environment first
-        match env::var(key) {
-            Ok(value) => Some(value),
-            Err(_) => {
-                // Fall back to settings
-                self.env.get(key).cloned()
-            }
+        self.resolve_with(&SystemEnv, active_profile_from(&SystemEnv).as_deref(), key)
+    }
+
+    /// Isolated / AWS-faithful resolution: `raw` (the process environment) wins;
+    /// then the active profile's `env` if `active` is set, else the base `env`.
+    /// The base map is **not** consulted when a profile is active, so a missing
+    /// key fails loud rather than silently reusing a default credential against
+    /// the wrong tenant.
+    ///
+    /// This is the pure seam: production wrappers pass `&SystemEnv`; tests pass
+    /// a `MapEnv` and an explicit `active`, mutating no process-global state.
+    pub fn resolve_with<E: EnvSource>(
+        &self,
+        raw: &E,
+        active: Option<&str>,
+        key: &str,
+    ) -> Option<String> {
+        if let Some(value) = raw.var(key) {
+            return Some(value);
         }
+        match active {
+            Some(name) => self
+                .profiles
+                .get(name)
+                .and_then(|p| p.env.get(key).cloned()),
+            None => self.env.get(key).cloned(),
+        }
+    }
+
+    /// Validates that `name` is a known profile, returning a hard error that
+    /// lists the known profiles (sorted) otherwise. Called once at the CLI
+    /// boundary so a typo never silently falls back to base credentials.
+    pub fn validate_profile(&self, name: &str) -> Result<()> {
+        if self.profiles.contains_key(name) {
+            return Ok(());
+        }
+        let known = if self.profiles.is_empty() {
+            "(none)".to_string()
+        } else {
+            let mut names: Vec<&str> = self.profiles.keys().map(String::as_str).collect();
+            names.sort_unstable();
+            names.join(", ")
+        };
+        Err(anyhow::anyhow!(
+            "unknown profile '{name}'; known profiles: {known}"
+        ))
     }
 }
 
-/// Returns an environment variable with fallback to settings.
+/// Returns an environment variable with fallback to settings, honouring the
+/// active profile from `OMNI_DEV_PROFILE`.
 pub fn get_env_var(key: &str) -> Result<String> {
-    // Try to get from actual environment first
-    match env::var(key) {
-        Ok(value) => Ok(value),
-        Err(_) => {
-            // Try to load settings and check there
-            match Settings::load() {
-                Ok(settings) => settings
-                    .env
-                    .get(key)
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("Environment variable not found: {key}")),
-                Err(err) => {
-                    // If we couldn't load settings, just return the original env var error
-                    Err(anyhow::anyhow!("Environment variable not found: {key}").context(err))
-                }
-            }
+    get_env_var_with(&SystemEnv, Settings::load, key)
+}
+
+/// Pure core of [`get_env_var`]: `env` is the raw source and `load` produces the
+/// settings lazily — it is invoked only on a raw-env miss, preserving the
+/// no-disk fast path. Tests inject a `MapEnv` and a closure returning `Ok`/`Err`
+/// to cover both the resolved and load-failure branches without touching disk.
+fn get_env_var_with<E, F>(env: &E, load: F, key: &str) -> Result<String>
+where
+    E: EnvSource,
+    F: FnOnce() -> Result<Settings>,
+{
+    // A raw process-env hit short-circuits without loading settings from disk.
+    if let Some(value) = env.var(key) {
+        return Ok(value);
+    }
+    match load() {
+        Ok(settings) => settings
+            .resolve_with(env, active_profile_from(env).as_deref(), key)
+            .ok_or_else(|| anyhow::anyhow!("Environment variable not found: {key}")),
+        Err(err) => {
+            // If we couldn't load settings, just return the original env var error
+            Err(anyhow::anyhow!("Environment variable not found: {key}").context(err))
         }
     }
 }
@@ -134,8 +223,29 @@ pub fn get_env_vars(keys: &[&str]) -> Result<String> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::test_support::env::MapEnv;
+    use std::env;
     use std::fs;
     use tempfile::TempDir;
+
+    /// Builds a `Settings` with a base `env` and one profile, for the pure
+    /// resolver tests (no disk, no process env).
+    fn settings_with_profile() -> Settings {
+        let mut base = HashMap::new();
+        base.insert("ATLASSIAN_EMAIL".to_string(), "base@x.com".to_string());
+        base.insert("SHARED".to_string(), "base-shared".to_string());
+
+        let mut work_env = HashMap::new();
+        work_env.insert("ATLASSIAN_EMAIL".to_string(), "me@work.com".to_string());
+
+        let mut profiles = HashMap::new();
+        profiles.insert("work".to_string(), Profile { env: work_env });
+
+        Settings {
+            env: base,
+            profiles,
+        }
+    }
 
     #[test]
     fn settings_load_from_path() {
@@ -200,5 +310,182 @@ mod tests {
 
         // Clean up
         env::remove_var("TEST_VAR_ENV");
+    }
+
+    // ── profile resolution (pure: MapEnv raw env, explicit active profile) ──
+
+    #[test]
+    fn resolve_no_profile_uses_base_env() {
+        let settings = settings_with_profile();
+        let raw = MapEnv::new();
+        assert_eq!(
+            settings
+                .resolve_with(&raw, None, "ATLASSIAN_EMAIL")
+                .as_deref(),
+            Some("base@x.com")
+        );
+    }
+
+    #[test]
+    fn resolve_active_profile_uses_profile_env() {
+        let settings = settings_with_profile();
+        let raw = MapEnv::new();
+        assert_eq!(
+            settings
+                .resolve_with(&raw, Some("work"), "ATLASSIAN_EMAIL")
+                .as_deref(),
+            Some("me@work.com")
+        );
+    }
+
+    #[test]
+    fn resolve_active_profile_does_not_consult_base() {
+        // Isolated / AWS-faithful: a key present only in base is invisible while
+        // a profile is active — fail loud rather than reuse a default token.
+        let settings = settings_with_profile();
+        let raw = MapEnv::new();
+        assert_eq!(settings.resolve_with(&raw, Some("work"), "SHARED"), None);
+    }
+
+    #[test]
+    fn resolve_process_env_wins_over_profile_and_base() {
+        let settings = settings_with_profile();
+        let raw = MapEnv::new().with("ATLASSIAN_EMAIL", "cli@x.com");
+        assert_eq!(
+            settings
+                .resolve_with(&raw, Some("work"), "ATLASSIAN_EMAIL")
+                .as_deref(),
+            Some("cli@x.com")
+        );
+        assert_eq!(
+            settings
+                .resolve_with(&raw, None, "ATLASSIAN_EMAIL")
+                .as_deref(),
+            Some("cli@x.com")
+        );
+    }
+
+    #[test]
+    fn resolve_unknown_active_profile_yields_none() {
+        // An unknown name never falls back to base; validation catches it at the
+        // CLI boundary, but the resolver itself stays isolated.
+        let settings = settings_with_profile();
+        let raw = MapEnv::new();
+        assert_eq!(
+            settings.resolve_with(&raw, Some("nope"), "ATLASSIAN_EMAIL"),
+            None
+        );
+    }
+
+    #[test]
+    fn active_profile_from_reads_and_trims_empty() {
+        assert_eq!(active_profile_from(&MapEnv::new()), None);
+        assert_eq!(
+            active_profile_from(&MapEnv::new().with(PROFILE_ENV_VAR, "")),
+            None
+        );
+        assert_eq!(
+            active_profile_from(&MapEnv::new().with(PROFILE_ENV_VAR, "work")).as_deref(),
+            Some("work")
+        );
+    }
+
+    #[test]
+    fn validate_profile_accepts_known() {
+        assert!(settings_with_profile().validate_profile("work").is_ok());
+    }
+
+    #[test]
+    fn validate_profile_rejects_unknown_and_lists_sorted() {
+        let mut settings = settings_with_profile();
+        settings
+            .profiles
+            .insert("personal".to_string(), Profile::default());
+        let err = settings.validate_profile("wrok").unwrap_err().to_string();
+        assert_eq!(
+            err,
+            "unknown profile 'wrok'; known profiles: personal, work"
+        );
+    }
+
+    #[test]
+    fn validate_profile_reports_none_when_empty() {
+        let settings = Settings::default();
+        let err = settings.validate_profile("work").unwrap_err().to_string();
+        assert_eq!(err, "unknown profile 'work'; known profiles: (none)");
+    }
+
+    #[test]
+    fn settings_parse_profiles_from_json() {
+        let json = r#"{
+            "env": { "BASE": "b" },
+            "profiles": {
+                "work": { "env": { "ATLASSIAN_EMAIL": "me@work.com" } }
+            }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.env.get("BASE").unwrap(), "b");
+        assert_eq!(
+            settings
+                .profiles
+                .get("work")
+                .unwrap()
+                .env
+                .get("ATLASSIAN_EMAIL")
+                .unwrap(),
+            "me@work.com"
+        );
+    }
+
+    #[test]
+    fn settings_without_profiles_key_defaults_empty() {
+        let settings: Settings = serde_json::from_str(r#"{ "env": {} }"#).unwrap();
+        assert!(settings.profiles.is_empty());
+    }
+
+    // ── free get_env_var seam (pure: injected raw env + lazy settings loader) ──
+
+    #[test]
+    fn get_env_var_with_returns_raw_hit_without_loading() {
+        let env = MapEnv::new().with("K", "v");
+        let value = get_env_var_with(&env, || panic!("must not load settings"), "K").unwrap();
+        assert_eq!(value, "v");
+    }
+
+    #[test]
+    fn get_env_var_with_falls_back_to_base_settings() {
+        let settings = settings_with_profile();
+        let env = MapEnv::new();
+        let value = get_env_var_with(&env, || Ok(settings), "ATLASSIAN_EMAIL").unwrap();
+        assert_eq!(value, "base@x.com");
+    }
+
+    #[test]
+    fn get_env_var_with_honours_active_profile() {
+        let settings = settings_with_profile();
+        let env = MapEnv::new().with(PROFILE_ENV_VAR, "work");
+        let value = get_env_var_with(&env, || Ok(settings), "ATLASSIAN_EMAIL").unwrap();
+        assert_eq!(value, "me@work.com");
+    }
+
+    #[test]
+    fn get_env_var_with_missing_key_is_not_found() {
+        let env = MapEnv::new();
+        let err = get_env_var_with(&env, || Ok(Settings::default()), "MISSING")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Environment variable not found: MISSING"));
+    }
+
+    #[test]
+    fn get_env_var_with_load_error_maps_to_not_found() {
+        let env = MapEnv::new();
+        let err =
+            get_env_var_with(&env, || Err(anyhow::anyhow!("disk boom")), "MISSING").unwrap_err();
+        // The load failure is the top-level context; the not-found error is its
+        // source. The full chain (`{:#}`) carries both.
+        assert_eq!(err.to_string(), "disk boom");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("Environment variable not found: MISSING"));
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -558,6 +558,7 @@ async fn cli_execute_dispatches_git_commit_message_view() {
         claude_cli_max_budget_usd: None,
         models_yaml: None,
         repo: None,
+        profile: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Commit(CommitCommand {
                 command: CommitSubcommands::Message(MessageCommand {
@@ -585,6 +586,7 @@ async fn cli_execute_dispatches_git_branch_info() {
         claude_cli_max_budget_usd: None,
         models_yaml: None,
         repo: None,
+        profile: None,
         command: Commands::Git(GitCommand {
             command: GitSubcommands::Branch(BranchCommand {
                 command: BranchSubcommands::Info(InfoCommand { base_branch: None }),
@@ -606,6 +608,7 @@ async fn cli_execute_dispatches_ai_chat() {
         claude_cli_max_budget_usd: None,
         models_yaml: None,
         repo: None,
+        profile: None,
         command: Commands::Ai(AiCommand {
             command: AiSubcommands::Chat(ChatCommand { model: None }),
         }),

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -37,6 +37,8 @@ Options:
           Per-invocation spending cap in USD for the `claude-cli` backend
       --models-yaml <PATH>
           Path to a single user-side `models.yaml` that short-circuits the standard `./.omni-dev/models.yaml` and `~/.omni-dev/models.yaml` lookup. The file is still merged over the embedded catalog. Equivalent to setting `OMNI_DEV_MODELS_YAML`
+      --profile <NAME>
+          Selects a named credential/config profile from `~/.omni-dev/settings.json` (AWS-CLI style)
   -C, --repo <PATH>
           Run as if omni-dev was started in `<PATH>` instead of the current working directory
   -h, --help


### PR DESCRIPTION
## Description

This PR adds named credential profiles to `~/.omni-dev/settings.json`, following the same model as the AWS CLI's `--profile`. Users working with multiple Atlassian tenants, Datadog orgs, or Snowflake accounts on a single machine can now store each credential set as a named profile and select one per invocation — eliminating the need to manually juggle environment variables between workspaces.

The design is **isolated / AWS-faithful**: when a profile is active, the base `env` map is not consulted. A key missing from the selected profile fails loud rather than silently reusing a default credential against the wrong tenant. Process environment variables always win, so CI/secret-injection workflows are unaffected.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue
Fixes #1089

## Changes Made

**Core Changes (`src/utils/settings.rs`):**
- Added `Profile` struct with its own `env: HashMap<String, String>` bundle
- Extended `Settings` with a `profiles: HashMap<String, Profile>` field (serde `default` so existing files without `profiles` are unchanged)
- Added `PROFILE_ENV_VAR = "OMNI_DEV_PROFILE"` constant mirroring `AWS_PROFILE`
- Added `active_profile_from<E: EnvSource>(raw: &E) -> Option<String>` — reads the raw process env only (never self-referential)
- Added `Settings::resolve_with<E: EnvSource>(&self, raw, active, key)` — pure, injectable resolver: process env wins, then active profile's `env`, else base `env` (when no profile)
- Added `Settings::validate_profile(&self, name: &str) -> Result<()>` — returns a hard error listing known profiles sorted, so `--profile wrok` fails at the CLI boundary before any backend call
- Updated `Settings::get_env_var` and module-level `get_env_var` to route through `resolve_with`, honouring `OMNI_DEV_PROFILE`
- Added `SettingsEnv::load_with_profile(profile: Option<&str>)` for tests/embedders that supply the active profile explicitly
- Simplified `Settings::load` early-return from manual struct construction to `Self::default()`

**CLI Changes (`src/cli.rs`):**
- Added `--profile <NAME>` global flag to `Cli` struct with doc-comment explaining AWS-CLI-style semantics
- Updated `propagate_global_flags` to write `OMNI_DEV_PROFILE` when `--profile` is provided (flag beats env var; absent flag leaves existing env var untouched)
- Added early profile validation in `Cli::execute` — calls `Settings::validate_profile` once before dispatch so typos fail fast without any extra disk I/O on no-profile invocations

**Simplification / Refactoring:**
- Replaced manual `Settings { env: HashMap::new() }` fallback construction in `src/atlassian/auth.rs` (×2) and `src/snowflake/mod.rs` with `unwrap_or_default()`

**Documentation:**
- Added comprehensive "Credential Profiles" section to `docs/configuration-best-practices.md` with JSON examples, resolution table, backward-compatibility notes, and isolation rationale
- Added profile cross-reference blurb to `docs/datadog.md`, `docs/snowflake-service.md`, and `docs/user-guide.md` (Atlassian section)

**Testing:**
- Added pure resolver unit tests in `src/utils/settings.rs` using `MapEnv` (no disk, no process env): no-profile uses base env, active profile uses profile env, active profile does NOT consult base env, process env wins over both, unknown profile yields `None`
- Added `active_profile_from` tests for absent key, empty string, and non-empty value
- Added `validate_profile` tests for known name, unknown name (error lists profiles sorted), and empty profile map
- Added JSON parsing tests for `profiles` field and default (missing key → empty map)
- Added CLI flag tests: `parses_profile_flag`, `profile_absent_is_none`, `propagate_global_flags_sets_profile`, `propagate_global_flags_profile_flag_beats_env_var`, `propagate_global_flags_absent_profile_leaves_env_var`
- Updated `GlobalFlagsEnvGuard` to snapshot/restore `OMNI_DEV_PROFILE` alongside the other global flags
- Added `profile: None` to three existing `Cli` struct literals in `tests/integration_test.rs`
- Updated `tests/snapshots/integration_test__help_all_output.snap` to include the new `--profile <NAME>` option

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (`--profile work` selects correct credential set)
- [x] Tested error/edge cases (unknown profile name produces clear error listing known profiles)
- [ ] Cross-platform testing (if applicable)
- [x] Backward compatibility verified (settings files without `profiles` key behave identically to before)

### Test Commands
```bash
# Core test suite
cargo test

# Run profile-specific unit tests
cargo test resolve_

# Run CLI flag tests
cargo test parses_profile_flag
cargo test propagate_global_flags

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual smoke test — unknown profile should fail loud
omni-dev --profile wrok atlassian jira read PROJ-1
# Expected: error: unknown profile 'wrok'; known profiles: personal, work

# Manual smoke test — valid profile selects correct env
omni-dev --profile work atlassian jira read PROJ-1
OMNI_DEV_PROFILE=personal omni-dev snowflake query "SELECT 1"
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — isolation semantics: active profile must NOT fall back to base `env`, preventing silent credential cross-contamination
- [ ] Performance impact
- [x] Architecture changes — new `resolve_with` seam in `Settings` that all env-var lookups now route through
- [x] Error handling — `validate_profile` at CLI boundary; `resolve_with` returns `None` for unknown profiles (validation catches it first)
- [ ] User experience
- [x] Backward compatibility — existing `settings.json` files without `profiles` key deserialize to empty map via `#[serde(default)]`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

Profile validation only runs when a profile is active (guarded by `if let Some(name) = active_profile_from(...)`), so no-profile invocations pay zero extra disk I/O. The process-env short-circuit in the free function `get_env_var` is also preserved.

## Security Considerations
- [x] Security improvement (describe below)

The **isolated resolution** model is a security property: when a profile is active, the base `env` map is never consulted. A key missing from the selected profile fails loud rather than silently reusing a base-level credential (e.g. a personal API token) against an unintended tenant. Process environment variables still override everything, so secret-injection via CI environment remains unaffected.

## Breaking Changes

None. This is a purely additive, backward-compatible change. Settings files without a `profiles` key behave byte-for-byte identically to before. No environment variable names were removed or renamed.

## Deployment Notes
- [x] No special deployment requirements

Users who want to use profiles add a `profiles` map to their existing `~/.omni-dev/settings.json`. No migration is needed for existing configurations.

## Additional Notes

**Future Enhancements:**
- Profile support could be extended to other backends (e.g. `claude-cli`, browser-bridge) as needs arise; the `resolve_with` seam makes this straightforward
- A `omni-dev profile list` subcommand could surface available profiles without requiring users to open `settings.json` directly

**Known Limitations:**
- `OMNI_BRIDGE_TOKEN` (browser-bridge) reads the raw process environment only and intentionally ignores both the `env` map and profiles — this is by design and documented
- Profiles do not support nested inheritance (a profile cannot extend another profile); values common to all profiles (e.g. `CLAUDE_API_KEY`) must be duplicated into each profile that needs them

**Alternatives Considered:**
- **Falling back to base `env` when a profile key is missing** — rejected because it would silently reuse a default credential against the wrong tenant, which is the exact problem profiles are meant to prevent