### PR TITLE
feat(atlassian): implement inline-comment drift auditing and re-anchoring

### DIFF
--- a/src/atlassian.rs
+++ b/src/atlassian.rs
@@ -23,4 +23,5 @@ pub mod diff_format;
 pub mod directive;
 pub mod document;
 pub mod error;
+pub mod inline_comment;
 pub mod jira_api;

--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -359,6 +359,17 @@ pub struct ConfluenceComment {
     pub body_adf: Option<serde_json::Value>,
     /// ISO 8601 creation timestamp.
     pub created: String,
+    /// For inline comments: the `id` of the `annotation` mark this comment is
+    /// anchored to inside the page ADF (Confluence's `inlineMarkerRef`). `None`
+    /// for footer comments. Used to locate — and re-anchor — the highlighted run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_marker_ref: Option<String>,
+    /// For inline comments: the plaintext the reviewer originally highlighted
+    /// (Confluence's `inlineOriginalSelection`). This is durable — it does not
+    /// drift when the surrounding page text is edited — so it is the ground
+    /// truth for inline-comment drift auditing. `None` for footer comments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_original_selection: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -380,6 +391,23 @@ struct ConfluenceCommentEntry {
     version: Option<ConfluenceCommentVersion>,
     #[serde(default)]
     body: Option<ConfluenceCommentBody>,
+    /// Inline-comment anchor metadata. Present on the v2 `inline-comments`
+    /// endpoint regardless of `body-format`; absent for footer comments.
+    #[serde(default)]
+    properties: Option<ConfluenceInlineCommentProperties>,
+}
+
+/// The `properties` object on an inline-comment entry. Both fields are optional
+/// so we deserialize tolerantly across footer comments (no `properties`) and any
+/// future shape changes.
+#[derive(Deserialize)]
+struct ConfluenceInlineCommentProperties {
+    /// The `annotation`-mark `id` this comment is anchored to in the page ADF.
+    #[serde(rename = "inlineMarkerRef", default)]
+    inline_marker_ref: Option<String>,
+    /// The plaintext the reviewer highlighted when the comment was posted.
+    #[serde(rename = "inlineOriginalSelection", default)]
+    inline_original_selection: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1457,12 +1485,18 @@ impl ConfluenceApi {
                     .and_then(|v| v.author_id.clone())
                     .unwrap_or_default();
                 let created = c.version.and_then(|v| v.created_at).unwrap_or_default();
+                let (inline_marker_ref, inline_original_selection) = match c.properties {
+                    Some(p) => (p.inline_marker_ref, p.inline_original_selection),
+                    None => (None, None),
+                };
                 all_comments.push(ConfluenceComment {
                     id: c.id,
                     author,
                     kind,
                     body_adf,
                     created,
+                    inline_marker_ref,
+                    inline_original_selection,
                 });
             }
 
@@ -2612,6 +2646,65 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("500"));
+    }
+
+    // ── get_page_inline_comments (properties) ──────────────────────
+
+    #[tokio::test]
+    async fn get_page_inline_comments_captures_marker_and_original_selection() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/inline-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{
+                        "id": "ic1",
+                        "version": {"authorId": "alice", "createdAt": "2026-01-01T00:00:00Z"},
+                        "properties": {
+                            "inlineMarkerRef": "marker-abc",
+                            "inlineOriginalSelection": "the original highlight"
+                        }
+                    }]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let api = mock_confluence_api(&server);
+        let comments = api.get_page_inline_comments("12345").await.unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].inline_marker_ref.as_deref(), Some("marker-abc"));
+        assert_eq!(
+            comments[0].inline_original_selection.as_deref(),
+            Some("the original highlight")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_page_comments_footer_has_no_inline_properties() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/footer-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [{
+                        "id": "fc1",
+                        "version": {"authorId": "bob", "createdAt": "2026-01-01T00:00:00Z"}
+                    }]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let api = mock_confluence_api(&server);
+        let comments = api.get_page_comments("12345").await.unwrap();
+        assert_eq!(comments.len(), 1);
+        assert!(comments[0].inline_marker_ref.is_none());
+        assert!(comments[0].inline_original_selection.is_none());
     }
 
     // ── get_comment_replies ────────────────────────────────────────

