### PR TITLE
feat(cli, mcp): add --ignore-filename-regex for coverage diff filtering

### DIFF
--- a/src/cli/coverage.rs
+++ b/src/cli/coverage.rs
@@ -53,6 +53,7 @@ mod tests {
                 format: None,
                 fail_under_patch: None,
                 strip_prefix: None,
+                ignore_filename_regex: Vec::new(),
                 collapse_ranges: false,
                 all_files: false,
                 artifact_url: None,

--- a/src/cli/coverage/diff.rs
+++ b/src/cli/coverage/diff.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use git2::Repository;
+use regex::RegexSet;
 
 use crate::coverage::{
     analyze, default_base_ref, parse, render, DiffModel, DiffScope, Format, OutputFormat,
@@ -103,6 +104,19 @@ pub struct DiffCommand {
     #[arg(long, value_name = "PATH")]
     pub strip_prefix: Option<PathBuf>,
 
+    /// Exclude files whose repo-relative path matches any of these regexes
+    /// from BOTH the head and baseline reports before computing the diff.
+    ///
+    /// Repeatable, or comma-separated. Matching is unanchored (partial), the
+    /// same semantics as `cargo llvm-cov --ignore-filename-regex`, and is
+    /// applied after `--strip-prefix` normalisation so the pattern matches the
+    /// repo-relative path. Filtering both sides symmetrically keeps the total,
+    /// per-file deltas, patch coverage, and indirect-change list — and the
+    /// `--fail-under-patch` gate — computed over the same denominator, even
+    /// when the baseline predates the exclusion.
+    #[arg(long, value_name = "REGEX", value_delimiter = ',')]
+    pub ignore_filename_regex: Vec<String>,
+
     /// Collapse consecutive uncovered new lines into ranges (e.g. `9-11`).
     #[arg(long)]
     pub collapse_ranges: bool,
@@ -194,10 +208,15 @@ impl DiffCommand {
             .clone()
             .or_else(|| repo.workdir().map(std::path::Path::to_path_buf));
 
+        // Compiled once so an invalid pattern is a single up-front error rather
+        // than failing separately per report.
+        let ignore = self.compile_ignore()?;
+
         let head = self.load_report(
             &self.report,
             self.report_format,
             strip_prefix.as_deref(),
+            ignore.as_ref(),
             &repo_path,
         )?;
         let baseline = match &self.baseline_report {
@@ -205,6 +224,7 @@ impl DiffCommand {
                 path,
                 self.baseline_report_format,
                 strip_prefix.as_deref(),
+                ignore.as_ref(),
                 &repo_path,
             )?),
             None => None,
@@ -245,6 +265,7 @@ impl DiffCommand {
         path: &std::path::Path,
         format: ReportFormat,
         strip_prefix: Option<&std::path::Path>,
+        ignore: Option<&RegexSet>,
         repo_root: &Path,
     ) -> Result<crate::coverage::CoverageReport> {
         let path = if path.is_absolute() {
@@ -259,7 +280,33 @@ impl DiffCommand {
         if let Some(prefix) = strip_prefix {
             report.strip_prefix(prefix);
         }
+        // Match on the repo-relative path (post strip-prefix), so the same
+        // pattern applies identically to head and baseline.
+        if let Some(ignore) = ignore {
+            report.retain_paths(|path| !ignore.is_match(path));
+        }
         Ok(report)
+    }
+
+    /// Compiles `--ignore-filename-regex` into a [`RegexSet`], or `None` when it
+    /// was not supplied. A file is excluded when it matches *any* pattern.
+    ///
+    /// Empty patterns are dropped: comma-splitting a trailing or doubled comma
+    /// (`foo,` / `a,,b`) yields an empty element, and an empty regex matches
+    /// *every* path — which would silently exclude the whole report (and make a
+    /// `--fail-under-patch` gate pass vacuously). Treating it as a no-op is the
+    /// safe reading of an obvious typo.
+    fn compile_ignore(&self) -> Result<Option<RegexSet>> {
+        let patterns: Vec<&String> = self
+            .ignore_filename_regex
+            .iter()
+            .filter(|p| !p.is_empty())
+            .collect();
+        if patterns.is_empty() {
+            return Ok(None);
+        }
+        let set = RegexSet::new(patterns).context("invalid --ignore-filename-regex pattern")?;
+        Ok(Some(set))
     }
 
     /// Builds the render options, falling back to the `COVERAGE_*` environment
@@ -357,6 +404,7 @@ mod tests {
             format: None,
             fail_under_patch: None,
             strip_prefix: None,
+            ignore_filename_regex: Vec::new(),
             collapse_ranges: false,
             all_files: false,
             artifact_url: None,
@@ -502,6 +550,98 @@ mod tests {
             all_md.contains("`a.rs`"),
             "All scope must surface untouched a.rs"
         );
+    }
+
+    #[test]
+    fn ignore_filename_regex_excludes_file_from_patch() {
+        // The only diff-added file is `b.rs`; ignoring it removes it from the
+        // head report, so `head.hits` misses and no added lines remain to
+        // measure — patch coverage becomes undefined rather than 66.7%.
+        let (_dir, repo, base) = repo_with_added_file();
+        let report = write_head_lcov(&repo);
+        let mut cmd = command(report, &base);
+        cmd.ignore_filename_regex = vec![r"b\.rs".to_string()];
+        let outcome = cmd.run(Some(&repo)).unwrap();
+        assert_eq!(outcome.patch_percent, None);
+        assert!(!outcome.rendered.contains("`b.rs:2`"));
+    }
+
+    #[test]
+    fn ignore_filename_regex_drops_file_from_both_reports() {
+        // `a.rs` is unchanged but has different coverage in head vs baseline, so
+        // `--all-files` would normally surface it in the delta table (it is read
+        // from both `head.files` and `baseline.files`). The regex must remove it
+        // from both sides symmetrically so it disappears entirely.
+        let (_dir, repo, base) = repo_with_added_file();
+        let head = format!(
+            "SF:{a}\nDA:1,1\nDA:2,1\nDA:3,1\nDA:4,0\nend_of_record\n\
+             SF:{b}\nDA:1,1\nDA:2,0\nDA:3,4\nend_of_record\n",
+            a = repo.join("a.rs").display(),
+            b = repo.join("b.rs").display(),
+        );
+        let report = repo.join("head.lcov");
+        fs::write(&report, head).unwrap();
+        let baseline = repo.join("base.lcov");
+        fs::write(
+            &baseline,
+            format!(
+                "SF:{}\nDA:1,1\nDA:2,1\nDA:3,0\nDA:4,0\nend_of_record\n",
+                repo.join("a.rs").display()
+            ),
+        )
+        .unwrap();
+
+        let mut cmd = command(report, &base);
+        cmd.baseline_report = Some(baseline);
+        cmd.all_files = true;
+        cmd.ignore_filename_regex = vec![r"a\.rs".to_string()];
+        let md = cmd.run(Some(&repo)).unwrap().rendered;
+        assert!(
+            !md.contains("`a.rs`"),
+            "ignored a.rs must not appear in the delta table"
+        );
+        // The un-ignored added file is still reported.
+        assert!(md.contains("`b.rs"));
+    }
+
+    #[test]
+    fn ignore_filename_regex_parses_repeatable_and_comma() {
+        use clap::Parser;
+        let cmd = DiffCommand::try_parse_from([
+            "diff",
+            "--report",
+            "r.lcov",
+            "--ignore-filename-regex",
+            "foo,bar",
+            "--ignore-filename-regex",
+            "baz",
+        ])
+        .unwrap();
+        assert_eq!(cmd.ignore_filename_regex, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn ignore_filename_regex_treats_empty_pattern_as_noop() {
+        // A trailing/doubled comma splits to an empty element; an empty regex
+        // matches every path and would silently wipe the whole report (and pass
+        // a --fail-under-patch gate vacuously). It must be dropped instead.
+        let (_dir, repo, base) = repo_with_added_file();
+        let report = write_head_lcov(&repo);
+        let mut cmd = command(report, &base);
+        cmd.ignore_filename_regex = vec![String::new(), r"nomatch\.rs".to_string()];
+        let outcome = cmd.run(Some(&repo)).unwrap();
+        // b.rs is still measured: 2/3, not wiped to nothing.
+        assert_eq!(outcome.patch_percent, Some(2.0 / 3.0 * 100.0));
+        assert!(outcome.rendered.contains("`b.rs:2`"));
+    }
+
+    #[test]
+    fn invalid_ignore_pattern_errors() {
+        let (_dir, repo, base) = repo_with_added_file();
+        let report = write_head_lcov(&repo);
+        let mut cmd = command(report, &base);
+        cmd.ignore_filename_regex = vec!["(unclosed".to_string()];
+        assert!(cmd.run(Some(&repo)).is_err());
     }
 
     #[test]

--- a/src/coverage/model.rs
+++ b/src/coverage/model.rs
@@ -149,6 +149,19 @@ impl CoverageReport {
         }
         self.files = remapped;
     }
+
+    /// Drops every file whose path does not satisfy `keep`.
+    ///
+    /// Used to apply `--ignore-filename-regex`: because it is called *after*
+    /// [`strip_prefix`](Self::strip_prefix), the predicate sees repo-relative
+    /// paths — the same space git diffs report in — so head and baseline
+    /// reports are filtered identically before any delta is computed.
+    pub fn retain_paths<F>(&mut self, keep: F)
+    where
+        F: Fn(&str) -> bool,
+    {
+        self.files.retain(|path, _| keep(path));
+    }
 }
 
 /// Strips `prefix_slash` (a trailing-slash directory prefix) from `path`, then
@@ -270,5 +283,19 @@ mod tests {
         report.insert(f);
         report.strip_prefix(Path::new("/some/other/root"));
         assert!(report.files.contains_key("src/a.rs"));
+    }
+
+    #[test]
+    fn retain_paths_drops_non_matching_files() {
+        let mut report = CoverageReport::new();
+        for path in ["src/a.rs", "src/gpu/mlx.rs", "src/b.rs"] {
+            let mut f = FileCoverage::new(path);
+            f.record(1, 1);
+            report.insert(f);
+        }
+        report.retain_paths(|path| !path.contains("gpu/"));
+        assert!(report.files.contains_key("src/a.rs"));
+        assert!(report.files.contains_key("src/b.rs"));
+        assert!(!report.files.contains_key("src/gpu/mlx.rs"));
     }
 }

--- a/src/mcp/coverage_tools.rs
+++ b/src/mcp/coverage_tools.rs
@@ -102,6 +102,12 @@ pub struct CoverageDiffParams {
     /// repo-relative (default: the repository working directory).
     #[serde(default)]
     pub strip_prefix: Option<String>,
+    /// Exclude files whose repo-relative path matches any of these regexes from
+    /// both the head and baseline reports before computing the diff. Matching is
+    /// unanchored, applied after `strip_prefix` (same semantics as
+    /// `cargo llvm-cov --ignore-filename-regex`).
+    #[serde(default)]
+    pub ignore_filename_regex: Vec<String>,
     /// Collapse consecutive uncovered new lines into ranges (e.g. `9-11`).
     #[serde(default)]
     pub collapse_ranges: bool,
@@ -162,6 +168,7 @@ impl OmniDevServer {
             format: None,
             fail_under_patch: params.fail_under_patch,
             strip_prefix: params.strip_prefix.map(PathBuf::from),
+            ignore_filename_regex: params.ignore_filename_regex,
             collapse_ranges: params.collapse_ranges,
             all_files: params.all_files,
             artifact_url: params.artifact_url,
@@ -299,6 +306,7 @@ mod tests {
             format: CoverageOutputFormat::Markdown,
             fail_under_patch: None,
             strip_prefix: None,
+            ignore_filename_regex: Vec::new(),
             collapse_ranges: false,
             all_files: false,
             artifact_url: None,

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -2319,6 +2319,8 @@ Options:
           Fail (non-zero exit) when patch coverage is below this percentage
       --strip-prefix <PATH>
           Override the path prefix stripped from report file paths to make them repo-relative (default: the repository working directory)
+      --ignore-filename-regex <REGEX>
+          Exclude files whose repo-relative path matches any of these regexes from BOTH the head and baseline reports before computing the diff
       --collapse-ranges
           Collapse consecutive uncovered new lines into ranges (e.g. `9-11`)
       --all-files


### PR DESCRIPTION
## Description

This PR implements file exclusion for coverage diff analysis via a new repeatable `--ignore-filename-regex` flag. This feature enables users to exclude files matching specific patterns from both head and baseline coverage reports before computing the diff, matching the semantics of `cargo llvm-cov --ignore-filename-regex`.

The key design principle is **symmetric filtering**: patterns are applied to both head and baseline reports after strip-prefix normalization, ensuring they are computed over the same denominator. This preserves the validity of total coverage, per-file deltas, patch coverage metrics, and the `--fail-under-patch` gate even when the baseline predates the exclusion rule.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] CLI changes
- [x] Test coverage improvement

## Related Issue
Relates to #1220

## Changes Made

**Core Changes:**
- Added `ignore_filename_regex` field to `DiffCommand` in `src/cli/coverage/diff.rs` with comma-separated and repeatable parsing via clap
- Implemented `compile_ignore()` method to compile regex patterns into a `RegexSet` with upfront validation, returning an error immediately if any pattern is invalid
- Applied filtering symmetrically to both head and baseline reports in the `load_report()` method using the new `retain_paths()` filtering method
- Added `retain_paths()` method to `CoverageReport` in `src/coverage/model.rs` for flexible path filtering that operates on repo-relative paths (post strip-prefix)
- Wired the `ignore_filename_regex` parameter through `CoverageDiffParams` in `src/mcp/coverage_tools.rs` with `serde(default)` for MCP integration

**Testing:**
- Added test for pattern parsing: `ignore_filename_regex_parses_repeatable_and_comma` verifies both repeatable and comma-separated argument parsing
- Added test for file exclusion from patch: `ignore_filename_regex_excludes_file_from_patch` confirms that ignored files are removed from head report and patch coverage becomes undefined when all new lines are excluded
- Added test for symmetric filtering: `ignore_filename_regex_drops_file_from_both_reports` verifies files are removed from both head and baseline reports identically, preventing unwanted entries in delta tables
- Added test for invalid patterns: `invalid_ignore_pattern_errors` confirms proper error handling for malformed regex syntax
- Added unit test for `retain_paths()` method in `CoverageReport`: `retain_paths_drops_non_matching_files` verifies correct file filtering behavior

**Documentation:**
- Updated CLI help snapshot with new `--ignore-filename-regex <REGEX>` option documentation explaining the feature and its semantics

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (5 comprehensive test cases)
- [x] Pattern parsing tests cover both repeatable and comma-separated formats
- [x] File exclusion tests verify symmetric filtering across head and baseline reports
- [x] Error handling tests confirm invalid regex patterns are caught early

**Manual Testing:**
- [x] Tested pattern parsing with repeatable and comma-separated arguments
- [x] Tested file exclusion scenarios with single and multiple patterns
- [x] Tested error/edge cases (invalid regex syntax, excluded files affecting patch coverage)
- [x] Backward compatibility verified (flag is optional, defaults to empty vec)

### Test Commands
```bash
# Core test suite
cargo test

# Coverage diff tests specifically
cargo test coverage::diff

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check

# Build validation
./scripts/build.sh
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Symmetric filtering approach: files are removed from both head and baseline identically
- [x] Regex compilation strategy: patterns are compiled once upfront to catch errors early rather than per-report
- [x] Path matching semantics: filtering is applied after strip-prefix normalization for consistent behavior
- [x] MCP integration: parameter is properly wired through `CoverageDiffParams` with serde defaults
- [x] Error handling: invalid regex patterns produce clear, upfront errors

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact
- Regex patterns are compiled once per command invocation, and matching is performed only when the flag is supplied
- Filtering operations are O(n) where n is the number of files in the report

## Security Considerations
- [x] No security implications
- Regex patterns are user-supplied and validated for correctness via `RegexSet::new()`

## Breaking Changes
None. This is a purely additive feature. The `--ignore-filename-regex` flag is optional and defaults to an empty vector, preserving existing behavior when not supplied.

## Deployment Notes
- [x] No special deployment requirements
- The feature is entirely additive and backward compatible

## Additional Notes

**Design Rationale:**
The symmetric filtering approach ensures that when users exclude files from coverage analysis, the baseline and head reports are computed over the same denominator. This is critical because it keeps derivative metrics (patch coverage, indirect-change lists, fail-under-patch gates) valid even when the baseline predates the exclusion rule. Without symmetric filtering, excluding files could cause misleading patch coverage percentages or invalid comparisons.

**Future Enhancements:**
- Additional providers could be supported through the same pattern-based exclusion mechanism
- Pattern caching could be added if the same patterns are used across multiple invocations

**Known Limitations:**
- Patterns are unanchored (partial matches), matching the semantics of `cargo llvm-cov --ignore-filename-regex`
- Filtering is performed after strip-prefix normalization, so patterns match repo-relative paths