### PR TITLE
docs(mcp): clarify dry_run helper scope and supported tools

### DIFF
--- a/src/mcp/dry_run.rs
+++ b/src/mcp/dry_run.rs
@@ -1,12 +1,17 @@
 //! Shared helper for the `dry_run` parameter on mutating Atlassian MCP tools.
 //!
-//! When a mutating tool (`jira_create`, `jira_write`, `jira_link`,
-//! `confluence_create`, `confluence_write`) is called with `dry_run: true`, it
-//! performs all local resolution and ADF validation but stops short of the
-//! network call, returning the **would-be HTTP request** (method, path, body)
-//! as YAML instead. This lets an AI agent validate required fields and JFM→ADF
-//! formatting before committing an irreversible mutation — the MCP-side mirror
-//! of the CLI's `--dry-run` flag (see issue #1048).
+//! When a mutating create/write/link tool such as `jira_create`, `jira_write`,
+//! `jira_edit`, `jira_link`, `confluence_create`, or `confluence_write` is
+//! called with `dry_run: true`, it performs all local resolution and ADF
+//! validation but stops short of the network call, returning the **would-be HTTP
+//! request** (method, path, body) as YAML instead. This lets an AI agent
+//! validate required fields and JFM→ADF formatting before committing an
+//! irreversible mutation — the MCP-side mirror of the CLI's `--dry-run` flag
+//! (see issue #1048).
+//!
+//! Other tools expose dry-run previews without this HTTP-request helper. For
+//! example, `confluence_comment_reanchor` computes a comment move preview, and
+//! `git_twiddle_commits` formats its own amendment preview.
 //!
 //! The preview is rendered as YAML (the AI-friendly default per ADR-0020 /
 //! ADR-0021) rather than printed, since the MCP server speaks JSON-RPC over


### PR DESCRIPTION
## Description

This PR clarifies the documentation for the `dry_run` helper module in the MCP (Model Context Protocol) implementation. The changes expand and improve the module-level documentation to better explain the scope of which tools support dry-run previews and provide concrete examples of tools that use different preview mechanisms.

The documentation now explicitly lists all mutating tools that support the HTTP request preview pattern (`jira_create`, `jira_write`, `jira_edit`, `jira_link`, `confluence_create`, `confluence_write`) and introduces examples of other tools that expose dry-run previews using different approaches, such as `confluence_comment_reanchor` and `git_twiddle_commits`.

This improves developer experience by clarifying the dry-run implementation pattern and helping maintainers and contributors understand which tools use this particular approach versus custom preview implementations.

## Type of Change

- [x] Documentation update

## Related Issue

Relates to #1238 - dry-run documentation tools clarification

## Changes Made

**Documentation:**
- Updated the module-level documentation in `src/mcp/dry_run.rs` to provide clearer scoping of which tools use the dry-run HTTP request preview pattern
- Added explicit mention of `jira_edit` to the list of mutating tools that support dry-run previews
- Added new section documenting that other tools expose dry-run previews using different mechanisms
- Included concrete examples of tools with custom preview implementations (`confluence_comment_reanchor`, `git_twiddle_commits`)
- Improved formatting and clarity of the existing documentation to make the concepts more accessible

## Testing

**Automated Testing:**
- [x] All existing tests pass (documentation-only change)

**Manual Testing:**
- [x] Documentation builds without errors
- [x] Module documentation is readable and properly formatted

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Deployment Notes

- [x] No special deployment requirements