### PR TITLE
docs(browser): note stdout token exposure as accepted risk (#1148)

### DIFF
--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -122,6 +122,10 @@ prefix.
 - No request URLs, query expressions, headers, or bodies are logged at the default
   level (they carry authenticated/sensitive data); only connection lifecycle and
   rejection reasons are logged at `info`/`warn`.
+- A foreground `serve` prints the session token to stdout (the operator must
+  paste it into DevTools); capture of that output in terminal scrollback, tmux
+  logs, or CI transcripts is a residual exposure of a loopback-only,
+  process-lifetime credential — **accepted**; restart to rotate (#1148).
 
 ## Consequences
 

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -330,6 +330,14 @@ bridge runs.
   snippet cannot smuggle those — a relied-upon browser control.
 - No request URLs, queries, headers, or bodies are logged at the default level
   (they contain authenticated/sensitive data).
+- **Token in stdout / scrollback.** A foreground `serve` prints the session
+  token to stdout twice — the labeled `session token :` line and embedded in
+  the paste-ready snippet. This is required operator UX (the token must be
+  pasted into DevTools), but stdout can persist in terminal scrollback, tmux
+  logs (`capture-pane` / pane logging), or CI transcripts. The token is
+  loopback-only and dies with the process; if a transcript may be exposed,
+  restart `serve` to rotate it. Under the daemon nothing is printed — the token
+  lives only in the `0600` `bridge.token` file — **accepted** (#1148).
 
 ## Flags
 


### PR DESCRIPTION
## Summary

Documents the residual risk from issue #1148 (Info severity, found during the #1101 security review): a foreground `bridge serve` prints the session token to stdout — by design, since the operator must paste it into the DevTools snippet (ADR-0036) — and that output can persist in terminal scrollback, tmux logs, or CI transcripts.

Per the issue's fix direction, this is a **documentation-only** change:

- `docs/browser-bridge.md` — new bullet under *Accepted risks / relied-upon controls*: notes the token reaches stdout twice (labeled line + embedded in the snippet), the capture surfaces, restart-to-rotate guidance, and that daemon mode prints nothing (token lives only in the `0600` `bridge.token` file).
- `docs/adrs/adr-0036.md` — mirrored shorter bullet in the ADR's parallel *Accepted risks* list, keeping the ADR and operator guide in sync.

No code change; `src/browser/bridge.rs` untouched.

Closes #1148