### PR TITLE
fix(request-log,docs): redact secret-bearing headers by name substring

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -114,7 +114,10 @@ omni-dev log -f --service browser-bridge
 No secret material is ever written, under any code path:
 
 - Auth headers/tokens are **redacted centrally** before writing; only a
-  non-secret `auth_principal` identity is ever kept.
+  non-secret `auth_principal` identity is ever kept. Redaction matches both a
+  fixed list of known header names and any name containing `auth`, `token`,
+  `key`, `secret`, `cookie`, `password`, `session`, `signature`, or
+  `credential` (case-insensitive).
 - Request/response bodies are **opt-in** via `OMNI_DEV_LOG_BODIES=1`.
 - The `OMNI_DEV_*` env snapshot redacts any name containing `TOKEN`, `SECRET`,
   `KEY`, `PASSWORD`, or `PASSWD`.

--- a/src/request_log.rs
+++ b/src/request_log.rs
@@ -502,12 +502,34 @@ const SENSITIVE_HEADERS: &[&str] = &[
     "x-omni-bridge-target",
 ];
 
+/// Substrings that mark a header name as secret-bearing (compared lowercased),
+/// guarding against off-list auth headers (e.g. `x-auth-token`,
+/// `x-goog-api-key`). False positives redact harmlessly.
+const SENSITIVE_HEADER_MARKERS: &[&str] = &[
+    "auth",
+    "token",
+    "secret",
+    "key",
+    "cookie",
+    "password",
+    "session",
+    "signature",
+    "credential",
+];
+
 /// Replaces sensitive header values with `REDACTED`, passing others through.
+///
+/// A header is sensitive when its lowercased name is in [`SENSITIVE_HEADERS`]
+/// or contains any [`SENSITIVE_HEADER_MARKERS`] substring.
 pub fn redact_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
     headers
         .iter()
         .map(|(name, value)| {
-            let redacted = SENSITIVE_HEADERS.contains(&name.to_ascii_lowercase().as_str());
+            let lower = name.to_ascii_lowercase();
+            let redacted = SENSITIVE_HEADERS.contains(&lower.as_str())
+                || SENSITIVE_HEADER_MARKERS
+                    .iter()
+                    .any(|marker| lower.contains(marker));
             (
                 name.clone(),
                 if redacted {
@@ -669,6 +691,42 @@ mod tests {
         assert_eq!(out["Authorization"], "REDACTED");
         assert_eq!(out["X-Api-Key"], "REDACTED");
         assert_eq!(out["Content-Type"], "application/json");
+    }
+
+    #[test]
+    fn off_list_secretish_headers_are_redacted() {
+        let mut headers = BTreeMap::new();
+        for name in [
+            "X-Auth-Token",
+            "x-amz-security-token",
+            "X-Goog-Api-Key",
+            "x-csrf-token",
+            "X-Vendor-Token",
+            "X-Omni-Bridge",
+        ] {
+            headers.insert(name.to_string(), "secret-value".to_string());
+        }
+        for name in [
+            "Content-Type",
+            "Accept",
+            "User-Agent",
+            "x-request-id",
+            "traceparent",
+        ] {
+            headers.insert(name.to_string(), "plain-value".to_string());
+        }
+        let out = redact_headers(&headers);
+        assert_eq!(out["X-Auth-Token"], "REDACTED");
+        assert_eq!(out["x-amz-security-token"], "REDACTED");
+        assert_eq!(out["X-Goog-Api-Key"], "REDACTED");
+        assert_eq!(out["x-csrf-token"], "REDACTED");
+        assert_eq!(out["X-Vendor-Token"], "REDACTED");
+        assert_eq!(out["X-Omni-Bridge"], "REDACTED");
+        assert_eq!(out["Content-Type"], "plain-value");
+        assert_eq!(out["Accept"], "plain-value");
+        assert_eq!(out["User-Agent"], "plain-value");
+        assert_eq!(out["x-request-id"], "plain-value");
+        assert_eq!(out["traceparent"], "plain-value");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1134 (low-severity latent finding from the #1101 security review).

`redact_headers` in `src/request_log.rs` redacted only header names on the
exact-match `SENSITIVE_HEADERS` denylist, so an off-list auth header
(`x-auth-token`, `x-amz-security-token`, `x-goog-api-key`, custom
`x-<vendor>-token`, …) would be written in the clear the moment a caller
starts populating `HttpExtra` headers. The path is currently dormant — no
emitter populates headers yet — so this hardens the control before it can
leak.

## Changes

- Add `SENSITIVE_HEADER_MARKERS`, a substring denylist (`auth`, `token`,
  `secret`, `key`, `cookie`, `password`, `session`, `signature`,
  `credential`) mirroring the existing `SECRETISH` env-var convention in the
  same file. A header is now redacted when its lowercased name is on the
  exact list **or** contains any marker. False positives (e.g.
  `www-authenticate`) redact harmlessly — the conservative direction for a
  security control.
- Keep the exact `SENSITIVE_HEADERS` list unchanged; it still covers
  `x-omni-bridge` / `x-omni-bridge-target`, which match no generic marker.
- New test `off_list_secretish_headers_are_redacted` covering marker-based
  redaction (mixed case), the exact-list path, and pass-through of safe
  headers (`Content-Type`, `Accept`, `User-Agent`, `x-request-id`,
  `traceparent`).
- Update the redaction-posture section of `docs/log.md` to document the
  two-tier match.

## Verification

- Full test suite passes (5313 lib tests + all integration suites, 0 failures)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- No CLI surface change, so no `insta` snapshot updates required