### PR TITLE
docs: correct SO_REUSEADDR fail-closed binding prose

### DIFF
--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -98,8 +98,12 @@ the snippet is tampered with.
 Per-request timeout (`--request-timeout`, default 30s → `504` and drop from the
 pending map), max response body size (`--max-body-bytes`), and a concurrency
 semaphore (`--max-concurrent`) bound memory and prevent local DoS. Both listeners
-bind without `SO_REUSEADDR`; if a fixed port is taken the process exits rather than
-racing a possible squatter. Passing `0` for either port binds an OS-assigned free
+bind with `SO_REUSEADDR` so a restart can rebind the fixed ports immediately even
+when a just-closed connection still holds them in `TIME_WAIT` (#990); `SO_REUSEADDR`
+(unlike `SO_REUSEPORT`, which is not used) does not permit a second live listener on
+the same address+port, so if a fixed port is held by a live listener the bind still
+fails with `EADDRINUSE` and the process exits rather than racing a possible
+squatter. Passing `0` for either port binds an OS-assigned free
 port, read back from the listener and reflected in the printed snippet and the
 `Host` allowlist.
 

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -316,8 +316,10 @@ bridge runs.
 ### Resource & robustness limits
 - Per-request timeout (`--request-timeout`, default 30s → `504`), max response
   body size (`--max-body-bytes`), and a concurrency cap (`--max-concurrent`).
-- **Fail-closed binding**: ports bind without `SO_REUSEADDR`; if a fixed port is
-  taken, the bridge exits rather than racing a squatter.
+- **Fail-closed binding**: ports bind with `SO_REUSEADDR` so a restart can rebind
+  through a lingering `TIME_WAIT` (#990); a live listener on a fixed port still
+  yields `EADDRINUSE` and the bridge exits rather than racing a squatter
+  (`SO_REUSEADDR` ≠ `SO_REUSEPORT`).
 - Caller header names/values with CR/LF are rejected; the request path is
   normalized and traversal-checked before the `/__bridge/` routing split.
 


### PR DESCRIPTION
## Summary

Fixes documentation drift found in the #1101 security review: since #990, `bind_loopback_reuse` (`src/browser/bridge.rs`) binds both bridge planes **with** `SO_REUSEADDR`, but ADR-0036 and `docs/browser-bridge.md` still asserted the opposite.

Both locations now describe the actual behaviour and why fail-closed holds:

- `SO_REUSEADDR` lets a restart rebind the fixed ports immediately even when a just-closed connection still holds them in `TIME_WAIT` (#990).
- Unlike `SO_REUSEPORT` (not used), it does **not** permit a second live listener on the same address+port — a live squatter still yields `EADDRINUSE` and the process exits (covered by `start_fails_closed_on_taken_control_port`).

Docs-only; no code or CLI-surface changes.

Closes #1150