### PR TITLE
docs(docs): add ADR-0041 for pushed commit amendment guard

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -64,3 +64,4 @@ by Michael Nygard.
 | [ADR-0038](adr-0038.md)  | ✅ Accepted                              | 2026-06-13 | Voice Functionality Extracted to the omni-voice Repository                             |
 | [ADR-0039](adr-0039.md)  | ✅ Accepted                              | 2026-06-18 | Extensible omni-dev Daemon Hosting Pluggable Services over a Unix Control Socket       |
 | [ADR-0040](adr-0040.md)  | ✅ Accepted                              | 2026-06-23 | Cross-Window Worktrees Daemon Service Fed by a Companion VS Code Extension             |
+| [ADR-0041](adr-0041.md)  | ✅ Accepted                              | 2026-07-07 | Refuse to Amend Pushed Commits; Override Denied Only to Autonomous AI Rewrites         |

--- a/docs/adrs/adr-0041.md
+++ b/docs/adrs/adr-0041.md
@@ -1,0 +1,177 @@
+# ADR-0041: Refuse to Amend Pushed Commits; Override Denied Only to Autonomous AI Rewrites
+
+## Status
+
+✅ Accepted (2026-07-07)
+
+## Context
+
+omni-dev rewrites commit messages through four surfaces: the CLI `git commit
+message twiddle` (AI generates new messages) and `amend` (applies a
+caller-supplied YAML plan deterministically), plus the matching MCP tools
+`git_twiddle_commits` and `git_amend_commits`. Rewriting a commit that has
+already been pushed to a shared main branch rewrites *published* history:
+anyone who has pulled it now has a divergent copy, and a force-push is required
+to reconcile. That is a foot-gun on the human path and a genuine hazard on the
+autonomous one.
+
+[Issue #1105](https://github.com/rust-works/omni-dev/issues/1105) (commit
+`bd3bfa96`, `feat(git,cli)!`) added a guard: every amendment target is checked
+for containment in a remote main branch and refused by default, with an
+`--allow-pushed` escape hatch.
+
+The obvious way to describe the trust boundary is "the human CLI can override,
+the autonomous MCP surface cannot." **That description is wrong**, and writing
+the ADR to it would encode a boundary the code does not implement. The actual
+override availability is:
+
+| Surface | Command / tool | Content origin | Override exposed? |
+|---|---|---|---|
+| CLI | `git commit message twiddle` | AI-generated | ✅ `--allow-pushed` |
+| CLI | `git commit message amend` | deterministic YAML | ✅ `--allow-pushed` |
+| MCP | `git_amend_commits` | deterministic YAML | ✅ `allow_pushed` param |
+| MCP | `git_twiddle_commits` | AI-generated | ❌ none |
+
+The guard refuses pushed commits by **default** on all four; only the
+*availability of the override* differs. It is denied on **exactly one** surface,
+`git_twiddle_commits` — the intersection of two properties:
+
+1. **Autonomous** — no human is in the loop (MCP, not an interactive CLI run).
+2. **AI generates the content** — the new messages are model output, not a
+   caller-supplied plan.
+
+When either property is false the escape hatch is available: a human at the CLI
+keeps it even for AI-generated `twiddle`, and a deterministic caller-supplied
+plan keeps it even on the MCP `git_amend_commits` tool. Only when *both* hold —
+an AI silently generating rewrites with no human review — is the override
+withheld, because that combination *is* the failure mode the guard exists to
+prevent.
+
+This is adjacent to [ADR-0027](adr-0027.md) (destructive Atlassian mutations
+confirm by default, overridable by a human) but is a **different mechanism on a
+different surface**: containment-refusal over git-history rewriting, versus
+interactive-confirm over API deletes. It is recorded separately rather than
+folded in, and the containment-detection and library-signature decisions below
+have no analogue there.
+
+## Decision
+
+### Default-refuse via a single chokepoint
+
+All four surfaces converge on
+[`AmendmentHandler::validate_commit_amendable`](../../src/git/amendment.rs)
+(`src/git/amendment.rs:114-145`), called from `perform_safety_checks` before any
+rebase or `git commit --amend`. For each target commit it computes the remote
+main branches that contain it and, if the set is non-empty and `allow_pushed` is
+unset, refuses with an error that names the short hash, the containing branch(es),
+and the escape hatch:
+
+```
+Refusing to amend commit <short>: it is already in remote main branch(es): <branches>
+Amending pushed commits rewrites published history. Re-run with --allow-pushed to override.
+```
+
+A single chokepoint (rather than a check duplicated per surface) means the
+refusal, the message, and the override semantics cannot drift between CLI and
+MCP, or between `twiddle` and `amend`.
+
+### The override is the two-factor boundary, by construction
+
+`AmendmentHandler` carries an `allow_pushed` flag, default `false`, set only via
+the explicit builder `with_allow_pushed` (`src/git/amendment.rs:35-43`). The four
+surfaces wire it as follows, and the asymmetry is an intentional consequence of
+*which callers are given a way to set the flag*:
+
+- **CLI `amend`** — `--allow-pushed` clap flag threaded into the handler
+  (`src/cli/git/amend.rs:16`, and in `run_amend`). A human typed the flag.
+- **CLI `twiddle`** — `--allow-pushed` clap flag threaded into the handler
+  (`src/cli/git/twiddle.rs:23`, `:813`). AI generated the messages, but a human
+  ran the command (and, without `--auto-apply`, reviews before applying).
+- **MCP `git_amend_commits`** — `allow_pushed: bool` parameter
+  (`src/mcp/git_tools.rs:125`) threaded through `run_amend` (`:288`). No human,
+  but the caller supplied an explicit, deterministic YAML plan naming exact
+  40-char SHAs; the mutation is auditable and no AI generated the content, so the
+  "AI silently rewrites history" failure mode does not apply.
+- **MCP `git_twiddle_commits`** — **no** `allow_pushed` field on
+  `GitTwiddleCommitsParams` (`src/mcp/git_tools.rs:76`); its non-interactive core
+  `run_twiddle` constructs the handler with no `.with_allow_pushed` call
+  (`src/cli/git/twiddle.rs:1909`), so the flag is unconditionally `false`. This
+  is the one surface where *both* factors hold, so it is the one surface with no
+  override.
+
+The `git_twiddle_commits` tool description points a caller that hits the refusal
+at the human path (`omni-dev git commit message amend --allow-pushed`) rather
+than exposing a way to bypass it in-band.
+
+### Offline, local containment detection
+
+Containment is detected without any network call or `gh` invocation, in
+[`src/git/main_branches.rs`](../../src/git/main_branches.rs):
+
+- `detect_main_branch_tips` iterates the repo's remotes and resolves each one's
+  main branch **locally** via `RemoteInfo::detect_main_branch_local`: first the
+  remote's symbolic `refs/remotes/<remote>/HEAD`, then a common-name fallback
+  (`main` → `master` → `develop`) among existing remote-tracking refs. A remote
+  whose main cannot be resolved locally contributes **no tip** rather than a
+  guessed one, so an exotic branch layout fails open (no false refusal) rather
+  than refusing the wrong commits.
+- `branches_containing` reports a commit contained when it equals a tip or is an
+  ancestor of one (`git2::Repository::graph_descendant_of`).
+
+The tradeoff: detection is only as fresh as the last `fetch` — a commit merged
+upstream but not yet fetched locally is not seen as pushed. This is accepted
+deliberately in exchange for offline determinism and zero network latency on
+every amend; a human who knows a commit is published can still decline to pass
+`--allow-pushed`, and the inverse error (refusing an *un*pushed commit) cannot
+happen because unresolved remotes contribute no tips.
+
+### Breaking library change: precompute tips once per query
+
+Populating the new `CommitInfo.in_main_branches: Vec<String>` field
+(`src/git/commit.rs:33`) for every commit in a range must not recompute the
+remote tips per commit. So `CommitInfo::from_git_commit` gained a **mandatory**
+`main_tips: &[MainBranchTip]` parameter (`src/git/commit.rs:122-125`): callers
+compute the tips once (`RepositoryData` does so at
+`src/git/repository.rs:161` and reuses them across every `from_git_commit` call
+in the range) and thread the slice down, where `branches_containing` turns it
+into the per-commit `in_main_branches`. This is a breaking change to a public
+constructor; all call sites were updated in the same change.
+
+## Consequences
+
+**Positive**
+
+- Published history is protected by default on **all four** surfaces; rewriting
+  a pushed commit now requires an explicit, deliberate opt-in.
+- A single `validate_commit_amendable` chokepoint keeps the refusal, its error
+  text, and the override semantics identical across CLI/MCP and twiddle/amend —
+  no drift.
+- Detection is offline and deterministic: no network round-trip, no `gh`
+  dependency, works on a plane.
+- Precomputing tips once per query (rather than per commit) keeps range analysis
+  from doing O(commits) redundant remote resolution.
+- The one surface an autonomous AI drives to *generate and apply* rewrites is
+  structurally unable to touch published history — the exact failure mode is
+  closed, while auditable deterministic MCP applies (`git_amend_commits`) are
+  not needlessly hobbled.
+
+**Negative**
+
+- Breaking change to the public `CommitInfo::from_git_commit` signature (new
+  mandatory `main_tips` parameter); every call site had to be updated.
+- Detection freshness is bounded by the last fetch: a commit published upstream
+  but not yet fetched locally is not recognised as pushed, so the default
+  refusal will not fire for it.
+- The trust boundary is subtle — it is *not* the intuitive "CLI overrides, MCP
+  cannot" line, but a two-factor (autonomous AND AI-generated) rule that lands on
+  exactly one tool. This ADR exists precisely because that distinction is easy to
+  state wrong (the originating issue and an early review comment both did).
+
+**Neutral**
+
+- Default-refuse is uniform across surfaces; the only variation is whether a
+  given caller is handed a way to set `allow_pushed`.
+- Shelling out for the containment-sensitive mutations while reading tips through
+  `git2` is consistent with the hybrid-git split in [ADR-0003](adr-0003.md).
+- Shares the human-can-override spirit of [ADR-0027](adr-0027.md) without sharing
+  its mechanism (interactive confirm) or surface (Atlassian API deletes).


