### PR TITLE
chore(docs): remove git worktree convention guidance from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,9 +214,6 @@ Common git operations in this project:
 - `git branch -r --contains <commit>` - Check remote branch containment
 - `git status --porcelain` - Get working directory status
 
-### Git Worktrees
-New git worktrees should be created in the `.work/` directory of the current project (e.g., `git worktree add .work/<branch-name> <branch-name>`). The `.work/` directory is gitignored and keeps worktrees scoped to the project rather than scattered across sibling directories.
-
 ## Testing Approach
 
 ### Test Types


### PR DESCRIPTION
## Description

This PR removes outdated git worktree convention guidance from the CLAUDE.md documentation file. The section describing the requirement to create git worktrees in the `.work/` directory has been removed as this convention is no longer in use or needed for the project.

## Type of Change
- [x] Documentation update

## Changes Made

**Documentation:**
- Removed git worktrees section from CLAUDE.md that described the `.work/` directory convention for creating worktrees

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No test changes required for documentation-only change

**Manual Testing:**
- [x] Documentation file reviewed for accuracy and readability

## Review Focus Areas

**Please pay special attention to:**
- [ ] Security implications
- [ ] Performance impact
- [ ] Architecture changes
- [ ] Error handling
- [ ] User experience
- [ ] Backward compatibility

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes

None. This is a documentation-only change that removes outdated guidance.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

This cleanup removes obsolete documentation that was no longer applicable to current project workflows.