### PR TITLE
docs(docs): amend ADR-0027 to narrow MCP dry-run scope for create/write tools

### DIFF
--- a/docs/adrs/adr-0027.md
+++ b/docs/adrs/adr-0027.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-✅ Accepted (2026-05-11)
+✅ Accepted (2026-05-11; amended 2026-07-07 to narrow the MCP dry-run stance for
+create/write tools, where preview-by-read is impossible, [#1048](https://github.com/rust-works/omni-dev/issues/1048))
 
 ## Context
 
@@ -80,11 +81,56 @@ Every destructive MCP tool requires a mandatory `confirm: bool` parameter and
 returns an explanatory error when called without `confirm: true`. The three
 tools that previously lacked the guard (`jira_watcher_remove`,
 `jira_link_remove`, `confluence_label_remove`) now match the existing
-`jira_delete` / `confluence_delete` shape. There is no `dry_run` parameter on
-the MCP surface — assistants can preview by reading the relevant resource
-(`jira_read`, `confluence_read`, `jira_watcher_list`, `jira_link_list`, etc.)
-before mutating, and adding a per-tool dry-run mode would diverge from the
-established MCP convention.
+`jira_delete` / `confluence_delete` shape.
+
+At the time of this decision there was no `dry_run` parameter on the MCP
+surface. The reasoning was that an assistant can preview a mutation by reading
+the relevant resource (`jira_read`, `confluence_read`, `jira_watcher_list`,
+`jira_link_list`, etc.) before mutating, so a per-tool dry-run mode would
+diverge from the established `confirm` convention for no gain. That reasoning
+holds for delete-style tools but was later found not to hold for create/write
+tools; see [MCP dry-run for create/write tools](#mcp-dry-run-for-createwrite-tools)
+below, added by amendment.
+
+### MCP dry-run for create/write tools
+
+*Added by amendment (2026-07-07,
+[#1048](https://github.com/rust-works/omni-dev/issues/1048)).*
+
+The "preview by reading first" rationale above is sound for
+**delete-by-identifier** tools — the object already exists, so an assistant can
+GET it before mutating. It does **not** hold for **create/write** tools: you
+cannot read an object that does not yet exist, and the payload actually sent is
+*derived* (JFM→ADF conversion, `createmeta` field resolution, required-field
+validation) and only materialises at send time. Without a preview, the only way
+to see the would-be request is to send it.
+
+So a bounded exception was made. The following mutating tools now accept an
+optional `dry_run: bool` (default `false`) that short-circuits before the
+network call and returns the **would-be HTTP request** — method, path, and body
+rendered as YAML — via the shared `src/mcp/dry_run.rs` helper
+(`dry_run_request_yaml`), the MCP-side mirror of the CLI `--dry-run`:
+
+- `jira_create`, `jira_write`, `jira_edit`
+- `jira_link` — all three variants: create, parent, and remove
+- `confluence_create`, `confluence_write`
+
+Two further tools carry a `dry_run` field but render their preview through their
+own path rather than the shared helper: `confluence_comment_reanchor` (via
+`reanchor_inline_comment`) and the non-Atlassian `git_amend_commits` (via
+`format_twiddle_payload`, outside this ADR's Atlassian scope).
+
+Delete-style tools (`jira_delete`, `confluence_delete`, `jira_watcher_remove`,
+`confluence_label_remove`) remain `confirm`-only: the preview-by-read path still
+serves them, so the original rationale is unchanged for those tools.
+
+`confirm` and `dry_run` are **orthogonal** affordances that compose on a single
+tool. `jira_link` remove carries both: `confirm` is the destructive-action gate,
+`dry_run` is the mutation preview. When `dry_run: true` is set it takes
+precedence — the preview short-circuits before the network call *and* before the
+`confirm` check, so a dry-run neither mutates nor requires `confirm`. This
+mirrors the CLI "`--dry-run` wins over `--force`" rule in
+[Flag precedence](#flag-precedence) below.
 
 ### Flag precedence
 
@@ -142,3 +188,7 @@ same pattern.
 - Adding `--dry-run` to commands that currently have `--force` (the two
   delete commands) does not change their behaviour for any existing flag
   combination.
+- The MCP dry-run stance was **narrowed, not reversed**, after acceptance: an
+  optional `dry_run` preview was added to the create/write tools (where
+  preview-by-read is impossible), while delete-style tools stay `confirm`-only.
+  See [MCP dry-run for create/write tools](#mcp-dry-run-for-createwrite-tools).


### PR DESCRIPTION
> **Superseded by #1246** (merged). This branch was closed unmerged; the same
> change landed via #1246. Kept for history.

## Description

Amends **ADR-0027** to narrow the MCP dry-run scope, distinguishing delete-by-identifier tools (where preview-by-read is sufficient) from create/write tools (where the payload is derived and only materializes at send time, making a dry-run preview necessary).

## Type of Change

- [x] Documentation update

## Related Issue

Relates to #1211 (closed via the superseding #1246)

## Changes Made

**Documentation:**
- Amends `docs/adrs/adr-0027.md`: adds `dry_run` to create/write MCP tools, keeps delete-style tools `confirm`-only (the preview-by-read rationale still applies), and explains that `confirm` and `dry_run` are orthogonal and compose on a single tool (`dry_run` taking precedence when both are present).

## Testing

- [x] Documentation-only change; no code or tests affected.