### PR DESCRIPTION
## Description

This PR documents the design decision to refuse amending commits that have been pushed to remote main branches by default, with override mechanisms that are intentionally asymmetric by construction. ADR-0041 clarifies the trust boundary for preventing rewrites of published history across all four amendment surfaces: CLI `amend`, CLI `twiddle`, MCP `git_amend_commits`, and MCP `git_twiddle_commits`.

The key insight is that the override availability is determined by two factors: whether execution is autonomous (MCP vs. interactive CLI) and whether content is AI-generated or deterministic caller-supplied YAML. The override is denied on exactly one surface—`git_twiddle_commits`—where both conditions hold (autonomous execution AND AI-generated content). This is the precise failure mode the guard exists to prevent.

## Type of Change
- [x] Documentation update

## Related Issue
Relates to #1105 (commit bd3bfa96 which added the initial pushed commit guard)

## Changes Made

**Documentation:**
- Added ADR-0041 documenting the design decision for the pushed commit amendment guard
- Updated docs/adrs/README.md to include the new ADR entry with acceptance date and title
- Documented the asymmetric override availability across four surfaces (CLI amend, CLI twiddle, MCP git_amend_commits, MCP git_twiddle_commits)
- Explained the two-factor boundary: autonomous execution AND AI-generated content
- Detailed the implementation approach via `AmendmentHandler::validate_commit_amendable` chokepoint
- Documented offline, deterministic containment detection using local remote tips
- Documented the breaking library change requiring mandatory `main_tips` parameter in `CommitInfo::from_git_commit`
- Listed consequences (positive: protected published history by default; negative: breaking change to public API, fetch-time freshness limitation, subtle trust boundary)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests required (documentation-only change)

