### PR TITLE
feat(snowflake): thread originating invocation id for request correlation

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -259,10 +259,21 @@ data-sensitivity note, not a credential leak.
 ## Daemon-served requests
 
 Requests executed inside the daemon (the browser bridge and the Snowflake
-session pool) set `via_daemon: true`. Because the daemon is a separate process
-from the CLI that asked it to act, such requests carry the *daemon's*
-`invocation_id`, not the CLI's — cross-socket correlation is a planned follow-up
+session pool) set `via_daemon: true`. Although the daemon is a separate process
+from the CLI that asked it to act, such requests are still stamped with the
+*originating* CLI invocation's `invocation_id`: the thin client threads its id
+across to the daemon — on the control socket for Snowflake (an
+`origin_invocation_id` envelope field) and on the `X-Omni-Bridge-Origin` header
+for the bridge — and the daemon scopes it around the request it serves. So
+`omni-dev log --id <cli-invocation>` surfaces the `via_daemon` requests that run
+triggered, correlating both halves of one logical operation
 ([#1198](https://github.com/rust-works/omni-dev/issues/1198)).
+
+The threaded id is non-secret (it is not a token), and the record's `source`
+stays `daemon`, so a daemon-served request remains distinguishable by
+`via_daemon` / `source` even while its `invocation_id` points at the caller. The
+same mechanism correlates a standalone `bridge serve` (there `source` stays
+`cli` and `via_daemon` is unset).
 
 ## Schema and compatibility
 

--- a/src/browser/auth.rs
+++ b/src/browser/auth.rs
@@ -37,6 +37,14 @@ pub const BRIDGE_HEADER_VALUE: &str = "1";
 /// takes precedence over a `target` body field, and is stripped before forwarding.
 pub const BRIDGE_TARGET_HEADER: &str = "x-omni-bridge-target";
 
+/// Optional header carrying the originating client's request-log `invocation_id`.
+///
+/// Threaded so the bridge can correlate the HTTP records it writes while serving
+/// a request back to the CLI/MCP invocation that issued it, rather than the
+/// bridge's own (#1198). Non-secret, server-side only — never forwarded to the
+/// browser.
+pub const BRIDGE_ORIGIN_HEADER: &str = "x-omni-bridge-origin";
+
 /// Number of random bytes behind a generated token (URL-safe base64, no pad).
 const TOKEN_BYTES: usize = 32;
 

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -668,13 +668,26 @@ async fn request_handler(
     if let Some(target) = target_header(&headers) {
         req.target = Some(target);
     }
+    // Correlate the HTTP records this request spawns to the originating client's
+    // invocation when it threaded its id on the origin header (#1198).
+    let origin = origin_header(&headers);
     if req.stream {
-        return match start_stream(&state, req).await {
+        let stream = start_stream(&state, req);
+        let result = match origin {
+            Some(id) => request_log::scope_origin_id(id, stream).await,
+            None => stream.await,
+        };
+        return match result {
             Ok((status, headers, driver)) => ndjson_stream_response(status, headers, driver),
             Err((code, msg)) => (code, msg).into_response(),
         };
     }
-    match dispatch(&state, req).await {
+    let dispatch = dispatch(&state, req);
+    let result = match origin {
+        Some(id) => request_log::scope_origin_id(id, dispatch).await,
+        None => dispatch.await,
+    };
+    match result {
         Ok(env) => Json(env).into_response(),
         Err((code, msg)) => (code, msg).into_response(),
     }
@@ -803,6 +816,18 @@ fn forwardable_headers(headers: &axum::http::HeaderMap) -> BTreeMap<String, Stri
 fn target_header(headers: &axum::http::HeaderMap) -> Option<String> {
     headers
         .get(auth::BRIDGE_TARGET_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Extracts the `X-Omni-Bridge-Origin` correlation id from request headers, if
+/// present and non-empty — the originating client's request-log `invocation_id`
+/// (#1198).
+fn origin_header(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get(auth::BRIDGE_ORIGIN_HEADER)
         .and_then(|v| v.to_str().ok())
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -1561,6 +1586,16 @@ mod tests {
         assert_eq!(target_header(&h).as_deref(), Some("2"));
         h.insert(auth::BRIDGE_TARGET_HEADER, "   ".parse().unwrap());
         assert_eq!(target_header(&h), None);
+    }
+
+    #[test]
+    fn origin_header_trims_and_drops_empty() {
+        let mut h = axum::http::HeaderMap::new();
+        assert_eq!(origin_header(&h), None);
+        h.insert(auth::BRIDGE_ORIGIN_HEADER, "  cli-42  ".parse().unwrap());
+        assert_eq!(origin_header(&h).as_deref(), Some("cli-42"));
+        h.insert(auth::BRIDGE_ORIGIN_HEADER, "   ".parse().unwrap());
+        assert_eq!(origin_header(&h), None);
     }
 
     #[test]

--- a/src/browser/client.rs
+++ b/src/browser/client.rs
@@ -40,11 +40,20 @@ impl BridgeClient {
     /// Builds the authenticated `POST /__bridge/request` request for `payload`,
     /// without sending it. Callers that need the raw streamed response (e.g. the
     /// `request --stream` path) drive this builder themselves.
+    ///
+    /// Carries this process's request-log `invocation_id` on the
+    /// [`auth::BRIDGE_ORIGIN_HEADER`] so daemon-hosted (or standalone) bridge HTTP
+    /// records correlate back to the originating CLI invocation (#1198). This
+    /// covers every `BridgeClient` caller — `request` and `harvest` alike.
     pub fn request_builder(&self, payload: &ControlRequest) -> reqwest::RequestBuilder {
         self.http
             .post(self.endpoint())
             .bearer_auth(&self.token)
             .header(auth::BRIDGE_HEADER, auth::BRIDGE_HEADER_VALUE)
+            .header(
+                auth::BRIDGE_ORIGIN_HEADER,
+                crate::request_log::current_context().invocation_id,
+            )
             .json(payload)
     }
 
@@ -78,7 +87,7 @@ impl BridgeClient {
 mod tests {
     use std::collections::BTreeMap;
 
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -128,6 +137,28 @@ mod tests {
         let env = client_for(&server).await.send(&req()).await.unwrap();
         assert_eq!(env.status, 200);
         assert_eq!(env.body, "hello");
+    }
+
+    #[tokio::test]
+    async fn send_attaches_origin_correlation_header() {
+        // Every control-plane request carries the origin id header (#1198); the
+        // mock only matches when it is present, so a successful send proves it.
+        let server = MockServer::start().await;
+        let envelope = ResponseEnvelope {
+            id: 1,
+            status: 200,
+            headers: BTreeMap::new(),
+            body: String::new(),
+            encoding: None,
+        };
+        Mock::given(method("POST"))
+            .and(path("/__bridge/request"))
+            .and(header_exists(auth::BRIDGE_ORIGIN_HEADER))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&envelope))
+            .mount(&server)
+            .await;
+
+        assert!(client_for(&server).await.send(&req()).await.is_ok());
     }
 
     #[tokio::test]

--- a/src/cli/snowflake.rs
+++ b/src/cli/snowflake.rs
@@ -289,9 +289,14 @@ fn disconnect_message(disconnected: bool, account: &str, user: &str) -> String {
 
 /// Sends one `snowflake` service op over the control socket, returning its
 /// payload or turning an `ok: false` reply into an error.
+///
+/// The envelope carries this CLI process's request-log `invocation_id` so the
+/// HTTP records the daemon writes while serving the op correlate back to this
+/// invocation rather than the daemon's own (#1198).
 async fn call(socket: &Path, op: &str, payload: Value) -> Result<Value> {
+    let origin = crate::request_log::current_context().invocation_id;
     let reply = DaemonClient::new(socket)
-        .request(DaemonEnvelope::service(SERVICE, op, payload))
+        .request(DaemonEnvelope::service(SERVICE, op, payload).with_origin(origin))
         .await?;
     if reply.ok {
         Ok(reply.payload)

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -33,6 +33,12 @@ pub struct DaemonEnvelope {
     /// Operation payload; `null` when the op takes no arguments.
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub payload: Value,
+    /// Originating client's request-log `invocation_id`, threaded across the
+    /// socket so daemon-side HTTP records correlate to the CLI/MCP invocation
+    /// that triggered them rather than the daemon's own (#1198). Non-secret.
+    /// Absent from older clients; the daemon simply skips the correlation then.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_invocation_id: Option<String>,
 }
 
 impl DaemonEnvelope {
@@ -42,6 +48,7 @@ impl DaemonEnvelope {
             service: Some(name.into()),
             op: op.into(),
             payload,
+            origin_invocation_id: None,
         }
     }
 
@@ -51,7 +58,17 @@ impl DaemonEnvelope {
             service: None,
             op: op.into(),
             payload: Value::Null,
+            origin_invocation_id: None,
         }
+    }
+
+    /// Stamps the originating client's request-log `invocation_id` on the
+    /// envelope so the daemon can correlate the requests it serves back to the
+    /// caller's invocation (#1198).
+    #[must_use]
+    pub fn with_origin(mut self, invocation_id: impl Into<String>) -> Self {
+        self.origin_invocation_id = Some(invocation_id.into());
+        self
     }
 }
 
@@ -93,4 +110,40 @@ impl DaemonReply {
 pub struct StatusReport {
     /// One entry per registered service, in registration order.
     pub services: Vec<ServiceStatus>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_omits_origin_when_absent() {
+        // Without an origin the field is skipped, keeping the wire byte-identical
+        // to what older clients/servers exchange.
+        let line = serde_json::to_string(&DaemonEnvelope::service(
+            "snowflake",
+            "query",
+            serde_json::json!({ "sql": "SELECT 1" }),
+        ))
+        .unwrap();
+        assert!(!line.contains("origin_invocation_id"), "{line}");
+    }
+
+    #[test]
+    fn envelope_round_trips_origin() {
+        let env = DaemonEnvelope::service("snowflake", "query", Value::Null).with_origin("cli-42");
+        let line = serde_json::to_string(&env).unwrap();
+        assert!(line.contains("origin_invocation_id"), "{line}");
+        let back: DaemonEnvelope = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.origin_invocation_id.as_deref(), Some("cli-42"));
+    }
+
+    #[test]
+    fn envelope_from_older_client_defaults_origin_to_none() {
+        // A line written before #1198 has no origin field; it must decode fine.
+        let back: DaemonEnvelope =
+            serde_json::from_str(r#"{"service":"snowflake","op":"query"}"#).unwrap();
+        assert!(back.origin_invocation_id.is_none());
+    }
 }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -268,16 +268,24 @@ async fn dispatch_line(
     };
     match envelope.service.as_deref() {
         None | Some(DAEMON_SERVICE) => handle_builtin(&envelope.op, registry, shutdown).await,
-        Some(name) => match registry
-            .dispatch(name, &envelope.op, envelope.payload)
-            .await
-        {
-            Ok(payload) => DaemonReply::ok(payload),
-            // `{:#}` includes the full anyhow source chain (e.g. "Snowflake
-            // query failed: snowflake server error (000630): …") so the client
-            // can see the underlying cause, not just the top-level wrapper.
-            Err(e) => DaemonReply::err(format!("{e:#}")),
-        },
+        Some(name) => {
+            // Correlate any HTTP the service issues to the originating client's
+            // invocation, when it threaded its id across the socket (#1198).
+            // Built-in ops issue no HTTP, so only the service path is scoped.
+            let dispatch = registry.dispatch(name, &envelope.op, envelope.payload);
+            let result = match envelope.origin_invocation_id {
+                Some(origin) => crate::request_log::scope_origin_id(origin, dispatch).await,
+                None => dispatch.await,
+            };
+            match result {
+                Ok(payload) => DaemonReply::ok(payload),
+                // `{:#}` includes the full anyhow source chain (e.g. "Snowflake
+                // query failed: snowflake server error (000630): …") so the
+                // client can see the underlying cause, not just the top-level
+                // wrapper.
+                Err(e) => DaemonReply::err(format!("{e:#}")),
+            }
+        }
     }
 }
 

--- a/src/request_log.rs
+++ b/src/request_log.rs
@@ -271,6 +271,24 @@ pub fn current_context() -> RequestLogContext {
     RequestLogContext::default()
 }
 
+/// Runs `fut` with the active context's `invocation_id` replaced by
+/// `origin_id`, preserving `source` and `mcp_tool`.
+///
+/// The daemon and the browser bridge scope this around a request they serve on
+/// behalf of a CLI/MCP client, so the HTTP records that request spawns
+/// correlate to the *originating* invocation rather than the server's own
+/// (#1198). `source` is deliberately preserved: a request served inside the
+/// daemon keeps `source = Daemon`, so `via_daemon` detection is unaffected while
+/// `invocation_id` now points at the caller's invocation record.
+pub async fn scope_origin_id<F, T>(origin_id: String, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let mut ctx = current_context();
+    ctx.invocation_id = origin_id;
+    CTX.scope(ctx, fut).await
+}
+
 /// Whether logging is disabled entirely (`OMNI_DEV_LOG_DISABLE=1`).
 pub fn disabled() -> bool {
     env_flag("OMNI_DEV_LOG_DISABLE")
@@ -1822,5 +1840,29 @@ mod tests {
         );
         assert!(result.is_err(), "a failing rewrite surfaces as an error");
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[tokio::test]
+    async fn scope_origin_id_overwrites_id_but_preserves_source() {
+        // A daemon-side base context: source = Daemon (so `via_daemon` detection
+        // keeps working) with the daemon's own invocation id.
+        let base = RequestLogContext {
+            invocation_id: "daemon-1".to_string(),
+            source: Source::Daemon,
+            mcp_tool: None,
+        };
+        CTX.scope(base, async {
+            scope_origin_id("cli-42".to_string(), async {
+                let ctx = current_context();
+                // Correlation id now points at the originating CLI invocation…
+                assert_eq!(ctx.invocation_id, "cli-42");
+                // …while the source stays Daemon, so `via_daemon` is unaffected.
+                assert_eq!(ctx.source, Source::Daemon);
+            })
+            .await;
+            // The override is scoped: outside it, the base id is restored.
+            assert_eq!(current_context().invocation_id, "daemon-1");
+        })
+        .await;
     }
 }

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -44,6 +44,7 @@ use omni_dev::daemon::service::{DaemonService, MenuSnapshot, ServiceStatus};
 use omni_dev::daemon::services::echo::EchoService;
 use omni_dev::daemon::services::worktrees::WorktreesService;
 use omni_dev::daemon::single_instance::{bind_or_reclaim, bind_private};
+use omni_dev::request_log;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
@@ -662,5 +663,86 @@ async fn stray_ping_fails_fast_while_draining() {
 
     // Let the drain complete and the server task return cleanly.
     release.notify_one();
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+}
+
+/// A service that reports the request-log `invocation_id` its handler observes.
+///
+/// `record_http_with` stamps every HTTP record with `current_context().
+/// invocation_id`, so returning that same value is a faithful stand-in for
+/// "what id would the request this handler serves be logged under" — without
+/// touching the process-global log file.
+struct ContextProbeService;
+
+#[async_trait]
+impl DaemonService for ContextProbeService {
+    fn name(&self) -> &'static str {
+        "ctx-probe"
+    }
+    async fn handle(&self, _op: &str, _payload: Value) -> Result<Value> {
+        let ctx = request_log::current_context();
+        Ok(json!({ "seen_invocation_id": ctx.invocation_id }))
+    }
+    fn menu(&self) -> MenuSnapshot {
+        MenuSnapshot::default()
+    }
+    async fn menu_action(&self, _action_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn status(&self) -> ServiceStatus {
+        ServiceStatus {
+            name: self.name().to_string(),
+            healthy: true,
+            summary: "ready".to_string(),
+            detail: Value::Null,
+        }
+    }
+    async fn shutdown(&self) {}
+}
+
+/// End-to-end proof of #1198: an envelope's `origin_invocation_id` is threaded
+/// across the real control socket and scoped around the service dispatch, so the
+/// id a daemon-side HTTP record would inherit is the *caller's*, not the
+/// daemon's. Without the field, the handler falls back to the ambient context.
+#[tokio::test]
+async fn origin_invocation_id_is_scoped_around_dispatch() {
+    let _gate = UMASK_GATE.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("d.sock");
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(ContextProbeService));
+    let handle = tokio::spawn(run(
+        registry,
+        DaemonOptions {
+            socket_path: socket.clone(),
+        },
+    ));
+
+    let client = DaemonClient::new(&socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // With an origin id, the handler sees exactly that id — the correlation key
+    // an HTTP record it issued would be logged under, matching `log --id`.
+    let reply = client
+        .request(DaemonEnvelope::service("ctx-probe", "probe", Value::Null).with_origin("cli-abc"))
+        .await
+        .unwrap();
+    assert!(reply.ok, "probe failed: {:?}", reply.error);
+    assert_eq!(reply.payload["seen_invocation_id"], json!("cli-abc"));
+
+    // Without an origin (an older client), the handler falls back to the ambient
+    // context — never the caller's id, since none was sent.
+    let reply = client
+        .request(DaemonEnvelope::service("ctx-probe", "probe", Value::Null))
+        .await
+        .unwrap();
+    assert_ne!(reply.payload["seen_invocation_id"], json!("cli-abc"));
+
+    client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
 }


### PR DESCRIPTION
## Description

This PR implements cross-service invocation correlation for daemon-served requests, enabling end-to-end request tracing when the CLI or MCP calls through the daemon (for Snowflake operations or browser requests). When a thin client invokes the daemon, the originating client's request-log `invocation_id` is now threaded across the control socket and browser bridge HTTP headers, allowing HTTP records spawned by daemon-side operations to correlate back to the caller's invocation instead of being logged under the daemon's own id.

The key benefit: `omni-dev log --id <cli-invocation>` now surfaces both halves of a logical operation—the CLI request and the daemon-triggered HTTP requests—providing unified request tracing across process boundaries. This resolves issue #1198.

The threaded id is non-secret (not a token) and `source` is preserved on records, so daemon-served requests remain distinguishable by `via_daemon: true` while their `invocation_id` now points at the originating caller. The implementation is fully backward compatible: older clients omit the field, and the daemon gracefully skips correlation in those cases.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Fixes #1198

## Changes Made

**Core Protocol Changes:**
- Added `origin_invocation_id` optional field to `DaemonEnvelope` in `src/daemon/protocol.rs` with `with_origin()` builder method for stamping the originating client's invocation id
- Envelope omits the field when absent, maintaining wire compatibility with older clients
- Added comprehensive tests for envelope round-trip serialization and backward compatibility

**CLI Integration:**
- Modified `call()` function in `src/cli/snowflake.rs` to extract and thread the current process's request-log `invocation_id` via `DaemonEnvelope::with_origin()`
- All Snowflake operations now automatically carry the originating CLI invocation id to the daemon

**Browser Bridge (Server-side):**
- Added `BRIDGE_ORIGIN_HEADER` constant (`x-omni-bridge-origin`) in `src/browser/auth.rs` for threading the originating invocation id
- Implemented `origin_header()` extraction function in `src/browser/bridge.rs` with proper trimming and empty-string filtering
- Updated request handler to scope the `scope_origin_id()` around both streaming and regular dispatch paths when origin header is present
- Added unit test validating header parsing, trimming, and empty string handling

**Browser Bridge (Client-side):**
- Modified `request_builder()` in `src/browser/client.rs` to attach the current context's `invocation_id` on every HTTP request via the `BRIDGE_ORIGIN_HEADER`
- Updated docstring explaining correlation mechanism for all `BridgeClient` callers (request and harvest alike)
- Added integration test verifying origin header is attached to all control-plane requests

**Daemon Server Dispatch:**
- Updated `dispatch_line()` in `src/daemon/server.rs` to scope `scope_origin_id()` around service dispatch when `origin_invocation_id` is present
- Built-in daemon ops (which issue no HTTP) remain unaffected; only the service dispatch path is scoped
- Preserves full error context in replies

**Request Log Infrastructure:**
- Implemented `scope_origin_id()` async function in `src/request_log.rs` to override `invocation_id` within a future's scope while preserving `source` and `mcp_tool`
- This allows daemon-side operations to report the caller's invocation id while maintaining `via_daemon` detection via the preserved source field
- Added comprehensive test demonstrating id override scoping and source preservation

**Integration Testing:**
- Added end-to-end test in `tests/daemon_socket.rs` with `ContextProbeService` that validates the full correlation path
- Test proves origin id flows through the control socket and is properly scoped around service dispatch
- Test also validates backward compatibility when origin id is omitted

**Documentation:**
- Updated `docs/log.md` to explain the daemon-served request correlation mechanism
- Documented that `invocation_id` now points to the originating caller while `via_daemon` and `source` remain distinguishable
- Clarified that the mechanism also supports standalone `bridge serve` scenarios

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for protocol serialization: envelope round-trip, backward compatibility from older clients
- [x] New tests added for browser bridge: origin header parsing, trimming, empty string filtering
- [x] New tests added for browser client: origin header attachment verification
- [x] New tests added for request log: scope_origin_id preserves source while overriding id
- [x] End-to-end integration test validating full correlation path across control socket and service dispatch
- [x] Backward compatibility test confirming fallback behavior when origin id omitted

**Manual Testing:**
- [x] Tested happy path: CLI request with origin id flows to daemon and is scoped around dispatch
- [x] Tested backward compatibility: older clients without origin id work correctly
- [x] Tested error scenarios: origin id scoping preserves error handling
- [x] Verified `omni-dev log --id` retrieves correlated daemon-side HTTP records

### Test Commands
```bash
# Run full test suite
cargo test

# Run daemon protocol tests specifically
cargo test daemon::protocol

# Run request log tests
cargo test request_log

# Run daemon socket integration tests
cargo test --test daemon_socket

# Run browser bridge tests
cargo test browser::bridge

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility: envelope gracefully handles missing origin field from older clients
- [x] Request correlation scope: verify `scope_origin_id()` properly restores context after future completes
- [x] Source preservation: confirm `via_daemon` detection still works because source field is untouched
- [x] Header security: origin id is non-secret and never forwarded to browser; server-side only
- [x] Error handling: correlation mechanism doesn't interfere with error propagation
- [x] Integration points: all three paths (CLI→daemon, browser client, browser server) properly thread the id

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact
- [x] No performance impact
- The origin id is simply passed through the envelope and HTTP headers with minimal overhead

## Security Considerations
- [x] No security implications
- The origin id is non-secret (not a token) and is never forwarded to external systems
- Server-side only; the browser bridge never sends it to the browser
- Preserves source field so daemon-served requests remain distinguishable

## Breaking Changes
None. This is a purely additive feature. The `origin_invocation_id` field is optional and skipped from serialization when absent, maintaining wire compatibility with older clients. Older clients continue to work without any changes—they simply omit the field, and the daemon skips the correlation.

## Deployment Notes
- [x] No special deployment requirements
- The feature is transparent; no environment variables or configuration changes needed
- Older and newer clients/servers interoperate seamlessly

## Additional Notes

**How It Works:**
1. CLI extracts its current `invocation_id` from request-log context
2. CLI stamps it on the `DaemonEnvelope` via `with_origin()` when calling Snowflake ops through the daemon
3. Browser client attaches it to every HTTP request via `X-Omni-Bridge-Origin` header
4. Daemon receives the envelope or header and scopes `scope_origin_id()` around the service dispatch
5. Any HTTP records the service issues inherit the scoped id, correlating them to the originating invocation
6. `omni-dev log --id <cli-invocation>` now retrieves both the CLI request and the daemon-triggered HTTP records

**Why This Matters:**
Users can now trace a logical operation end-to-end. A single `omni-dev log --id` call surfaces the complete flow when the CLI delegates work to the daemon, solving the observability problem of split invocation ids across process boundaries.

**Future Enhancements:**
- Could extend this pattern to other daemon-served operations beyond Snowflake and browser bridge
- Could add metrics or tracing spans keyed by the correlation id for distributed tracing integration

**Known Limitations:**
- Only correlates daemon-served requests where the client threads the origin id; manual daemon operations or missing client support fall back to ambient context
- The correlation is one-directional: logs correlate daemon requests to the CLI invocation, but not vice versa

**Alternatives Considered:**
- Passing correlation id via environment variables: would be unwieldy and process-specific
- Using the caller's process id: not suitable across socket boundaries and less semantically meaningful than invocation ids
- Storing correlation state in a shared file: would introduce synchronization complexity and race conditions