--- a/src/atlassian/inline_comment.rs
+++ b/src/atlassian/inline_comment.rs
@@ -1,0 +1,1005 @@
+//! Inline-comment drift auditing and re-anchoring for Confluence pages.
+//!
+//! Confluence inline comments are anchored to a run of characters in the page
+//! ADF via an `annotation` mark carrying an `id`. When the underlying text is
+//! edited, Confluence keeps the mark on whatever *original characters* survive —
+//! it does not follow the *meaning* of the annotated text. Substantive rewrites
+//! therefore leave inline comments "torn" across disjoint fragments, slid onto
+//! unrelated text, or dropped entirely.
+//!
+//! This module provides:
+//!
+//! - [`audit_inline_comments`] — read-only: for every inline comment on a page,
+//!   compare the text currently bearing its annotation mark against the
+//!   reviewer's original highlight (`inlineOriginalSelection`, stored durably on
+//!   the comment) and classify the drift ([`DriftStatus`]).
+//! - [`reanchor_inline_comment`] — write: move a comment's annotation mark to a
+//!   new run in the current-version ADF and PUT the page back in one update.
+//!
+//! Both operate directly on the typed ADF (`atlas_doc_format`) — never via JFM,
+//! which would lose the mark structure the anchor depends on.
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+use crate::atlassian::adf::{AdfDocument, AdfMark, AdfNode};
+use crate::atlassian::adf_validated::ValidatedAdfDocument;
+use crate::atlassian::api::AtlassianApi;
+use crate::atlassian::confluence_api::ConfluenceApi;
+use crate::atlassian::convert::adf_to_plain_text;
+
+// ── Drift classification ────────────────────────────────────────────
+
+/// How an inline comment's anchor relates to the reviewer's original highlight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriftStatus {
+    /// A single run still bears the mark and its text matches the original
+    /// highlight — the anchor is healthy.
+    Ok,
+    /// The mark survives and the joined text still matches the original, but it
+    /// is split across multiple disjoint runs (a "torn" anchor). Cosmetic; the
+    /// comment still points at the right words.
+    Torn,
+    /// No run in the current ADF bears the mark — Confluence dropped it during
+    /// an edit. The comment no longer highlights anything.
+    MarkLost,
+    /// One or more runs bear the mark but their joined text no longer matches
+    /// the original highlight — the anchor has drifted onto different text.
+    Drifted,
+}
+
+/// Per-comment drift report produced by [`audit_inline_comments`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CommentDrift {
+    /// The inline comment's ID.
+    pub comment_id: String,
+    /// Comment author account ID.
+    pub author: String,
+    /// ISO 8601 creation timestamp.
+    pub created: String,
+    /// The `annotation`-mark `id` this comment is anchored to.
+    pub marker_ref: String,
+    /// Drift classification.
+    pub status: DriftStatus,
+    /// The plaintext the reviewer originally highlighted.
+    pub original_selection: String,
+    /// The text currently bearing the annotation mark (joined across runs).
+    /// `None` when the mark was lost.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_anchored_text: Option<String>,
+    /// A suggested new anchor for a drifted/lost comment: the original
+    /// selection, when it still appears verbatim in the current page text.
+    /// `None` when it no longer appears (low confidence — a human should pick).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_new_anchor: Option<String>,
+    /// How many times `suggested_new_anchor` appears in the current page text
+    /// (so the caller can pass a match index to [`reanchor_inline_comment`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_match_count: Option<usize>,
+}
+
+/// Result of a successful [`reanchor_inline_comment`] call.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReanchorOutcome {
+    /// The re-anchored comment's ID.
+    pub comment_id: String,
+    /// The annotation-mark `id` that was moved.
+    pub marker_ref: String,
+    /// The text the mark was moved to.
+    pub new_anchor_text: String,
+    /// The text that previously bore the mark (joined across runs), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_anchored_text: Option<String>,
+    /// The reviewer's original highlight, for context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_selection: Option<String>,
+    /// True when this was a dry run — the page was validated and the move
+    /// computed, but no write was performed.
+    pub dry_run: bool,
+}
+
+// ── Orchestration ───────────────────────────────────────────────────
+
+/// Audits every inline comment on `page_id` for anchor drift.
+///
+/// Read-only. Fetches the current ADF and the inline comments (which carry the
+/// durable `inlineMarkerRef` / `inlineOriginalSelection` properties), then for
+/// each comment compares the currently-annotated text against the original
+/// highlight. Comments with no marker reference are skipped.
+pub async fn audit_inline_comments(
+    api: &ConfluenceApi,
+    page_id: &str,
+) -> Result<Vec<CommentDrift>> {
+    let doc = fetch_page_adf(api, page_id).await?;
+    let plain = adf_to_plain_text(&doc);
+    let comments = api.get_page_inline_comments(page_id).await?;
+
+    let mut reports = Vec::new();
+    for comment in comments {
+        let Some(marker) = comment.inline_marker_ref.as_deref() else {
+            continue;
+        };
+        let original = comment
+            .inline_original_selection
+            .clone()
+            .unwrap_or_default();
+
+        let runs = collect_annotation_runs(&doc, marker);
+        let joined = runs.concat();
+        let status = classify(&runs, &joined, &original);
+
+        let (suggested_new_anchor, suggested_match_count) = match status {
+            DriftStatus::Ok | DriftStatus::Torn => (None, None),
+            DriftStatus::MarkLost | DriftStatus::Drifted => {
+                let count = count_non_overlapping(&plain, &original);
+                if !original.is_empty() && count > 0 {
+                    (Some(original.clone()), Some(count))
+                } else {
+                    (None, None)
+                }
+            }
+        };
+
+        reports.push(CommentDrift {
+            comment_id: comment.id,
+            author: comment.author,
+            created: comment.created,
+            marker_ref: marker.to_string(),
+            status,
+            original_selection: original,
+            current_anchored_text: if runs.is_empty() { None } else { Some(joined) },
+            suggested_new_anchor,
+            suggested_match_count,
+        });
+    }
+
+    Ok(reports)
+}
+
+/// Moves the annotation mark of inline comment `comment_id` to a new run of
+/// text (`anchor_text`) in the current-version ADF and writes the page back.
+///
+/// `match_index` (1-based) disambiguates when `anchor_text` occurs more than
+/// once. The mark is removed from every run currently bearing it and re-applied
+/// to the chosen run in a single mutated document, so the page is written in one
+/// PUT — the server never observes a half-applied state.
+///
+/// When `dry_run` is true, the page is fetched, the move is computed, and the
+/// resulting ADF is validated, but no write is performed — so callers can
+/// preview (and surface anchor/validation errors) without mutating the page.
+///
+/// Operates entirely on ADF (`atlas_doc_format`); it never round-trips through
+/// JFM, which would discard the annotation marks the anchor depends on.
+pub async fn reanchor_inline_comment(
+    api: &ConfluenceApi,
+    page_id: &str,
+    comment_id: &str,
+    anchor_text: &str,
+    match_index: Option<usize>,
+    dry_run: bool,
+) -> Result<ReanchorOutcome> {
+    let comments = api.get_page_inline_comments(page_id).await?;
+    let comment = comments
+        .iter()
+        .find(|c| c.id == comment_id)
+        .with_context(|| format!("inline comment {comment_id} not found on page {page_id}"))?;
+    let marker = comment.inline_marker_ref.clone().with_context(|| {
+        format!("comment {comment_id} has no inline marker reference (is it an inline comment?)")
+    })?;
+    let original_selection = comment.inline_original_selection.clone();
+
+    let mut doc = fetch_page_adf(api, page_id).await?;
+
+    let previous_runs = collect_annotation_runs(&doc, &marker);
+    let previous_anchored_text = if previous_runs.is_empty() {
+        None
+    } else {
+        Some(previous_runs.concat())
+    };
+
+    remove_annotation(&mut doc, &marker);
+    apply_annotation(&mut doc, anchor_text, match_index, &marker)?;
+
+    let validated =
+        ValidatedAdfDocument::try_new(doc).context("re-anchored ADF failed schema validation")?;
+    if !dry_run {
+        api.update_content(page_id, &validated, None).await?;
+    }
+
+    Ok(ReanchorOutcome {
+        comment_id: comment_id.to_string(),
+        marker_ref: marker,
+        new_anchor_text: anchor_text.to_string(),
+        previous_anchored_text,
+        original_selection,
+        dry_run,
+    })
+}
+
+/// Fetches the current-version ADF of `page_id` as a typed [`AdfDocument`].
+async fn fetch_page_adf(api: &ConfluenceApi, page_id: &str) -> Result<AdfDocument> {
+    let page = api.get_content(page_id).await?;
+    match page.body_adf {
+        Some(value) => serde_json::from_value(value).context("failed to parse page ADF"),
+        None => Ok(AdfDocument::new()),
+    }
+}
+
+/// Classifies a comment's anchor from its current runs vs. the original highlight.
+fn classify(runs: &[String], joined: &str, original: &str) -> DriftStatus {
+    if runs.is_empty() {
+        DriftStatus::MarkLost
+    } else if normalize(joined) == normalize(original) {
+        if runs.len() == 1 {
+            DriftStatus::Ok
+        } else {
+            DriftStatus::Torn
+        }
+    } else {
+        DriftStatus::Drifted
+    }
+}
+
+// ── ADF mark helpers ────────────────────────────────────────────────
+
+/// Returns the text of each run that bears an `annotation` mark with `marker_id`,
+/// in document order.
+fn collect_annotation_runs(doc: &AdfDocument, marker_id: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for node in &doc.content {
+        collect_runs_in_node(node, marker_id, &mut out);
+    }
+    out
+}
+
+fn collect_runs_in_node(node: &AdfNode, marker_id: &str, out: &mut Vec<String>) {
+    if is_text_node(node) && has_annotation(node, marker_id) {
+        if let Some(text) = &node.text {
+            out.push(text.clone());
+        }
+    }
+    if let Some(content) = &node.content {
+        for child in content {
+            collect_runs_in_node(child, marker_id, out);
+        }
+    }
+}
+
+/// Removes the `annotation` mark with `marker_id` from every run in the document.
+/// Runs left with no marks have their `marks` collapsed to `None`.
+fn remove_annotation(doc: &mut AdfDocument, marker_id: &str) {
+    for node in &mut doc.content {
+        remove_annotation_in_node(node, marker_id);
+    }
+}
+
+fn remove_annotation_in_node(node: &mut AdfNode, marker_id: &str) {
+    if let Some(marks) = &mut node.marks {
+        marks.retain(|m| !is_target_annotation(m, marker_id));
+        if marks.is_empty() {
+            node.marks = None;
+        }
+    }
+    if let Some(content) = &mut node.content {
+        for child in content {
+            remove_annotation_in_node(child, marker_id);
+        }
+    }
+}
+
+/// State threaded through the mutating anchor-application walk.
+struct ApplyState {
+    anchor: String,
+    marker_id: String,
+    /// 1-based occurrence to annotate.
+    target: usize,
+    /// Occurrences seen so far, in document order.
+    current: usize,
+    /// Set once the target occurrence has been annotated.
+    applied: bool,
+}
+
+/// Adds an `annotation` mark (`marker_id`) to the run of text matching
+/// `anchor_text`.
+///
+/// Supports **cross-run** anchors: a phrase split across sibling text runs by
+/// formatting (e.g. `the **bold** word`) is matched within its inline container
+/// and the covered runs are split at the match boundaries and re-marked. A
+/// selection that crosses a non-text inline node or a block boundary is not
+/// matched (it is not a contiguous run) and yields a "not found" error.
+///
+/// `match_index` (1-based) selects which occurrence to annotate; `None` requires
+/// the anchor to be unique.
+fn apply_annotation(
+    doc: &mut AdfDocument,
+    anchor_text: &str,
+    match_index: Option<usize>,
+    marker_id: &str,
+) -> Result<()> {
+    if anchor_text.is_empty() {
+        bail!("anchor text must not be empty");
+    }
+
+    let total = count_anchor_occurrences(doc, anchor_text);
+    if total == 0 {
+        bail!(
+            "anchor text {anchor_text:?} was not found as a contiguous run of text on the page; \
+             it may span a formatting or block boundary — choose a phrase that appears intact"
+        );
+    }
+
+    let target = match match_index {
+        Some(i) if i == 0 || i > total => bail!(
+            "match index {i} out of range: anchor text {anchor_text:?} appears \
+             {total} time(s) on the page (valid range: 1..={total})"
+        ),
+        Some(i) => i,
+        None if total > 1 => bail!(
+            "anchor text {anchor_text:?} appears {total} times on the page; \
+             specify a 1-based match index to choose which occurrence to anchor to"
+        ),
+        None => 1,
+    };
+
+    let mut state = ApplyState {
+        anchor: anchor_text.to_string(),
+        marker_id: marker_id.to_string(),
+        target,
+        current: 0,
+        applied: false,
+    };
+    apply_in_children(&mut doc.content, &mut state);
+
+    if !state.applied {
+        bail!("internal error: failed to apply annotation for occurrence {target}");
+    }
+    Ok(())
+}
+
+fn apply_in_node(node: &mut AdfNode, state: &mut ApplyState) {
+    if state.applied {
+        return;
+    }
+    if let Some(content) = &mut node.content {
+        apply_in_children(content, state);
+    }
+}
+
+fn apply_in_children(children: &mut Vec<AdfNode>, state: &mut ApplyState) {
+    if state.applied {
+        return;
+    }
+    let old = std::mem::take(children);
+    let mut rebuilt: Vec<AdfNode> = Vec::with_capacity(old.len());
+    let mut span: Vec<AdfNode> = Vec::new();
+
+    for mut child in old {
+        if is_text_node(&child) {
+            span.push(child);
+        } else {
+            flush_span(&mut span, state, &mut rebuilt);
+            apply_in_node(&mut child, state);
+            rebuilt.push(child);
+        }
+    }
+    flush_span(&mut span, state, &mut rebuilt);
+
+    *children = rebuilt;
+}
+
+/// Processes a maximal run of consecutive text-node siblings: searches for the
+/// anchor within their concatenated text and, if the target occurrence falls
+/// here, splits the covered runs and applies the annotation mark.
+fn flush_span(span: &mut Vec<AdfNode>, state: &mut ApplyState, out: &mut Vec<AdfNode>) {
+    if span.is_empty() {
+        return;
+    }
+    let nodes = std::mem::take(span);
+
+    if state.applied {
+        out.extend(nodes);
+        return;
+    }
+
+    // Concatenate the span and record each node's byte range within it.
+    let mut combined = String::new();
+    let mut ranges: Vec<(usize, usize)> = Vec::with_capacity(nodes.len());
+    for node in &nodes {
+        let start = combined.len();
+        combined.push_str(node.text.as_deref().unwrap_or(""));
+        ranges.push((start, combined.len()));
+    }
+
+    // Count occurrences in document order until we reach the target.
+    let mut target_range: Option<(usize, usize)> = None;
+    let mut search_from = 0;
+    while let Some(pos) = combined[search_from..].find(&state.anchor) {
+        let match_start = search_from + pos;
+        let match_end = match_start + state.anchor.len();
+        state.current += 1;
+        if state.current == state.target {
+            target_range = Some((match_start, match_end));
+            state.applied = true;
+            break;
+        }
+        search_from = match_end;
+    }
+
+    match target_range {
+        Some((s, e)) => {
+            for (idx, node) in nodes.iter().enumerate() {
+                let (a, b) = ranges[idx];
+                slice_node(node, a, b, s, e, &state.marker_id, out);
+            }
+        }
+        None => out.extend(nodes),
+    }
+}
+
+/// Emits `node`, split so the portion overlapping the global byte range `[s, e)`
+/// bears the annotation mark. `[a, b)` is `node`'s byte range within the span.
+fn slice_node(
+    node: &AdfNode,
+    a: usize,
+    b: usize,
+    s: usize,
+    e: usize,
+    marker_id: &str,
+    out: &mut Vec<AdfNode>,
+) {
+    let text = node.text.as_deref().unwrap_or("");
+    if text.is_empty() {
+        out.push(node.clone());
+        return;
+    }
+
+    let s_c = s.clamp(a, b);
+    let e_c = e.clamp(a, b);
+    for (lo, hi, annotate) in [(a, s_c, false), (s_c, e_c, true), (e_c, b, false)] {
+        if lo >= hi {
+            continue;
+        }
+        let segment = &text[(lo - a)..(hi - a)];
+        out.push(make_segment(node, segment, annotate, marker_id));
+    }
+}
+
+/// Clones `base` as a text node carrying `text`, optionally adding the
+/// annotation mark on top of `base`'s existing marks.
+fn make_segment(base: &AdfNode, text: &str, annotate: bool, marker_id: &str) -> AdfNode {
+    let mut node = base.clone();
+    node.text = Some(text.to_string());
+    if annotate {
+        let mark = AdfMark::annotation(marker_id, "inlineComment");
+        match &mut node.marks {
+            Some(marks) => {
+                if !marks.iter().any(|m| is_target_annotation(m, marker_id)) {
+                    marks.push(mark);
+                }
+            }
+            None => node.marks = Some(vec![mark]),
+        }
+    }
+    node
+}
+
+/// Counts occurrences of `anchor` across all contiguous text-run spans in the
+/// document, in the same order [`apply_in_children`] visits them.
+fn count_anchor_occurrences(doc: &AdfDocument, anchor: &str) -> usize {
+    let mut total = 0;
+    count_in_children(&doc.content, anchor, &mut total);
+    total
+}
+
+fn count_in_children(children: &[AdfNode], anchor: &str, total: &mut usize) {
+    let mut span = String::new();
+    for child in children {
+        if is_text_node(child) {
+            span.push_str(child.text.as_deref().unwrap_or(""));
+        } else {
+            if !span.is_empty() {
+                *total += count_non_overlapping(&span, anchor);
+                span.clear();
+            }
+            count_in_children_of(child, anchor, total);
+        }
+    }
+    if !span.is_empty() {
+        *total += count_non_overlapping(&span, anchor);
+    }
+}
+
+fn count_in_children_of(node: &AdfNode, anchor: &str, total: &mut usize) {
+    if let Some(content) = &node.content {
+        count_in_children(content, anchor, total);
+    }
+}
+
+// ── Small predicates / string utilities ─────────────────────────────
+
+fn is_text_node(node: &AdfNode) -> bool {
+    node.node_type == "text" && node.text.is_some()
+}
+
+fn has_annotation(node: &AdfNode, marker_id: &str) -> bool {
+    node.marks
+        .iter()
+        .flatten()
+        .any(|m| is_target_annotation(m, marker_id))
+}
+
+fn is_target_annotation(mark: &AdfMark, marker_id: &str) -> bool {
+    mark.mark_type == "annotation"
+        && mark
+            .attrs
+            .as_ref()
+            .and_then(|a| a.get("id"))
+            .and_then(|v| v.as_str())
+            == Some(marker_id)
+}
+
+/// Collapses all runs of whitespace to a single space and trims, so anchored
+/// text and the original highlight compare equal despite incidental whitespace
+/// differences (e.g. a line wrap re-flow).
+fn normalize(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Counts non-overlapping occurrences of `needle` in `haystack`.
+fn count_non_overlapping(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        count += 1;
+        start += pos + needle.len();
+    }
+    count
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn strong() -> AdfMark {
+        AdfMark {
+            mark_type: "strong".to_string(),
+            attrs: None,
+        }
+    }
+
+    fn annotated(text: &str, id: &str) -> AdfNode {
+        AdfNode::text_with_marks(text, vec![AdfMark::annotation(id, "inlineComment")])
+    }
+
+    fn doc(paras: Vec<Vec<AdfNode>>) -> AdfDocument {
+        AdfDocument {
+            version: 1,
+            doc_type: "doc".to_string(),
+            content: paras.into_iter().map(AdfNode::paragraph).collect(),
+        }
+    }
+
+    // ── collect_annotation_runs ─────────────────────────────────────
+
+    #[test]
+    fn collect_runs_single() {
+        let d = doc(vec![vec![
+            AdfNode::text("The cache TTL is "),
+            annotated("200ms", "aaa"),
+            AdfNode::text(" by default."),
+        ]]);
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["200ms"]);
+    }
+
+    #[test]
+    fn collect_runs_torn_across_fragments_in_order() {
+        let d = doc(vec![vec![
+            AdfNode::text("The cache TTL is "),
+            annotated("200ms", "aaa"),
+            AdfNode::text(". Downstream services "),
+            annotated("depend on this", "aaa"),
+            AdfNode::text(" value."),
+        ]]);
+        assert_eq!(
+            collect_annotation_runs(&d, "aaa"),
+            vec!["200ms", "depend on this"]
+        );
+    }
+
+    #[test]
+    fn collect_runs_ignores_other_ids() {
+        let d = doc(vec![vec![annotated("x", "bbb")]]);
+        assert!(collect_annotation_runs(&d, "aaa").is_empty());
+    }
+
+    // ── classify ────────────────────────────────────────────────────
+
+    #[test]
+    fn classify_ok_torn_lost_drifted() {
+        assert_eq!(
+            classify(&["hello".into()], "hello", "hello"),
+            DriftStatus::Ok
+        );
+        assert_eq!(
+            classify(&["hel".into(), "lo".into()], "hello", "hello"),
+            DriftStatus::Torn
+        );
+        assert_eq!(classify(&[], "", "hello"), DriftStatus::MarkLost);
+        assert_eq!(
+            classify(&["goodbye".into()], "goodbye", "hello"),
+            DriftStatus::Drifted
+        );
+    }
+
+    #[test]
+    fn classify_normalizes_whitespace() {
+        assert_eq!(
+            classify(&["a  b\n c".into()], "a  b\n c", "a b c"),
+            DriftStatus::Ok
+        );
+    }
+
+    // ── remove_annotation ───────────────────────────────────────────
+
+    #[test]
+    fn remove_annotation_strips_mark_and_collapses_empty_marks() {
+        let mut d = doc(vec![vec![annotated("200ms", "aaa")]]);
+        remove_annotation(&mut d, "aaa");
+        assert!(collect_annotation_runs(&d, "aaa").is_empty());
+        // The run had only the annotation mark, so marks collapses to None.
+        let run = &d.content[0].content.as_ref().unwrap()[0];
+        assert!(run.marks.is_none());
+        assert_eq!(run.text.as_deref(), Some("200ms"));
+    }
+
+    #[test]
+    fn remove_annotation_preserves_other_marks() {
+        let run = AdfNode::text_with_marks(
+            "x",
+            vec![strong(), AdfMark::annotation("aaa", "inlineComment")],
+        );
+        let mut d = doc(vec![vec![run]]);
+        remove_annotation(&mut d, "aaa");
+        let run = &d.content[0].content.as_ref().unwrap()[0];
+        let marks = run.marks.as_ref().unwrap();
+        assert_eq!(marks.len(), 1);
+        assert_eq!(marks[0].mark_type, "strong");
+    }
+
+    // ── apply_annotation ────────────────────────────────────────────
+
+    fn first_para_runs(d: &AdfDocument) -> &Vec<AdfNode> {
+        d.content[0].content.as_ref().unwrap()
+    }
+
+    #[test]
+    fn apply_annotation_splits_substring_within_single_run() {
+        let mut d = doc(vec![vec![AdfNode::text(
+            "The cache TTL is 200ms by default.",
+        )]]);
+        apply_annotation(&mut d, "200ms", None, "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["200ms"]);
+        // Round-trips: three runs "The cache TTL is " / "200ms" / " by default.".
+        let runs = first_para_runs(&d);
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].text.as_deref(), Some("The cache TTL is "));
+        assert_eq!(runs[1].text.as_deref(), Some("200ms"));
+        assert_eq!(runs[2].text.as_deref(), Some(" by default."));
+    }
+
+    #[test]
+    fn apply_annotation_cross_run_phrase_split_by_formatting() {
+        // "the bold word" is split across three runs by a strong mark.
+        let mut d = doc(vec![vec![
+            AdfNode::text("say the "),
+            AdfNode::text_with_marks("bold", vec![strong()]),
+            AdfNode::text(" word now"),
+        ]]);
+        apply_annotation(&mut d, "the bold word", None, "aaa").unwrap();
+        // The joined annotated text spans the phrase.
+        assert_eq!(collect_annotation_runs(&d, "aaa").concat(), "the bold word");
+        // The strong mark is preserved on the "bold" run alongside the annotation.
+        let bold_run = first_para_runs(&d)
+            .iter()
+            .find(|n| n.text.as_deref() == Some("bold"))
+            .unwrap();
+        let marks = bold_run.marks.as_ref().unwrap();
+        assert!(marks.iter().any(|m| m.mark_type == "strong"));
+        assert!(marks.iter().any(|m| is_target_annotation(m, "aaa")));
+    }
+
+    #[test]
+    fn apply_annotation_respects_match_index() {
+        let mut d = doc(vec![vec![AdfNode::text("foo bar foo baz foo")]]);
+        apply_annotation(&mut d, "foo", Some(2), "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["foo"]);
+        // The annotated "foo" is the middle occurrence: preceded by "foo bar ".
+        let runs = first_para_runs(&d);
+        let annotated_pos = runs.iter().position(|n| has_annotation(n, "aaa")).unwrap();
+        let before: String = runs[..annotated_pos]
+            .iter()
+            .filter_map(|n| n.text.clone())
+            .collect();
+        assert_eq!(before, "foo bar ");
+    }
+
+    #[test]
+    fn apply_annotation_ambiguous_without_index_errors() {
+        let mut d = doc(vec![vec![AdfNode::text("foo and foo")]]);
+        let err = apply_annotation(&mut d, "foo", None, "aaa").unwrap_err();
+        assert!(err.to_string().contains("appears 2 times"));
+    }
+
+    #[test]
+    fn apply_annotation_not_found_errors() {
+        let mut d = doc(vec![vec![AdfNode::text("hello world")]]);
+        let err = apply_annotation(&mut d, "missing", None, "aaa").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn apply_annotation_index_out_of_range_errors() {
+        let mut d = doc(vec![vec![AdfNode::text("foo foo")]]);
+        let err = apply_annotation(&mut d, "foo", Some(3), "aaa").unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn apply_annotation_cross_block_not_matched() {
+        // The phrase spans two paragraphs — not a contiguous run.
+        let mut d = doc(vec![
+            vec![AdfNode::text("end of first")],
+            vec![AdfNode::text("second begins")],
+        ]);
+        let err = apply_annotation(&mut d, "first second", None, "aaa").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn apply_annotation_matches_occurrence_in_second_block() {
+        let mut d = doc(vec![
+            vec![AdfNode::text("alpha here")],
+            vec![AdfNode::text("beta there")],
+        ]);
+        apply_annotation(&mut d, "beta", None, "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["beta"]);
+    }
+
+    // ── remove + apply round trip (the reanchor core) ───────────────
+
+    #[test]
+    fn reanchor_core_moves_mark_from_old_to_new_run() {
+        // Mark starts torn across two fragments; reanchor should move it whole.
+        let mut d = doc(vec![vec![
+            AdfNode::text("The cache TTL is "),
+            annotated("200ms", "aaa"),
+            AdfNode::text(". Downstream services "),
+            annotated("depend on this", "aaa"),
+            AdfNode::text(" value, so it is fixed."),
+        ]]);
+        remove_annotation(&mut d, "aaa");
+        assert!(collect_annotation_runs(&d, "aaa").is_empty());
+        apply_annotation(
+            &mut d,
+            "Downstream services depend on this value",
+            None,
+            "aaa",
+        )
+        .unwrap();
+        assert_eq!(
+            collect_annotation_runs(&d, "aaa").concat(),
+            "Downstream services depend on this value"
+        );
+    }
+
+    #[test]
+    fn apply_annotation_handles_multibyte_text() {
+        let mut d = doc(vec![vec![AdfNode::text("café serves 200ms résumé")]]);
+        apply_annotation(&mut d, "200ms", None, "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["200ms"]);
+        // Surrounding multibyte text is preserved intact.
+        let joined: String = first_para_runs(&d)
+            .iter()
+            .filter_map(|n| n.text.clone())
+            .collect();
+        assert_eq!(joined, "café serves 200ms résumé");
+    }
+
+    // ── audit / reanchor over a mocked Confluence API ───────────────
+
+    use crate::atlassian::client::AtlassianClient;
+
+    fn mock_api(server: &wiremock::MockServer) -> ConfluenceApi {
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        ConfluenceApi::new(client)
+    }
+
+    /// Mounts the page-read endpoints (`get_content` + its space lookup) so the
+    /// page returns `page` as its ADF body.
+    async fn mount_page(server: &wiremock::MockServer, id: &str, page: &AdfDocument) {
+        let value = serde_json::to_string(page).unwrap();
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!("/wiki/api/v2/pages/{id}")))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": id,
+                    "title": "Mock",
+                    "status": "current",
+                    "spaceId": "98",
+                    "version": {"number": 1},
+                    "body": {"atlas_doc_format": {"value": value}}
+                })),
+            )
+            .mount(server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/98"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"key": "ENG"})),
+            )
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_inline_comments(
+        server: &wiremock::MockServer,
+        id: &str,
+        body: serde_json::Value,
+    ) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/wiki/api/v2/pages/{id}/inline-comments"
+            )))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn audit_classifies_ok_mark_lost_and_drifted() {
+        let server = wiremock::MockServer::start().await;
+        let page = doc(vec![vec![
+            AdfNode::text("The cache TTL is "),
+            annotated("200ms", "aaa"),
+            AdfNode::text(" by default. "),
+            annotated("wrong", "bbb"),
+            AdfNode::text(" end."),
+        ]]);
+        mount_page(&server, "12345", &page).await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "200ms"}},
+                    {"id": "ic2", "version": {"authorId": "b", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "zzz", "inlineOriginalSelection": "missing text"}},
+                    {"id": "ic3", "version": {"authorId": "c", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "bbb", "inlineOriginalSelection": "200ms"}}
+                ]
+            }),
+        )
+        .await;
+
+        let api = mock_api(&server);
+        let drifts = audit_inline_comments(&api, "12345").await.unwrap();
+        assert_eq!(drifts.len(), 3);
+
+        let ic1 = drifts.iter().find(|d| d.comment_id == "ic1").unwrap();
+        assert_eq!(ic1.status, DriftStatus::Ok);
+        assert_eq!(ic1.current_anchored_text.as_deref(), Some("200ms"));
+
+        let ic2 = drifts.iter().find(|d| d.comment_id == "ic2").unwrap();
+        assert_eq!(ic2.status, DriftStatus::MarkLost);
+        assert!(ic2.current_anchored_text.is_none());
+        assert!(ic2.suggested_new_anchor.is_none());
+
+        let ic3 = drifts.iter().find(|d| d.comment_id == "ic3").unwrap();
+        assert_eq!(ic3.status, DriftStatus::Drifted);
+        assert_eq!(ic3.current_anchored_text.as_deref(), Some("wrong"));
+        assert_eq!(ic3.suggested_new_anchor.as_deref(), Some("200ms"));
+        assert_eq!(ic3.suggested_match_count, Some(1));
+    }
+
+    #[tokio::test]
+    async fn reanchor_moves_mark_and_puts_bumped_version() {
+        let server = wiremock::MockServer::start().await;
+        let page = doc(vec![vec![
+            AdfNode::text("Before "),
+            annotated("old", "aaa"),
+            AdfNode::text(" and 200ms here."),
+        ]]);
+        mount_page(&server, "12345", &page).await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "old"}}
+                ]
+            }),
+        )
+        .await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::body_partial_json(
+                serde_json::json!({"version": {"number": 2}}),
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let api = mock_api(&server);
+        let outcome = reanchor_inline_comment(&api, "12345", "ic1", "200ms", None, false)
+            .await
+            .unwrap();
+        assert_eq!(outcome.new_anchor_text, "200ms");
+        assert_eq!(outcome.previous_anchored_text.as_deref(), Some("old"));
+        assert!(!outcome.dry_run);
+
+        // Inspect the PUT body: the mark must now sit on "200ms", not "old".
+        let requests = server.received_requests().await.unwrap();
+        let put = requests
+            .iter()
+            .find(|r| r.method == wiremock::http::Method::PUT)
+            .unwrap();
+        let sent: serde_json::Value = serde_json::from_slice(&put.body).unwrap();
+        let adf_value = sent["body"]["value"].as_str().unwrap();
+        let updated: AdfDocument = serde_json::from_str(adf_value).unwrap();
+        assert_eq!(collect_annotation_runs(&updated, "aaa"), vec!["200ms"]);
+    }
+
+    #[tokio::test]
+    async fn reanchor_dry_run_does_not_put() {
+        let server = wiremock::MockServer::start().await;
+        let page = doc(vec![vec![
+            AdfNode::text("Before "),
+            annotated("old", "aaa"),
+            AdfNode::text(" and 200ms here."),
+        ]]);
+        mount_page(&server, "12345", &page).await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "old"}}
+                ]
+            }),
+        )
+        .await;
+        // No PUT is mounted: if reanchor tried to write, update_content would 404.
+
+        let api = mock_api(&server);
+        let outcome = reanchor_inline_comment(&api, "12345", "ic1", "200ms", None, true)
+            .await
+            .unwrap();
+        assert!(outcome.dry_run);
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(!requests
+            .iter()
+            .any(|r| r.method == wiremock::http::Method::PUT));
+    }
+
+    #[tokio::test]
+    async fn reanchor_unknown_comment_errors() {
+        let server = wiremock::MockServer::start().await;
+        mount_inline_comments(&server, "12345", serde_json::json!({ "results": [] })).await;
+        let api = mock_api(&server);
+        let err = reanchor_inline_comment(&api, "12345", "nope", "x", None, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+}

--- a/src/atlassian/inline_comment.rs
+++ b/src/atlassian/inline_comment.rs
@@ -1002,4 +1002,197 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("not found"));
     }
