### PR TITLE
feat(cli): implement auto-detecting transcript fetch subcommand

### DIFF
--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -7,6 +7,26 @@ generic VTT/SRT URLs, …) can be added without restructuring.
 
 ## CLI usage
 
+### Auto-detecting `fetch`
+
+`omni-dev transcript fetch <url>` probes every registered source and dispatches
+to the one that recognises the locator — no provider name required. It accepts
+the same flags as the per-source `fetch` below and is the shortest path when you
+have a URL and don't care which source handles it:
+
+```bash
+# Source auto-detected from the locator shape.
+omni-dev transcript fetch https://www.youtube.com/watch?v=jNQXAC9IVRw
+omni-dev transcript fetch jNQXAC9IVRw --format vtt -o me-at-the-zoo.vtt
+```
+
+A locator no registered source recognises fails with `InvalidLocator` before any
+network call. With only YouTube registered today, `fetch <url>` resolves to the
+YouTube source whenever the URL is a YouTube locator; the dispatch generalises
+the moment a second source is added (see "Adding a new source").
+
+### Per-source subcommands
+
 The provider is the first positional argument so per-source flags and help
 output stay clean:
 
@@ -153,6 +173,7 @@ that bridges `clap` argument parsing to library types.
 src/
   transcript/                     # library: no clap
     cue.rs                        # Cue { start_ms, end_ms, text }
+    detect.rs                     # detect(url) → Box<dyn TranscriptSource>
     error.rs                      # TranscriptError + Result alias
     source.rs                     # TranscriptSource trait + value types
     format.rs                     # Format enum + dispatch
@@ -162,6 +183,7 @@ src/
       youtube/{url,player_response,timedtext,innertube,watch_page}.rs
   cli/transcript/                 # CLI: clap dispatch only
     mod.rs                        # TranscriptCommand + TranscriptSubcommands
+    fetch.rs                      # provider-less auto-detecting `fetch`
     format.rs                     # CliFormat ↔ Format bridge
     youtube/{mod,fetch,info,list_langs}.rs
 ```
@@ -181,8 +203,13 @@ pub trait TranscriptSource: Send + Sync {
 ```
 
 `matches` is `where Self: Sized` so it stays out of the `dyn` vtable —
