### PR TITLE
feat(atlassian): add account ID to user record lookup for JIRA and Confluence

### DIFF
--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -430,6 +430,81 @@ pub struct JiraUserSearchResults {
     pub count: u32,
 }
 
+/// A single user resolved by account ID via `GET /rest/api/3/user?accountId=`.
+///
+/// Unlike the search result, this is the *reverse* direction (ID → record) and
+/// is failure-tolerant: on a per-ID lookup failure (unknown / anonymised
+/// account, or a non-auth error) all fields except `account_id` are `None` and
+/// `error` carries the reason, so a batch lookup never aborts for one bad ID.
+/// Deactivated accounts still come back as a real record with `active: false`.
+///
+/// See [`JiraUserGetResults`] for the batch wrapper.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraUserRecord {
+    /// Account ID (always present — echoed back even when the lookup failed).
+    pub account_id: String,
+    /// Display name. Absent on GDPR-redacted tenants or failed lookups.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Email address. Often absent due to GDPR / privacy settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_address: Option<String>,
+    /// Whether the account is currently active. `None` when the lookup failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
+    /// Account type, e.g. `"atlassian"`, `"app"`, `"customer"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_type: Option<String>,
+    /// Reason this ID could not be resolved (e.g. `"HTTP 404"`). Absent on
+    /// success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Batch wrapper around [`JiraUserRecord`] from resolving one or more account
+/// IDs via `GET /rest/api/3/user?accountId=`.
+#[derive(Debug, Clone, Serialize)]
+pub struct JiraUserGetResults {
+    /// Resolved users, one per requested account ID (in request order).
+    pub users: Vec<JiraUserRecord>,
+}
+
+/// A single user resolved by account ID via `GET /wiki/rest/api/user?accountId=`.
+///
+/// The Confluence v1 user object does not report an `active` flag, so `active`
+/// is always `None` here. Failure-tolerant in the same way as
+/// [`JiraUserRecord`]. See [`ConfluenceUserGetResults`] for the batch wrapper.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceUserRecord {
+    /// Account ID (always present — echoed back even when the lookup failed).
+    pub account_id: String,
+    /// Display name (falls back to `publicName` when `displayName` is absent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Email address. Absent unless the caller has permission to see it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Account type, e.g. `"atlassian"`, `"app"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_type: Option<String>,
+    /// Always `None` — the Confluence v1 user endpoint does not return an
+    /// active flag. Present for parity with [`JiraUserRecord`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
+    /// Reason this ID could not be resolved (e.g. `"HTTP 404"`). Absent on
+    /// success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Batch wrapper around [`ConfluenceUserRecord`] from resolving one or more
+/// account IDs via `GET /wiki/rest/api/user?accountId=`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfluenceUserGetResults {
+    /// Resolved users, one per requested account ID (in request order).
+    pub users: Vec<ConfluenceUserRecord>,
+}
+
 /// A JIRA issue comment returned by `GET /rest/api/3/issue/{key}/comment`.
 #[derive(Debug, Clone, Serialize)]
 pub struct JiraComment {
@@ -1371,6 +1446,38 @@ struct ConfluenceSearchUser {
     public_name: Option<String>,
 }
 
+// ── Confluence user-get API response struct ───────────────────────
+
+/// Deserialization helper for `GET /wiki/rest/api/user?accountId=` — a bare
+/// user object (not wrapped in `results`). `publicName` is the fallback when
+/// `displayName` is unavailable; the v1 endpoint has no `active` flag.
+#[derive(Deserialize)]
+struct ConfluenceUserGetEntry {
+    #[serde(rename = "accountId", default)]
+    account_id: Option<String>,
+    #[serde(rename = "accountType", default)]
+    account_type: Option<String>,
+    #[serde(rename = "displayName", default)]
+    display_name: Option<String>,
+    #[serde(rename = "publicName", default)]
+    public_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+/// Builds the `error` string stored on a stub user record when a single
+/// account-ID lookup fails. Includes a short body snippet when the API
+/// returned one so callers can distinguish "not found" from "no permission".
+fn user_lookup_error(status: u16, body: &str) -> String {
+    let snippet = body.trim();
+    if snippet.is_empty() {
+        format!("HTTP {status}")
+    } else {
+        let snippet: String = snippet.chars().take(200).collect();
+        format!("HTTP {status}: {snippet}")
+    }
+}
+
 // ── Agile API response structs ─────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -1964,6 +2071,230 @@ mod tests {
             .unwrap();
         // After max retries, returns the 429 response to the caller
         assert_eq!(resp.status().as_u16(), 429);
+    }
+
+    // ── user-get (account ID → record) ────────────────────────────
+
+    #[test]
+    fn user_lookup_error_formats() {
+        assert_eq!(user_lookup_error(404, ""), "HTTP 404");
+        assert_eq!(user_lookup_error(404, "   "), "HTTP 404");
+        assert_eq!(
+            user_lookup_error(403, "no permission"),
+            "HTTP 403: no permission"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_jira_user_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .and(wiremock::matchers::query_param("accountId", "abc123"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "displayName": "Alice Smith",
+                    "emailAddress": "alice@example.com",
+                    "active": true,
+                    "accountType": "atlassian"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_jira_user("abc123").await.unwrap();
+        assert_eq!(record.account_id, "abc123");
+        assert_eq!(record.display_name.as_deref(), Some("Alice Smith"));
+        assert_eq!(record.email_address.as_deref(), Some("alice@example.com"));
+        assert_eq!(record.active, Some(true));
+        assert_eq!(record.account_type.as_deref(), Some("atlassian"));
+        assert!(record.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_jira_user_deactivated_is_a_record_not_an_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "gone1",
+                    "active": false,
+                    "accountType": "atlassian"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_jira_user("gone1").await.unwrap();
+        assert_eq!(record.account_id, "gone1");
+        assert_eq!(record.active, Some(false));
+        assert!(record.display_name.is_none());
+        assert!(record.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_jira_user_not_found_yields_stub() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_jira_user("missing").await.unwrap();
+        assert_eq!(record.account_id, "missing");
+        assert!(record.display_name.is_none());
+        assert!(record.error.as_deref().unwrap().starts_with("HTTP 404"));
+    }
+
+    #[tokio::test]
+    async fn get_jira_user_unauthorized_is_hard_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(wiremock::ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        assert!(client.get_jira_user("whoever").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_jira_users_batch_survives_one_bad_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .and(wiremock::matchers::query_param("accountId", "good"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "good",
+                    "displayName": "Good User",
+                    "active": true
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .and(wiremock::matchers::query_param("accountId", "bad"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let ids = vec!["good".to_string(), "bad".to_string()];
+        let results = client.get_jira_users(&ids).await.unwrap();
+        assert_eq!(results.users.len(), 2);
+        assert_eq!(results.users[0].account_id, "good");
+        assert_eq!(results.users[0].display_name.as_deref(), Some("Good User"));
+        assert!(results.users[0].error.is_none());
+        assert_eq!(results.users[1].account_id, "bad");
+        assert!(results.users[1].error.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_jira_users_empty_input_makes_no_requests() {
+        let client = AtlassianClient::new("https://org.atlassian.net", "u@t.com", "tok").unwrap();
+        let results = client.get_jira_users(&[]).await.unwrap();
+        assert!(results.users.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_confluence_user_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "abc123"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "accountType": "atlassian",
+                    "displayName": "Alice Smith",
+                    "email": "alice@example.com"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_confluence_user("abc123").await.unwrap();
+        assert_eq!(record.account_id, "abc123");
+        assert_eq!(record.display_name.as_deref(), Some("Alice Smith"));
+        assert_eq!(record.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(record.account_type.as_deref(), Some("atlassian"));
+        assert!(record.active.is_none());
+        assert!(record.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_confluence_user_falls_back_to_public_name() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "app1",
+                    "accountType": "app",
+                    "publicName": "Automation App"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_confluence_user("app1").await.unwrap();
+        assert_eq!(record.display_name.as_deref(), Some("Automation App"));
+    }
+
+    #[tokio::test]
+    async fn get_confluence_user_not_found_yields_stub() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let record = client.get_confluence_user("missing").await.unwrap();
+        assert_eq!(record.account_id, "missing");
+        assert!(record.error.as_deref().unwrap().starts_with("HTTP 404"));
+    }
+
+    #[tokio::test]
+    async fn get_confluence_users_batch_survives_one_bad_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "good"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "good",
+                    "displayName": "Good User"
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "bad"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        let ids = vec!["good".to_string(), "bad".to_string()];
+        let results = client.get_confluence_users(&ids).await.unwrap();
+        assert_eq!(results.users.len(), 2);
+        assert_eq!(results.users[0].display_name.as_deref(), Some("Good User"));
+        assert!(results.users[0].error.is_none());
+        assert!(results.users[1].error.is_some());
     }
 
     #[tokio::test]
@@ -8293,6 +8624,130 @@ impl AtlassianClient {
             users: all_results,
             total,
         })
+    }
+
+    /// Resolves a single JIRA user by account ID
+    /// (`GET /rest/api/3/user?accountId=`).
+    ///
+    /// Failure-tolerant: an unknown / anonymised account (HTTP 404) or any
+    /// other non-auth failure resolves to a stub record with `error` set rather
+    /// than an `Err`, so a batch lookup never aborts for one bad ID. A `401`
+    /// (bad credentials) is a hard error worth surfacing. Deactivated accounts
+    /// come back from Atlassian as a real `200` record with `active: false`.
+    pub async fn get_jira_user(&self, account_id: &str) -> Result<JiraUserRecord> {
+        let base = format!("{}/rest/api/3/user", self.instance_url);
+        let url = reqwest::Url::parse_with_params(&base, &[("accountId", account_id)])
+            .context("Failed to build JIRA user get URL")?;
+
+        let response = self.get_json(url.as_str()).await?;
+        let status = response.status();
+
+        if status.is_success() {
+            let entry: JiraUserSearchEntry = response
+                .json()
+                .await
+                .context("Failed to parse JIRA user get response")?;
+            return Ok(JiraUserRecord {
+                account_id: entry.account_id,
+                display_name: entry.display_name,
+                email_address: entry.email_address,
+                active: Some(entry.active),
+                account_type: entry.account_type,
+                error: None,
+            });
+        }
+
+        if status.as_u16() == 401 {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status: 401, body }.into());
+        }
+
+        let code = status.as_u16();
+        let body = response.text().await.unwrap_or_default();
+        Ok(JiraUserRecord {
+            account_id: account_id.to_string(),
+            display_name: None,
+            email_address: None,
+            active: None,
+            account_type: None,
+            error: Some(user_lookup_error(code, &body)),
+        })
+    }
+
+    /// Resolves multiple JIRA users by account ID, concurrently.
+    ///
+    /// Each ID is fetched independently via [`Self::get_jira_user`]; per-ID
+    /// failures become stub records, so the batch only errors on a genuine auth
+    /// failure (or transport error). Results preserve request order.
+    pub async fn get_jira_users(&self, account_ids: &[String]) -> Result<JiraUserGetResults> {
+        let lookups = account_ids.iter().map(|id| self.get_jira_user(id));
+        let users = futures::future::join_all(lookups)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        Ok(JiraUserGetResults { users })
+    }
+
+    /// Resolves a single Confluence user by account ID
+    /// (`GET /wiki/rest/api/user?accountId=`).
+    ///
+    /// Failure-tolerant in the same way as [`Self::get_jira_user`]. The v1 user
+    /// object has no `active` flag, so [`ConfluenceUserRecord::active`] is
+    /// always `None`; `displayName` falls back to `publicName`.
+    pub async fn get_confluence_user(&self, account_id: &str) -> Result<ConfluenceUserRecord> {
+        let base = format!("{}/wiki/rest/api/user", self.instance_url);
+        let url = reqwest::Url::parse_with_params(&base, &[("accountId", account_id)])
+            .context("Failed to build Confluence user get URL")?;
+
+        let response = self.get_json(url.as_str()).await?;
+        let status = response.status();
+
+        if status.is_success() {
+            let entry: ConfluenceUserGetEntry = response
+                .json()
+                .await
+                .context("Failed to parse Confluence user get response")?;
+            return Ok(ConfluenceUserRecord {
+                account_id: entry.account_id.unwrap_or_else(|| account_id.to_string()),
+                display_name: entry.display_name.or(entry.public_name),
+                email: entry.email,
+                account_type: entry.account_type,
+                active: None,
+                error: None,
+            });
+        }
+
+        if status.as_u16() == 401 {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AtlassianError::ApiRequestFailed { status: 401, body }.into());
+        }
+
+        let code = status.as_u16();
+        let body = response.text().await.unwrap_or_default();
+        Ok(ConfluenceUserRecord {
+            account_id: account_id.to_string(),
+            display_name: None,
+            email: None,
+            account_type: None,
+            active: None,
+            error: Some(user_lookup_error(code, &body)),
+        })
+    }
+
+    /// Resolves multiple Confluence users by account ID, concurrently.
+    ///
+    /// Behaves like [`Self::get_jira_users`]: per-ID failures become stub
+    /// records; the batch only errors on a genuine auth / transport failure.
+    pub async fn get_confluence_users(
+        &self,
+        account_ids: &[String],
+    ) -> Result<ConfluenceUserGetResults> {
+        let lookups = account_ids.iter().map(|id| self.get_confluence_user(id));
+        let users = futures::future::join_all(lookups)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ConfluenceUserGetResults { users })
     }
 
     /// Lists agile boards with auto-pagination.

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -2268,6 +2268,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_confluence_user_unauthorized_is_hard_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(wiremock::ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .mount(&server)
+            .await;
+
+        let client = AtlassianClient::new(&server.uri(), "user@test.com", "token").unwrap();
+        assert!(client.get_confluence_user("whoever").await.is_err());
+    }
+
+    #[tokio::test]
     async fn get_confluence_users_batch_survives_one_bad_id() {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))

--- a/src/cli/atlassian/confluence/comment.rs
+++ b/src/cli/atlassian/confluence/comment.rs
@@ -81,6 +81,9 @@ impl From<CommentKindArg> for CommentKind {
 }
 
 /// Lists comments on a Confluence page.
+///
+/// Comment authors are returned as Atlassian account IDs — resolve them to
+/// display names with `omni-dev atlassian confluence user get`.
 #[derive(Parser)]
 pub struct ListCommand {
     /// Confluence page ID.

--- a/src/cli/atlassian/confluence/history.rs
+++ b/src/cli/atlassian/confluence/history.rs
@@ -12,6 +12,9 @@ use crate::cli::atlassian::format::{output_as, JsonlSerialize, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Lists version history (metadata only) for a Confluence page.
+///
+/// Authors are returned as Atlassian account IDs — resolve them to display
+/// names with `omni-dev atlassian confluence user get`.
 #[derive(Parser)]
 pub struct HistoryCommand {
     /// Confluence page ID.

--- a/src/cli/atlassian/confluence/read.rs
+++ b/src/cli/atlassian/confluence/read.rs
@@ -8,6 +8,9 @@ use crate::cli::atlassian::format::ContentFormat;
 use crate::cli::atlassian::helpers::{create_client, run_read};
 
 /// Fetches a Confluence page and outputs it as JFM markdown or ADF JSON.
+///
+/// Any author/version metadata is returned as Atlassian account IDs — resolve
+/// them to display names with `omni-dev atlassian confluence user get`.
 #[derive(Parser)]
 pub struct ReadCommand {
     /// Confluence page ID (e.g., 12345678).

--- a/src/cli/atlassian/confluence/user.rs
+++ b/src/cli/atlassian/confluence/user.rs
@@ -216,9 +216,14 @@ fn print_user_get_results(result: &ConfluenceUserGetResults) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::await_holding_lock // env lock intentionally held across await on a single-thread runtime
+)]
 mod tests {
     use super::*;
+    use crate::atlassian::auth::{ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL};
     use crate::atlassian::client::{ConfluenceUserRecord, ConfluenceUserSearchResult};
 
     fn mock_client(base_url: &str) -> AtlassianClient {
@@ -424,6 +429,8 @@ mod tests {
             users: vec![
                 sample_record("abc123", Some("Alice Smith"), None),
                 sample_record("bad", None, Some("HTTP 404")),
+                // No display name and no error — exercises the "-" fallback arm.
+                sample_record("noinfo", None, None),
             ],
         };
         print_user_get_results(&result);
@@ -485,5 +492,76 @@ mod tests {
         let client = mock_client(&server.uri());
         let ids = vec!["good".to_string(), "bad".to_string()];
         assert!(run_get(&client, &ids, &OutputFormat::Yaml).await.is_ok());
+    }
+
+    // ── execute() with env-backed credentials ─────────────────────
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    struct EnvGuard;
+
+    impl EnvGuard {
+        fn set(instance_url: &str) -> Self {
+            std::env::set_var(ATLASSIAN_INSTANCE_URL, instance_url);
+            std::env::set_var(ATLASSIAN_EMAIL, "user@test.com");
+            std::env::set_var(ATLASSIAN_API_TOKEN, "fake-token");
+            Self
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(ATLASSIAN_INSTANCE_URL);
+            std::env::remove_var(ATLASSIAN_EMAIL);
+            std::env::remove_var(ATLASSIAN_API_TOKEN);
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_get_command_execute_round_trip() {
+        let _lock = env_lock();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "accountType": "atlassian",
+                    "displayName": "Alice"
+                })),
+            )
+            .mount(&server)
+            .await;
+        let _env = EnvGuard::set(&server.uri());
+
+        let cmd = UserGetCommand {
+            account_id: vec!["abc123".to_string()],
+            output: OutputFormat::Json,
+        };
+        cmd.execute().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_command_dispatches_to_get() {
+        let _lock = env_lock();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let _env = EnvGuard::set(&server.uri());
+
+        let cmd = UserCommand {
+            command: UserSubcommands::Get(UserGetCommand {
+                account_id: vec!["missing".to_string()],
+                output: OutputFormat::Yaml,
+            }),
+        };
+        cmd.execute().await.unwrap();
     }
 }

--- a/src/cli/atlassian/confluence/user.rs
+++ b/src/cli/atlassian/confluence/user.rs
@@ -3,7 +3,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use crate::atlassian::client::{AtlassianClient, ConfluenceUserSearchResults};
+use crate::atlassian::client::{
+    AtlassianClient, ConfluenceUserGetResults, ConfluenceUserSearchResults,
+};
 use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
@@ -20,6 +22,8 @@ pub struct UserCommand {
 pub enum UserSubcommands {
     /// Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool).
     Search(UserSearchCommand),
+    /// Resolves account IDs to user records — the reverse of `search` (mirrors the `confluence_user_get` MCP tool).
+    Get(UserGetCommand),
 }
 
 impl UserCommand {
@@ -27,6 +31,7 @@ impl UserCommand {
     pub async fn execute(self) -> Result<()> {
         match self.command {
             UserSubcommands::Search(cmd) => cmd.execute().await,
+            UserSubcommands::Get(cmd) => cmd.execute().await,
         }
     }
 }
@@ -125,11 +130,96 @@ fn print_user_results(result: &ConfluenceUserSearchResults) {
     }
 }
 
+/// Resolves Confluence account IDs to user records (the reverse of `search`).
+#[derive(Parser)]
+pub struct UserGetCommand {
+    /// Account ID to resolve (repeat for a bulk lookup). Unknown or deactivated
+    /// IDs are returned as a stub record with an `error` field rather than
+    /// failing the whole batch.
+    #[arg(long = "account-id", required = true)]
+    pub account_id: Vec<String>,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl UserGetCommand {
+    /// Executes the user lookup and prints results.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_get(&client, &self.account_id, &self.output).await
+    }
+}
+
+/// Resolves the given account IDs and prints the records using the given client.
+async fn run_get(
+    client: &AtlassianClient,
+    account_ids: &[String],
+    output: &OutputFormat,
+) -> Result<()> {
+    let result = client.get_confluence_users(account_ids).await?;
+    if output_as(&result, output)? {
+        return Ok(());
+    }
+    print_user_get_results(&result);
+    Ok(())
+}
+
+/// Prints resolved Confluence user records as a formatted table.
+fn print_user_get_results(result: &ConfluenceUserGetResults) {
+    if result.users.is_empty() {
+        println!("No users resolved.");
+        return;
+    }
+
+    let id_width = result
+        .users
+        .iter()
+        .map(|u| u.account_id.len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+    let name_width = result
+        .users
+        .iter()
+        .map(|u| u.display_name.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    let email_sep = "-".repeat(5);
+    println!(
+        "{:<id_width$}  {:<name_width$}  EMAIL",
+        "ACCOUNT_ID", "NAME"
+    );
+    println!(
+        "{:<id_width$}  {:<name_width$}  {email_sep}",
+        "-".repeat(id_width),
+        "-".repeat(name_width),
+    );
+
+    for user in &result.users {
+        // A failed lookup carries only account_id + error; surface the reason
+        // in the NAME column so a table reader still sees what went wrong.
+        let name = match (&user.display_name, &user.error) {
+            (Some(name), _) => name.clone(),
+            (None, Some(err)) => format!("({err})"),
+            (None, None) => "-".to_string(),
+        };
+        let email = user.email.as_deref().unwrap_or("-");
+        println!(
+            "{:<id_width$}  {:<name_width$}  {email}",
+            user.account_id, name
+        );
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::atlassian::client::ConfluenceUserSearchResult;
+    use crate::atlassian::client::{ConfluenceUserRecord, ConfluenceUserSearchResult};
 
     fn mock_client(base_url: &str) -> AtlassianClient {
         AtlassianClient::new(base_url, "user@test.com", "token").unwrap()
@@ -304,5 +394,96 @@ mod tests {
         let client = mock_client(&server.uri());
         let result = run_search(&client, "alice", 25, &OutputFormat::Table).await;
         assert!(result.is_err());
+    }
+
+    // ── user get (account ID → record) ────────────────────────────
+
+    fn sample_record(
+        account_id: &str,
+        display_name: Option<&str>,
+        error: Option<&str>,
+    ) -> ConfluenceUserRecord {
+        ConfluenceUserRecord {
+            account_id: account_id.to_string(),
+            display_name: display_name.map(String::from),
+            email: None,
+            account_type: Some("atlassian".to_string()),
+            active: None,
+            error: error.map(String::from),
+        }
+    }
+
+    #[test]
+    fn print_get_results_empty() {
+        print_user_get_results(&ConfluenceUserGetResults { users: vec![] });
+    }
+
+    #[test]
+    fn print_get_results_with_users_and_error() {
+        let result = ConfluenceUserGetResults {
+            users: vec![
+                sample_record("abc123", Some("Alice Smith"), None),
+                sample_record("bad", None, Some("HTTP 404")),
+            ],
+        };
+        print_user_get_results(&result);
+    }
+
+    #[tokio::test]
+    async fn run_get_table_output() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "accountType": "atlassian",
+                    "displayName": "Alice Smith",
+                    "email": "alice@example.com"
+                })),
+            )
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["abc123".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Table).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_get_json_output_stub_on_404() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["missing".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Json).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_get_batch_survives_bad_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "good"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "good",
+                    "displayName": "Good User"
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "bad"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["good".to_string(), "bad".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Yaml).await.is_ok());
     }
 }

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -766,6 +766,53 @@ mod tests {
     }
 
     #[test]
+    fn jira_user_get_results_jsonl() {
+        use crate::atlassian::client::{JiraUserGetResults, JiraUserRecord};
+        let list = JiraUserGetResults {
+            users: vec![
+                JiraUserRecord {
+                    account_id: "u1".to_string(),
+                    display_name: Some("Alice".to_string()),
+                    email_address: Some("alice@example.com".to_string()),
+                    active: Some(true),
+                    account_type: Some("atlassian".to_string()),
+                    error: None,
+                },
+                JiraUserRecord {
+                    account_id: "bad".to_string(),
+                    display_name: None,
+                    email_address: None,
+                    active: None,
+                    account_type: None,
+                    error: Some("HTTP 404".to_string()),
+                },
+            ],
+        };
+        let out = jsonl_string(&list);
+        assert_eq!(out.lines().count(), 2);
+        assert!(out.contains("\"account_id\":\"u1\""));
+        assert!(out.contains("\"error\":\"HTTP 404\""));
+    }
+
+    #[test]
+    fn confluence_user_get_results_jsonl() {
+        use crate::atlassian::client::{ConfluenceUserGetResults, ConfluenceUserRecord};
+        let list = ConfluenceUserGetResults {
+            users: vec![ConfluenceUserRecord {
+                account_id: "abc".to_string(),
+                display_name: Some("Alice".to_string()),
+                email: Some("a@x.com".to_string()),
+                account_type: Some("atlassian".to_string()),
+                active: None,
+                error: None,
+            }],
+        };
+        let out = jsonl_string(&list);
+        assert_eq!(out.lines().count(), 1);
+        assert!(out.contains("\"account_id\":\"abc\""));
+    }
+
+    #[test]
     fn jira_dev_status_jsonl_single_line() {
         let status = JiraDevStatus {
             pull_requests: vec![],

--- a/src/cli/atlassian/format.rs
+++ b/src/cli/atlassian/format.rs
@@ -7,9 +7,10 @@ use clap::ValueEnum;
 use serde::Serialize;
 
 use crate::atlassian::client::{
-    AgileBoardList, AgileSprintList, ConfluenceSearchResults, ConfluenceUserSearchResults,
-    CreateMeta, JiraDevStatus, JiraDevStatusSummary, JiraProjectList, JiraProjectVersionList,
-    JiraSearchResult, JiraUserSearchResults, JiraWatcherList, JiraWorklogList,
+    AgileBoardList, AgileSprintList, ConfluenceSearchResults, ConfluenceUserGetResults,
+    ConfluenceUserSearchResults, CreateMeta, JiraDevStatus, JiraDevStatusSummary, JiraProjectList,
+    JiraProjectVersionList, JiraSearchResult, JiraUserGetResults, JiraUserSearchResults,
+    JiraWatcherList, JiraWorklogList,
 };
 use crate::atlassian::confluence_api::{
     ConfluenceAttachmentPage, ConfluenceSpacePage, PageSummaryPage,
@@ -156,6 +157,18 @@ impl JsonlSerialize for PageSummaryPage {
 }
 
 impl JsonlSerialize for JiraUserSearchResults {
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
+        write_items_jsonl(self.users.iter(), out)
+    }
+}
+
+impl JsonlSerialize for JiraUserGetResults {
+    fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
+        write_items_jsonl(self.users.iter(), out)
+    }
+}
+
+impl JsonlSerialize for ConfluenceUserGetResults {
     fn write_jsonl(&self, out: &mut dyn Write) -> Result<()> {
         write_items_jsonl(self.users.iter(), out)
     }

--- a/src/cli/atlassian/jira/changelog.rs
+++ b/src/cli/atlassian/jira/changelog.rs
@@ -10,6 +10,9 @@ use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
 /// Shows change history for one or more JIRA issues.
+///
+/// Change authors are returned as Atlassian account IDs — resolve them to
+/// display names with `omni-dev atlassian jira user get`.
 #[derive(Parser)]
 pub struct ChangelogCommand {
     /// Issue keys, comma-separated (e.g., PROJ-1 or PROJ-1,PROJ-2).

--- a/src/cli/atlassian/jira/comment.rs
+++ b/src/cli/atlassian/jira/comment.rs
@@ -42,6 +42,9 @@ impl CommentCommand {
 }
 
 /// Lists comments on a JIRA issue.
+///
+/// Comment authors are returned as Atlassian account IDs — resolve them to
+/// display names with `omni-dev atlassian jira user get`.
 #[derive(Parser)]
 pub struct ListCommand {
     /// JIRA issue key (e.g., PROJ-123).

--- a/src/cli/atlassian/jira/read.rs
+++ b/src/cli/atlassian/jira/read.rs
@@ -9,6 +9,9 @@ use crate::cli::atlassian::format::ContentFormat;
 use crate::cli::atlassian::helpers::{create_client, run_read, run_read_jira_with_fields};
 
 /// Fetches a JIRA issue and outputs it as JFM markdown or ADF JSON.
+///
+/// Assignee/reporter and other people fields are Atlassian account IDs —
+/// resolve them to display names with `omni-dev atlassian jira user get`.
 #[derive(Parser)]
 pub struct ReadCommand {
     /// JIRA issue key (e.g., PROJ-123).

--- a/src/cli/atlassian/jira/user.rs
+++ b/src/cli/atlassian/jira/user.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use crate::atlassian::client::{AtlassianClient, JiraUserSearchResults};
+use crate::atlassian::client::{AtlassianClient, JiraUserGetResults, JiraUserSearchResults};
 use crate::cli::atlassian::format::{output_as, OutputFormat};
 use crate::cli::atlassian::helpers::create_client;
 
@@ -20,6 +20,8 @@ pub struct UserCommand {
 pub enum UserSubcommands {
     /// Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool).
     Search(UserSearchCommand),
+    /// Resolves account IDs to user records — the reverse of `search` (mirrors the `jira_user_get` MCP tool).
+    Get(UserGetCommand),
 }
 
 impl UserCommand {
@@ -27,6 +29,7 @@ impl UserCommand {
     pub async fn execute(self) -> Result<()> {
         match self.command {
             UserSubcommands::Search(cmd) => cmd.execute().await,
+            UserSubcommands::Get(cmd) => cmd.execute().await,
         }
     }
 }
@@ -112,6 +115,94 @@ fn print_user_results(result: &JiraUserSearchResults) {
     }
 }
 
+/// Resolves JIRA account IDs to user records (the reverse of `search`).
+#[derive(Parser)]
+pub struct UserGetCommand {
+    /// Account ID to resolve (repeat for a bulk lookup). Unknown or deactivated
+    /// IDs are returned as a stub record with an `error` field rather than
+    /// failing the whole batch.
+    #[arg(long = "account-id", required = true)]
+    pub account_id: Vec<String>,
+
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl UserGetCommand {
+    /// Executes the user lookup and prints results.
+    pub async fn execute(self) -> Result<()> {
+        let (client, _instance_url) = create_client()?;
+        run_get(&client, &self.account_id, &self.output).await
+    }
+}
+
+async fn run_get(
+    client: &AtlassianClient,
+    account_ids: &[String],
+    output: &OutputFormat,
+) -> Result<()> {
+    let result = client.get_jira_users(account_ids).await?;
+    if output_as(&result, output)? {
+        return Ok(());
+    }
+    print_user_get_results(&result);
+    Ok(())
+}
+
+/// Prints resolved JIRA user records as a formatted table.
+fn print_user_get_results(result: &JiraUserGetResults) {
+    if result.users.is_empty() {
+        println!("No users resolved.");
+        return;
+    }
+
+    let id_width = result
+        .users
+        .iter()
+        .map(|u| u.account_id.len())
+        .max()
+        .unwrap_or(10)
+        .max(10);
+    let name_width = result
+        .users
+        .iter()
+        .map(|u| u.display_name.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    println!(
+        "{:<id_width$}  {:<name_width$}  ACTIVE  EMAIL",
+        "ACCOUNT_ID", "NAME"
+    );
+    println!(
+        "{:<id_width$}  {:<name_width$}  ------  -----",
+        "-".repeat(id_width),
+        "-".repeat(name_width),
+    );
+
+    for user in &result.users {
+        // A failed lookup carries only account_id + error; surface the reason
+        // in the NAME column so a table reader still sees what went wrong.
+        let name = match (&user.display_name, &user.error) {
+            (Some(name), _) => name.clone(),
+            (None, Some(err)) => format!("({err})"),
+            (None, None) => "-".to_string(),
+        };
+        let active = match user.active {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "-",
+        };
+        let email = user.email_address.as_deref().unwrap_or("-");
+        println!(
+            "{:<id_width$}  {:<name_width$}  {active:<6}  {email}",
+            user.account_id, name,
+        );
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -121,7 +212,7 @@ fn print_user_results(result: &JiraUserSearchResults) {
 mod tests {
     use super::*;
     use crate::atlassian::auth::{ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL};
-    use crate::atlassian::client::JiraUserSearchResult;
+    use crate::atlassian::client::{JiraUserRecord, JiraUserSearchResult};
 
     fn mock_client(base_url: &str) -> AtlassianClient {
         AtlassianClient::new(base_url, "user@test.com", "token").unwrap()
@@ -313,6 +404,145 @@ mod tests {
             command: UserSubcommands::Search(UserSearchCommand {
                 query: "nobody".to_string(),
                 limit: 25,
+                output: OutputFormat::Yaml,
+            }),
+        };
+        cmd.execute().await.unwrap();
+    }
+
+    // ── user get (account ID → record) ────────────────────────────
+
+    fn sample_record(
+        account_id: &str,
+        display_name: Option<&str>,
+        active: Option<bool>,
+        error: Option<&str>,
+    ) -> JiraUserRecord {
+        JiraUserRecord {
+            account_id: account_id.to_string(),
+            display_name: display_name.map(String::from),
+            email_address: None,
+            active,
+            account_type: Some("atlassian".to_string()),
+            error: error.map(String::from),
+        }
+    }
+
+    #[test]
+    fn print_get_results_empty() {
+        print_user_get_results(&JiraUserGetResults { users: vec![] });
+    }
+
+    #[test]
+    fn print_get_results_with_users_and_error() {
+        let result = JiraUserGetResults {
+            users: vec![
+                sample_record("abc123", Some("Alice"), Some(true), None),
+                sample_record("gone1", None, Some(false), None),
+                sample_record("bad", None, None, Some("HTTP 404")),
+            ],
+        };
+        print_user_get_results(&result);
+    }
+
+    #[tokio::test]
+    async fn run_get_table_output() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "displayName": "Alice Smith",
+                    "active": true,
+                    "accountType": "atlassian"
+                })),
+            )
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["abc123".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Table).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_get_json_output() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["missing".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Json).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_get_batch_survives_bad_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .and(wiremock::matchers::query_param("accountId", "good"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "good",
+                    "displayName": "Good User",
+                    "active": true
+                })),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .and(wiremock::matchers::query_param("accountId", "bad"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["good".to_string(), "bad".to_string()];
+        assert!(run_get(&client, &ids, &OutputFormat::Yaml).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_get_command_execute_round_trip() {
+        let _lock = env_lock();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc123",
+                    "displayName": "Alice",
+                    "active": true,
+                    "accountType": "atlassian"
+                })),
+            )
+            .mount(&server)
+            .await;
+        let _env = EnvGuard::set(&server.uri());
+
+        let cmd = UserGetCommand {
+            account_id: vec!["abc123".to_string()],
+            output: OutputFormat::Json,
+        };
+        cmd.execute().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_command_dispatches_to_get() {
+        let _lock = env_lock();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/rest/api/3/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let _env = EnvGuard::set(&server.uri());
+
+        let cmd = UserCommand {
+            command: UserSubcommands::Get(UserGetCommand {
+                account_id: vec!["missing".to_string()],
                 output: OutputFormat::Yaml,
             }),
         };

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -3351,6 +3351,33 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn confluence_user_get_handler_success_path_via_mock() {
+        let _lock = env_lock();
+        let srv = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc",
+                    "accountType": "atlassian",
+                    "displayName": "Alice"
+                })),
+            )
+            .mount(&srv)
+            .await;
+        let _env = EnvGuard::set(&srv.uri());
+
+        let server = make_server();
+        let result = server
+            .confluence_user_get(Parameters(ConfluenceUserGetParams {
+                account_ids: vec!["abc".to_string()],
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn confluence_search_handler_error_path() {
         let _lock = env_lock();
         clear_env();
@@ -5375,6 +5402,47 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── get_users_yaml ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_users_yaml_resolves_record() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .and(wiremock::matchers::query_param("accountId", "abc"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "accountId": "abc",
+                    "accountType": "atlassian",
+                    "displayName": "Alice"
+                })),
+            )
+            .mount(&server)
+            .await;
+        let ids = vec!["abc".to_string()];
+        let yaml = get_users_yaml(&phase2d_mock_client(&server.uri()), &ids)
+            .await
+            .unwrap();
+        assert!(yaml.contains("Alice"));
+        assert!(yaml.contains("abc"));
+    }
+
+    #[tokio::test]
+    async fn get_users_yaml_stubs_unknown_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/wiki/rest/api/user"))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let ids = vec!["missing".to_string()];
+        let yaml = get_users_yaml(&phase2d_mock_client(&server.uri()), &ids)
+            .await
+            .unwrap();
+        assert!(yaml.contains("account_id: missing"));
+        assert!(yaml.contains("error:"));
     }
 
     // ── confluence_compare / confluence_compare_section ────────────

--- a/src/mcp/confluence_tools.rs
+++ b/src/mcp/confluence_tools.rs
@@ -359,6 +359,14 @@ pub struct ConfluenceUserSearchParams {
     pub limit: Option<u32>,
 }
 
+/// Parameters for the `confluence_user_get` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfluenceUserGetParams {
+    /// One or more Atlassian account IDs to resolve
+    /// (e.g. `557058:00ce7e71-9edc-47da-a0c6-f796533ae2cd`).
+    pub account_ids: Vec<String>,
+}
+
 /// Parameters for the `confluence_attachment_upload` tool.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ConfluenceAttachmentUploadParams {
@@ -1045,6 +1053,13 @@ pub async fn search_users_yaml(
     to_yaml(&results)
 }
 
+/// Builds the YAML output for the `confluence_user_get` tool — resolves the
+/// given account IDs to user records.
+pub async fn get_users_yaml(client: &AtlassianClient, account_ids: &[String]) -> Result<String> {
+    let results = client.get_confluence_users(account_ids).await?;
+    to_yaml(&results)
+}
+
 /// Uploads a file as an attachment and returns YAML for the resulting attachment.
 pub async fn upload_attachment_result(
     api: &ConfluenceApi,
@@ -1205,6 +1220,8 @@ impl OmniDevServer {
                        a short YAML summary (path/bytes/format) — useful for large pages. This reads a \
                        single page; to fetch a whole page tree or an entire space to disk, use \
                        `confluence_download` instead. \
+                       Any author/version metadata is returned as Atlassian account IDs — resolve them to \
+                       display names with `confluence_user_get`. \
                        Mirrors `omni-dev atlassian confluence read`."
     )]
     pub async fn confluence_read(
@@ -1388,11 +1405,12 @@ impl OmniDevServer {
         description = "List version history (metadata only) for a Confluence page. \
                        Returns version number, timestamp, author account ID, edit \
                        message, and minor-edit flag for each version, newest-first. \
-                       Does NOT fetch version bodies — use `confluence_read` for \
-                       content. `since` filters to versions at or after a numeric \
-                       version (\"5\") or ISO 8601 date (\"2026-01-01T00:00:00Z\"). \
-                       `limit` defaults to 20; `0` means unlimited. Mirrors \
-                       `omni-dev atlassian confluence history`."
+                       Resolve those author account IDs to display names with \
+                       `confluence_user_get`. Does NOT fetch version bodies — use \
+                       `confluence_read` for content. `since` filters to versions at or \
+                       after a numeric version (\"5\") or ISO 8601 date \
+                       (\"2026-01-01T00:00:00Z\"). `limit` defaults to 20; `0` means \
+                       unlimited. Mirrors `omni-dev atlassian confluence history`."
     )]
     pub async fn confluence_history(
         &self,
@@ -1415,8 +1433,10 @@ impl OmniDevServer {
     #[tool(description = "List comments on a Confluence page (auto-paginated). \
                        `kind` selects \"footer\", \"inline\", or \"all\" (default — \
                        both kinds merged and sorted by creation time). `limit` of 0 \
-                       returns every comment. Mirrors \
-                       `omni-dev atlassian confluence comment list`.")]
+                       returns every comment. Comment authors are returned as Atlassian \
+                       account IDs (e.g. `557058:...`) — resolve them to display names \
+                       with `confluence_user_get` (pass every distinct author ID in one \
+                       call). Mirrors `omni-dev atlassian confluence comment list`.")]
     pub async fn confluence_comment_list(
         &self,
         Parameters(params): Parameters<ConfluenceCommentListParams>,
@@ -1579,6 +1599,29 @@ impl OmniDevServer {
     ) -> Result<CallToolResult, McpError> {
         let (client, _url) = create_client().map_err(tool_error)?;
         let yaml = search_users_yaml(&client, &params.query, params.limit.unwrap_or(25))
+            .await
+            .map_err(tool_error)?;
+        Ok(CallToolResult::success(vec![Content::text(yaml)]))
+    }
+
+    /// Resolves Confluence account IDs to user records.
+    #[tool(
+        description = "Resolve one or more Atlassian `account_id`s (as emitted by author \
+                       fields in `confluence_comment_list`, `confluence_history`, \
+                       `confluence_read`, etc.) to user records — the reverse of \
+                       `confluence_user_search`. Returns YAML with one entry per requested ID: \
+                       `account_id`, `display_name`, `email` (when accessible), and \
+                       `account_type`. Pass every distinct author ID from a batch in one call. \
+                       Unknown, anonymised, or permission-denied IDs come back as a stub record \
+                       with an `error` field (the batch never fails). Mirrors \
+                       `omni-dev atlassian confluence user get`."
+    )]
+    pub async fn confluence_user_get(
+        &self,
+        Parameters(params): Parameters<ConfluenceUserGetParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _url) = create_client().map_err(tool_error)?;
+        let yaml = get_users_yaml(&client, &params.account_ids)
             .await
             .map_err(tool_error)?;
         Ok(CallToolResult::success(vec![Content::text(yaml)]))
@@ -4294,6 +4337,7 @@ mod tests {
             "confluence_label_add",
             "confluence_label_remove",
             "confluence_user_search",
+            "confluence_user_get",
             "confluence_attachment_upload",
             "confluence_attachment_list",
             "confluence_attachment_download",

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -375,6 +375,14 @@ pub struct JiraUserSearchParams {
     pub limit: Option<u32>,
 }
 
+/// Parameters for the `jira_user_get` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct JiraUserGetParams {
+    /// One or more Atlassian account IDs to resolve
+    /// (e.g. `557058:00ce7e71-9edc-47da-a0c6-f796533ae2cd`).
+    pub account_ids: Vec<String>,
+}
+
 // ── format helpers ─────────────────────────────────────────────────────────
 
 /// Output format for JIRA read/write operations.
@@ -1062,6 +1070,12 @@ async fn run_jira_user_search(client: &AtlassianClient, query: &str, limit: u32)
     yaml_result(&result)
 }
 
+/// Resolves JIRA account IDs to user records and returns the result as YAML.
+async fn run_jira_user_get(client: &AtlassianClient, account_ids: &[String]) -> Result<String> {
+    let result = client.get_jira_users(account_ids).await?;
+    yaml_result(&result)
+}
+
 // ── tool router ────────────────────────────────────────────────────────────
 
 #[allow(missing_docs)] // #[tool_router] generates a pub `jira_core_tool_router` fn.
@@ -1074,7 +1088,9 @@ impl OmniDevServer {
                        `omni-dev://specs/jfm`) or the raw ADF description JSON when \
                        `format = \"adf\"`. When `output_file` is set, the content is written \
                        to that path and the tool returns a short YAML summary \
-                       (path/bytes/format) — useful for large issues."
+                       (path/bytes/format) — useful for large issues. Assignee/reporter and \
+                       other people fields are Atlassian account IDs — resolve them to \
+                       display names with `jira_user_get`."
     )]
     pub async fn jira_read(
         &self,
@@ -1291,9 +1307,10 @@ impl OmniDevServer {
                        `action = \"list\"` returns comments as YAML; `action = \"add\"` posts the \
                        given `body` (JFM markdown — GitHub-style, see resource \
                        `omni-dev://specs/jfm`). Supply the body as `body` (inline) OR `body_path` \
-                       (a filesystem path the server reads) — not both. To change the text of an \
-                       existing comment use `jira_comment_edit` (it needs the comment id from the \
-                       `list` output)."
+                       (a filesystem path the server reads) — not both. Listed comment authors \
+                       are Atlassian account IDs — resolve them to display names with \
+                       `jira_user_get`. To change the text of an existing comment use \
+                       `jira_comment_edit` (it needs the comment id from the `list` output)."
     )]
     pub async fn jira_comment(
         &self,
@@ -1377,6 +1394,29 @@ impl OmniDevServer {
         let limit = params.limit.unwrap_or(25);
         let (client, _instance_url) = create_client().map_err(tool_error)?;
         let text = run_jira_user_search(&client, &params.query, limit)
+            .await
+            .map_err(tool_error)?;
+        ok_text(text)
+    }
+
+    /// Tool: resolve JIRA account IDs to user records.
+    #[tool(
+        description = "Resolve one or more Atlassian `account_id`s (as emitted by author \
+                       fields in `jira_comment`, `jira_read`, `jira_changelog`, etc.) to user \
+                       records — the reverse of `jira_user_search`. Returns YAML with one entry \
+                       per requested ID: `account_id`, `display_name`, `email_address` (often \
+                       redacted by GDPR), `active`, and `account_type`. Pass every distinct \
+                       author ID from a batch in one call. Unknown, anonymised, or \
+                       permission-denied IDs come back as a stub record with an `error` field \
+                       (the batch never fails); deactivated accounts resolve normally with \
+                       `active: false`. Mirrors `omni-dev atlassian jira user get`."
+    )]
+    pub async fn jira_user_get(
+        &self,
+        Parameters(params): Parameters<JiraUserGetParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let (client, _instance_url) = create_client().map_err(tool_error)?;
+        let text = run_jira_user_get(&client, &params.account_ids)
             .await
             .map_err(tool_error)?;
         ok_text(text)

--- a/src/mcp/jira_core_tools.rs
+++ b/src/mcp/jira_core_tools.rs
@@ -1431,6 +1431,7 @@ impl OmniDevServer {
 )]
 mod tests {
     use super::*;
+    use crate::atlassian::auth::{ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL};
     use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -1446,25 +1447,22 @@ mod tests {
         CatalogueCache::new(std::time::Duration::from_secs(60))
     }
 
-    /// Serialize env-backed handler tests — the tool handlers build their
-    /// client via `create_client()`, which reads process-wide environment
-    /// variables. Routes through the crate-wide `AUTH_ENV_MUTEX` so we don't
-    /// race env-mutating tests in other Atlassian-touching modules.
+    fn make_server() -> OmniDevServer {
+        OmniDevServer::new()
+    }
+
+    /// Serialize env-backed tests — `create_client()` reads process-wide env
+    /// vars, so concurrent tests would race without the crate-wide lock.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         crate::atlassian::auth::test_util::AUTH_ENV_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// Points the ATLASSIAN_* credentials at a mock server for the duration of
-    /// a handler test, restoring the prior (empty) state on drop.
     struct EnvGuard;
 
     impl EnvGuard {
         fn set(instance_url: &str) -> Self {
-            use crate::atlassian::auth::{
-                ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL,
-            };
             std::env::set_var(ATLASSIAN_INSTANCE_URL, instance_url);
             std::env::set_var(ATLASSIAN_EMAIL, "user@test.com");
             std::env::set_var(ATLASSIAN_API_TOKEN, "fake-token");
@@ -1474,9 +1472,6 @@ mod tests {
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            use crate::atlassian::auth::{
-                ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_INSTANCE_URL,
-            };
             std::env::remove_var(ATLASSIAN_INSTANCE_URL);
             std::env::remove_var(ATLASSIAN_EMAIL);
             std::env::remove_var(ATLASSIAN_API_TOKEN);
@@ -4134,6 +4129,71 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("403"));
+    }
+
+    // ── run_jira_user_get ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_jira_user_get_resolves_record() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/user"))
+            .and(query_param("accountId", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accountId": "abc123",
+                "displayName": "Alice Smith",
+                "active": true,
+                "accountType": "atlassian"
+            })))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["abc123".to_string()];
+        let yaml = run_jira_user_get(&client, &ids).await.unwrap();
+        assert!(yaml.contains("account_id: abc123"));
+        assert!(yaml.contains("display_name: Alice Smith"));
+        assert!(yaml.contains("active: true"));
+    }
+
+    #[tokio::test]
+    async fn run_jira_user_get_stubs_unknown_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/user"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server.uri());
+        let ids = vec!["missing".to_string()];
+        let yaml = run_jira_user_get(&client, &ids).await.unwrap();
+        assert!(yaml.contains("account_id: missing"));
+        assert!(yaml.contains("error:"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn jira_user_get_handler_success_path_via_mock() {
+        let _lock = env_lock();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accountId": "abc123",
+                "displayName": "Alice",
+                "active": true,
+                "accountType": "atlassian"
+            })))
+            .mount(&server)
+            .await;
+        let _env = EnvGuard::set(&server.uri());
+
+        let srv = make_server();
+        let result = srv
+            .jira_user_get(Parameters(JiraUserGetParams {
+                account_ids: vec!["abc123".to_string()],
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
     }
 
     // ── ok_text / yaml_result helpers ──────────────────────────────────────

--- a/src/mcp/jira_tools.rs
+++ b/src/mcp/jira_tools.rs
@@ -1517,8 +1517,9 @@ impl OmniDevServer {
     /// Tool: get the change history for an issue.
     #[tool(
         description = "Get the change history for a JIRA issue. Returns YAML with one entry \
-                       per change (author, timestamp, items). Mirrors `omni-dev atlassian jira \
-                       changelog`."
+                       per change (author, timestamp, items). The author is an Atlassian \
+                       account ID — resolve it to a display name with `jira_user_get`. \
+                       Mirrors `omni-dev atlassian jira changelog`."
     )]
     pub async fn jira_changelog(
         &self,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -187,6 +187,7 @@ mod tests {
             "confluence_label_add",
             "confluence_label_remove",
             "confluence_user_search",
+            "confluence_user_get",
             "confluence_attachment_upload",
             "confluence_attachment_list",
             "confluence_attachment_download",
@@ -339,6 +340,7 @@ mod tests {
             "jira_comment_edit",
             "jira_dev",
             "jira_user_search",
+            "jira_user_get",
         ] {
             assert!(server.tool_router.has_route(name), "missing tool: {name}");
         }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -886,10 +886,25 @@ Usage: user <COMMAND>
 
 Commands:
   search  Searches Confluence users by display name or email (mirrors the `confluence_user_search` MCP tool)
+  get     Resolves account IDs to user records — the reverse of `search` (mirrors the `confluence_user_get` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian confluence user get - Resolves account IDs to user records — the reverse of `search` (mirrors the `confluence_user_get` MCP tool)
+
+Resolves account IDs to user records — the reverse of `search` (mirrors the `confluence_user_get` MCP tool)
+
+Usage: get [OPTIONS] --account-id <ACCOUNT_ID>
+
+Options:
+      --account-id <ACCOUNT_ID>  Account ID to resolve (repeat for a bulk lookup). Unknown or deactivated IDs are returned as a stub record with an `error` field rather than failing the whole batch
+  -o, --output <OUTPUT>          Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help                     Print help (see more with '--help')
 
 
 ================================================================================
@@ -1706,10 +1721,25 @@ Usage: user <COMMAND>
 
 Commands:
   search  Searches JIRA users by display name or email substring (mirrors the `jira_user_search` MCP tool)
+  get     Resolves account IDs to user records — the reverse of `search` (mirrors the `jira_user_get` MCP tool)
   help    Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev atlassian jira user get - Resolves account IDs to user records — the reverse of `search` (mirrors the `jira_user_get` MCP tool)
+
+Resolves account IDs to user records — the reverse of `search` (mirrors the `jira_user_get` MCP tool)
+
+Usage: get [OPTIONS] --account-id <ACCOUNT_ID>
+
+Options:
+      --account-id <ACCOUNT_ID>  Account ID to resolve (repeat for a bulk lookup). Unknown or deactivated IDs are returned as a stub record with an `error` field rather than failing the whole batch
+  -o, --output <OUTPUT>          Output format [default: table] [possible values: table, json, yaml, yamls, jsonl]
+  -h, --help                     Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR adds reverse user lookup — resolving Atlassian account IDs to full user records — for both JIRA and Confluence. Many API responses (issue fields, comments, history, changelog) return people as opaque account IDs rather than display names. Previously there was no way to resolve those IDs within the tool; now there is.

The new `get` subcommand (`omni-dev atlassian jira user get` and `omni-dev atlassian confluence user get`) and corresponding MCP tools (`jira_user_get` / `confluence_user_get`) accept one or more account IDs and return structured user records. The implementation is failure-tolerant: unknown, anonymised, or permission-denied IDs resolve to stub records with an `error` field rather than aborting the batch — only a `401` (bad credentials) is treated as a hard error. Multiple IDs are fetched concurrently.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue

Fixes #1091

## Changes Made

**Core API Client (`src/atlassian/client.rs`):**
- Added `JiraUserRecord` and `JiraUserGetResults` structs for the JIRA user-get response
- Added `ConfluenceUserRecord` and `ConfluenceUserGetResults` structs for the Confluence user-get response
- Added `ConfluenceUserGetEntry` private deserialization helper (handles `displayName` / `publicName` fallback)
- Added `user_lookup_error()` helper that formats an `"HTTP {status}: {snippet}"` error string for stub records
- Implemented `get_jira_user()` / `get_jira_users()` — single and concurrent batch lookup via `GET /rest/api/3/user?accountId=`
- Implemented `get_confluence_user()` / `get_confluence_users()` — single and concurrent batch lookup via `GET /wiki/rest/api/user?accountId=`

**CLI (`src/cli/atlassian/jira/user.rs`, `src/cli/atlassian/confluence/user.rs`):**
- Added `UserGetCommand` struct with repeatable `--account-id` flag and `--output` format option for both JIRA and Confluence
- Added `Get(UserGetCommand)` variant to `UserSubcommands` enum and wired dispatch in `UserCommand::execute()`
- Added `run_get()` async helper and `print_user_get_results()` table formatter for both products

**Serialization (`src/cli/atlassian/format.rs`):**
- Added `JsonlSerialize` implementations for `JiraUserGetResults` and `ConfluenceUserGetResults`

**MCP Tools (`src/mcp/jira_core_tools.rs`, `src/mcp/confluence_tools.rs`, `src/mcp/jira_tools.rs`):**
- Added `JiraUserGetParams` and `ConfluenceUserGetParams` parameter structs
- Added `jira_user_get` and `confluence_user_get` MCP tools with detailed descriptions including GDPR/deactivation semantics
- Updated tool descriptions on `jira_read`, `jira_comment`, `jira_changelog`, `confluence_read`, `confluence_history`, `confluence_comment_list` to point to the new lookup tools when account IDs appear in output

**MCP Server (`src/mcp/server.rs`):**
- Registered `jira_user_get` and `confluence_user_get` in the server tool-route tests

**Documentation (`src/cli/atlassian/confluence/comment.rs`, `history.rs`, `read.rs`, `src/cli/atlassian/jira/changelog.rs`, `comment.rs`, `read.rs`):**
- Added doc-comment cross-references on commands that emit account IDs, directing users to the new `user get` subcommand

**Snapshots (`tests/snapshots/integration_test__help_all_output.snap`):**
- Updated help-all snapshot to include the new `get` subcommands and their usage text for both JIRA and Confluence

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

**New tests added in `src/atlassian/client.rs`:**
- `user_lookup_error_formats` — verifies empty-body and non-empty-body error string formatting
- `get_jira_user_success` — happy path with full field set
- `get_jira_user_deactivated_is_a_record_not_an_error` — deactivated account returns `active: false`, not an error
- `get_jira_user_not_found_yields_stub` — 404 becomes a stub record
- `get_jira_user_unauthorized_is_hard_error` — 401 propagates as `Err`
- `get_jira_users_batch_survives_one_bad_id` — batch continues when one ID returns 404
- `get_jira_users_empty_input_makes_no_requests` — empty slice makes no HTTP calls
- Equivalent set for Confluence: `get_confluence_user_success`, `get_confluence_user_falls_back_to_public_name`, `get_confluence_user_not_found_yields_stub`, `get_confluence_users_batch_survives_one_bad_id`

**New tests added in `src/cli/atlassian/jira/user.rs` and `confluence/user.rs`:**
- `print_get_results_empty` — table output with no users
- `print_get_results_with_users_and_error` — table output mixing success and stub records
- `run_get_table_output` / `run_get_json_output` / `run_get_batch_survives_bad_id` — output format variants via wiremock
- `user_get_command_execute_round_trip` — full command execute path
- `user_command_dispatches_to_get` — verifies `UserCommand` routes to `UserGetCommand`

### Test Commands
```bash
# Core test suite
cargo test

# Atlassian-specific tests
cargo test atlassian
cargo test user_get
cargo test user_lookup

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the failure-tolerance boundary (404/non-auth → stub; 401 → hard error) in `get_jira_user()` and `get_confluence_user()`
- [x] Backward compatibility — all new subcommands are purely additive; existing `search` behaviour is unchanged

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact on existing paths. Batch lookups (`get_jira_users` / `get_confluence_users`) use `futures::future::join_all` for concurrent requests, so a batch of N IDs takes roughly one round-trip time rather than N serial round-trips.

## Security Considerations

- [x] No security implications. The new endpoints use the same credential model as all existing Atlassian API calls. GDPR-redacted email addresses and anonymised accounts are handled gracefully (fields absent or stubbed) consistent with Atlassian's privacy model.

## Breaking Changes

None. All additions are new subcommands and MCP tools; no existing interfaces were modified.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Design decisions:**
- The `active` field is always `None` for `ConfluenceUserRecord` because the Confluence v1 `/wiki/rest/api/user` endpoint does not return an active flag; this is documented explicitly in both the struct and tool description.
- `displayName` falls back to `publicName` for Confluence app accounts which often omit `displayName`.
- The batch functions preserve request order in their output, matching the input slice order.