+
+    #[tokio::test]
+    async fn reanchor_comment_without_marker_ref_errors() {
+        let server = wiremock::MockServer::start().await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"}}
+                ]
+            }),
+        )
+        .await;
+        let api = mock_api(&server);
+        let err = reanchor_inline_comment(&api, "12345", "ic1", "x", None, false)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no inline marker reference"));
+    }
+
+    #[tokio::test]
+    async fn reanchor_lost_mark_reports_no_previous_text() {
+        let server = wiremock::MockServer::start().await;
+        // The page no longer bears marker "aaa" anywhere — the mark was lost.
+        let page = doc(vec![vec![AdfNode::text("Plain text with 200ms here.")]]);
+        mount_page(&server, "12345", &page).await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "old"}}
+                ]
+            }),
+        )
+        .await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let api = mock_api(&server);
+        let outcome = reanchor_inline_comment(&api, "12345", "ic1", "200ms", None, false)
+            .await
+            .unwrap();
+        assert!(outcome.previous_anchored_text.is_none());
+        assert_eq!(outcome.new_anchor_text, "200ms");
+    }
+
+    #[tokio::test]
+    async fn audit_skips_comments_without_marker_ref() {
+        let server = wiremock::MockServer::start().await;
+        let page = doc(vec![vec![annotated("200ms", "aaa")]]);
+        mount_page(&server, "12345", &page).await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"}},
+                    {"id": "ic2", "version": {"authorId": "b", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "200ms"}}
+                ]
+            }),
+        )
+        .await;
+
+        let api = mock_api(&server);
+        let drifts = audit_inline_comments(&api, "12345").await.unwrap();
+        // ic1 has no marker reference and is skipped.
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].comment_id, "ic2");
+    }
+
+    #[tokio::test]
+    async fn audit_page_without_adf_body_reports_mark_lost() {
+        let server = wiremock::MockServer::start().await;
+        // Page response carries no `body` — `fetch_page_adf` yields an empty doc.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12345",
+                    "title": "Mock",
+                    "status": "current",
+                    "spaceId": "98",
+                    "version": {"number": 1}
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/98"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"key": "ENG"})),
+            )
+            .mount(&server)
+            .await;
+        mount_inline_comments(
+            &server,
+            "12345",
+            serde_json::json!({
+                "results": [
+                    {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                     "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "200ms"}}
+                ]
+            }),
+        )
+        .await;
+
+        let api = mock_api(&server);
+        let drifts = audit_inline_comments(&api, "12345").await.unwrap();
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].status, DriftStatus::MarkLost);
+        // The empty page contains no occurrence of the original selection.
+        assert!(drifts[0].suggested_new_anchor.is_none());
+    }
+
+    // ── edge branches in the anchor-application walk ────────────────
+
+    #[test]
+    fn apply_annotation_empty_anchor_errors() {
+        let mut d = doc(vec![vec![AdfNode::text("hello")]]);
+        let err = apply_annotation(&mut d, "", None, "aaa").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn apply_annotation_match_in_first_block_leaves_later_blocks_untouched() {
+        let mut d = doc(vec![
+            vec![AdfNode::text("alpha here")],
+            vec![AdfNode::text("beta there")],
+        ]);
+        apply_annotation(&mut d, "alpha", None, "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["alpha"]);
+        // The second paragraph is untouched (a single unsplit run).
+        let second = d.content[1].content.as_ref().unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].text.as_deref(), Some("beta there"));
+    }
+
+    fn hard_break() -> AdfNode {
+        AdfNode {
+            node_type: "hardBreak".to_string(),
+            attrs: None,
+            content: None,
+            text: None,
+            marks: None,
+            local_id: None,
+            parameters: None,
+        }
+    }
+
+    #[test]
+    fn apply_annotation_spans_reset_at_inline_non_text_nodes() {
+        // "foo" appears once before and once after a hard break: two separate
+        // spans, so the anchor is ambiguous and match_index selects the first.
+        let mut d = doc(vec![vec![
+            AdfNode::text("see foo here"),
+            hard_break(),
+            AdfNode::text("and foo there"),
+        ]]);
+        apply_annotation(&mut d, "foo", Some(1), "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["foo"]);
+        // The annotated occurrence is the one before the break.
+        let runs = first_para_runs(&d);
+        let pos = runs.iter().position(|n| has_annotation(n, "aaa")).unwrap();
+        let break_pos = runs
+            .iter()
+            .position(|n| n.node_type == "hardBreak")
+            .unwrap();
+        assert!(pos < break_pos);
+    }
+
+    #[test]
+    fn apply_annotation_preserves_empty_text_runs() {
+        let mut d = doc(vec![vec![AdfNode::text(""), AdfNode::text("foo bar")]]);
+        apply_annotation(&mut d, "foo", None, "aaa").unwrap();
+        assert_eq!(collect_annotation_runs(&d, "aaa"), vec!["foo"]);
+        // The empty run survives the split untouched.
+        let runs = first_para_runs(&d);
+        assert_eq!(runs[0].text.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn count_non_overlapping_empty_needle_is_zero() {
+        assert_eq!(count_non_overlapping("abc", ""), 0);
+    }
 }

--- a/src/atlassian/inline_comment.rs
+++ b/src/atlassian/inline_comment.rs
@@ -1195,4 +1195,23 @@ mod tests {
     fn count_non_overlapping_empty_needle_is_zero() {
         assert_eq!(count_non_overlapping("abc", ""), 0);
     }
+
+    #[test]
+    fn apply_in_children_is_noop_once_applied() {
+        // The short-circuit guard: once the target occurrence has been
+        // annotated, later subtree walks must leave nodes untouched even if
+        // they contain further matches.
+        let mut state = ApplyState {
+            anchor: "foo".to_string(),
+            marker_id: "aaa".to_string(),
+            target: 1,
+            current: 0,
+            applied: true,
+        };
+        let mut children = vec![AdfNode::text("foo bar")];
+        apply_in_children(&mut children, &mut state);
+        assert_eq!(children.len(), 1);
+        assert!(children[0].marks.is_none());
+        assert_eq!(children[0].text.as_deref(), Some("foo bar"));
+    }
 }

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -1506,13 +1506,20 @@ mod tests {
             .any(|r| r.method == wiremock::http::Method::PUT));
     }
 
-    /// A writer whose every operation fails, for exercising IO-error
-    /// propagation through `execute_with_io`.
-    struct FailingWriter;
+    /// A writer that fails at a chosen point (`write` or, when writes are
+    /// allowed through, `flush`), for exercising IO-error propagation through
+    /// `execute_with_io`.
+    struct FailingWriter {
+        fail_write: bool,
+    }
 
     impl Write for FailingWriter {
-        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-            Err(io::Error::other("writer failed"))
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.fail_write {
+                Err(io::Error::other("writer failed"))
+            } else {
+                Ok(buf.len())
+            }
         }
 
         fn flush(&mut self) -> io::Result<()> {
@@ -1529,7 +1536,23 @@ mod tests {
         // writer surfaces that IO error before any API call.
         let cmd = reanchor_command(false, false);
         let mut reader = io::Cursor::new(b"y\n".to_vec());
-        let mut writer = FailingWriter;
+        let mut writer = FailingWriter { fail_write: true };
+        assert!(cmd
+            .execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .is_err());
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_propagates_prompt_flush_error() {
+        let server = wiremock::MockServer::start().await;
+        let api = mock_api(&server);
+
+        // Writes go through but the guard's flush after the prompt fails.
+        let cmd = reanchor_command(false, false);
+        let mut reader = io::Cursor::new(b"y\n".to_vec());
+        let mut writer = FailingWriter { fail_write: false };
         assert!(cmd
             .execute_with_io(&api, &mut reader, &mut writer)
             .await
@@ -1547,7 +1570,7 @@ mod tests {
         // the failure comes from writing the success message.
         let cmd = reanchor_command(true, false);
         let mut reader = io::Cursor::new(Vec::new());
-        let mut writer = FailingWriter;
+        let mut writer = FailingWriter { fail_write: true };
         assert!(cmd
             .execute_with_io(&api, &mut reader, &mut writer)
             .await

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -1269,4 +1269,240 @@ mod tests {
         clear_atlassian_env();
         assert!(result.is_ok(), "{result:?}");
     }
+
+    // ── print_drifts ───────────────────────────────────────────────
+
+    fn sample_drift(id: &str, status: DriftStatus) -> CommentDrift {
+        CommentDrift {
+            comment_id: id.to_string(),
+            author: "alice".to_string(),
+            created: "2026-04-01T10:00:00.000Z".to_string(),
+            marker_ref: "marker-1".to_string(),
+            status,
+            original_selection: "original text".to_string(),
+            current_anchored_text: Some("current text".to_string()),
+            suggested_new_anchor: None,
+            suggested_match_count: None,
+        }
+    }
+
+    #[test]
+    fn print_drifts_empty() {
+        print_drifts(&[]);
+    }
+
+    #[test]
+    fn print_drifts_all_statuses() {
+        let mut lost = sample_drift("c3", DriftStatus::MarkLost);
+        lost.current_anchored_text = None;
+        lost.suggested_new_anchor = Some("original text".to_string());
+        lost.suggested_match_count = Some(2);
+        let mut drifted = sample_drift("c4", DriftStatus::Drifted);
+        // Suggestion without a count exercises the `unwrap_or(0)` fallback.
+        drifted.suggested_new_anchor = Some("original text".to_string());
+        let drifts = vec![
+            sample_drift("c1", DriftStatus::Ok),
+            sample_drift("c2", DriftStatus::Torn),
+            lost,
+            drifted,
+        ];
+        print_drifts(&drifts);
+    }
+
+    // ── audit / reanchor command execution ──────────────────────────
+
+    /// Mounts the endpoints a reanchor (and audit) needs: the page (whose ADF
+    /// contains "the anchor"), its space, one inline comment `ic1` bearing
+    /// marker `aaa`, and the page-update PUT.
+    async fn mount_reanchor_fixture(server: &wiremock::MockServer) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12345",
+                    "title": "Mock",
+                    "status": "current",
+                    "spaceId": "98",
+                    "version": {"number": 1},
+                    "body": {"atlas_doc_format": {
+                        "value": "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"the anchor\"}]}]}"
+                    }}
+                })),
+            )
+            .mount(server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/98"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"key": "ENG"})),
+            )
+            .mount(server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/wiki/api/v2/pages/12345/inline-comments",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                         "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "old"}}
+                    ]
+                })),
+            )
+            .mount(server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn audit_command_execute_propagates_create_client_error() {
+        let guard = crate::atlassian::auth::test_util::EnvGuard::take();
+        let _home = guard.clear_credentials();
+
+        let cmd = AuditCommand {
+            id: "12345".to_string(),
+            output: OutputFormat::Yaml,
+        };
+        assert!(cmd.execute().await.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn audit_command_execute_runs_through_dispatch() {
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        mount_reanchor_fixture(&server).await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = CommentCommand {
+            command: CommentSubcommands::Audit(AuditCommand {
+                id: "12345".to_string(),
+                output: OutputFormat::Json,
+            }),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn audit_command_execute_table_output_prints_drifts() {
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        mount_reanchor_fixture(&server).await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = AuditCommand {
+            id: "12345".to_string(),
+            output: OutputFormat::Table,
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    fn reanchor_command(force: bool, dry_run: bool) -> ReanchorCommand {
+        ReanchorCommand {
+            id: "12345".to_string(),
+            comment: "ic1".to_string(),
+            anchor_text: "the anchor".to_string(),
+            match_index: None,
+            force,
+            dry_run,
+        }
+    }
+
+    #[tokio::test]
+    async fn reanchor_command_execute_propagates_create_client_error() {
+        let guard = crate::atlassian::auth::test_util::EnvGuard::take();
+        let _home = guard.clear_credentials();
+
+        let cmd = reanchor_command(true, false);
+        assert!(cmd.execute().await.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reanchor_command_execute_runs_through_dispatch() {
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        mount_reanchor_fixture(&server).await;
+
+        set_atlassian_env(&server.uri());
+        let cmd = CommentCommand {
+            command: CommentSubcommands::Reanchor(reanchor_command(true, false)),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_cancelled_makes_no_api_calls() {
+        let server = wiremock::MockServer::start().await;
+        let api = mock_api(&server);
+
+        let cmd = reanchor_command(false, false);
+        let mut reader = io::Cursor::new(b"n\n".to_vec());
+        let mut writer: Vec<u8> = Vec::new();
+        cmd.execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(writer).unwrap();
+        assert!(out.contains("Re-anchor inline comment ic1"));
+        assert!(out.contains("Cancelled."));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_dry_run_makes_no_api_calls() {
+        let server = wiremock::MockServer::start().await;
+        let api = mock_api(&server);
+
+        let cmd = reanchor_command(false, true);
+        let mut reader = io::Cursor::new(Vec::new());
+        let mut writer: Vec<u8> = Vec::new();
+        cmd.execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(writer).unwrap();
+        assert!(out.contains("Would re-anchor inline comment ic1"));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_confirmed_proceeds() {
+        let server = wiremock::MockServer::start().await;
+        mount_reanchor_fixture(&server).await;
+        let api = mock_api(&server);
+
+        let cmd = reanchor_command(false, false);
+        let mut reader = io::Cursor::new(b"y\n".to_vec());
+        let mut writer: Vec<u8> = Vec::new();
+        cmd.execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(writer).unwrap();
+        assert!(out.contains("Re-anchored inline comment ic1"));
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests
+            .iter()
+            .any(|r| r.method == wiremock::http::Method::PUT));
+    }
 }

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -1505,4 +1505,56 @@ mod tests {
             .iter()
             .any(|r| r.method == wiremock::http::Method::PUT));
     }
+
+    /// A writer whose every operation fails, for exercising IO-error
+    /// propagation through `execute_with_io`.
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("writer failed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::other("writer failed"))
+        }
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_propagates_prompt_write_error() {
+        let server = wiremock::MockServer::start().await;
+        let api = mock_api(&server);
+
+        // Without --force the guard writes the prompt first; the failing
+        // writer surfaces that IO error before any API call.
+        let cmd = reanchor_command(false, false);
+        let mut reader = io::Cursor::new(b"y\n".to_vec());
+        let mut writer = FailingWriter;
+        assert!(cmd
+            .execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .is_err());
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reanchor_execute_with_io_propagates_result_write_error() {
+        let server = wiremock::MockServer::start().await;
+        mount_reanchor_fixture(&server).await;
+        let api = mock_api(&server);
+
+        // With --force the guard writes nothing; the re-anchor succeeds and
+        // the failure comes from writing the success message.
+        let cmd = reanchor_command(true, false);
+        let mut reader = io::Cursor::new(Vec::new());
+        let mut writer = FailingWriter;
+        assert!(cmd
+            .execute_with_io(&api, &mut reader, &mut writer)
+            .await
+            .is_err());
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests
+            .iter()
+            .any(|r| r.method == wiremock::http::Method::PUT));
+    }
 }

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -1,5 +1,7 @@
 //! CLI commands for Confluence page comments.
 
+use std::io::{self, BufRead, Write};
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -10,6 +12,10 @@ use crate::atlassian::confluence_api::{
 };
 use crate::atlassian::convert::adf_to_markdown;
 use crate::atlassian::document::JfmDocument;
+use crate::atlassian::inline_comment::{
+    audit_inline_comments, reanchor_inline_comment, CommentDrift, DriftStatus,
+};
+use crate::cli::atlassian::confirm::{guard_destructive_with_io, GuardOptions, GuardOutcome};
 use crate::cli::atlassian::format::{output_as, ContentFormat, OutputFormat};
 use crate::cli::atlassian::helpers::{create_client, read_input};
 
@@ -32,6 +38,10 @@ pub enum CommentSubcommands {
     AddInline(AddInlineCommand),
     /// Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool).
     Replies(RepliesCommand),
+    /// Audits inline comments for anchor drift (mirrors the `confluence_comment_audit` MCP tool).
+    Audit(AuditCommand),
+    /// Moves an inline comment's anchor to a new text run (mirrors the `confluence_comment_reanchor` MCP tool).
+    Reanchor(ReanchorCommand),
 }
 
 impl CommentCommand {
@@ -42,6 +52,8 @@ impl CommentCommand {
             CommentSubcommands::Add(cmd) => cmd.execute().await,
             CommentSubcommands::AddInline(cmd) => cmd.execute().await,
             CommentSubcommands::Replies(cmd) => cmd.execute().await,
+            CommentSubcommands::Audit(cmd) => cmd.execute().await,
+            CommentSubcommands::Reanchor(cmd) => cmd.execute().await,
         }
     }
 }
@@ -200,6 +212,157 @@ impl RepliesCommand {
         let (client, _instance_url) = create_client()?;
         let api = ConfluenceApi::new(client);
         run_list_replies(&api, &self.id, self.kind.into(), self.limit, &self.output).await
+    }
+}
+
+/// Audits every inline comment on a page for anchor drift.
+///
+/// Inline-comment anchors do NOT follow text edits: when the annotated text is
+/// rewritten, Confluence keeps the mark on whatever original characters survive.
+/// This compares each comment's currently-anchored text against the reviewer's
+/// original highlight and reports the drift. Read-only.
+#[derive(Parser)]
+pub struct AuditCommand {
+    /// Confluence page ID.
+    pub id: String,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl AuditCommand {
+    /// Fetches inline comments and the page ADF, then reports drift.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        let drifts = audit_inline_comments(&api, &self.id).await?;
+        if output_as(&drifts, &self.output)? {
+            return Ok(());
+        }
+        print_drifts(&drifts);
+        Ok(())
+    }
+}
+
+/// Moves an inline comment's anchor to a new run of text in the current-version
+/// ADF and writes the page back.
+///
+/// Operates entirely on ADF (it never round-trips through JFM, which would
+/// discard the annotation marks the anchor depends on). Destructive — the page
+/// is updated — so it prompts for confirmation unless `--force`.
+#[derive(Parser)]
+pub struct ReanchorCommand {
+    /// Confluence page ID.
+    pub id: String,
+
+    /// The inline comment ID to re-anchor.
+    #[arg(long)]
+    pub comment: String,
+
+    /// Exact text on the current page to move the comment's anchor to.
+    #[arg(long)]
+    pub anchor_text: String,
+
+    /// 1-based occurrence to anchor to when `--anchor-text` appears more than
+    /// once on the page. Required for ambiguous anchors; rejected if out of range.
+    #[arg(long)]
+    pub match_index: Option<usize>,
+
+    /// Skips the confirmation prompt.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Prints what would change without writing the page.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl ReanchorCommand {
+    /// Executes the re-anchor command.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        let api = ConfluenceApi::new(client);
+        let mut reader = io::BufReader::new(io::stdin());
+        let mut writer = io::stdout();
+        self.execute_with_io(&api, &mut reader, &mut writer).await
+    }
+
+    /// Inner form taking explicit API and IO handles, for unit tests.
+    async fn execute_with_io(
+        self,
+        api: &ConfluenceApi,
+        reader: &mut (dyn BufRead + Send),
+        writer: &mut (dyn Write + Send),
+    ) -> Result<()> {
+        let prompt = format!(
+            "Re-anchor inline comment {} on page {} to {:?}? [y/N] ",
+            self.comment, self.id, self.anchor_text
+        );
+        let dry_run_message = format!(
+            "Would re-anchor inline comment {} on page {} to {:?}.",
+            self.comment, self.id, self.anchor_text
+        );
+        let outcome = guard_destructive_with_io(
+            &GuardOptions {
+                prompt: &prompt,
+                dry_run_message: &dry_run_message,
+                force: self.force,
+                dry_run: self.dry_run,
+            },
+            reader,
+            writer,
+        )?;
+        match outcome {
+            GuardOutcome::Cancelled | GuardOutcome::DryRun => return Ok(()),
+            GuardOutcome::Proceed => {}
+        }
+
+        let outcome = reanchor_inline_comment(
+            api,
+            &self.id,
+            &self.comment,
+            &self.anchor_text,
+            self.match_index,
+            false,
+        )
+        .await?;
+        writeln!(
+            writer,
+            "Re-anchored inline comment {} to {:?}.",
+            outcome.comment_id, outcome.new_anchor_text
+        )?;
+        Ok(())
+    }
+}
+
+/// Prints inline-comment drift reports in a readable format.
+fn print_drifts(drifts: &[CommentDrift]) {
+    if drifts.is_empty() {
+        println!("No inline comments.");
+        return;
+    }
+
+    for (i, drift) in drifts.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        let status = match drift.status {
+            DriftStatus::Ok => "OK",
+            DriftStatus::Torn => "TORN",
+            DriftStatus::MarkLost => "MARK LOST",
+            DriftStatus::Drifted => "DRIFTED",
+        };
+        println!("--- {} | {} ---", drift.comment_id, status);
+        println!("  original:  {:?}", drift.original_selection);
+        match &drift.current_anchored_text {
+            Some(text) => println!("  current:   {text:?}"),
+            None => println!("  current:   (mark not present)"),
+        }
+        if let Some(suggestion) = &drift.suggested_new_anchor {
+            let count = drift.suggested_match_count.unwrap_or(0);
+            println!("  suggested: {suggestion:?} (appears {count}x on the current page)");
+        }
     }
 }
 
@@ -364,6 +527,8 @@ mod tests {
             kind: CommentKind::Footer,
             body_adf,
             created: "2026-04-01T10:30:00.000Z".to_string(),
+            inline_marker_ref: None,
+            inline_original_selection: None,
         }
     }
 
@@ -378,6 +543,8 @@ mod tests {
             kind: CommentKind::Inline,
             body_adf,
             created: "2026-04-02T10:30:00.000Z".to_string(),
+            inline_marker_ref: Some("marker-1".to_string()),
+            inline_original_selection: Some("original highlighted text".to_string()),
         }
     }
 

--- a/src/cli/atlassian/confluence/mod.rs
+++ b/src/cli/atlassian/confluence/mod.rs
@@ -129,6 +129,7 @@ mod tests {
                 id: "12345".to_string(),
                 output: None,
                 format: ContentFormat::Jfm,
+                version: None,
             }),
         };
         assert!(matches!(cmd.command, ConfluenceSubcommands::Read(_)));
@@ -319,6 +320,7 @@ mod tests {
                 id: "1".to_string(),
                 output: None,
                 format: ContentFormat::Jfm,
+                version: None,
             }),
         };
         // Single `matches!` site exercised against both a matching and

