### PR TITLE
feat(browser): add binary request body support with base64 encoding

### DIFF
--- a/docs/adrs/adr-0036.md
+++ b/docs/adrs/adr-0036.md
@@ -149,7 +149,13 @@ prefix.
   Binary response bodies have since been added (#906): the snippet base64-encodes
   non-text bodies and tags the frame with `encoding: "base64"`, the proxy decodes
   before writing the HTTP response, and `--max-body-bytes` is accounted against
-  the decoded size.
+  the decoded size. Binary **request** bodies were later added symmetrically
+  (#1123): the CLI `--body-file` (or a raw caller setting `encoding: "base64"` on
+  the request) base64-encodes the body, the snippet decodes it to a byte array
+  before `fetch()`, and the new optional `encoding` field on `ControlRequest`/
+  `Command` uses the same `skip_serializing_if` contract so an absent value keeps
+  the wire byte-identical for older clients. This does not revisit the trust
+  boundary — it only widens the body representation.
 - Streaming/chunked response bodies have since been added (#907) as a
   caller-opt-in protocol extension that does **not** revisit the trust boundary:
   scope, token, and origin checks run on the streamed request exactly as for a

--- a/docs/browser-bridge.md
+++ b/docs/browser-bridge.md
@@ -169,7 +169,7 @@ curl -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
 | Method & path            | Purpose                                                                 |
 |--------------------------|-------------------------------------------------------------------------|
 | `GET  /__bridge/status`  | `{ "connected": bool, "browser_origin": str?, "tabs": [{id, origin?}], "pending": int }`. `tabs` lists every connected tab; `browser_origin` is the lone tab's origin (present only when exactly one is connected, for back-compat). |
-| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?, target?, allow_origin?, credentials?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Cross-origin `url` rejected unless `serve --allow-origin` or the per-request `allow_origin` permits it (see [Outbound request scope](#outbound-request-scope-default-closed)). See [Routing to a tab](#routing-to-a-specific-tab) for `target`. |
+| `POST /__bridge/request` | Full control. Body `{url, method, headers, body, stream?, target?, allow_origin?, credentials?, encoding?}`; returns a structured response envelope, or — when `"stream": true` — an NDJSON chunk stream (see [Streaming](#streaming-responses)). Set `"encoding": "base64"` to send a binary `body` (see [Binary request bodies](#binary-request-bodies)). Cross-origin `url` rejected unless `serve --allow-origin` or the per-request `allow_origin` permits it (see [Outbound request scope](#outbound-request-scope-default-closed)). See [Routing to a tab](#routing-to-a-specific-tab) for `target`. |
 
 ```bash
 curl -s -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
@@ -189,12 +189,16 @@ curl -s -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
 ```bash
 omni-dev browser bridge request --url /loki/api/v1/labels --method GET
 omni-dev browser bridge request --url /api/foo --method POST --body @payload.json
+omni-dev browser bridge request --url /upload --method POST --body-file avatar.png
 omni-dev browser bridge request --control-port 9998 --url /api/foo   # custom port
 omni-dev browser bridge request --url /api/foo --header "Accept: application/json"
 omni-dev browser bridge request --url https://cdn.example.com/x.js --credentials omit
 ```
 
-`--body @file` reads the body from a file; otherwise the value is sent verbatim.
+`--body @file` reads the body from a file as UTF-8 text; otherwise the value is
+sent verbatim. `--body-file <path>` reads the body as **raw bytes** for binary
+payloads (see [Binary request bodies](#binary-request-bodies)); it is mutually
+exclusive with `--body`.
 
 `--credentials <include|omit|same-origin>` sets the browser `fetch()` credentials
 mode (default `include`, unchanged). Use `omit` to read a wildcard-CORS
@@ -208,6 +212,17 @@ Binary responses (images, gzipped blobs, file downloads) come back in the
 envelope as a base64 string with `"encoding": "base64"`; the caller decodes it.
 The transparent proxy (below) decodes automatically, so `curl` receives the raw
 bytes — pipe straight to a file with `--output`.
+
+#### Binary request bodies
+
+The request side is symmetric. `--body`/`@file` carries UTF-8 text only; to
+upload a binary payload (image, protobuf, gzip) use `--body-file <path>`, which
+reads the file as raw bytes and base64-encodes them on the wire. The browser
+snippet decodes the base64 back to a byte array before `fetch()`, so the upstream
+server receives the exact bytes. A raw `POST /__bridge/request` caller does the
+same by base64-encoding `body` and setting `"encoding": "base64"`; omitting
+`encoding` (the default) keeps `body` as UTF-8 text, byte-identical to older
+clients. The transparent proxy always forwards the inbound request body as text.
 
 Pass `--stream` to consume a streaming / chunked / long-lived endpoint (SSE,
 log-tail) instead of buffering the whole response: the decoded body bytes are
@@ -352,7 +367,9 @@ bridge runs.
 | `--token-file <PATH>` | — | Read the session token from this `0600` file instead of generating one. |
 
 The `request` subcommand takes `--url`, `--method` (default `GET`),
-`--header` (repeatable), `--body` (`@file` supported),
+`--header` (repeatable), `--body` (`@file` supported, UTF-8 text),
+`--body-file <path>` (raw-bytes binary body, base64 on the wire; mutually
+exclusive with `--body`),
 `--credentials <include|omit|same-origin>` (default `include`), `--stream`
 (chunk the response to stdout), `--target` (route to a connection id / origin —
 see [Routing to a specific tab](#routing-to-a-specific-tab)), `--allow-origin`

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -719,6 +719,9 @@ async fn proxy_handler(State(state): State<AppState>, request: Request) -> Respo
         // The transparent proxy has no per-request credentials control; it keeps
         // the snippet default (`include`), matching pre-credentials behavior.
         credentials: None,
+        // The proxy already lossily decodes the inbound body as UTF-8 text above,
+        // so it never tags a base64 request encoding.
+        encoding: None,
     };
 
     if stream {
@@ -983,6 +986,7 @@ async fn dispatch(
         body: req.body,
         stream: false,
         credentials: req.credentials,
+        encoding: req.encoding,
     };
     let frame = match serde_json::to_string(&command) {
         Ok(f) => f,
@@ -1161,6 +1165,7 @@ async fn start_stream(
         body: req.body,
         stream: true,
         credentials: req.credentials,
+        encoding: req.encoding,
     };
     let frame = match serde_json::to_string(&command) {
         Ok(f) => f,
@@ -1598,6 +1603,7 @@ mod tests {
             target: None,
             allow_origin: None,
             credentials: None,
+            encoding: None,
         }
     }
 

--- a/src/browser/client.rs
+++ b/src/browser/client.rs
@@ -94,6 +94,7 @@ mod tests {
             target: None,
             allow_origin: None,
             credentials: None,
+            encoding: None,
         }
     }
 

--- a/src/browser/harvest/facebook.rs
+++ b/src/browser/harvest/facebook.rs
@@ -521,6 +521,7 @@ impl Harvester {
             target: self.config.target.clone(),
             allow_origin: None,
             credentials: None,
+            encoding: None,
         }
     }
 
@@ -543,6 +544,7 @@ impl Harvester {
                 target: self.config.target.clone(),
                 allow_origin: Some(FBCDN_HOST.to_string()),
                 credentials: Some("omit".to_string()),
+                encoding: None,
             };
             tried += 1;
             // A single failing bundle must not abort discovery.
@@ -600,6 +602,7 @@ impl Harvester {
             target: self.config.target.clone(),
             allow_origin: None,
             credentials: None,
+            encoding: None,
         };
 
         let mut last_err = None;

--- a/src/browser/protocol.rs
+++ b/src/browser/protocol.rs
@@ -54,6 +54,12 @@ pub struct ControlRequest {
     /// the browser snippet defaults to `include`, preserving v1 behavior.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credentials: Option<String>,
+    /// Request-body transfer encoding. `Some("base64")` means `body` is a base64
+    /// string the browser snippet decodes to a byte array before `fetch()`;
+    /// absent (the default) means `body` is UTF-8 text, preserving v1
+    /// wire-compat. Mirrors the response-side `encoding` on [`BrowserReply`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
 }
 
 fn default_method() -> String {
@@ -91,6 +97,12 @@ pub struct Command {
     /// to let the browser snippet default to `include`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credentials: Option<String>,
+    /// Request-body transfer encoding. `Some("base64")` tells the browser
+    /// snippet to decode `body` to a byte array before `fetch()`; absent (the
+    /// default) means `body` is UTF-8 text, kept off the wire for back-compat
+    /// with buffered clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
 }
 
 /// Server → browser cancellation frame.
@@ -385,6 +397,7 @@ mod tests {
             target: None,
             allow_origin: None,
             credentials: None,
+            encoding: None,
         };
         // Back-compat: an absent override is not serialised, so the wire body
         // stays byte-identical to a pre-feature client's.
@@ -411,6 +424,7 @@ mod tests {
             body: None,
             stream: false,
             credentials: None,
+            encoding: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(!json.contains('\n'));
@@ -430,6 +444,7 @@ mod tests {
             body: None,
             stream: true,
             credentials: None,
+            encoding: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"stream\":true"));
@@ -530,6 +545,7 @@ mod tests {
             target: None,
             allow_origin: None,
             credentials: None,
+            encoding: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("credentials"));
@@ -545,9 +561,52 @@ mod tests {
             body: None,
             stream: false,
             credentials: Some("omit".to_string()),
+            encoding: None,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains(r#""credentials":"omit""#));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn request_encoding_omitted_when_absent_and_round_trips_when_present() {
+        // Absent (the default): a base64 request encoding is never serialised, so
+        // the wire stays byte-identical to a pre-feature client's.
+        let cmd = Command {
+            id: 3,
+            url: "/upload".to_string(),
+            method: "POST".to_string(),
+            headers: BTreeMap::new(),
+            body: Some("plain".to_string()),
+            stream: false,
+            credentials: None,
+            encoding: None,
+        };
+        assert!(!serde_json::to_string(&cmd).unwrap().contains("encoding"));
+
+        // Present: `encoding: "base64"` round-trips on both request-side types.
+        let req = ControlRequest {
+            url: "/upload".to_string(),
+            method: "POST".to_string(),
+            headers: BTreeMap::new(),
+            body: Some("aGk=".to_string()),
+            stream: false,
+            target: None,
+            allow_origin: None,
+            credentials: None,
+            encoding: Some("base64".to_string()),
+        };
+        let back: ControlRequest =
+            serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
+        assert_eq!(back.encoding.as_deref(), Some("base64"));
+
+        let cmd = Command {
+            encoding: Some("base64".to_string()),
+            ..cmd
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains(r#""encoding":"base64""#));
         let back: Command = serde_json::from_str(&json).unwrap();
         assert_eq!(cmd, back);
     }

--- a/src/cli/browser/bridge.rs
+++ b/src/cli/browser/bridge.rs
@@ -202,6 +202,7 @@ mod tests {
                 method: "GET".to_string(),
                 headers: Vec::new(),
                 body: None,
+                body_file: None,
                 // Port 0 never has a listener, so the client fails fast.
                 control_port: 0,
                 token_file: None,

--- a/src/cli/browser/request.rs
+++ b/src/cli/browser/request.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -65,8 +65,15 @@ pub struct RequestCommand {
     pub headers: Vec<String>,
 
     /// Request body. Prefix with `@` to read from a file (e.g. `@payload.json`).
+    /// UTF-8 text only; use `--body-file` for binary payloads.
     #[arg(long)]
     pub body: Option<String>,
+
+    /// Read the request body from a file as raw bytes, base64-encoded on the
+    /// wire (the browser decodes it before `fetch()`). Use for binary payloads
+    /// such as images, protobuf, or gzip. Mutually exclusive with `--body`.
+    #[arg(long, value_name = "PATH", conflicts_with = "body")]
+    pub body_file: Option<PathBuf>,
 
     /// Fetch credentials mode. Defaults to `include` (cookies/auth sent). Use
     /// `omit` to read a wildcard-CORS cross-origin response (e.g. a public CDN
@@ -108,7 +115,7 @@ impl RequestCommand {
     pub async fn execute(self) -> Result<()> {
         let token = super::resolve_client_token(self.token_file.as_deref())?;
         let headers = parse_headers(&self.headers)?;
-        let body = resolve_body(self.body.as_deref())?;
+        let (body, encoding) = resolve_body(self.body.as_deref(), self.body_file.as_deref())?;
 
         let payload = ControlRequest {
             url: self.url,
@@ -119,6 +126,7 @@ impl RequestCommand {
             target: self.target,
             allow_origin: self.allow_origin,
             credentials: self.credentials.map(Credentials::to_fetch_value),
+            encoding,
         };
 
         let client = BridgeClient::new(self.control_port, token);
@@ -210,18 +218,33 @@ fn parse_headers(raw: &[String]) -> Result<BTreeMap<String, String>> {
     Ok(map)
 }
 
-/// Resolves a `--body` argument, reading from a file when prefixed with `@`.
-fn resolve_body(body: Option<&str>) -> Result<Option<String>> {
-    match body {
-        None => Ok(None),
-        Some(spec) => match spec.strip_prefix('@') {
+/// Resolves the request body into a `(body, encoding)` pair.
+///
+/// `--body` carries UTF-8 text (verbatim, or read from a file when prefixed with
+/// `@`) and never sets an encoding. `--body-file` reads raw bytes and
+/// base64-encodes them, tagging `encoding = "base64"` so the browser snippet
+/// decodes the body back to bytes before `fetch()`. The two are mutually
+/// exclusive (enforced by clap `conflicts_with`; re-checked here defensively).
+fn resolve_body(
+    body: Option<&str>,
+    body_file: Option<&Path>,
+) -> Result<(Option<String>, Option<String>)> {
+    match (body, body_file) {
+        (Some(_), Some(_)) => bail!("--body and --body-file are mutually exclusive"),
+        (None, Some(path)) => {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("Failed to read body file {}", path.display()))?;
+            Ok((Some(BASE64.encode(bytes)), Some("base64".to_string())))
+        }
+        (Some(spec), None) => match spec.strip_prefix('@') {
             Some(path) => {
                 let contents = std::fs::read_to_string(path)
                     .with_context(|| format!("Failed to read body file {path}"))?;
-                Ok(Some(contents))
+                Ok((Some(contents), None))
             }
-            None => Ok(Some(spec.to_string())),
+            None => Ok((Some(spec.to_string()), None)),
         },
+        (None, None) => Ok((None, None)),
     }
 }
 
@@ -290,16 +313,65 @@ mod tests {
 
     #[test]
     fn resolve_body_inline_and_file() {
-        assert_eq!(resolve_body(None).unwrap(), None);
-        assert_eq!(resolve_body(Some("hi")).unwrap(), Some("hi".to_string()));
+        // No body → no encoding.
+        assert_eq!(resolve_body(None, None).unwrap(), (None, None));
+        // Inline text → verbatim, no encoding.
+        assert_eq!(
+            resolve_body(Some("hi"), None).unwrap(),
+            (Some("hi".to_string()), None)
+        );
 
+        // `@file` → text contents, no encoding.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("payload.json");
         std::fs::write(&path, "{\"a\":1}").unwrap();
         let spec = format!("@{}", path.display());
         assert_eq!(
-            resolve_body(Some(&spec)).unwrap(),
-            Some("{\"a\":1}".to_string())
+            resolve_body(Some(&spec), None).unwrap(),
+            (Some("{\"a\":1}".to_string()), None)
         );
+    }
+
+    #[test]
+    fn resolve_body_file_base64_round_trips_binary() {
+        // Non-UTF-8 bytes that `read_to_string` would reject.
+        let raw: &[u8] = &[0xFF, 0xFE, 0x00, 0x01, 0x80];
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob.bin");
+        std::fs::write(&path, raw).unwrap();
+
+        let (body, encoding) = resolve_body(None, Some(path.as_path())).unwrap();
+        assert_eq!(encoding.as_deref(), Some("base64"));
+        // The base64 payload decodes back to the exact original bytes.
+        let decoded = BASE64.decode(body.unwrap().as_bytes()).unwrap();
+        assert_eq!(decoded, raw);
+    }
+
+    #[test]
+    fn resolve_body_file_always_base64_even_for_text() {
+        // `--body-file` is the raw-bytes path: it always base64-encodes, even a
+        // perfectly valid UTF-8 file (byte-exact on the wire either way).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("text.txt");
+        std::fs::write(&path, "hello").unwrap();
+
+        let (body, encoding) = resolve_body(None, Some(path.as_path())).unwrap();
+        assert_eq!(encoding.as_deref(), Some("base64"));
+        assert_eq!(BASE64.decode(body.unwrap().as_bytes()).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn body_and_body_file_are_mutually_exclusive() {
+        // clap rejects the two flags together (`conflicts_with`).
+        assert!(RequestCommand::try_parse_from([
+            "request",
+            "--url",
+            "/x",
+            "--body",
+            "hi",
+            "--body-file",
+            "payload.bin",
+        ])
+        .is_err());
     }
 }

--- a/src/templates/browser-bridge.js
+++ b/src/templates/browser-bridge.js
@@ -27,6 +27,14 @@
     }
     return btoa(bin);
   };
+  // Inverse of toBase64: decode a base64 request body to a Uint8Array so binary
+  // payloads (images, protobuf, gzip) go out over `fetch` byte-for-byte.
+  const fromBase64 = (b64) => {
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+  };
   const connect = () => {
     log('connecting to ' + ENDPOINT + ' …');
     ws = new WebSocket(ENDPOINT, [TOKEN]);
@@ -53,7 +61,7 @@
         const resp = await fetch(cmd.url, {
           method: cmd.method || 'GET',
           headers: cmd.headers || {},
-          body: cmd.body || undefined,
+          body: cmd.encoding === 'base64' ? fromBase64(cmd.body || '') : (cmd.body || undefined),
           credentials: cmd.credentials || 'include',
         });
         const headers = {};

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2095,7 +2095,8 @@ Options:
       --url <URL>                    Request URL, relative to the browser's page origin (e.g. `/api/foo`)
       --method <METHOD>              HTTP method [default: GET]
       --header <NAME: VALUE>         Request header as `Name: Value`. May be repeated
-      --body <BODY>                  Request body. Prefix with `@` to read from a file (e.g. `@payload.json`)
+      --body <BODY>                  Request body. Prefix with `@` to read from a file (e.g. `@payload.json`). UTF-8 text only; use `--body-file` for binary payloads
+      --body-file <PATH>             Read the request body from a file as raw bytes, base64-encoded on the wire (the browser decodes it before `fetch()`). Use for binary payloads such as images, protobuf, or gzip. Mutually exclusive with `--body`
       --credentials <CREDENTIALS>    Fetch credentials mode. Defaults to `include` (cookies/auth sent). Use `omit` to read a wildcard-CORS cross-origin response (e.g. a public CDN asset), which a credentialed request cannot read [possible values: include, omit, same-origin]
       --control-port <CONTROL_PORT>  Control-plane port of the running bridge [default: 9998]
       --token-file <PATH>            Read the session token from this `0600` file instead of the environment


### PR DESCRIPTION
## Description

This PR extends the browser bridge request protocol to support binary payloads (images, protobuf, gzip) symmetrically to the existing binary response body support. CLI users can now upload binary files via `--body-file`, which reads raw bytes and base64-encodes them on the wire; the browser snippet decodes back to a `Uint8Array` before `fetch()`, preserving byte-exact transmission to upstream servers.

The wire format is fully backward-compatible: the new optional `encoding` field on `ControlRequest` and `Command` uses `#[serde(default, skip_serializing_if = "Option::is_none")]`, so an absent value is byte-identical to pre-feature clients (no encoding = UTF-8 text body). The transparent proxy path is explicitly left unchanged — it continues to decode inbound request bodies as UTF-8 and never tags a base64 encoding.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Fixes #1123

## Changes Made

**Protocol Layer (`src/browser/protocol.rs`):**
- Added optional `encoding: Option<String>` field to `ControlRequest` struct with `#[serde(default, skip_serializing_if = "Option::is_none")]` for wire back-compat
- Added optional `encoding: Option<String>` field to `Command` struct with the same serde attributes
- Added test `request_encoding_omitted_when_absent_and_round_trips_when_present` covering both `ControlRequest` and `Command` serialization round-trips

**CLI (`src/cli/browser/request.rs`):**
- Added `--body-file <PATH>` flag to `RequestCommand`, mutually exclusive with `--body` via clap `conflicts_with`
- Refactored `resolve_body()` to accept both `body: Option<&str>` and `body_file: Option<&Path>`, returning a `(Option<String>, Option<String>)` tuple of `(body, encoding)`
- `--body-file` reads raw bytes and base64-encodes them, tagging `encoding = "base64"`; `--body` / `@file` continues to carry UTF-8 text with no encoding tag
- Updated `RequestCommand::execute()` to destructure the tuple and set `encoding` on the outgoing `ControlRequest`

**Bridge Dispatch (`src/browser/bridge.rs`):**
- Threaded `encoding` field from `ControlRequest` through to `Command` in both `dispatch()` and `start_stream()` handlers
- Explicitly set `encoding: None` in the transparent proxy path (`proxy_handler`) with a comment explaining why it never tags base64
- Updated test helper `make_req()` with `encoding: None`

**Browser Snippet (`src/templates/browser-bridge.js`):**
- Added `fromBase64()` helper that decodes a base64 string to a `Uint8Array` using `atob()`
- Updated the `fetch()` call to use `fromBase64(cmd.body)` when `cmd.encoding === 'base64'`, otherwise falls back to the existing `cmd.body || undefined` behavior

**Supporting Files:**
- Updated `src/browser/client.rs` and `src/browser/harvest/facebook.rs` to include `encoding: None` in all `ControlRequest` struct literals
- Updated help snapshot `tests/snapshots/integration_test__help_all_output.snap` to reflect new `--body` and `--body-file` help text

**Documentation:**
- `docs/browser-bridge.md`: Added "Binary request bodies" subsection, updated `POST /__bridge/request` API table to include `encoding?`, updated `--body`/`--body-file` CLI reference, added `--body-file` example in quick-start commands
- `docs/adrs/adr-0036.md`: Updated ADR-0036 history section to record the symmetric binary request body addition (#1123) and the `skip_serializing_if` wire-compat contract

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Integration tests updated/added
- [ ] Performance tests (if applicable)

**Manual Testing:**
- [x] Tested happy path scenarios
- [x] Tested error/edge cases
- [x] Backward compatibility verified

**New tests in `src/cli/browser/request.rs`:**
- `resolve_body_file_base64_round_trips_binary` — writes non-UTF-8 bytes (`[0xFF, 0xFE, 0x00, 0x01, 0x80]`) to a temp file, asserts `encoding = "base64"`, and verifies the decoded bytes match the original
- `resolve_body_file_always_base64_even_for_text` — confirms `--body-file` base64-encodes UTF-8 content too (byte-exact transmission regardless of content type)
- `body_and_body_file_are_mutually_exclusive` — confirms clap rejects `--body` and `--body-file` together
- Updated `resolve_body_inline_and_file` to cover the new `(body, encoding)` return tuple for all `--body` paths

**New tests in `src/browser/protocol.rs`:**
- `request_encoding_omitted_when_absent_and_round_trips_when_present` — verifies `encoding` is absent from serialized JSON when `None`, and round-trips correctly on both `ControlRequest` and `Command` when `Some("base64")`

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Binary upload via CLI
omni-dev browser bridge request --url /upload --method POST --body-file avatar.png

# Raw API (base64-encode body manually, set encoding field)
curl -s -H "Authorization: Bearer $T" -H "X-Omni-Bridge: 1" \
  -H "Content-Type: application/json" \
  -d '{"url":"/upload","method":"POST","body":"<base64>","encoding":"base64"}' \
  http://localhost:9998/__bridge/request
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility — the `skip_serializing_if = "Option::is_none"` contract must hold; any `encoding: None` must not appear on the wire
- [x] Security implications — the trust boundary is unchanged; only the body representation is widened
- [x] Error handling — `resolve_body()` defensive mutual-exclusivity check supplements clap's `conflicts_with`
- [x] Browser snippet correctness — `fromBase64` must produce a `Uint8Array` (not a string) so `fetch()` sends binary data

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

The base64 encode/decode is only applied when `--body-file` is used or `encoding: "base64"` is set. All existing paths that do not set an encoding are unchanged.

## Security Considerations

- [x] No security implications

The trust boundary is explicitly preserved: scope, token, and origin checks run identically. The transparent proxy path never tags a base64 encoding (documented with an inline comment). The new feature only widens the body representation for callers who opt in by setting `encoding: "base64"` or using `--body-file`.

## Breaking Changes

None. The `encoding` field is optional with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Older clients that omit the field receive byte-identical wire frames. No migration required.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Design Symmetry:**
Binary response bodies were added in #906 (snippet base64-encodes non-text responses, proxy decodes before writing HTTP). This PR mirrors that design on the request side: CLI base64-encodes binary input, snippet decodes before `fetch()`. The ADR (adr-0036.md) has been updated to record this history.

**Known Limitations:**
- `--body @file` continues to read files as UTF-8 text only; non-UTF-8 files must use `--body-file`
- The transparent proxy path does not support binary request bodies (it decodes the inbound body as UTF-8); only the controlled `/__bridge/request` endpoint supports `encoding: "base64"`