**Manual Testing:**
- [x] Documentation reviewed for accuracy and clarity
- [x] Cross-references to related ADRs (ADR-0027, ADR-0003) verified
- [x] Code references validated (file paths and line numbers accurate)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] Security improvement (described below)

This ADR documents a critical security boundary for protecting published git history from autonomous AI-generated rewrites. The design ensures that the combination of autonomous execution and AI-generated content (the highest-risk scenario) is structurally prevented from amending pushed commits, while still allowing human oversight and auditable deterministic operations to override this guard when appropriate.

## Breaking Changes

This ADR documents a breaking library change that was introduced: `CommitInfo::from_git_commit` now requires a mandatory `main_tips: &[MainBranchTip]` parameter. All call sites must pass this parameter; callers should compute the tips once per query using `detect_main_branch_tips()` and thread them through all `from_git_commit` calls in a range to avoid redundant remote resolution.

## Additional Notes

**Design Rationale:**

The override availability matrix is intentionally subtle and two-factor:
- CLI `amend` with `--allow-pushed`: human-supplied deterministic plan with human override
- CLI `twiddle` with `--allow-pushed`: AI-generated content but interactive CLI with human review and override
- MCP `git_amend_commits` with `allow_pushed` parameter: autonomous but deterministic caller-supplied YAML (no AI-generated content)
- MCP `git_twiddle_commits` with no override: autonomous AND AI-generated (the failure mode being prevented)

**Implementation Highlights:**
- Single `AmendmentHandler::validate_commit_amendable` chokepoint prevents drift between CLI and MCP surfaces
- Offline containment detection using `git2::Repository::graph_descendant_of` ensures determinism and zero network latency
- Fresh local remote tips are computed once per query and reused across all commits in a range
- Error message names the short commit hash, containing branches, and the escape hatch
- Remote resolution fails open: unresolved remotes contribute no tips, avoiding false refusals on exotic branch layouts