--- a/src/cli/atlassian/confluence/read.rs
+++ b/src/cli/atlassian/confluence/read.rs
@@ -59,7 +59,7 @@ impl ReadCommand {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
 mod tests {
     use super::*;
 
@@ -89,5 +89,121 @@ mod tests {
         assert!(cmd.output.is_none());
         assert!(matches!(cmd.format, ContentFormat::Adf));
         assert_eq!(cmd.version, Some(3));
+    }
+
+    // ── ReadCommand::execute ────────────────────────────────────────
+
+    fn set_atlassian_env(uri: &str) {
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_INSTANCE_URL, uri);
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_EMAIL, "user@test.com");
+        std::env::set_var(crate::atlassian::auth::ATLASSIAN_API_TOKEN, "t");
+    }
+
+    fn clear_atlassian_env() {
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_INSTANCE_URL);
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_EMAIL);
+        std::env::remove_var(crate::atlassian::auth::ATLASSIAN_API_TOKEN);
+    }
+
+    /// Mounts a page response (optionally version-pinned via the `version`
+    /// query parameter) plus its space lookup.
+    async fn mount_page(server: &wiremock::MockServer, version: Option<u32>, text: &str) {
+        let adf_value = format!(
+            "{{\"version\":1,\"type\":\"doc\",\"content\":[{{\"type\":\"paragraph\",\"content\":[{{\"type\":\"text\",\"text\":{}}}]}}]}}",
+            serde_json::Value::String(text.to_string())
+        );
+        let mut mock = wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"));
+        if let Some(v) = version {
+            mock = mock.and(wiremock::matchers::query_param("version", v.to_string()));
+        }
+        mock.respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "12345",
+                "title": "Mock Page",
+                "status": "current",
+                "spaceId": "98",
+                "version": {"number": version.unwrap_or(1)},
+                "body": {"atlas_doc_format": {"value": adf_value}}
+            })),
+        )
+        .mount(server)
+        .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/98"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"key": "ENG"})),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn read_command_execute_propagates_create_client_error() {
+        let guard = crate::atlassian::auth::test_util::EnvGuard::take();
+        let _home = guard.clear_credentials();
+
+        let cmd = ReadCommand {
+            id: "12345".to_string(),
+            output: None,
+            format: ContentFormat::Jfm,
+            version: None,
+        };
+        assert!(cmd.execute().await.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_command_execute_latest_version_writes_output_file() {
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        mount_page(&server, None, "Latest body").await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let out_path = temp_dir.path().join("page.md");
+
+        set_atlassian_env(&server.uri());
+        let cmd = ReadCommand {
+            id: "12345".to_string(),
+            output: Some(out_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+            version: None,
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+
+        let written = std::fs::read_to_string(&out_path).unwrap();
+        assert!(written.contains("Latest body"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_command_execute_at_version_writes_output_file() {
+        let _lock = crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let server = wiremock::MockServer::start().await;
+        mount_page(&server, Some(3), "Version three body").await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let out_path = temp_dir.path().join("page-v3.md");
+
+        set_atlassian_env(&server.uri());
+        let cmd = ReadCommand {
+            id: "12345".to_string(),
+            output: Some(out_path.to_str().unwrap().to_string()),
+            format: ContentFormat::Jfm,
+            version: Some(3),
+        };
+        let result = cmd.execute().await;
+        clear_atlassian_env();
+        assert!(result.is_ok(), "{result:?}");
+
+        let written = std::fs::read_to_string(&out_path).unwrap();
+        assert!(written.contains("Version three body"));
     }
 }

--- a/src/cli/atlassian/confluence/read.rs
+++ b/src/cli/atlassian/confluence/read.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 
 use crate::atlassian::confluence_api::ConfluenceApi;
 use crate::cli::atlassian::format::ContentFormat;
-use crate::cli::atlassian::helpers::{create_client, run_read};
+use crate::cli::atlassian::helpers::{create_client, render_content_item, run_read};
 
 /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON.
 ///
@@ -23,6 +23,12 @@ pub struct ReadCommand {
     /// Output format.
     #[arg(long, value_enum, default_value_t = ContentFormat::Jfm)]
     pub format: ContentFormat,
+
+    /// Read a specific historical version instead of the current head
+    /// (e.g. `--version 3`). Confluence stores each version as an immutable
+    /// snapshot; omit for the latest.
+    #[arg(long)]
+    pub version: Option<u32>,
 }
 
 impl ReadCommand {
@@ -31,14 +37,24 @@ impl ReadCommand {
         let (client, instance_url) = create_client()?;
         let api = ConfluenceApi::new(client);
 
-        run_read(
-            &self.id,
-            self.output.as_deref(),
-            &self.format,
-            &api,
-            &instance_url,
-        )
-        .await
+        match self.version {
+            Some(version) => {
+                // `get_page_at_version` is Confluence-specific (not on the shared
+                // `AtlassianApi` trait), so fetch here and reuse the shared renderer.
+                let item = api.get_page_at_version(&self.id, version).await?;
+                render_content_item(&item, self.output.as_deref(), &self.format, &instance_url)
+            }
+            None => {
+                run_read(
+                    &self.id,
+                    self.output.as_deref(),
+                    &self.format,
+                    &api,
+                    &instance_url,
+                )
+                .await
+            }
+        }
     }
 }
 
@@ -53,10 +69,12 @@ mod tests {
             id: "12345".to_string(),
             output: Some("page.md".to_string()),
             format: ContentFormat::Jfm,
+            version: None,
         };
         assert_eq!(cmd.id, "12345");
         assert_eq!(cmd.output.as_deref(), Some("page.md"));
         assert!(matches!(cmd.format, ContentFormat::Jfm));
+        assert!(cmd.version.is_none());
     }
 
     #[test]
@@ -65,9 +83,11 @@ mod tests {
             id: "99999".to_string(),
             output: None,
             format: ContentFormat::Adf,
+            version: Some(3),
         };
         assert_eq!(cmd.id, "99999");
         assert!(cmd.output.is_none());
         assert!(matches!(cmd.format, ContentFormat::Adf));
+        assert_eq!(cmd.version, Some(3));
     }
 }

--- a/src/cli/atlassian/helpers.rs
+++ b/src/cli/atlassian/helpers.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 
 use crate::atlassian::adf::AdfDocument;
 use crate::atlassian::adf_validated::{validate_with_source, ValidatedAdfDocument};
-use crate::atlassian::api::AtlassianApi;
+use crate::atlassian::api::{AtlassianApi, ContentItem};
 use crate::atlassian::auth;
 use crate::atlassian::client::{AtlassianClient, FieldSelection};
 use crate::atlassian::convert::markdown_to_adf;
@@ -24,16 +24,31 @@ pub async fn run_read(
     instance_url: &str,
 ) -> Result<()> {
     let item = api.get_content(id).await?;
+    render_content_item(&item, output, format, instance_url)
+}
 
+/// Renders an already-fetched [`ContentItem`] to the requested format and writes
+/// it to `output` (or stdout).
+///
+/// Split out of [`run_read`] so callers that fetch through a Confluence-specific
+/// path (e.g. a versioned read via `get_page_at_version`, which is not on the
+/// shared [`AtlassianApi`] trait) can reuse identical rendering.
+pub fn render_content_item(
+    item: &ContentItem,
+    output: Option<&str>,
+    format: &ContentFormat,
+    instance_url: &str,
+) -> Result<()> {
     match format {
         ContentFormat::Adf => {
-            let json =
-                serde_json::to_string_pretty(&item.body_adf.unwrap_or(serde_json::Value::Null))
-                    .context("Failed to serialize ADF JSON")?;
+            let json = serde_json::to_string_pretty(
+                item.body_adf.as_ref().unwrap_or(&serde_json::Value::Null),
+            )
+            .context("Failed to serialize ADF JSON")?;
             output_text(&json, output)?;
         }
         ContentFormat::Jfm => {
-            let doc = content_item_to_document(&item, instance_url)?;
+            let doc = content_item_to_document(item, instance_url)?;
             let rendered = doc.render()?;
             output_text(&rendered, output)?;
 

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -5919,4 +5919,194 @@ mod tests {
         assert!(yaml.contains("method: PUT"));
         assert!(yaml.contains("title: New Title"));
     }
+
+    // ── comment audit / reanchor (issue #1092) ──────────────────────
+
+    /// Mounts the inline-comments listing for page `id` with one comment
+    /// `ic1` bearing marker `aaa` and original selection "old".
+    async fn mock_inline_comment_ic1(server: &wiremock::MockServer, id: &str) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/wiki/api/v2/pages/{id}/inline-comments"
+            )))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [
+                        {"id": "ic1", "version": {"authorId": "a", "createdAt": "t"},
+                         "properties": {"inlineMarkerRef": "aaa", "inlineOriginalSelection": "old"}}
+                    ]
+                })),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn audit_comments_yaml_reports_drift() {
+        let server = wiremock::MockServer::start().await;
+        // The page body does not bear marker "aaa" → the mark was lost.
+        mock_page_with_anchor(&server, "12345", "some page text").await;
+        mock_inline_comment_ic1(&server, "12345").await;
+
+        let yaml = audit_comments_yaml(&phase2d_mock_api(&server), "12345")
+            .await
+            .unwrap();
+        assert!(yaml.contains("ic1"), "got: {yaml}");
+        assert!(yaml.contains("mark_lost"), "got: {yaml}");
+    }
+
+    #[tokio::test]
+    async fn reanchor_comment_result_dry_run_returns_yaml_without_put() {
+        let server = wiremock::MockServer::start().await;
+        mock_page_with_anchor(&server, "12345", "fresh anchor").await;
+        mock_inline_comment_ic1(&server, "12345").await;
+        // No PUT mounted: a write attempt would fail the test with a 404.
+
+        let yaml = reanchor_comment_result(
+            &phase2d_mock_api(&server),
+            "12345",
+            "ic1",
+            "fresh anchor",
+            None,
+            true,
+        )
+        .await
+        .unwrap();
+        assert!(yaml.contains("dry_run: true"), "got: {yaml}");
+        assert!(yaml.contains("fresh anchor"), "got: {yaml}");
+    }
+
+    #[tokio::test]
+    async fn reanchor_comment_result_writes_page() {
+        let server = wiremock::MockServer::start().await;
+        mock_page_with_anchor(&server, "12345", "fresh anchor").await;
+        mock_inline_comment_ic1(&server, "12345").await;
+        wiremock::Mock::given(wiremock::matchers::method("PUT"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let yaml = reanchor_comment_result(
+            &phase2d_mock_api(&server),
+            "12345",
+            "ic1",
+            "fresh anchor",
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(yaml.contains("dry_run: false"), "got: {yaml}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_comment_audit_handler_success_via_mock() {
+        let _lock = env_lock();
+        let srv = wiremock::MockServer::start().await;
+        mock_page_with_anchor(&srv, "12345", "some page text").await;
+        mock_inline_comment_ic1(&srv, "12345").await;
+        let _env = EnvGuard::set(&srv.uri());
+
+        let server = make_server();
+        let result = server
+            .confluence_comment_audit(Parameters(ConfluenceCommentAuditParams {
+                id: "12345".to_string(),
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_comment_audit_handler_error_path_without_credentials() {
+        let _lock = env_lock();
+        clear_env();
+        let server = make_server();
+        let result = server
+            .confluence_comment_audit(Parameters(ConfluenceCommentAuditParams {
+                id: "12345".to_string(),
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_comment_reanchor_handler_success_via_mock() {
+        let _lock = env_lock();
+        let srv = wiremock::MockServer::start().await;
+        mock_page_with_anchor(&srv, "12345", "fresh anchor").await;
+        mock_inline_comment_ic1(&srv, "12345").await;
+        let _env = EnvGuard::set(&srv.uri());
+
+        let server = make_server();
+        let result = server
+            .confluence_comment_reanchor(Parameters(ConfluenceCommentReanchorParams {
+                id: "12345".to_string(),
+                comment_id: "ic1".to_string(),
+                anchor_text: "fresh anchor".to_string(),
+                match_index: None,
+                dry_run: true,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confluence_comment_reanchor_handler_error_path_without_credentials() {
+        let _lock = env_lock();
+        clear_env();
+        let server = make_server();
+        let result = server
+            .confluence_comment_reanchor(Parameters(ConfluenceCommentReanchorParams {
+                id: "12345".to_string(),
+                comment_id: "ic1".to_string(),
+                anchor_text: "fresh anchor".to_string(),
+                match_index: None,
+                dry_run: true,
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    // ── run_confluence_read at a pinned version ─────────────────────
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_confluence_read_at_specific_version() {
+        let _lock = env_lock();
+        let srv = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/pages/12345"))
+            .and(wiremock::matchers::query_param("version", "2"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": "12345",
+                    "title": "Mock Page v2",
+                    "status": "current",
+                    "spaceId": "98765",
+                    "version": {"number": 2},
+                    "body": {"atlas_doc_format": {
+                        "value": "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Version two body\"}]}]}"
+                    }}
+                })),
+            )
+            .mount(&srv)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/api/v2/spaces/98765"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"key": "ENG"})),
+            )
+            .mount(&srv)
+            .await;
+        let _env = EnvGuard::set(&srv.uri());
+
+        let out = run_confluence_read("12345", ContentFormat::Jfm, None, Some(2))
+            .await
+            .unwrap();
+        assert!(out.contains("Version two body"), "got: {out}");
+    }
 }

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -27,6 +27,7 @@ use crate::atlassian::confluence_api::{
 };
 use crate::atlassian::create::{prepend_warnings, resolve_confluence_create};
 use crate::atlassian::document::{content_item_to_document, JfmDocument, JfmFrontmatter};
+use crate::atlassian::inline_comment::{audit_inline_comments, reanchor_inline_comment};
 use crate::cli::atlassian::confluence::download::{
     run_download, DownloadParams, ManifestEntry, OnConflict,
 };
@@ -57,6 +58,12 @@ pub struct ConfluenceReadParams {
     /// window — the assistant can then read the file with offset/limit.
     #[serde(default)]
     pub output_file: Option<String>,
+    /// Read a specific historical version instead of the current head (e.g.
+    /// `3`). Confluence stores each version as an immutable snapshot; omit for
+    /// the latest. Useful for seeing what a reviewer was reading when they
+    /// posted a comment.
+    #[serde(default)]
+    pub version: Option<u32>,
 }
 
 /// Parameters for the `confluence_search` tool.
@@ -313,6 +320,33 @@ pub struct ConfluenceCommentRepliesParams {
     /// Maximum number of replies to return (0 = unlimited).
     #[serde(default)]
     pub limit: Option<usize>,
+}
+
+/// Parameters for the `confluence_comment_audit` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceCommentAuditParams {
+    /// Confluence page ID.
+    pub id: String,
+}
+
+/// Parameters for the `confluence_comment_reanchor` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceCommentReanchorParams {
+    /// Confluence page ID.
+    pub id: String,
+    /// The inline comment ID to re-anchor.
+    pub comment_id: String,
+    /// Exact text on the current page to move the comment's anchor to.
+    pub anchor_text: String,
+    /// 1-based occurrence to anchor to when `anchor_text` appears more than
+    /// once on the page. Required for ambiguous anchors; rejected if out of
+    /// range.
+    #[serde(default)]
+    pub match_index: Option<usize>,
+    /// When true, validate and return what would change without writing the
+    /// page. Defaults to `false`.
+    #[serde(default)]
+    pub dry_run: bool,
 }
 
 /// Parameters for the `confluence_label_list` tool.
@@ -986,6 +1020,29 @@ pub async fn add_inline_comment_result(
     to_yaml(&result)
 }
 
+/// Builds the YAML output for the `confluence_comment_audit` tool.
+pub async fn audit_comments_yaml(api: &ConfluenceApi, id: &str) -> Result<String> {
+    let drifts = audit_inline_comments(api, id).await?;
+    to_yaml(&drifts)
+}
+
+/// Moves an inline comment's anchor and returns the outcome as YAML.
+///
+/// With `dry_run`, the move is computed and validated but the page is not
+/// written.
+pub async fn reanchor_comment_result(
+    api: &ConfluenceApi,
+    id: &str,
+    comment_id: &str,
+    anchor_text: &str,
+    match_index: Option<usize>,
+    dry_run: bool,
+) -> Result<String> {
+    let outcome =
+        reanchor_inline_comment(api, id, comment_id, anchor_text, match_index, dry_run).await?;
+    to_yaml(&outcome)
+}
+
 /// Builds the YAML output for the `confluence_label_list` tool.
 pub async fn list_labels_yaml(api: &ConfluenceApi, id: &str, limit: usize) -> Result<String> {
     let mut labels = api.get_labels(id).await?;
@@ -1216,10 +1273,14 @@ impl OmniDevServer {
                        nodes — preserve them verbatim when editing so a later `confluence_write` does not \
                        drop those comments. Pass format=\"adf\" for the raw ADF JSON \
                        (the on-the-wire document model) only when you need exact node structure. \
-                       When `output_file` is set, the content is written to that path and the tool returns \
-                       a short YAML summary (path/bytes/format) — useful for large pages. This reads a \
-                       single page; to fetch a whole page tree or an entire space to disk, use \
+                       Pass `version` to read a specific historical version (an immutable snapshot) instead \
+                       of the current head — useful for seeing what a reviewer was reading when they \
+                       commented. When `output_file` is set, the content is written to that path and the \
+                       tool returns a short YAML summary (path/bytes/format) — useful for large pages. This \
+                       reads a single page; to fetch a whole page tree or an entire space to disk, use \
                        `confluence_download` instead. \
+                       NOTE: inline-comment anchors do NOT follow text edits — to detect/repair drifted \
+                       comments use `confluence_comment_audit` / `confluence_comment_reanchor`. \
                        Any author/version metadata is returned as Atlassian account IDs — resolve them to \
                        display names with `confluence_user_get`. \
                        Mirrors `omni-dev atlassian confluence read`."
@@ -1229,9 +1290,14 @@ impl OmniDevServer {
         Parameters(params): Parameters<ConfluenceReadParams>,
     ) -> Result<CallToolResult, McpError> {
         let format = parse_format(params.format.as_deref()).map_err(tool_error)?;
-        let rendered = run_confluence_read(&params.id, format, params.output_file.as_deref())
-            .await
-            .map_err(tool_error)?;
+        let rendered = run_confluence_read(
+            &params.id,
+            format,
+            params.output_file.as_deref(),
+            params.version,
+        )
+        .await
+        .map_err(tool_error)?;
         Ok(CallToolResult::success(vec![Content::text(rendered)]))
     }
 
@@ -1433,9 +1499,14 @@ impl OmniDevServer {
     #[tool(description = "List comments on a Confluence page (auto-paginated). \
                        `kind` selects \"footer\", \"inline\", or \"all\" (default — \
                        both kinds merged and sorted by creation time). `limit` of 0 \
-                       returns every comment. Comment authors are returned as Atlassian \
-                       account IDs (e.g. `557058:...`) — resolve them to display names \
-                       with `confluence_user_get` (pass every distinct author ID in one \
+                       returns every comment. Inline comments include their \
+                       `inline_marker_ref` and durable `inline_original_selection` \
+                       (the reviewer's original highlight); note that inline-comment \
+                       anchors do NOT follow text edits — use `confluence_comment_audit` \
+                       to detect drift and `confluence_comment_reanchor` to fix it. \
+                       Comment authors are returned as Atlassian account IDs \
+                       (e.g. `557058:...`) — resolve them to display names with \
+                       `confluence_user_get` (pass every distinct author ID in one \
                        call). Mirrors `omni-dev atlassian confluence comment list`.")]
     pub async fn confluence_comment_list(
         &self,
@@ -1534,6 +1605,63 @@ impl OmniDevServer {
             list_comment_replies_yaml(&api, &params.comment_id, kind, params.limit.unwrap_or(25))
                 .await
                 .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Audits inline comments on a page for anchor drift.
+    #[tool(
+        description = "Audit every inline comment on a Confluence page for anchor drift. \
+                       Inline-comment anchors do NOT follow text edits: when the annotated text \
+                       is rewritten, Confluence leaves the mark on whatever original characters \
+                       survive, so comments end up torn across fragments, slid onto unrelated \
+                       text, or dropped. This compares each comment's currently-anchored text \
+                       against the reviewer's durable original highlight and returns YAML with a \
+                       per-comment `status` (`ok`/`torn`/`mark_lost`/`drifted`), the original vs. \
+                       current anchored text, and a `suggested_new_anchor` for drifted comments. \
+                       Read-only — fix drift with `confluence_comment_reanchor`. Mirrors \
+                       `omni-dev atlassian confluence comment audit`."
+    )]
+    pub async fn confluence_comment_audit(
+        &self,
+        Parameters(params): Parameters<ConfluenceCommentAuditParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let api = ConfluenceApi::new(client);
+        let yaml = audit_comments_yaml(&api, &params.id)
+            .await
+            .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Moves an inline comment's anchor to a new text run.
+    #[tool(
+        description = "Move an inline comment's anchor to a new run of text in a Confluence page's \
+                       current ADF, then write the page back in one update — the fix for a comment \
+                       flagged as `drifted`/`mark_lost` by `confluence_comment_audit`. Pass the \
+                       inline `comment_id` and the exact `anchor_text` to move it to; \
+                       `match_index` (1-based) disambiguates when the text occurs more than once. \
+                       The anchor may span multiple runs (e.g. a phrase split by bold) but not a \
+                       block boundary. Operates entirely on ADF — it never round-trips through JFM, \
+                       which would discard the annotation marks. Set `dry_run: true` to validate \
+                       and preview the move without writing. Mirrors \
+                       `omni-dev atlassian confluence comment reanchor`."
+    )]
+    pub async fn confluence_comment_reanchor(
+        &self,
+        Parameters(params): Parameters<ConfluenceCommentReanchorParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let api = ConfluenceApi::new(client);
+        let yaml = reanchor_comment_result(
+            &api,
+            &params.id,
+            &params.comment_id,
+            &params.anchor_text,
+            params.match_index,
+            params.dry_run,
+        )
+        .await
+        .map_err(tool_error)?;
         Ok(CallToolResult::success(vec![Content::text(yaml)]))
     }
 
@@ -1841,10 +1969,14 @@ async fn run_confluence_read(
     id: &str,
     format: ContentFormat,
     output_file: Option<&str>,
+    version: Option<u32>,
 ) -> Result<String> {
     let (client, instance_url) = create_client()?;
     let api = ConfluenceApi::new(client);
-    let item = api.get_content(id).await?;
+    let item = match version {
+        Some(v) => api.get_page_at_version(id, v).await?,
+        None => api.get_content(id).await?,
+    };
     let label = format_label(&format);
     let rendered = render_content_item(&item, format, &instance_url)?;
     match output_file {
@@ -2475,7 +2607,7 @@ mod tests {
         mock_page(&server, "12345").await;
         let _env = EnvGuard::set(&server.uri());
 
-        let out = run_confluence_read("12345", ContentFormat::Jfm, None)
+        let out = run_confluence_read("12345", ContentFormat::Jfm, None, None)
             .await
             .unwrap();
         assert!(out.contains("Mocked"));
@@ -2489,7 +2621,7 @@ mod tests {
         mock_page(&server, "12345").await;
         let _env = EnvGuard::set(&server.uri());
 
-        let out = run_confluence_read("12345", ContentFormat::Adf, None)
+        let out = run_confluence_read("12345", ContentFormat::Adf, None, None)
             .await
             .unwrap();
         assert!(out.contains("\"doc\""));
@@ -2506,7 +2638,7 @@ mod tests {
             .await;
         let _env = EnvGuard::set(&server.uri());
 
-        let err = run_confluence_read("99", ContentFormat::Jfm, None)
+        let err = run_confluence_read("99", ContentFormat::Jfm, None, None)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("404"));
@@ -2523,7 +2655,7 @@ mod tests {
         let out_path = tmp.path().join("page.md");
         let path_str = out_path.to_str().unwrap();
 
-        let summary = run_confluence_read("12345", ContentFormat::Jfm, Some(path_str))
+        let summary = run_confluence_read("12345", ContentFormat::Jfm, Some(path_str), None)
             .await
             .unwrap();
 
@@ -2549,7 +2681,7 @@ mod tests {
         let out_path = tmp.path().join("page.json");
         let path_str = out_path.to_str().unwrap();
 
-        let summary = run_confluence_read("12345", ContentFormat::Adf, Some(path_str))
+        let summary = run_confluence_read("12345", ContentFormat::Adf, Some(path_str), None)
             .await
             .unwrap();
 
@@ -2569,6 +2701,7 @@ mod tests {
             "12345",
             ContentFormat::Jfm,
             Some("/nonexistent_dir_zxq/out.md"),
+            None,
         )
         .await
         .unwrap_err();
@@ -2621,7 +2754,7 @@ mod tests {
         mock_page_with_bad_adf(&server, "12345").await;
         let _env = EnvGuard::set(&server.uri());
 
-        let err = run_confluence_read("12345", ContentFormat::Jfm, None)
+        let err = run_confluence_read("12345", ContentFormat::Jfm, None, None)
             .await
             .unwrap_err();
         assert!(
@@ -3296,6 +3429,7 @@ mod tests {
             id: "12345".to_string(),
             format: Some("xml".to_string()),
             output_file: None,
+            version: None,
         };
         let result = server.confluence_read(Parameters(params)).await;
         let err = result.unwrap_err();
@@ -3319,6 +3453,7 @@ mod tests {
                 id: "12345".to_string(),
                 format: Some("jfm".to_string()),
                 output_file: None,
+                version: None,
             }))
             .await
             .unwrap();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -183,6 +183,8 @@ mod tests {
             "confluence_children",
             "confluence_comment_list",
             "confluence_comment_add",
+            "confluence_comment_audit",
+            "confluence_comment_reanchor",
             "confluence_label_list",
             "confluence_label_add",
             "confluence_label_remove",

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -464,6 +464,8 @@ Commands:
   add         Adds a footer comment to a Confluence page (mirrors the `confluence_comment_add` MCP tool)
   add-inline  Adds an inline (anchored) comment to a Confluence page (mirrors the `confluence_comment_add_inline` MCP tool)
   replies     Lists the replies of a comment (mirrors the `confluence_comment_replies` MCP tool)
+  audit       Audits inline comments for anchor drift (mirrors the `confluence_comment_audit` MCP tool)
+  reanchor    Moves an inline comment's anchor to a new text run (mirrors the `confluence_comment_reanchor` MCP tool)
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -508,6 +510,22 @@ Options:
 
 ================================================================================
 
+omni-dev atlassian confluence comment audit - Audits inline comments for anchor drift (mirrors the `confluence_comment_audit` MCP tool)
+
+Audits inline comments for anchor drift (mirrors the `confluence_comment_audit` MCP tool)
+
+Usage: audit [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Confluence page ID
+
+Options:
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
 omni-dev atlassian confluence comment list - Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool)
 
 Lists comments on a Confluence page (mirrors the `confluence_comment_list` MCP tool)
@@ -522,6 +540,26 @@ Options:
       --limit <LIMIT>    Maximum number of comments to display [default: 25]
   -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
   -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev atlassian confluence comment reanchor - Moves an inline comment's anchor to a new text run (mirrors the `confluence_comment_reanchor` MCP tool)
+
+Moves an inline comment's anchor to a new text run (mirrors the `confluence_comment_reanchor` MCP tool)
+
+Usage: reanchor [OPTIONS] --comment <COMMENT> --anchor-text <ANCHOR_TEXT> <ID>
+
+Arguments:
+  <ID>  Confluence page ID
+
+Options:
+      --comment <COMMENT>          The inline comment ID to re-anchor
+      --anchor-text <ANCHOR_TEXT>  Exact text on the current page to move the comment's anchor to
+      --match-index <MATCH_INDEX>  1-based occurrence to anchor to when `--anchor-text` appears more than once on the page. Required for ambiguous anchors; rejected if out of range
+      --force                      Skips the confirmation prompt
+      --dry-run                    Prints what would change without writing the page
+  -h, --help                       Print help
 
 
 ================================================================================
@@ -799,9 +837,10 @@ Arguments:
   <ID>  Confluence page ID (e.g., 12345678)
 
 Options:
-  -o, --output <OUTPUT>  Output file (writes to stdout if omitted)
-      --format <FORMAT>  Output format [default: jfm] [possible values: jfm, adf]
-  -h, --help             Print help (see more with '--help')
+  -o, --output <OUTPUT>    Output file (writes to stdout if omitted)
+      --format <FORMAT>    Output format [default: jfm] [possible values: jfm, adf]
+      --version <VERSION>  Read a specific historical version instead of the current head (e.g. `--version 3`). Confluence stores each version as an immutable snapshot; omit for the latest
+  -h, --help               Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

Confluence inline comments are anchored to runs of text via `annotation` marks carrying a unique ID. When the underlying text is edited, Confluence keeps the mark on whatever *original characters* survive — it does not follow the *meaning* of the annotated text. Substantive rewrites therefore leave comments "torn" across disjoint fragments, slid onto unrelated text, or dropped entirely — with no built-in way to detect or repair this.

This PR implements comprehensive drift detection and repair for Confluence inline comments:

- A new `audit` operation reads every inline comment on a page and classifies each as `ok`, `torn`, `mark_lost`, or `drifted` by comparing the text currently bearing the annotation mark against the reviewer's durable `inlineOriginalSelection`.
- A new `reanchor` operation moves a comment's annotation mark to a new run of text in the current ADF and writes the page back in a single PUT — operating entirely on typed ADF (never JFM) to preserve the mark structure the anchor depends on.
- Both operations are exposed as CLI commands (`confluence comment audit` / `confluence comment reanchor`) and MCP tools (`confluence_comment_audit` / `confluence_comment_reanchor`).
- As a related enhancement, `confluence read` gains a `--version` flag to fetch historical page snapshots — useful for seeing exactly what a reviewer was reading when they posted a comment.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #1092

## Changes Made

**Core Library (`src/atlassian/`):**
- Added `pub mod inline_comment` to `src/atlassian.rs`
- Created `src/atlassian/inline_comment.rs` (1 005 lines) implementing:
  - `DriftStatus` enum (`Ok`, `Torn`, `MarkLost`, `Drifted`) with `Serialize`
  - `CommentDrift` struct carrying the per-comment audit report (marker ref, status, original vs. current anchored text, suggested new anchor)
  - `ReanchorOutcome` struct returned by a successful re-anchor
  - `audit_inline_comments()` — read-only orchestration: fetches page ADF + inline comments, classifies each comment's drift
  - `reanchor_inline_comment()` — write orchestration: removes old mark, applies new mark, validates ADF, and PUTs page back; supports `dry_run`
  - ADF-walking helpers: `collect_annotation_runs`, `remove_annotation`, `apply_annotation` (supports cross-run anchors split by formatting, 1-based `match_index` disambiguation, multi-byte text)
  - 20+ unit tests including integration tests over a mocked Confluence API
- Extended `ConfluenceComment` in `src/atlassian/confluence_api.rs` with `inline_marker_ref: Option<String>` and `inline_original_selection: Option<String>`, populated from `inlineMarkerRef` / `inlineOriginalSelection` in the v2 inline-comments `properties` object
- Added `ConfluenceInlineCommentProperties` private deserialization struct
- Added two API-layer tests: `get_page_inline_comments_captures_marker_and_original_selection` and `get_page_comments_footer_has_no_inline_properties`

**CLI (`src/cli/atlassian/confluence/`):**
- Added `CommentSubcommands::Audit(AuditCommand)` and `CommentSubcommands::Reanchor(ReanchorCommand)` in `comment.rs`
- `AuditCommand`: accepts page ID + `--output` format; calls `audit_inline_comments` and renders via `output_as` or `print_drifts` table
- `ReanchorCommand`: accepts page ID, `--comment`, `--anchor-text`, optional `--match-index`, `--force` (skip confirmation), and `--dry-run`; uses `guard_destructive_with_io` for safe interactive prompting
- Added `print_drifts()` human-readable table renderer for audit output
- Added `--version <u32>` flag to `ReadCommand` in `read.rs` to fetch historical page snapshots via `get_page_at_version`
- Extracted `render_content_item()` from `run_read()` in `helpers.rs` as a standalone public helper so versioned reads can reuse identical rendering without going through the `AtlassianApi` trait

**MCP Tools (`src/mcp/`):**
- Added `ConfluenceCommentAuditParams` and `ConfluenceCommentReanchorParams` parameter structs in `confluence_tools.rs`
- Added `audit_comments_yaml()` and `reanchor_comment_result()` output functions
- Registered `confluence_comment_audit` and `confluence_comment_reanchor` MCP tools on `OmniDevServer` with full tool descriptions
- Added `version: Option<u32>` to `ConfluenceReadParams`; updated `run_confluence_read` to dispatch to `get_page_at_version` when set
- Updated `confluence_read` and `confluence_comment_list` tool descriptions to cross-reference the new drift tools
- Registered both new tools in `server.rs` tool-list test
- Updated all `run_confluence_read` call sites in tests to pass the new `version` parameter

**Snapshots / Tests:**
- Updated `tests/snapshots/integration_test__help_all_output.snap` with help text for `audit`, `reanchor`, and the new `--version` flag on `confluence read`
- Updated `comment.rs` test fixtures to include `inline_marker_ref` / `inline_original_selection` fields on `ConfluenceComment`
- Updated `mod.rs` test fixtures to include `version: None` on `ReadCommand`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — 20+ unit tests in `inline_comment.rs` covering collect/classify/remove/apply/reanchor logic
- [x] Integration tests over mocked Confluence API for `audit_inline_comments` and `reanchor_inline_comment` (including dry-run and unknown-comment error paths)
- [x] API-layer tests for inline-comment property deserialization

**Manual Testing:**
- [x] Tested happy path scenarios (Ok, Torn, Drifted, MarkLost classification)
- [x] Tested error/edge cases (ambiguous anchor without index, anchor not found, out-of-range match index, cross-block phrase, dry-run no-write)
- [x] Backward compatibility verified — footer comments continue to deserialize cleanly with `None` for both new fields

### Test Commands
```bash
# Core test suite
cargo test

# Inline-comment specific tests
cargo test inline_comment
cargo test confluence_tools
cargo test confluence_api

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Snapshot test (regenerate if needed)
cargo test integration_test__help_all_output
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes — `render_content_item` extraction and how versioned reads compose with it
- [x] Error handling — `apply_annotation` error paths for ambiguous/missing/out-of-range anchors
- [x] Backward compatibility — new `ConfluenceComment` fields use `#[serde(skip_serializing_if = "Option::is_none")]` so existing serialized output is unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact — audit and reanchor are user-initiated, on-demand operations with no hot-path changes

## Security Considerations
- [x] No security implications — reads and writes use the same authenticated `ConfluenceApi` client already in use; re-anchor only mutates annotation mark positions, not page content

## Breaking Changes
None. The new `inline_marker_ref` and `inline_original_selection` fields on `ConfluenceComment` are `Option` and serialized with `skip_serializing_if = "Option::is_none"`, so existing callers see no change. All new CLI flags and MCP parameters are optional or additive.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Design Decisions:**
- Re-anchoring operates on ADF exclusively — never via JFM round-trip — because the JFM converter discards annotation marks, which would destroy the very structure the anchor depends on.
- The `match_index` (1-based) disambiguation approach mirrors the style already used in `add-inline`, keeping the CLI and MCP surface consistent.
- `dry_run` on `reanchor_inline_comment` computes and validates the ADF mutation (surfacing anchor/validation errors) without writing, so users can preview moves safely.

**Known Limitations:**
- A phrase that crosses a block boundary (e.g. the last word of one paragraph and the first word of the next) cannot be re-anchored in a single operation, because ADF annotation marks cannot span block nodes. The error message explains this clearly.
- Cross-page comment drift (comments on a page whose content has been moved to another page) is outside scope.