-sources can be used through `Box<dyn TranscriptSource>` (a future
-`omni-dev transcript fetch <url>` auto-detect path, tracked in #1187).
+sources can be used through `Box<dyn TranscriptSource>`. That is what powers
+the auto-detecting `omni-dev transcript fetch <url>` path:
+[`detect`](../src/transcript/detect.rs) probes each registered source's
+`matches` in order and returns the first as a `Box<dyn TranscriptSource>`,
+which the CLI then drives through the trait's `fetch`/`list_languages`/`info`
+(`matches` itself is static, so `detect` names each source concretely rather
+than calling through the box). Delivered in #1187.
 
 Format converters take `&[Cue]` and never reach back into a source, so
 they are reused as-is by every implementation.
@@ -251,6 +278,16 @@ Register the module by adding one line to
 
 ```rust
 pub mod vimeo;
+```
+
+Then add one probe arm to [`detect`](../src/transcript/detect.rs) so the
+provider-less `transcript fetch <url>` path can route to it (order matters only
+if two sources could claim the same locator — put the more specific first):
+
+```rust
+if Vimeo::matches(url) {
+    return Ok(Box::new(Vimeo::new()?));
+}
 ```
 
 That's the entire library surface. Note what is *not* needed:

--- a/src/cli/transcript/fetch.rs
+++ b/src/cli/transcript/fetch.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use crate::cli::transcript::format::CliFormat;
 use crate::transcript::detect::detect;
 use crate::transcript::format::Format;
-use crate::transcript::source::FetchOpts;
+use crate::transcript::source::{FetchOpts, Transcript};
 
 /// Fetches a transcript, auto-detecting the source from the locator.
 #[derive(Parser)]
@@ -47,19 +47,34 @@ pub struct FetchCommand {
 }
 
 impl FetchCommand {
-    /// Detects the source, fetches the transcript, and writes it to stdout or
-    /// `--output`.
+    /// Detects the source from the locator, then fetches, renders, and writes.
     pub async fn execute(self) -> Result<()> {
         let source = detect(&self.url)?;
-        let opts = FetchOpts {
-            language: self.lang,
-            allow_auto: self.auto,
-            translate_to: self.translate,
-        };
-        let transcript = source.fetch(&self.url, &opts).await?;
-        let rendered = Format::from(self.format).render(&transcript)?;
-        write_output(&rendered, self.output.as_deref())
+        let transcript = source.fetch(&self.url, &self.fetch_opts()).await?;
+        render_and_write(&transcript, self.format, self.output.as_deref())
     }
+
+    /// Map the parsed CLI flags onto the library's [`FetchOpts`].
+    fn fetch_opts(&self) -> FetchOpts {
+        FetchOpts {
+            language: self.lang.clone(),
+            allow_auto: self.auto,
+            translate_to: self.translate.clone(),
+        }
+    }
+}
+
+/// Render `transcript` in `format` and write it to stdout or `output`.
+///
+/// Split from [`FetchCommand::execute`] so the render + write wiring is
+/// unit-testable without the network-bound fetch that precedes it.
+fn render_and_write(
+    transcript: &Transcript,
+    format: CliFormat,
+    output: Option<&str>,
+) -> Result<()> {
+    let rendered = Format::from(format).render(transcript)?;
+    write_output(&rendered, output)
 }
 
 fn write_output(text: &str, file: Option<&str>) -> Result<()> {
@@ -143,5 +158,33 @@ mod tests {
     fn write_output_invalid_path_errors() {
         let err = write_output("x", Some("/nonexistent_dir_for_test/out.txt")).unwrap_err();
         assert!(err.to_string().contains("Failed to write"));
+    }
+
+    use crate::transcript::cue::Cue;
+    use crate::transcript::source::{TrackKind, Transcript};
+
+    #[test]
+    fn fetch_opts_maps_flags() {
+        let cmd = parse(&["abc", "--lang", "fr", "--auto", "--translate", "en"]);
+        let opts = cmd.fetch_opts();
+        assert_eq!(opts.language, "fr");
+        assert!(opts.allow_auto);
+        assert_eq!(opts.translate_to.as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn render_and_write_renders_selected_format_to_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+        let transcript = Transcript {
+            source: "stub".into(),
+            locator_id: "vid".into(),
+            language: "en".into(),
+            kind: TrackKind::Manual,
+            cues: vec![Cue::new(0, 1_000, "hello world")],
+        };
+        render_and_write(&transcript, CliFormat::Txt, Some(path.to_str().unwrap())).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        assert!(out.contains("hello world"));
     }
 }

--- a/src/cli/transcript/fetch.rs
+++ b/src/cli/transcript/fetch.rs
@@ -1,0 +1,147 @@
+//! `omni-dev transcript fetch` — auto-detect the source from the locator and
+//! download a transcript, rendering it in the requested format.
+//!
+//! Unlike the per-source `transcript <source> fetch` subcommands, this probes
+//! every registered source's `matches` and dispatches to the one that
+//! recognises the URL (#1187). The flags mirror the per-source `fetch`.
+
+use std::fs;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::cli::transcript::format::CliFormat;
+use crate::transcript::detect::detect;
+use crate::transcript::format::Format;
+use crate::transcript::source::FetchOpts;
+
+/// Fetches a transcript, auto-detecting the source from the locator.
+#[derive(Parser)]
+pub struct FetchCommand {
+    /// Media URL or source-specific locator (e.g. a bare YouTube video ID).
+    /// The source is auto-detected from its shape.
+    pub url: String,
+
+    /// Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is
+    /// applied — `en` matches `en-US`.
+    #[arg(long, default_value = "en")]
+    pub lang: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = CliFormat::Srt)]
+    pub format: CliFormat,
+
+    /// Allow falling through to auto-generated (ASR) captions when no manual
+    /// track matches.
+    #[arg(long)]
+    pub auto: bool,
+
+    /// Synthesise a translated track in this target language when no native
+    /// track matches.
+    #[arg(long, value_name = "LANG")]
+    pub translate: Option<String>,
+
+    /// Output file (writes to stdout if omitted).
+    #[arg(short, long)]
+    pub output: Option<String>,
+}
+
+impl FetchCommand {
+    /// Detects the source, fetches the transcript, and writes it to stdout or
+    /// `--output`.
+    pub async fn execute(self) -> Result<()> {
+        let source = detect(&self.url)?;
+        let opts = FetchOpts {
+            language: self.lang,
+            allow_auto: self.auto,
+            translate_to: self.translate,
+        };
+        let transcript = source.fetch(&self.url, &opts).await?;
+        let rendered = Format::from(self.format).render(&transcript)?;
+        write_output(&rendered, self.output.as_deref())
+    }
+}
+
+fn write_output(text: &str, file: Option<&str>) -> Result<()> {
+    if let Some(path) = file {
+        fs::write(path, text).with_context(|| format!("Failed to write to {path}"))
+    } else {
+        print!("{text}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, FromArgMatches};
+
+    /// Build a parser for `FetchCommand` rooted at `fetch` so we can drive
+    /// it with realistic argv vectors.
+    fn parse(args: &[&str]) -> FetchCommand {
+        let cmd = FetchCommand::command().no_binary_name(true);
+        let matches = cmd.try_get_matches_from(args).unwrap();
+        FetchCommand::from_arg_matches(&matches).unwrap()
+    }
+
+    #[test]
+    fn fetch_command_defaults() {
+        let cmd = parse(&["https://youtu.be/dQw4w9WgXcQ"]);
+        assert_eq!(cmd.url, "https://youtu.be/dQw4w9WgXcQ");
+        assert_eq!(cmd.lang, "en");
+        assert_eq!(cmd.format, CliFormat::Srt);
+        assert!(!cmd.auto);
+        assert_eq!(cmd.translate, None);
+        assert_eq!(cmd.output, None);
+    }
+
+    #[test]
+    fn fetch_command_all_flags() {
+        let cmd = parse(&[
+            "abc",
+            "--lang",
+            "fr",
+            "--format",
+            "vtt",
+            "--auto",
+            "--translate",
+            "en",
+            "--output",
+            "out.vtt",
+        ]);
+        assert_eq!(cmd.url, "abc");
+        assert_eq!(cmd.lang, "fr");
+        assert_eq!(cmd.format, CliFormat::Vtt);
+        assert!(cmd.auto);
+        assert_eq!(cmd.translate.as_deref(), Some("en"));
+        assert_eq!(cmd.output.as_deref(), Some("out.vtt"));
+    }
+
+    #[test]
+    fn fetch_command_short_output_flag() {
+        let cmd = parse(&["abc", "-o", "out.srt"]);
+        assert_eq!(cmd.output.as_deref(), Some("out.srt"));
+    }
+
+    #[test]
+    fn write_output_to_file_writes_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+        write_output("hello\n", Some(path.to_str().unwrap())).unwrap();
+        let read = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(read, "hello\n");
+    }
+
+    #[test]
+    fn write_output_to_stdout_returns_ok() {
+        // Cannot easily capture stdout here; just exercise the branch.
+        write_output("noop", None).unwrap();
+    }
+
+    #[test]
+    fn write_output_invalid_path_errors() {
+        let err = write_output("x", Some("/nonexistent_dir_for_test/out.txt")).unwrap_err();
+        assert!(err.to_string().contains("Failed to write"));
+    }
+}

--- a/src/cli/transcript/mod.rs
+++ b/src/cli/transcript/mod.rs
@@ -40,6 +40,7 @@ impl TranscriptCommand {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cli::transcript::format::CliFormat;
@@ -57,6 +58,26 @@ mod tests {
             }),
         };
         assert!(matches!(cmd.command, TranscriptSubcommands::Fetch(_)));
+    }
+
+    /// Drives the `Fetch` dispatch arm end-to-end: an unrecognised locator
+    /// fails fast with the typed `InvalidLocator` error before any network
+    /// call — exercising `TranscriptCommand::execute` → `FetchCommand::execute`
+    /// → `detect`.
+    #[tokio::test]
+    async fn fetch_dispatch_surfaces_unrecognised_locator() {
+        let cmd = TranscriptCommand {
+            command: TranscriptSubcommands::Fetch(fetch::FetchCommand {
+                url: "https://vimeo.com/76979871".to_string(),
+                lang: "en".to_string(),
+                format: CliFormat::Srt,
+                auto: false,
+                translate: None,
+                output: None,
+            }),
+        };
+        let err = cmd.execute().await.unwrap_err();
+        assert!(err.to_string().contains("invalid transcript locator"));
     }
 
     #[test]

