### PR TITLE
fix(daemon): close extra file descriptors from launchd socket activation

### DIFF
--- a/src/daemon/launchd.rs
+++ b/src/daemon/launchd.rs
@@ -226,8 +226,8 @@ fn bootout(domain: &str) {
 ///
 /// launchd hands us a `malloc`-ed array of inherited fds; we take ownership of
 /// the first (the plist declares exactly one), set it non-blocking, adopt it as a
-/// Tokio listener, and free the array. The symbol lives in libSystem, so no
-/// `#[link]` attribute is required.
+/// Tokio listener, close any extra descriptors, and free the array. The symbol
+/// lives in libSystem, so no `#[link]` attribute is required.
 #[allow(unsafe_code)]
 pub(crate) fn launchd_listener(name: &str) -> Result<Option<UnixListener>> {
     use nix::libc::{self, c_char, c_int, size_t};
@@ -269,6 +269,26 @@ pub(crate) fn launchd_listener(name: &str) -> Result<Option<UnixListener>> {
     // SAFETY: on success `fds` points at `cnt >= 1` ints; read the first, then
     // free the array exactly once. The fd stays valid after the array is freed.
     let raw = unsafe { *fds };
+
+    // The plist declares exactly one `Listener`, so `cnt` is always 1 in practice.
+    // Should the kernel ever hand us more, we adopt only the first; close the rest
+    // so they are not leaked for the process lifetime.
+    if cnt > 1 {
+        tracing::warn!(
+            "launch_activate_socket({name}) returned {cnt} descriptors; adopting the first and \
+             closing {} extra",
+            cnt - 1
+        );
+        for i in 1..cnt {
+            // SAFETY: `fds` points at `cnt` ints; `i` is in `1..cnt`, so `fds.add(i)`
+            // is in bounds. Each extra fd is owned by us and closed exactly once.
+            let extra = unsafe { *fds.add(i) };
+            unsafe { libc::close(extra) };
+        }
+    }
+
+    // SAFETY: non-null `fds` is the array launchd allocated; free it exactly once.
+    // The fds read above stay valid after the array itself is freed.
     unsafe { libc::free(fds.cast()) };
 
     // SAFETY: `raw` is a listening Unix-domain socket fd handed off by launchd and


### PR DESCRIPTION
## Description

When launchd performs socket activation, it hands the process a `malloc`-ed array of inherited file descriptors. The plist declares exactly one `Listener`, so in practice `cnt == 1`, but there is no guarantee the kernel will never return more. Previously, any extra descriptors beyond the first were silently ignored and left open for the entire process lifetime, constituting a file descriptor leak.

This PR fixes the leak by detecting when `launch_activate_socket()` returns more than one descriptor, logging a warning, and explicitly closing each extra fd before freeing the array. Only the first descriptor is adopted as the Tokio listener, which is the intended behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #1145

## Changes Made

**Core Changes:**
- Added a `cnt > 1` check in `launchd_listener()` in `src/daemon/launchd.rs` to detect unexpected extra file descriptors returned by `launch_activate_socket()`
- Added a `tracing::warn!` log message indicating how many extra descriptors were found and that only the first is being adopted
- Added a loop to call `libc::close()` on each extra descriptor (`fds[1..cnt]`) before freeing the array, preventing fd leaks
- Added `// SAFETY` comment to the existing `libc::free()` call to document ownership semantics

**Documentation:**
- Updated the doc comment on `launchd_listener()` to clarify that extra descriptors are closed in addition to adopting the first and freeing the array

## Testing

**Automated Testing:**
- [x] All existing tests pass

**Manual Testing:**
- [x] Tested happy path scenarios (normal single-descriptor launchd activation)
- [x] Backward compatibility verified — behavior is unchanged when `cnt == 1`

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — all `unsafe` blocks manipulating raw fds and the `malloc`-ed array include `// SAFETY` justifications
- [x] Error handling — extra fds are closed unconditionally; the warning is informational and does not affect the happy path
- [x] Backward compatibility — the added code only executes when `cnt > 1`, which never occurs under normal plist configuration

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — the extra-descriptor loop only runs in an edge case that should never occur in practice

## Security Considerations

- [x] Security improvement — explicitly closing leaked file descriptors reduces the process's exposed fd table surface and prevents potential resource exhaustion in pathological scenarios. All `unsafe` blocks are annotated with `// SAFETY` comments documenting invariants.

## Breaking Changes

None. This is a purely defensive fix; behavior is identical when `cnt == 1`.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Known Limitations:**
- The fix relies on `libc::close()` returning successfully; errors from `close()` are not currently checked. In practice, closing a valid fd inherited from launchd should never fail.

**Alternatives Considered:**
- Returning an error if `cnt > 1` was considered but rejected — the extra descriptors are a kernel implementation detail and shouldn't prevent the daemon from starting normally.