### PR TITLE
refactor(atlassian,datadog): extract response handling helpers

### DIFF
--- a/.omni-dev/scopes.yaml
+++ b/.omni-dev/scopes.yaml
@@ -11,6 +11,10 @@ scopes:
     description: "Atlassian JIRA/Confluence integration and API client"
     examples: ["atlassian: add post_json to AtlassianClient", "atlassian: implement jira search"]
     file_patterns: ["src/atlassian/**", "src/cli/atlassian/**"]
+  - name: "datadog"
+    description: "Datadog monitoring integration and REST API client"
+    examples: ["datadog: add get_parsed to DatadogClient", "datadog: implement monitor search"]
+    file_patterns: ["src/datadog/**", "src/cli/datadog.rs", "src/cli/datadog/**"]
   - name: "cli"
     description: "Command-line interface and argument parsing"
     examples: ["cli: add twiddle contextual options", "cli: improve help text"]

--- a/src/atlassian/client.rs
+++ b/src/atlassian/client.rs
@@ -5766,11 +5766,7 @@ impl AtlassianClient {
     pub async fn get_bytes(&self, url: &str) -> Result<Vec<u8>> {
         let response = self.get_json_raw_accept(url, "*/*").await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        let response = Self::ensure_success(response).await?;
 
         let bytes = response
             .bytes()
@@ -5832,6 +5828,36 @@ impl AtlassianClient {
         .context("Failed to send GET request to Atlassian API")
     }
 
+    /// Returns `response` unchanged if its status is a success, otherwise reads
+    /// the body and fails with [`AtlassianError::ApiRequestFailed`].
+    ///
+    /// Centralises the "check status → read body → build error" block copied
+    /// after nearly every request. Call sites that need bespoke diagnostics for
+    /// specific status codes (e.g. `jira_write_error`, `confluence_write_error`)
+    /// build their error directly instead of using this helper.
+    pub(crate) async fn ensure_success(response: reqwest::Response) -> Result<reqwest::Response> {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        Err(AtlassianError::ApiRequestFailed { status, body }.into())
+    }
+
+    /// Deserialises `response`'s JSON body into `T`, attaching `context` on
+    /// failure.
+    ///
+    /// Pairs with [`Self::ensure_success`]; the common
+    /// `Self::parse_json(Self::ensure_success(resp).await?, "…").await?`
+    /// spelling replaces the hand-copied status-check + `json().context(…)`
+    /// block.
+    pub(crate) async fn parse_json<T: serde::de::DeserializeOwned>(
+        response: reqwest::Response,
+        context: &'static str,
+    ) -> Result<T> {
+        response.json().await.context(context)
+    }
+
     /// Fetches a JIRA issue by key with only the standard fields.
     ///
     /// Thin shim over [`Self::get_issue_with_fields`] with
@@ -5885,16 +5911,11 @@ impl AtlassianClient {
             .await
             .context("Failed to send request to JIRA API")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let envelope: JiraIssueEnvelope = response
-            .json()
-            .await
-            .context("Failed to parse JIRA issue response")?;
+        let envelope: JiraIssueEnvelope = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse JIRA issue response",
+        )
+        .await?;
 
         Ok(envelope.into_issue(&selection))
     }
@@ -5995,16 +6016,11 @@ impl AtlassianClient {
             .await
             .context("Failed to send editmeta request to JIRA API")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let raw: JiraEditMetaResponse = response
-            .json()
-            .await
-            .context("Failed to parse JIRA editmeta response")?;
+        let raw: JiraEditMetaResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse JIRA editmeta response",
+        )
+        .await?;
 
         let fields = raw
             .fields
@@ -6141,16 +6157,11 @@ impl AtlassianClient {
             .await
             .context("Failed to send createmeta request to JIRA API")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let raw: JiraCreateMetaResponse = response
-            .json()
-            .await
-            .context("Failed to parse JIRA createmeta response")?;
+        let raw: JiraCreateMetaResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse JIRA createmeta response",
+        )
+        .await?;
 
         let Some(project) = raw.projects.into_iter().next() else {
             return Ok(EditMeta::default());
@@ -6208,16 +6219,11 @@ impl AtlassianClient {
             .await
             .context("Failed to send createmeta request to JIRA API")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let raw: JiraCreateMetaFullResponse = response
-            .json()
-            .await
-            .context("Failed to parse JIRA createmeta response")?;
+        let raw: JiraCreateMetaFullResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse JIRA createmeta response",
+        )
+        .await?;
 
         let mut fields: Vec<CreateMetaField> = raw
             .projects
@@ -6288,16 +6294,11 @@ impl AtlassianClient {
 
             let response = self.get_json(&url).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: JiraCommentsResponse = response
-                .json()
-                .await
-                .context("Failed to parse comments response")?;
+            let resp: JiraCommentsResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse comments response",
+            )
+            .await?;
 
             let page_count = resp.comments.len() as u32;
             for c in resp.comments {
@@ -6335,11 +6336,7 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -6370,16 +6367,11 @@ impl AtlassianClient {
 
         let response = self.put_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entry: JiraCommentEntry = response
-            .json()
-            .await
-            .context("Failed to parse updated comment response")?;
+        let entry: JiraCommentEntry = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse updated comment response",
+        )
+        .await?;
 
         Ok(JiraComment {
             id: entry.id,
@@ -6405,16 +6397,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraWorklogResponse = response
-            .json()
-            .await
-            .context("Failed to parse worklog response")?;
+        let resp: JiraWorklogResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse worklog response",
+        )
+        .await?;
 
         let worklogs: Vec<JiraWorklog> = resp
             .worklogs
@@ -6470,11 +6457,7 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -6498,16 +6481,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraTransitionsResponse = response
-            .json()
-            .await
-            .context("Failed to parse transitions response")?;
+        let resp: JiraTransitionsResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse transitions response",
+        )
+        .await?;
 
         Ok(resp
             .transitions
@@ -6535,11 +6513,7 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -6574,16 +6548,11 @@ impl AtlassianClient {
                 .await
                 .context("Failed to send search request to JIRA API")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let page: JiraSearchResponse = response
-                .json()
-                .await
-                .context("Failed to parse JIRA search response")?;
+            let page: JiraSearchResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse JIRA search response",
+            )
+            .await?;
 
             let page_count = page.issues.len();
             for r in page.issues {
@@ -6644,16 +6613,11 @@ impl AtlassianClient {
 
             let response = self.get_json(url.as_str()).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceContentSearchResponse = response
-                .json()
-                .await
-                .context("Failed to parse Confluence search response")?;
+            let resp: ConfluenceContentSearchResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse Confluence search response",
+            )
+            .await?;
 
             let page_count = resp.results.len() as u32;
             for r in resp.results {
@@ -6723,16 +6687,11 @@ impl AtlassianClient {
 
             let response = self.get_json(url.as_str()).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let page: Vec<JiraUserSearchEntry> = response
-                .json()
-                .await
-                .context("Failed to parse JIRA user search response")?;
+            let page: Vec<JiraUserSearchEntry> = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse JIRA user search response",
+            )
+            .await?;
 
             let page_count = page.len() as u32;
             for entry in page {
@@ -6792,16 +6751,11 @@ impl AtlassianClient {
 
             let response = self.get_json(url.as_str()).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceUserSearchResponse = response
-                .json()
-                .await
-                .context("Failed to parse Confluence user search response")?;
+            let resp: ConfluenceUserSearchResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse Confluence user search response",
+            )
+            .await?;
 
             let page_count = resp.results.len() as u32;
             for r in resp.results {
@@ -6985,16 +6939,11 @@ impl AtlassianClient {
 
             let response = self.get_json(&url).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: AgileBoardListResponse = response
-                .json()
-                .await
-                .context("Failed to parse board list response")?;
+            let resp: AgileBoardListResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse board list response",
+            )
+            .await?;
 
             let page_count = resp.values.len() as u32;
             for b in resp.values {
@@ -7056,16 +7005,11 @@ impl AtlassianClient {
 
             let response = self.get_json(url.as_str()).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: AgileIssueListResponse = response
-                .json()
-                .await
-                .context("Failed to parse board issues response")?;
+            let resp: AgileIssueListResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse board issues response",
+            )
+            .await?;
 
             let page_count = resp.issues.len() as u32;
             for r in resp.issues {
@@ -7123,16 +7067,11 @@ impl AtlassianClient {
 
             let response = self.get_json(&url).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: AgileSprintListResponse = response
-                .json()
-                .await
-                .context("Failed to parse sprint list response")?;
+            let resp: AgileSprintListResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse sprint list response",
+            )
+            .await?;
 
             let page_count = resp.values.len() as u32;
             for s in resp.values {
@@ -7196,16 +7135,11 @@ impl AtlassianClient {
 
             let response = self.get_json(url.as_str()).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: AgileIssueListResponse = response
-                .json()
-                .await
-                .context("Failed to parse sprint issues response")?;
+            let resp: AgileIssueListResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse sprint issues response",
+            )
+            .await?;
 
             let page_count = resp.issues.len() as u32;
             for r in resp.issues {
@@ -7246,11 +7180,7 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -7282,16 +7212,11 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entry: AgileSprintEntry = response
-            .json()
-            .await
-            .context("Failed to parse sprint create response")?;
+        let entry: AgileSprintEntry = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse sprint create response",
+        )
+        .await?;
 
         Ok(AgileSprint {
             id: entry.id,
@@ -7345,11 +7270,7 @@ impl AtlassianClient {
             .put_json(&url, &serde_json::Value::Object(body))
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -7372,16 +7293,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entries: Vec<JiraProjectVersionEntry> = response
-            .json()
-            .await
-            .context("Failed to parse project versions response")?;
+        let entries: Vec<JiraProjectVersionEntry> = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse project versions response",
+        )
+        .await?;
 
         let versions: Vec<JiraProjectVersion> = entries
             .into_iter()
@@ -7442,16 +7358,11 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entry: JiraProjectVersionEntry = response
-            .json()
-            .await
-            .context("Failed to parse version create response")?;
+        let entry: JiraProjectVersionEntry = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse version create response",
+        )
+        .await?;
 
         Ok(JiraProjectVersion {
             id: entry.id,
@@ -7474,16 +7385,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraIssueLinksResponse = response
-            .json()
-            .await
-            .context("Failed to parse issue links response")?;
+        let resp: JiraIssueLinksResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse issue links response",
+        )
+        .await?;
 
         let mut links = Vec::new();
         for entry in resp.fields.issuelinks {
@@ -7522,16 +7428,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entries: Vec<JiraRemoteIssueLinkEntry> = response
-            .json()
-            .await
-            .context("Failed to parse remote issue links response")?;
+        let entries: Vec<JiraRemoteIssueLinkEntry> = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse remote issue links response",
+        )
+        .await?;
 
         let mut links = Vec::with_capacity(entries.len());
         for entry in entries {
@@ -7568,15 +7469,11 @@ impl AtlassianClient {
     pub async fn get_link_types(&self) -> Result<Vec<JiraLinkType>> {
         let url = format!("{}/rest/api/3/issueLinkType", self.instance_url);
         let response = self.get_json(&url).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-        let resp: JiraLinkTypesResponse = response
-            .json()
-            .await
-            .context("Failed to parse link types response")?;
+        let resp: JiraLinkTypesResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse link types response",
+        )
+        .await?;
         Ok(resp
             .issue_link_types
             .into_iter()
@@ -7599,11 +7496,7 @@ impl AtlassianClient {
         let url = format!("{}/rest/api/3/issueLink", self.instance_url);
         let body = serde_json::json!({"type": {"name": type_name}, "inwardIssue": {"key": inward_key}, "outwardIssue": {"key": outward_key}});
         let response = self.post_json(&url, &body).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -7611,11 +7504,7 @@ impl AtlassianClient {
     pub async fn remove_issue_link(&self, link_id: &str) -> Result<()> {
         let url = format!("{}/rest/api/3/issueLink/{}", self.instance_url, link_id);
         let response = self.delete(&url).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -7626,11 +7515,7 @@ impl AtlassianClient {
         let url = format!("{}/rest/api/3/issue/{}", self.instance_url, issue_key);
         let body = serde_json::json!({"fields": {"parent": {"key": parent_key}}});
         let response = self.put_json(&url, &body).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -7638,15 +7523,11 @@ impl AtlassianClient {
     pub async fn get_issue_id(&self, key: &str) -> Result<String> {
         let url = format!("{}/rest/api/3/issue/{}?fields=", self.instance_url, key);
         let response = self.get_json(&url).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-        let resp: JiraIssueIdResponse = response
-            .json()
-            .await
-            .context("Failed to parse issue ID response")?;
+        let resp: JiraIssueIdResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse issue ID response",
+        )
+        .await?;
         Ok(resp.id)
     }
 
@@ -7662,15 +7543,11 @@ impl AtlassianClient {
             self.instance_url, issue_id
         );
         let response = self.get_json(&url).await?;
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-        let resp: DevStatusSummaryResponse = response
-            .json()
-            .await
-            .context("Failed to parse DevStatus summary response")?;
+        let resp: DevStatusSummaryResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse DevStatus summary response",
+        )
+        .await?;
 
         fn extract_count(cat: Option<DevStatusSummaryCategory>) -> JiraDevStatusCount {
             match cat {
@@ -7771,20 +7648,11 @@ impl AtlassianClient {
                     self.instance_url, issue_id, app, dt
                 );
                 let response = self.get_json(&url).await?;
-                if !response.status().is_success() {
-                    let http_status = response.status().as_u16();
-                    let body = response.text().await.unwrap_or_default();
-                    return Err(AtlassianError::ApiRequestFailed {
-                        status: http_status,
-                        body,
-                    }
-                    .into());
-                }
-
-                let resp: DevStatusResponse = response
-                    .json()
-                    .await
-                    .context("Failed to parse DevStatus response")?;
+                let resp: DevStatusResponse = Self::parse_json(
+                    Self::ensure_success(response).await?,
+                    "Failed to parse DevStatus response",
+                )
+                .await?;
 
                 for detail in resp.detail {
                     for pr in detail.pull_requests {
@@ -7851,16 +7719,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraAttachmentIssueResponse = response
-            .json()
-            .await
-            .context("Failed to parse attachment response")?;
+        let resp: JiraAttachmentIssueResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse attachment response",
+        )
+        .await?;
 
         Ok(resp
             .fields
@@ -7896,16 +7759,11 @@ impl AtlassianClient {
 
             let response = self.get_json(&url).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: JiraChangelogResponse = response
-                .json()
-                .await
-                .context("Failed to parse changelog response")?;
+            let resp: JiraChangelogResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse changelog response",
+            )
+            .await?;
 
             let page_count = resp.values.len() as u32;
             for e in resp.values {
@@ -7940,16 +7798,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entries: Vec<JiraFieldEntry> = response
-            .json()
-            .await
-            .context("Failed to parse field list response")?;
+        let entries: Vec<JiraFieldEntry> = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse field list response",
+        )
+        .await?;
 
         Ok(entries
             .into_iter()
@@ -7979,16 +7832,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraFieldContextsResponse = response
-            .json()
-            .await
-            .context("Failed to parse field contexts response")?;
+        let resp: JiraFieldContextsResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse field contexts response",
+        )
+        .await?;
 
         Ok(resp.values.into_iter().map(|c| c.id).collect())
     }
@@ -8020,16 +7868,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: JiraFieldOptionsResponse = response
-            .json()
-            .await
-            .context("Failed to parse field options response")?;
+        let resp: JiraFieldOptionsResponse = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse field options response",
+        )
+        .await?;
 
         Ok(resp
             .values
@@ -8061,16 +7904,11 @@ impl AtlassianClient {
 
             let response = self.get_json(&url).await?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: JiraProjectSearchResponse = response
-                .json()
-                .await
-                .context("Failed to parse project search response")?;
+            let resp: JiraProjectSearchResponse = Self::parse_json(
+                Self::ensure_success(response).await?,
+                "Failed to parse project search response",
+            )
+            .await?;
 
             let page_count = resp.values.len() as u32;
             for p in resp.values {
@@ -8102,11 +7940,7 @@ impl AtlassianClient {
 
         let response = self.delete(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -8117,16 +7951,11 @@ impl AtlassianClient {
 
         let response = self.get_json(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let json: serde_json::Value = response
-            .json()
-            .await
-            .context("Failed to parse watchers response")?;
+        let json: serde_json::Value = Self::parse_json(
+            Self::ensure_success(response).await?,
+            "Failed to parse watchers response",
+        )
+        .await?;
 
         let watch_count = json["watchCount"].as_u64().unwrap_or(0) as u32;
 
@@ -8153,11 +7982,7 @@ impl AtlassianClient {
 
         let response = self.post_json(&url, &body).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -8171,11 +7996,7 @@ impl AtlassianClient {
 
         let response = self.delete(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        Self::ensure_success(response).await?;
 
         Ok(())
     }
@@ -8193,11 +8014,7 @@ impl AtlassianClient {
             .await
             .context("Failed to send request to JIRA API")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        let response = Self::ensure_success(response).await?;
 
         response
             .json()

--- a/src/atlassian/confluence_api.rs
+++ b/src/atlassian/confluence_api.rs
@@ -86,16 +86,11 @@ impl AtlassianApi for ConfluenceApi {
                 .await
                 .context("Failed to fetch Confluence page")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let page: ConfluencePageResponse = response
-                .json()
-                .await
-                .context("Failed to parse Confluence page response")?;
+            let page: ConfluencePageResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse Confluence page response",
+            )
+            .await?;
 
             debug!(
                 page_id = page.id,
@@ -275,16 +270,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to list Confluence spaces")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: ConfluenceSpacesResponse = response
-            .json()
-            .await
-            .context("Failed to parse Confluence spaces response")?;
+        let resp: ConfluenceSpacesResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse Confluence spaces response",
+        )
+        .await?;
 
         let next_cursor = resp
             .links
@@ -340,16 +330,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to list Confluence space pages")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: ConfluenceSpacePagesSummaryResponse = response
-            .json()
-            .await
-            .context("Failed to parse Confluence space pages response")?;
+        let resp: ConfluenceSpacePagesSummaryResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse Confluence space pages response",
+        )
+        .await?;
 
         let next_cursor = resp
             .links
@@ -489,11 +474,7 @@ impl ConfluenceApi {
             .await
             .context("Failed to fetch Confluence page with ancestors")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        let response = AtlassianClient::ensure_success(response).await?;
 
         response
             .json()
@@ -545,16 +526,11 @@ impl ConfluenceApi {
                 .await
                 .context("Failed to fetch child pages")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceChildrenResponse = response
-                .json()
-                .await
-                .context("Failed to parse children response")?;
+            let resp: ConfluenceChildrenResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse children response",
+            )
+            .await?;
 
             let page_count = resp.results.len();
             for child in resp.results {
@@ -596,16 +572,11 @@ impl ConfluenceApi {
                 .await
                 .context("Failed to fetch space root pages")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceSpacePagesResponse = response
-                .json()
-                .await
-                .context("Failed to parse space pages response")?;
+            let resp: ConfluenceSpacePagesResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse space pages response",
+            )
+            .await?;
 
             let page_count = resp.results.len();
             for entry in resp.results {
@@ -686,16 +657,11 @@ impl ConfluenceApi {
                 .await
                 .context("Failed to fetch Confluence comments")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceCommentsResponse = response
-                .json()
-                .await
-                .context("Failed to parse Confluence comments response")?;
+            let resp: ConfluenceCommentsResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse Confluence comments response",
+            )
+            .await?;
 
             let page_count = resp.results.len();
             for c in resp.results {
@@ -891,16 +857,11 @@ impl ConfluenceApi {
                 .await
                 .context("Failed to fetch page labels")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceLabelsResponse = response
-                .json()
-                .await
-                .context("Failed to parse labels response")?;
+            let resp: ConfluenceLabelsResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse labels response",
+            )
+            .await?;
 
             let page_count = resp.results.len();
             for entry in resp.results {
@@ -944,11 +905,7 @@ impl ConfluenceApi {
             .await
             .context("Failed to add labels")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        AtlassianClient::ensure_success(response).await?;
 
         Ok(())
     }
@@ -964,11 +921,7 @@ impl ConfluenceApi {
 
         let response = self.client.delete(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        AtlassianClient::ensure_success(response).await?;
 
         Ok(())
     }
@@ -990,16 +943,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to fetch Confluence page metadata")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let page: ConfluencePageResponse = response
-            .json()
-            .await
-            .context("Failed to parse Confluence page response")?;
+        let page: ConfluencePageResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse Confluence page response",
+        )
+        .await?;
 
         Ok(PageMetadata {
             id: page.id,
@@ -1042,16 +990,11 @@ impl ConfluenceApi {
                 .await
                 .context("Failed to fetch Confluence page versions")?;
 
-            if !response.status().is_success() {
-                let status = response.status().as_u16();
-                let body = response.text().await.unwrap_or_default();
-                return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-            }
-
-            let resp: ConfluenceVersionsResponse = response
-                .json()
-                .await
-                .context("Failed to parse Confluence versions response")?;
+            let resp: ConfluenceVersionsResponse = AtlassianClient::parse_json(
+                AtlassianClient::ensure_success(response).await?,
+                "Failed to parse Confluence versions response",
+            )
+            .await?;
 
             let page_count = resp.results.len();
             let next_link = resp.links.and_then(|l| l.next);
@@ -1153,16 +1096,11 @@ impl ConfluenceApi {
             .post_multipart(&url, form, &[("X-Atlassian-Token", "no-check")])
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: ConfluenceV1AttachmentResponse = response
-            .json()
-            .await
-            .context("Failed to parse upload attachment response")?;
+        let resp: ConfluenceV1AttachmentResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse upload attachment response",
+        )
+        .await?;
 
         let entry = resp
             .results
@@ -1200,16 +1138,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to fetch page attachments")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let resp: ConfluenceAttachmentsResponse = response
-            .json()
-            .await
-            .context("Failed to parse attachments response")?;
+        let resp: ConfluenceAttachmentsResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse attachments response",
+        )
+        .await?;
 
         let next_cursor = resp
             .links
@@ -1240,11 +1173,7 @@ impl ConfluenceApi {
 
         let response = self.client.delete(&url).await?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
+        AtlassianClient::ensure_success(response).await?;
 
         Ok(())
     }
@@ -1267,16 +1196,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to fetch attachment metadata")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let entry: ConfluenceAttachmentEntry = response
-            .json()
-            .await
-            .context("Failed to parse attachment response")?;
+        let entry: ConfluenceAttachmentEntry = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse attachment response",
+        )
+        .await?;
         Ok(entry.into())
     }
 
@@ -1336,16 +1260,11 @@ impl ConfluenceApi {
             .await
             .context("Failed to fetch Confluence page version")?;
 
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let body = response.text().await.unwrap_or_default();
-            return Err(AtlassianError::ApiRequestFailed { status, body }.into());
-        }
-
-        let page: ConfluencePageResponse = response
-            .json()
-            .await
-            .context("Failed to parse Confluence page response")?;
+        let page: ConfluencePageResponse = AtlassianClient::parse_json(
+            AtlassianClient::ensure_success(response).await?,
+            "Failed to parse Confluence page response",
+        )
+        .await?;
 
         debug!(
             page_id = page.id,

--- a/src/claude/context/patterns.rs
+++ b/src/claude/context/patterns.rs
@@ -353,8 +353,11 @@ fn estimate_lines_changed(diff_summary: &str) -> i32 {
     for line in diff_summary.lines() {
         if let Some(changes_part) = line.split('|').nth(1) {
             if let Some(numbers_part) = changes_part.split_whitespace().next() {
-                if let Ok(num) = numbers_part.parse::<i32>() {
-                    total += num;
+                // `git diff --stat` counts are always non-negative; parse as
+                // `u32` so a stray `-1` token can never drive the total below
+                // zero (the `estimate_lines_nonnegative` invariant).
+                if let Ok(num) = numbers_part.parse::<u32>() {
+                    total += num as i32;
                 }
             }
         }
@@ -491,6 +494,24 @@ mod tests {
     #[test]
     fn estimate_lines_no_numbers() {
         assert_eq!(estimate_lines_changed("no pipe here"), 0);
+    }
+
+    #[test]
+    fn estimate_lines_ignores_negative_token() {
+        // A negative count after `|` must not drive the total below zero
+        // (regression for the `estimate_lines_nonnegative` property, which
+        // shrank to `"|-1\u{b}"`).
+        assert_eq!(estimate_lines_changed("|-1\u{b}"), 0);
+        assert_eq!(estimate_lines_changed(" src/main.rs | -5 ----"), 0);
+    }
+
+    #[test]
+    fn estimate_lines_ignores_pipe_without_number() {
+        // A `|` with no token after it (`numbers_part` is `None`) must be
+        // skipped without contributing to the total. Covers the fall-through
+        // path deterministically instead of relying on the property test.
+        assert_eq!(estimate_lines_changed("src/main.rs |"), 0);
+        assert_eq!(estimate_lines_changed("src/main.rs |   "), 0);
     }
 
     // ── detect_single_commit_pattern ───────────────────────────────

--- a/src/datadog/client.rs
+++ b/src/datadog/client.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context, Result};
 use reqwest::Client;
+use url::Url;
 
 use crate::datadog::auth::{base_url_for_site, DatadogCredentials};
 use crate::datadog::error::DatadogError;
@@ -76,6 +77,49 @@ impl DatadogClient {
     #[must_use]
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Builds an absolute API URL by joining `path` onto `base_url`.
+    ///
+    /// `path` is the full path portion including the leading `/api/…` segment
+    /// (the version varies: `/api/v1/…`, `/api/v2/…`). Centralises the
+    /// `Url::parse(…).context("Invalid Datadog base URL")` spelling repeated
+    /// across the `*_api.rs` modules. Takes `base_url` (rather than `&self`) so
+    /// the free `build_*_url` functions — and their unit tests, which pass
+    /// literal base URLs — can call it unchanged.
+    pub(crate) fn api_url(base_url: &str, path: &str) -> Result<Url> {
+        Url::parse(&format!("{base_url}{path}")).context("Invalid Datadog base URL")
+    }
+
+    /// Checks `response` for success and deserialises its JSON body into `T`.
+    ///
+    /// Non-success responses become a [`DatadogError`] via
+    /// [`Self::response_to_error`] (preserving the 429 rate-limit summary); on
+    /// success the body is parsed with `context` attached on failure. Used by
+    /// the paginated and POST call sites that already hold a response;
+    /// single-shot GETs use [`Self::get_parsed`].
+    pub(crate) async fn parse_response<T: serde::de::DeserializeOwned>(
+        &self,
+        response: reqwest::Response,
+        context: &'static str,
+    ) -> Result<T> {
+        if !response.status().is_success() {
+            return Err(Self::response_to_error(response).await.into());
+        }
+        response.json().await.context(context)
+    }
+
+    /// Sends an authenticated GET and deserialises the JSON body into `T`.
+    ///
+    /// Convenience wrapper over [`Self::get_json`] + [`Self::parse_response`]
+    /// for the common single-request GET-then-parse pattern.
+    pub(crate) async fn get_parsed<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        context: &'static str,
+    ) -> Result<T> {
+        let response = self.get_json(url).await?;
+        self.parse_response(response, context).await
     }
 
     /// Sends an authenticated GET request and returns the raw response.

--- a/src/datadog/dashboards_api.rs
+++ b/src/datadog/dashboards_api.rs
@@ -8,7 +8,7 @@
 //! list façade does not loop. Any client-side `--limit` truncation belongs
 //! in the CLI layer.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -47,35 +47,28 @@ impl<'a> DashboardsApi<'a> {
     /// page this endpoint.
     pub async fn list(&self, filter: &DashboardListFilter) -> Result<Vec<DashboardSummary>> {
         let url = build_list_url(self.client.base_url(), filter)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        let parsed: DashboardListResponse = response
-            .json()
-            .await
-            .context("Failed to parse /api/v1/dashboard response")?;
+        let parsed: DashboardListResponse = self
+            .client
+            .get_parsed(url.as_str(), "Failed to parse /api/v1/dashboard response")
+            .await?;
         Ok(parsed.dashboards)
     }
 
     /// Fetches a single dashboard definition by id.
     pub async fn get(&self, id: &str) -> Result<Dashboard> {
         let url = build_get_url(self.client.base_url(), id)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<Dashboard>()
+        self.client
+            .get_parsed(
+                url.as_str(),
+                "Failed to parse /api/v1/dashboard/<id> response",
+            )
             .await
-            .context("Failed to parse /api/v1/dashboard/<id> response")
     }
 }
 
 /// Builds `{base_url}/api/v1/dashboard?{filters}`.
 fn build_list_url(base_url: &str, filter: &DashboardListFilter) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/dashboard")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/dashboard")?;
     if let Some(shared) = filter.filter_shared {
         url.query_pairs_mut()
             .append_pair("filter_shared", if shared { "true" } else { "false" });
@@ -88,8 +81,7 @@ fn build_list_url(base_url: &str, filter: &DashboardListFilter) -> Result<Url> {
 /// `id` is percent-encoded as a path segment so dashboard ids that
 /// contain reserved characters round-trip correctly.
 fn build_get_url(base_url: &str, id: &str) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/dashboard")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/dashboard")?;
     url.path_segments_mut()
         .map_err(|()| anyhow::anyhow!("Invalid Datadog base URL: cannot append path segment"))?
         .push(id);

--- a/src/datadog/downtimes_api.rs
+++ b/src/datadog/downtimes_api.rs
@@ -7,7 +7,7 @@
 //! server-side pagination — so the façade does not loop. The optional
 //! `current_only` filter restricts the response to active downtimes.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -30,20 +30,14 @@ impl<'a> DowntimesApi<'a> {
     /// downtimes are returned.
     pub async fn list(&self, current_only: bool) -> Result<Vec<Downtime>> {
         let url = build_list_url(self.client.base_url(), current_only)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<Vec<Downtime>>()
+        self.client
+            .get_parsed(url.as_str(), "Failed to parse /api/v1/downtime response")
             .await
-            .context("Failed to parse /api/v1/downtime response")
     }
 }
 
 fn build_list_url(base_url: &str, current_only: bool) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/downtime")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/downtime")?;
     if current_only {
         url.query_pairs_mut().append_pair("current_only", "true");
     }

--- a/src/datadog/events_api.rs
+++ b/src/datadog/events_api.rs
@@ -11,7 +11,7 @@
 //!
 //! [`MonitorsApi::list`]: crate::datadog::monitors_api::MonitorsApi::list
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -75,14 +75,9 @@ impl<'a> EventsApi<'a> {
             ));
         }
         let url = build_list_url(self.client.base_url(), filter, from, to, limit, after)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<EventsResponse>()
+        self.client
+            .get_parsed(url.as_str(), "Failed to parse /api/v2/events response")
             .await
-            .context("Failed to parse /api/v2/events response")
     }
 
     /// Lists events, auto-paginating via cursor as needed.
@@ -162,8 +157,7 @@ fn build_list_url(
     limit: usize,
     after: Option<&str>,
 ) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v2/events")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v2/events")?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(query) = filter.query.as_deref() {

--- a/src/datadog/hosts_api.rs
+++ b/src/datadog/hosts_api.rs
@@ -4,7 +4,7 @@
 //! endpoint (`GET /api/v1/hosts`). Auto-paginates via `start` / `count`
 //! query parameters, capped at [`HARD_CAP`] hosts per invocation.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -63,14 +63,10 @@ impl<'a> HostsApi<'a> {
             let remaining = cap - hosts.len();
             let count = remaining.min(LIST_PAGE_SIZE);
             let url = build_list_url(self.client.base_url(), filter, start, count)?;
-            let response = self.client.get_json(url.as_str()).await?;
-            if !response.status().is_success() {
-                return Err(DatadogClient::response_to_error(response).await.into());
-            }
-            let parsed: HostsResponse = response
-                .json()
-                .await
-                .context("Failed to parse /api/v1/hosts response")?;
+            let parsed: HostsResponse = self
+                .client
+                .get_parsed(url.as_str(), "Failed to parse /api/v1/hosts response")
+                .await?;
             let batch_len = parsed.host_list.len();
             let exhausted = batch_len < count;
             if total_matching.is_none() {
@@ -106,8 +102,7 @@ fn build_list_url(
     start: usize,
     count: usize,
 ) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/hosts")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/hosts")?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(f) = filter.filter.as_deref() {

--- a/src/datadog/logs_api.rs
+++ b/src/datadog/logs_api.rs
@@ -9,7 +9,7 @@
 //!
 //! [`MonitorsApi::list`]: crate::datadog::monitors_api::MonitorsApi::list
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Serialize;
 
 use crate::datadog::client::DatadogClient;
@@ -77,13 +77,12 @@ impl<'a> LogsApi<'a> {
         };
         let url = format!("{}/api/v2/logs/events/search", self.client.base_url());
         let response = self.client.post_json(&url, &body).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<LogSearchResult>()
+        self.client
+            .parse_response(
+                response,
+                "Failed to parse /api/v2/logs/events/search response",
+            )
             .await
-            .context("Failed to parse /api/v2/logs/events/search response")
     }
 
     /// Searches log events, auto-paginating via cursor as needed.

--- a/src/datadog/metrics_api.rs
+++ b/src/datadog/metrics_api.rs
@@ -5,7 +5,7 @@
 //! (`GET /api/v1/query`); subsequent slices will add scalar and multi-query
 //! variants.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -37,24 +37,16 @@ impl<'a> MetricsApi<'a> {
         to: i64,
     ) -> Result<MetricQueryResponse> {
         let url = build_query_url(self.client.base_url(), query, from, to)?;
-        let response = self.client.get_json(url.as_str()).await?;
-
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-
-        response
-            .json::<MetricQueryResponse>()
+        self.client
+            .get_parsed(url.as_str(), "Failed to parse /api/v1/query response")
             .await
-            .context("Failed to parse /api/v1/query response")
     }
 }
 
 /// Builds `{base_url}/api/v1/query?from=…&to=…&query=…` with proper
 /// percent-encoding for the query string.
 fn build_query_url(base_url: &str, query: &str, from: i64, to: i64) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/query")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/query")?;
     url.query_pairs_mut()
         .append_pair("from", &from.to_string())
         .append_pair("to", &to.to_string())

--- a/src/datadog/metrics_catalog_api.rs
+++ b/src/datadog/metrics_catalog_api.rs
@@ -5,7 +5,7 @@
 //! Phase 1 metrics *query* endpoint (`/api/v1/query`); the catalog
 //! returns the names of metrics ingested since `from`.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -32,20 +32,14 @@ impl<'a> MetricsCatalogApi<'a> {
         from: Option<i64>,
     ) -> Result<MetricCatalogResponse> {
         let url = build_list_url(self.client.base_url(), host, from)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<MetricCatalogResponse>()
+        self.client
+            .get_parsed(url.as_str(), "Failed to parse /api/v1/metrics response")
             .await
-            .context("Failed to parse /api/v1/metrics response")
     }
 }
 
 fn build_list_url(base_url: &str, host: Option<&str>, from: Option<i64>) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/metrics")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/metrics")?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(host) = host {

--- a/src/datadog/monitors_api.rs
+++ b/src/datadog/monitors_api.rs
@@ -7,7 +7,7 @@
 //!
 //! [#619]: https://github.com/rust-works/omni-dev/issues/619
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -68,14 +68,10 @@ impl<'a> MonitorsApi<'a> {
             let remaining = cap - out.len();
             let page_size = remaining.min(LIST_PAGE_SIZE);
             let url = build_list_url(self.client.base_url(), filter, page, page_size)?;
-            let response = self.client.get_json(url.as_str()).await?;
-            if !response.status().is_success() {
-                return Err(DatadogClient::response_to_error(response).await.into());
-            }
-            let batch: Vec<Monitor> = response
-                .json()
-                .await
-                .context("Failed to parse /api/v1/monitor response")?;
+            let batch: Vec<Monitor> = self
+                .client
+                .get_parsed(url.as_str(), "Failed to parse /api/v1/monitor response")
+                .await?;
             let exhausted = batch.len() < page_size;
             out.extend(batch);
             if out.len() >= cap || exhausted {
@@ -90,14 +86,12 @@ impl<'a> MonitorsApi<'a> {
     /// Fetches a single monitor by id.
     pub async fn get(&self, id: i64) -> Result<Monitor> {
         let url = build_get_url(self.client.base_url(), id)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        response
-            .json::<Monitor>()
+        self.client
+            .get_parsed(
+                url.as_str(),
+                "Failed to parse /api/v1/monitor/<id> response",
+            )
             .await
-            .context("Failed to parse /api/v1/monitor/<id> response")
     }
 
     /// Searches monitors against the free-text / faceted query string,
@@ -116,14 +110,13 @@ impl<'a> MonitorsApi<'a> {
             let remaining = cap - collected;
             let per_page = remaining.min(SEARCH_PAGE_SIZE);
             let url = build_search_url(self.client.base_url(), query, page, per_page)?;
-            let response = self.client.get_json(url.as_str()).await?;
-            if !response.status().is_success() {
-                return Err(DatadogClient::response_to_error(response).await.into());
-            }
-            let batch: MonitorSearchResult = response
-                .json()
-                .await
-                .context("Failed to parse /api/v1/monitor/search response")?;
+            let batch: MonitorSearchResult = self
+                .client
+                .get_parsed(
+                    url.as_str(),
+                    "Failed to parse /api/v1/monitor/search response",
+                )
+                .await?;
             let batch_len = batch.monitors.len();
             let page_count = batch.metadata.as_ref().and_then(|m| m.page_count);
             let exhausted_by_size = batch_len < per_page;
@@ -163,8 +156,7 @@ fn build_list_url(
     page: u32,
     page_size: usize,
 ) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/monitor")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/monitor")?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(name) = filter.name.as_deref() {
@@ -184,13 +176,12 @@ fn build_list_url(
 
 /// Builds `{base_url}/api/v1/monitor/{id}`.
 fn build_get_url(base_url: &str, id: i64) -> Result<Url> {
-    Url::parse(&format!("{base_url}/api/v1/monitor/{id}")).context("Invalid Datadog base URL")
+    DatadogClient::api_url(base_url, &format!("/api/v1/monitor/{id}"))
 }
 
 /// Builds `{base_url}/api/v1/monitor/search?query=…&page=…&per_page=…`.
 fn build_search_url(base_url: &str, query: &str, page: u32, per_page: usize) -> Result<Url> {
-    let mut url = Url::parse(&format!("{base_url}/api/v1/monitor/search"))
-        .context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/monitor/search")?;
     url.query_pairs_mut()
         .append_pair("query", query)
         .append_pair("page", &page.to_string())

--- a/src/datadog/slo_api.rs
+++ b/src/datadog/slo_api.rs
@@ -4,7 +4,7 @@
 //! Level Objective endpoints needed by the CLI: list and get. List
 //! auto-paginates when called with `limit == 0`, capped at [`HARD_CAP`].
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use url::Url;
 
 use crate::datadog::client::DatadogClient;
@@ -54,14 +54,10 @@ impl<'a> SloApi<'a> {
             let remaining = cap - out.len();
             let page_size = remaining.min(LIST_PAGE_SIZE);
             let url = build_list_url(self.client.base_url(), filter, offset, page_size)?;
-            let response = self.client.get_json(url.as_str()).await?;
-            if !response.status().is_success() {
-                return Err(DatadogClient::response_to_error(response).await.into());
-            }
-            let parsed: SloListResponse = response
-                .json()
-                .await
-                .context("Failed to parse /api/v1/slo response")?;
+            let parsed: SloListResponse = self
+                .client
+                .get_parsed(url.as_str(), "Failed to parse /api/v1/slo response")
+                .await?;
             let exhausted = parsed.data.len() < page_size;
             let batch_len = parsed.data.len();
             out.extend(parsed.data);
@@ -77,14 +73,10 @@ impl<'a> SloApi<'a> {
     /// Fetches a single SLO definition by id.
     pub async fn get(&self, id: &str) -> Result<Slo> {
         let url = build_get_url(self.client.base_url(), id)?;
-        let response = self.client.get_json(url.as_str()).await?;
-        if !response.status().is_success() {
-            return Err(DatadogClient::response_to_error(response).await.into());
-        }
-        let parsed: SloGetResponse = response
-            .json()
-            .await
-            .context("Failed to parse /api/v1/slo/<id> response")?;
+        let parsed: SloGetResponse = self
+            .client
+            .get_parsed(url.as_str(), "Failed to parse /api/v1/slo/<id> response")
+            .await?;
         Ok(parsed.data)
     }
 }
@@ -105,8 +97,7 @@ fn build_list_url(
     offset: usize,
     limit: usize,
 ) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/slo")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/slo")?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(tags) = filter.tags.as_deref() {
@@ -128,8 +119,7 @@ fn build_list_url(
 }
 
 fn build_get_url(base_url: &str, id: &str) -> Result<Url> {
-    let mut url =
-        Url::parse(&format!("{base_url}/api/v1/slo")).context("Invalid Datadog base URL")?;
+    let mut url = DatadogClient::api_url(base_url, "/api/v1/slo")?;
     url.path_segments_mut()
         .map_err(|()| anyhow::anyhow!("Invalid Datadog base URL: cannot append path segment"))?
         .push(id);


### PR DESCRIPTION
## Description

This PR centralises repetitive HTTP response validation and JSON parsing patterns across the Atlassian and Datadog API clients by introducing reusable helper methods. Previously, each API call site contained an identical 4–5 line block that checked the response status, read the error body, and constructed an error — this block was duplicated over 50 times across the two clients. The refactor eliminates that duplication without changing any observable behaviour.

A secondary fix addresses a pre-existing latent bug in `estimate_lines_changed` (in the Claude context patterns module) where parsing diff-stat line counts as `i32` allowed a malformed negative token to drive the running total below zero, violating the `estimate_lines_nonnegative` property test invariant.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue

Relates to #1151

## Changes Made

**Atlassian Client (`src/atlassian/client.rs`):**
- Added `pub(crate) async fn ensure_success(response: reqwest::Response) -> Result<reqwest::Response>` — validates HTTP status and returns `AtlassianError::ApiRequestFailed` with the response body on non-success
- Added `pub(crate) async fn parse_json<T: DeserializeOwned>(response, context: &'static str) -> Result<T>` — deserialises the JSON body attaching a context string on failure
- Replaced 30+ inline status-check + parse blocks with `Self::parse_json(Self::ensure_success(resp).await?, "…").await?`
- Call sites that only assert success (no JSON return) now use `Self::ensure_success(response).await?`

**Atlassian Confluence API (`src/atlassian/confluence_api.rs`):**
- Updated ~15 call sites to use `AtlassianClient::ensure_success()` and `AtlassianClient::parse_json()` helpers, removing all inline boilerplate blocks

**Datadog Client (`src/datadog/client.rs`):**
- Added `use url::Url` import
- Added `pub(crate) fn api_url(base_url: &str, path: &str) -> Result<Url>` — centralises the repeated `Url::parse(&format!("{base_url}{path}")).context("Invalid Datadog base URL")` pattern across all `*_api.rs` modules
- Added `pub(crate) async fn parse_response<T: DeserializeOwned>(&self, response, context) -> Result<T>` — checks status via `response_to_error` (preserving 429 rate-limit diagnostics) and parses JSON
- Added `pub(crate) async fn get_parsed<T: DeserializeOwned>(&self, url, context) -> Result<T>` — convenience wrapper over `get_json` + `parse_response` for the common single-shot GET pattern

**Datadog API modules (`dashboards_api.rs`, `downtimes_api.rs`, `events_api.rs`, `hosts_api.rs`, `logs_api.rs`, `metrics_api.rs`, `metrics_catalog_api.rs`, `monitors_api.rs`, `slo_api.rs`):**
- Replaced all inline `if !response.status().is_success() { … }` + `.json().await.context(…)` blocks with `self.client.get_parsed(url, "…").await?`
- `logs_api.rs` uses `self.client.parse_response(response, "…").await` directly since the endpoint is POST-based
- Replaced `Url::parse(&format!("{base_url}/api/…")).context("Invalid Datadog base URL")` with `DatadogClient::api_url(base_url, "/api/…")?` in all `build_*_url` helper functions
- Removed `use anyhow::Context` imports in all nine Datadog API modules (now only `use anyhow::Result` is needed)

**Bug fix — Claude context patterns (`src/claude/context/patterns.rs`):**
- Changed `numbers_part.parse::<i32>()` to `numbers_part.parse::<u32>()` in `estimate_lines_changed` so a stray negative token (e.g. `|-1`) is skipped instead of subtracting from the total, preserving the `estimate_lines_nonnegative` invariant
- Added `estimate_lines_ignores_negative_token` unit test covering the proptest-surfaced shrink case `"|-1\u{b}"`
- Added `estimate_lines_ignores_pipe_without_number` unit test covering the `|` with no token fall-through path

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality — two deterministic unit tests for the `estimate_lines_changed` bug fix
- [ ] Integration tests updated/added — response handling helpers are thin wrappers; behaviour is covered by existing integration tests

**Manual Testing:**
- [x] Backward compatibility verified — pure refactoring with no change to observable behaviour or error types for the Atlassian/Datadog helpers

### Test Commands
```bash
# Core test suite
cargo test

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — confirm that `ensure_success` / `parse_response` produce equivalent errors to the inline blocks they replace, especially the 429 rate-limit path in the Datadog client
- [x] Architecture changes — `ensure_success` and `parse_json` are `pub(crate)` on `AtlassianClient`; `api_url`, `parse_response`, and `get_parsed` are `pub(crate)` on `DatadogClient`
- [x] Backward compatibility — no public API surface changes; all helpers are crate-internal

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no user-facing docs needed for internal refactoring
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact — identical runtime behaviour; refactoring is purely structural

## Security Considerations

- [x] No security implications — response status checking and body extraction logic is unchanged; only the code structure is consolidated

## Breaking Changes

None. All helper methods are `pub(crate)` and no public API surface is modified.

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional Atlassian API modules can adopt `ensure_success` / `parse_json` as they are added
- The Datadog `get_parsed` pattern can be extended to a `post_parsed` variant when POST-then-parse call sites multiply

**Known Limitations:**
- Call sites that build bespoke error diagnostics for specific HTTP status codes (e.g. `jira_write_error`, `confluence_write_error`) intentionally do not use `ensure_success` and remain as-is

**Alternatives Considered:**
- A blanket `impl reqwest::Response` extension trait was considered but rejected to avoid leaking implementation detail through a trait; associated functions / methods on the existing client structs are more idiomatic for this codebase