--- a/src/cli/transcript/mod.rs
+++ b/src/cli/transcript/mod.rs
@@ -4,6 +4,7 @@
 //! later) lives under its own subcommand so per-source argument shapes and
 //! help text stay clean.
 
+pub mod fetch;
 pub mod format;
 pub mod youtube;
 
@@ -18,9 +19,12 @@ pub struct TranscriptCommand {
     pub command: TranscriptSubcommands,
 }
 
-/// Transcript subcommands, one per media platform.
+/// Transcript subcommands: a provider-less auto-detecting `fetch`, plus one
+/// namespace per media platform.
 #[derive(Subcommand)]
 pub enum TranscriptSubcommands {
+    /// Fetch a transcript, auto-detecting the source from the locator.
+    Fetch(fetch::FetchCommand),
     /// YouTube: fetch captions, list available languages, and inspect video metadata.
     Youtube(youtube::YoutubeCommand),
 }
@@ -29,6 +33,7 @@ impl TranscriptCommand {
     /// Dispatches to the selected provider.
     pub async fn execute(self) -> Result<()> {
         match self.command {
+            TranscriptSubcommands::Fetch(cmd) => cmd.execute().await,
             TranscriptSubcommands::Youtube(cmd) => cmd.execute().await,
         }
     }
@@ -37,6 +42,22 @@ impl TranscriptCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::transcript::format::CliFormat;
+
+    #[test]
+    fn transcript_subcommands_fetch_variant() {
+        let cmd = TranscriptCommand {
+            command: TranscriptSubcommands::Fetch(fetch::FetchCommand {
+                url: "https://youtu.be/dQw4w9WgXcQ".to_string(),
+                lang: "en".to_string(),
+                format: CliFormat::Srt,
+                auto: false,
+                translate: None,
+                output: None,
+            }),
+        };
+        assert!(matches!(cmd.command, TranscriptSubcommands::Fetch(_)));
+    }
 
     #[test]
     fn transcript_subcommands_youtube_variant() {

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -11,12 +11,14 @@
 //! external consumers.
 
 pub mod cue;
+pub mod detect;
 pub mod error;
 pub mod format;
 pub mod source;
 pub mod sources;
 
 pub use cue::Cue;
+pub use detect::detect;
 pub use error::{Result, TranscriptError};
 pub use format::Format;
 pub use source::{FetchOpts, LanguageInfo, MediaInfo, TrackKind, Transcript, TranscriptSource};

--- a/src/transcript/detect.rs
+++ b/src/transcript/detect.rs
@@ -1,0 +1,66 @@
+//! Source auto-detection: map a locator to the source that recognises it.
+//!
+//! Backs the provider-less `omni-dev transcript fetch <url>` path (#1187).
+//! Each registered source's static [`TranscriptSource::matches`] is probed in
+//! registration order; the first match is constructed and returned behind a
+//! `Box<dyn TranscriptSource>` for runtime dispatch. Detection is pure string
+//! inspection — no network — so an unrecognised locator fails fast before any
+//! HTTP.
+
+use crate::transcript::error::{Result, TranscriptError};
+use crate::transcript::source::TranscriptSource;
+use crate::transcript::sources::youtube::Youtube;
+
+/// Probe every registered source in priority order and construct the first
+/// whose [`TranscriptSource::matches`] recognises `url`.
+///
+/// Returns [`TranscriptError::InvalidLocator`] when no registered source claims
+/// the locator.
+///
+/// Registering a new source is one arm here plus a `pub mod` in
+/// [`crate::transcript::sources`] — see the "Adding a new source" recipe in
+/// `docs/transcript.md`.
+pub fn detect(url: &str) -> Result<Box<dyn TranscriptSource>> {
+    if Youtube::matches(url) {
+        return Ok(Box::new(Youtube::new()?));
+    }
+
+    Err(TranscriptError::InvalidLocator(format!(
+        "no transcript source recognises `{url}`"
+    )))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_youtube_watch_url() {
+        let source = detect("https://www.youtube.com/watch?v=dQw4w9WgXcQ").unwrap();
+        assert_eq!(source.name(), "youtube");
+    }
+
+    #[test]
+    fn detects_youtube_short_url() {
+        let source = detect("https://youtu.be/dQw4w9WgXcQ").unwrap();
+        assert_eq!(source.name(), "youtube");
+    }
+
+    #[test]
+    fn detects_bare_youtube_id() {
+        let source = detect("dQw4w9WgXcQ").unwrap();
+        assert_eq!(source.name(), "youtube");
+    }
+
+    #[test]
+    fn unrecognised_locator_is_invalid_locator() {
+        // `Box<dyn TranscriptSource>` is not `Debug`, so match rather than
+        // `unwrap_err` (which needs the `Ok` type to be `Debug`).
+        match detect("https://vimeo.com/76979871") {
+            Err(TranscriptError::InvalidLocator(msg)) => assert!(msg.contains("vimeo.com")),
+            Err(other) => panic!("expected InvalidLocator, got {other:?}"),
+            Ok(_) => panic!("expected InvalidLocator, but a source matched"),
+        }
+    }
+}

--- a/src/transcript/detect.rs
+++ b/src/transcript/detect.rs
@@ -55,12 +55,11 @@ mod tests {
 
     #[test]
     fn unrecognised_locator_is_invalid_locator() {
-        // `Box<dyn TranscriptSource>` is not `Debug`, so match rather than
-        // `unwrap_err` (which needs the `Ok` type to be `Debug`).
-        match detect("https://vimeo.com/76979871") {
-            Err(TranscriptError::InvalidLocator(msg)) => assert!(msg.contains("vimeo.com")),
-            Err(other) => panic!("expected InvalidLocator, got {other:?}"),
-            Ok(_) => panic!("expected InvalidLocator, but a source matched"),
-        }
+        // `Box<dyn TranscriptSource>` is not `Debug`, so use `matches!` rather
+        // than `unwrap_err` (which needs the `Ok` type to be `Debug`).
+        assert!(matches!(
+            detect("https://vimeo.com/76979871"),
+            Err(TranscriptError::InvalidLocator(msg)) if msg.contains("vimeo.com")
+        ));
     }
 }

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -3290,11 +3290,32 @@ Transcript and caption fetching from media platforms
 Usage: transcript <COMMAND>
 
 Commands:
+  fetch    Fetch a transcript, auto-detecting the source from the locator
   youtube  YouTube: fetch captions, list available languages, and inspect video metadata
   help     Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
+
+
+================================================================================
+
+omni-dev transcript fetch - Fetch a transcript, auto-detecting the source from the locator
+
+Fetch a transcript, auto-detecting the source from the locator
+
+Usage: fetch [OPTIONS] <URL>
+
+Arguments:
+  <URL>  Media URL or source-specific locator (e.g. a bare YouTube video ID). The source is auto-detected from its shape
+
+Options:
+      --lang <LANG>       Preferred caption language (e.g. `en`, `en-US`). Prefix fallback is applied — `en` matches `en-US` [default: en]
+      --format <FORMAT>   Output format [default: srt] [possible values: srt, vtt, txt, json]
+      --auto              Allow falling through to auto-generated (ASR) captions when no manual track matches
+      --translate <LANG>  Synthesise a translated track in this target language when no native track matches
+  -o, --output <OUTPUT>   Output file (writes to stdout if omitted)
+  -h, --help              Print help (see more with '--help')
 
 
 ================================================================================


### PR DESCRIPTION
## Description

This PR delivers #1187 by adding a provider-less `omni-dev transcript fetch <url>` command that probes every registered transcript source and dispatches to the one that recognises the locator — no provider name required.

The auto-detection is pure string inspection: the new `transcript::detect` module iterates each registered source's static `matches` method in priority order and returns the first match as a `Box<dyn TranscriptSource>` for runtime dispatch. Unrecognised locators fail fast with `TranscriptError::InvalidLocator` before any network call is made.

The new `fetch` subcommand accepts the same flags as the per-source `fetch` subcommands (`--lang`, `--format`, `--auto`, `--translate`, `-o/--output`), making it the shortest path when you have a URL and don't care which source handles it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD changes
- [ ] Dependency update

## Related Issue

Fixes #1187

## Changes Made

**Core Library (`src/transcript/`):**
- Added `src/transcript/detect.rs` with the `detect(url: &str) -> Result<Box<dyn TranscriptSource>>` function that probes registered sources in priority order and returns the first match
- Exported `detect` module and re-exported `detect` function from `src/transcript.rs` for convenient access by consumers
- Currently registers YouTube as the sole source; adding a new source requires one `if Source::matches(url)` arm in `detect` plus a `pub mod` in `transcript::sources`

**CLI (`src/cli/transcript/`):**
- Added `src/cli/transcript/fetch.rs` with the `FetchCommand` clap struct and `execute()` implementation, which calls `detect`, builds `FetchOpts`, fetches the transcript, renders it in the requested format, and writes to stdout or `--output`
- Added `pub mod fetch` to `src/cli/transcript/mod.rs`
- Added `Fetch(fetch::FetchCommand)` variant to `TranscriptSubcommands` enum (before `Youtube`) and wired it in `TranscriptCommand::execute()`

**Documentation:**
- Updated `docs/transcript.md` with a new "Auto-detecting `fetch`" usage section showing example invocations
- Expanded the architecture diagram to list `detect.rs` and `cli/transcript/fetch.rs`
- Updated the `matches` / `Box<dyn TranscriptSource>` explanation to reference the delivered auto-detect path
- Added a "Adding a new source" recipe showing the required `detect` probe arm for future contributors

**Testing:**
- Added unit tests in `src/transcript/detect.rs`: `detects_youtube_watch_url`, `detects_youtube_short_url`, `detects_bare_youtube_id`, `unrecognised_locator_is_invalid_locator`
- Added unit tests in `src/cli/transcript/fetch.rs`: `fetch_command_defaults`, `fetch_command_all_flags`, `fetch_command_short_output_flag`, `write_output_to_file_writes_bytes`, `write_output_to_stdout_returns_ok`, `write_output_invalid_path_errors`
- Added `transcript_subcommands_fetch_variant` unit test in `src/cli/transcript/mod.rs`
- Updated `tests/snapshots/integration_test__help_all_output.snap` with the new `fetch` subcommand help text

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (10 new unit tests)
- [x] Integration tests updated/added (help snapshot updated)
- [ ] Performance tests (not applicable)

**Manual Testing:**
- [x] Tested happy path scenarios (`omni-dev transcript fetch https://www.youtube.com/watch?v=...`)
- [x] Tested error/edge cases (unrecognised locator returns `InvalidLocator` without network call)
- [ ] Cross-platform testing (not applicable)
- [x] Backward compatibility verified (existing `transcript youtube fetch` path unchanged)

**Test Coverage:**
- New code coverage: detection logic and all CLI argument branches covered by unit tests
- Overall project coverage: no regression

### Test Commands

```bash
# Core test suite
cargo test

# Run detection-specific tests
cargo test transcript::detect

# Run fetch CLI tests
cargo test cli::transcript::fetch

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Manual smoke test (YouTube URL auto-detected)
omni-dev transcript fetch https://www.youtube.com/watch?v=jNQXAC9IVRw

# Manual smoke test (bare video ID)
omni-dev transcript fetch jNQXAC9IVRw --format vtt -o out.vtt

# Manual smoke test (unrecognised locator fails fast)
omni-dev transcript fetch https://vimeo.com/76979871
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [x] Architecture changes — the `detect` function establishes the registration pattern for future sources; the priority ordering and the `Box<dyn TranscriptSource>` dispatch model should be reviewed for extensibility
- [x] Error handling — `InvalidLocator` is returned before any HTTP call; ensure this is the right error variant
- [ ] User experience
- [x] Backward compatibility — `TranscriptSubcommands::Fetch` is inserted before `Youtube`; clap subcommand ordering is cosmetic only, no breakage

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — detection is pure string inspection with no I/O; the dispatch adds a single virtual call before the existing async fetch path

## Security Considerations

- [x] No security implications — the locator is never executed; it is only matched against static string patterns before being passed to the existing source fetch logic

## Breaking Changes

None. The new `Fetch` variant is additive. All existing `transcript youtube` subcommands are unchanged.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Registering a second source (e.g. Vimeo) requires only one probe arm in `detect` and a `pub mod` in `transcript::sources` — see the updated "Adding a new source" recipe in `docs/transcript.md`
- If two sources could claim the same locator shape, insertion order in `detect` determines priority; more specific patterns should be placed first

**Known Limitations:**
- Only YouTube is currently registered in `detect`; all other URLs yield `InvalidLocator`

**Alternatives Considered:**
- Trait-object registry (e.g. `Vec<Box<dyn SourceFactory>>`) — rejected in favour of the simpler explicit `if` chain, which keeps the priority order visible and avoids dynamic registration overhead