### PR TITLE
feat(cli,daemon): add parent repository tracking and worktree distinction in tray and list

### DIFF
--- a/docs/adrs/adr-0040.md
+++ b/docs/adrs/adr-0040.md
@@ -112,11 +112,13 @@ resync used across daemon restarts. Upserts of an existing key never evict.
 
 ### Tray submenu and CLI
 
-`menu()` contributes a "Worktrees" submenu listing each open window, with a
-`focus:<key>` **Action** per window. The action routes through the daemon's
-existing generic tray dispatch to `menu_action`, which spawns the VS Code CLI on
-the window's folder (`code <path>` — VS Code reuses the already-open window, so it
-focuses rather than re-opens). It is **best-effort**: the launcher is resolved via
+`menu()` contributes a "Worktrees" submenu with **one item per open window**: a
+`focus:<key>` **Action** whose label *is* the window's live stats line (the stats
+and the focus action are one item, not two rows). A folderless window has nothing
+to open, so it degrades to a non-clickable label. The action routes through the
+daemon's existing generic tray dispatch to `menu_action`, which spawns the VS Code
+CLI on the window's folder (`code <path>` — VS Code reuses the already-open
+window, so it focuses rather than re-opens). It is **best-effort**: the launcher is resolved via
 `OMNI_DEV_VSCODE_BIN`, then a short list of well-known absolute paths (so a
 launchd daemon with a minimal `PATH` still finds it), then bare `code`; failure is
 logged, not fatal. The folder is required to be an existing **absolute** directory
@@ -131,9 +133,11 @@ register/heartbeat/unregister ops are **not** CLI subcommands — the companion
 speaks them to the socket directly.
 
 Both the tray labels and the CLI table surface the daemon-computed git
-enrichment (branch and `+ahead -behind` sync state, see the last consequence
-below); the `menu`/`list`/`status` reads are also where the enrichment is
-computed.
+enrichment (branch, `+ahead -behind` sync state, and the parent-repo name — see
+the last consequence below); the `menu`/`list`/`status` reads are also where the
+enrichment is computed. The tray label leads with that parent-repo name and marks
+a linked worktree with a `⑂` fork glyph, so a worktree reads distinctly from its
+repo's main checkout.
 
 ## Consequences
 
@@ -169,15 +173,17 @@ computed.
   daemon work, #1237).
 - Git enrichment lives in Rust, not the extension: the companion reports raw
   folder paths (keeping it ~50 lines), and the richer per-worktree git data
-  (current branch, ahead/behind) is computed by the daemon with the `git2`
+  (current branch, ahead/behind, the parent-repository name from git's common
+  dir, and an `is_worktree` flag) is computed by the daemon with the `git2`
   dependency it already has (#1186). The **adapter** — not the pure registry
   **engine**, per the engine/adapter split in [ADR-0039](adr-0039.md) — computes
   it **on read** from the primary folder's on-disk state, off
   the registry lock (on a blocking thread for `list`/`status`, inline for the
   sync tray `menu`), so the values are always live rather than a registration-time
   snapshot. Each field is optional and degrades independently (no `branch` for a
-  non-repo or detached HEAD; no `ahead`/`behind` without an upstream), so it adds
-  no error path and stays wire-compatible with older clients.
+  non-repo or detached HEAD; no `ahead`/`behind` without an upstream; no
+  `main_repo` for a non-repo folder), so it adds no error path and stays
+  wire-compatible with older clients.
 
 See [ADR-0039](adr-0039.md) for the daemon framework this builds on and
 [docs/worktrees-service.md](../worktrees-service.md) for the operator-facing guide

--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -82,11 +82,13 @@ omni-dev worktrees list --socket /path/to/daemon.sock
 
 Each row shows the window's repo, its **current branch** and **ahead/behind sync
 state** (`+ahead -behind`, or `-` when the branch tracks no upstream), the
-primary folder, and how long ago the window was last seen. The branch and sync
-columns are computed by the daemon from the worktree on disk — see
-[Git enrichment](#git-enrichment) — so they reflect the live branch rather than
-whatever the companion happened to report. `-o json` carries the same fields plus
-the companion-reported `title`.
+primary folder, and how long ago the window was last seen. The REPO column shows
+the daemon-computed **main repository** (a linked worktree's parent repo, not its
+worktree-folder basename) when available, falling back to the companion-reported
+`repo`. The branch and sync columns are likewise computed by the daemon from the
+worktree on disk — see [Git enrichment](#git-enrichment) — so they reflect the
+live branch rather than whatever the companion happened to report. `-o json`
+carries the same fields plus the companion-reported `title`.
 
 The companion extension feeds the registry; the CLI only reads it. If the daemon
 is not running, `worktrees list` reports the connection failure (the companion, by
@@ -95,12 +97,21 @@ contrast, no-ops silently).
 ## Tray
 
 On a macOS `menu-bar` build the service contributes a **"Worktrees" submenu**:
-one line per open window, then a **"Focus …" action** per window. Each window's
-line shows its name and, when the primary folder is a git worktree, the live
-branch and ahead/behind state (`repo · branch (+2 -1)`); windows that are not a
-repo fall back to their reported title. Clicking a "Focus" action spawns the VS
-Code CLI on that window's folder; since VS Code reuses an already-open window,
-this focuses the right window rather than opening a new one.
+**one clickable line per open window** — the live stats and the focus action are
+the same item, not two separate rows. Each line shows the **main repository**
+name and, when the primary folder is a git repo, the live branch and ahead/behind
+state:
+
+- a normal checkout reads `omni-dev · branch (+2 -1)` (a middle dot);
+- a **linked worktree** reads `omni-dev ⑂ branch (+2 -1)` — the `⑂` fork glyph
+  sets it off from the main checkout, and the name is the **parent** repository
+  it belongs to (not the worktree-folder basename);
+- a window that is not a git repo falls back to its reported title.
+
+Clicking a line spawns the VS Code CLI on that window's folder; since VS Code
+reuses an already-open window, this focuses the right window rather than opening
+a new one. A window with no workspace folder has nothing to open, so it stays a
+non-clickable status line.
 
 Focusing is **best-effort**. The launcher is resolved in this order:
 
@@ -127,8 +138,10 @@ The `-o json` status detail carries the same enriched window entries as
 ## Git enrichment
 
 The companion reports only raw folder paths; the **daemon** computes the richer
-per-worktree git state — current branch and ahead/behind counts — with the
-`git2` dependency it already carries (#1186). Keeping this in Rust preserves the
+per-worktree git state — current branch, ahead/behind counts, the **main
+repository** name (from git's common dir, so a linked worktree resolves the
+parent repo it belongs to), and an **`is_worktree`** flag — with the `git2`
+dependency it already carries (#1186). Keeping this in Rust preserves the
 companion's thin-reporter contract ([ADR-0040](adrs/adr-0040.md)): the ~50-line
 extension never runs git.
 
@@ -143,7 +156,9 @@ extension never runs git.
   subdirectory or a linked worktree. A folder that is not a git repo, a detached
   HEAD, or a branch with no upstream is still listed — just without the fields it
   cannot supply (no `branch`, or `branch` with no `ahead`/`behind`). The
-  enrichment never fails a `list`.
+  `main_repo` name and `is_worktree` flag are resolved from the repository itself,
+  so they are present even for an unborn or detached HEAD (only a non-repo folder
+  omits them). The enrichment never fails a `list`.
 
 ## Security
 
@@ -196,19 +211,22 @@ Where:
   needs no retry logic (an evicted window re-registers off its next heartbeat).
 - `folders` — absolute workspace-folder paths.
 - A `list` `entry` is
-  `{ key, folders[], repo?, title?, pid?, branch?, ahead?, behind?, last_seen }`
-  with `last_seen` as an RFC 3339 timestamp; consumers compute age from it.
-  Entries are sorted by `(repo, key)` for deterministic output. The
-  companion-reported fields are stored and served verbatim on the wire (and in
-  `-o json`); only the human-readable `worktrees list` table sanitizes them for
-  terminal display (see Security).
-- `branch`, `ahead`, `behind` are **daemon-computed, not companion-reported**:
-  the daemon derives them from the primary folder's git state on every read (see
-  [Git enrichment](#git-enrichment)). Each is optional and omitted when it does
-  not apply — no `branch` for a non-repo or detached HEAD; no `ahead`/`behind`
-  when the branch tracks no upstream. New optional fields like these follow the
-  protocol's `#[serde(skip_serializing_if)]` convention, so an older client
-  simply ignores them.
+  `{ key, folders[], repo?, title?, pid?, branch?, ahead?, behind?, main_repo?,
+  is_worktree?, last_seen }` with `last_seen` as an RFC 3339 timestamp; consumers
+  compute age from it. Entries are sorted by `(repo, key)` for deterministic
+  output. The companion-reported fields are stored and served verbatim on the wire
+  (and in `-o json`); only the human-readable `worktrees list` table sanitizes
+  them for terminal display (see Security).
+- `branch`, `ahead`, `behind`, `main_repo`, `is_worktree` are **daemon-computed,
+  not companion-reported**: the daemon derives them from the primary folder's git
+  state on every read (see [Git enrichment](#git-enrichment)). Each is optional
+  and omitted when it does not apply — no `branch` for a non-repo or detached
+  HEAD; no `ahead`/`behind` when the branch tracks no upstream; no `main_repo` for
+  a non-repo folder; `is_worktree` omitted (false) for a normal checkout.
+  `main_repo` is the parent repository's directory name (so a linked worktree
+  names the repo it belongs to rather than its worktree-folder basename). New
+  optional fields like these follow the protocol's `#[serde(skip_serializing_if)]`
+  convention, so an older client simply ignores them.
 
 Companion lifecycle, per window:
 
@@ -225,7 +243,7 @@ Example exchange:
 → {"service":"worktrees","op":"register","payload":{"key":"3f1c…","folders":["/home/me/omni-dev"],"repo":"omni-dev","title":"omni-dev — main","pid":4321}}
 ← {"ok":true,"payload":{"ok":true}}
 → {"service":"worktrees","op":"list"}
-← {"ok":true,"payload":{"windows":[{"key":"3f1c…","folders":["/home/me/omni-dev"],"repo":"omni-dev","title":"omni-dev — main","pid":4321,"branch":"main","ahead":2,"behind":0,"last_seen":"2026-06-23T01:20:00Z"}]}}
+← {"ok":true,"payload":{"windows":[{"key":"3f1c…","folders":["/home/me/omni-dev"],"repo":"omni-dev","title":"omni-dev — main","pid":4321,"branch":"main","ahead":2,"behind":0,"main_repo":"omni-dev","last_seen":"2026-06-23T01:20:00Z"}]}}
 ```
 
 The companion sends no `branch`/`ahead`/`behind` on `register`; the daemon adds

--- a/src/cli/worktrees.rs
+++ b/src/cli/worktrees.rs
@@ -118,7 +118,7 @@ fn render_windows(result: &Value) -> String {
         "REPO", "BRANCH", "SYNC", "FOLDER", "AGE"
     );
     for window in windows {
-        let repo = sanitize(window.get("repo").and_then(Value::as_str).unwrap_or("-"));
+        let repo = sanitize(repo_name(window));
         let branch = sanitize(window.get("branch").and_then(Value::as_str).unwrap_or("-"));
         let sync = sync_summary(window);
         let folder_disp = folder_summary(window);
@@ -128,6 +128,17 @@ fn render_windows(result: &Value) -> String {
         ));
     }
     out
+}
+
+/// The repo name to show for a window: the daemon-computed `main_repo` (which
+/// names the *parent* repository of a linked worktree, not its worktree-folder
+/// basename) when present, else the companion-reported `repo`, else `-`.
+fn repo_name(window: &Value) -> &str {
+    window
+        .get("main_repo")
+        .and_then(Value::as_str)
+        .or_else(|| window.get("repo").and_then(Value::as_str))
+        .unwrap_or("-")
 }
 
 /// A compact `+ahead -behind` divergence indicator for a window, or `-` when
@@ -243,6 +254,37 @@ mod tests {
         assert!(table.contains("/home/me/omni-dev (+1)"), "{table}");
         // A header line plus exactly one data row.
         assert_eq!(table.lines().count(), 2, "{table}");
+    }
+
+    #[test]
+    fn render_windows_prefers_main_repo_over_companion_repo() {
+        // A linked worktree: the companion reports the worktree-folder basename,
+        // but the daemon-computed `main_repo` names the parent repo, and that is
+        // what the REPO column shows.
+        let result = json!({ "windows": [{
+            "key": "w1",
+            "repo": "issue-1250",
+            "main_repo": "omni-dev",
+            "branch": "issue-1250",
+            "folders": ["/home/me/worktrees/issue-1250"],
+            "last_seen": "2000-01-01T00:00:00Z",
+        }]});
+        let table = render_windows(&result);
+        assert!(table.contains("omni-dev"), "{table}");
+        // The misleading worktree-folder basename does not appear in REPO (it is
+        // still visible in the FOLDER column path).
+        let data_row = table.lines().nth(1).unwrap();
+        assert!(data_row.starts_with("omni-dev"), "{data_row}");
+    }
+
+    #[test]
+    fn repo_name_falls_back_to_companion_repo_then_dash() {
+        assert_eq!(
+            repo_name(&json!({ "main_repo": "omni-dev", "repo": "wt" })),
+            "omni-dev"
+        );
+        assert_eq!(repo_name(&json!({ "repo": "wt" })), "wt");
+        assert_eq!(repo_name(&json!({})), "-");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -112,7 +112,11 @@ pub async fn build_default_registry(
     registry.register(Arc::new(bridge));
     let snowflake = SnowflakeService::new(SnowflakeEngineConfig::from_env_and_settings()?);
     registry.register(Arc::new(snowflake));
-    registry.register(Arc::new(WorktreesService::new()));
+    // Start the off-thread menu-refresh loop so the tray serves a cached menu
+    // instead of running git enrichment on the macOS GUI thread (#1186 fix).
+    let worktrees = WorktreesService::new();
+    worktrees.start_menu_refresh();
+    registry.register(Arc::new(worktrees));
     Ok(registry)
 }
 

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -20,12 +20,16 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use git2::Repository;
 use serde::Serialize;
 use serde_json::{json, Value};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::daemon::service::{DaemonService, MenuAction, MenuItem, MenuSnapshot, ServiceStatus};
 use crate::worktrees::{RegisterRequest, WindowEntry, WorktreesRegistry};
@@ -33,23 +37,94 @@ use crate::worktrees::{RegisterRequest, WindowEntry, WorktreesRegistry};
 /// The worktrees service name (the control-socket routing key).
 pub const SERVICE_NAME: &str = "worktrees";
 
+/// The tray submenu title.
+const SUBMENU_TITLE: &str = "Worktrees";
+
 /// Environment override for the VS Code launcher used by the "focus" tray
 /// action, for when the daemon runs under launchd with a minimal `PATH`.
 const VSCODE_BIN_ENV: &str = "OMNI_DEV_VSCODE_BIN";
 
+/// How often the background task recomputes the tray menu snapshot off the main
+/// thread. The macOS tray polls `menu()` ~1 Hz; caching a couple of seconds keeps
+/// the displayed branch/sync state fresh without ever doing git I/O on the GUI
+/// thread (which would peg a core and stall shutdown — the #1186 regression).
+const MENU_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// A running background menu-refresh task and the token that stops it.
+struct RefreshTask {
+    /// Cancelled by `shutdown` to end the refresh loop.
+    token: CancellationToken,
+    /// The spawned loop, awaited on shutdown so it fully unwinds.
+    handle: JoinHandle<()>,
+}
+
 /// Hosts the cross-window [`WorktreesRegistry`] as a [`DaemonService`].
 pub struct WorktreesService {
-    /// The cross-window registry this adapter routes ops to.
-    registry: WorktreesRegistry,
+    /// The cross-window registry this adapter routes ops to. Behind an `Arc` so
+    /// the background menu-refresh task can read it off the main thread.
+    registry: Arc<WorktreesRegistry>,
+    /// The most recent tray menu snapshot, recomputed off the main thread by
+    /// [`start_menu_refresh`](Self::start_menu_refresh). `menu()` serves a clone
+    /// of this so it never blocks on git enrichment. `None` until the first
+    /// refresh lands — or when no runtime started a task (e.g. unit tests) — in
+    /// which case `menu()` falls back to a one-off inline compute.
+    menu_cache: Arc<Mutex<Option<Vec<MenuItem>>>>,
+    /// The background refresh task, once started (`None` in tests / no runtime).
+    refresh: Mutex<Option<RefreshTask>>,
 }
 
 impl WorktreesService {
-    /// Creates the service with an empty registry. Cheap — no I/O.
+    /// Creates the service with an empty registry. Cheap — no I/O and no task;
+    /// the daemon calls [`start_menu_refresh`](Self::start_menu_refresh) to begin
+    /// off-thread menu caching, while tests use the bare service (menu computed
+    /// inline on demand).
     #[must_use]
     pub fn new() -> Self {
         Self {
-            registry: WorktreesRegistry::new(),
+            registry: Arc::new(WorktreesRegistry::new()),
+            menu_cache: Arc::new(Mutex::new(None)),
+            refresh: Mutex::new(None),
         }
+    }
+
+    /// Starts the background task that recomputes the tray menu snapshot every
+    /// [`MENU_REFRESH_INTERVAL`] **off the main thread** — git enrichment is
+    /// blocking disk I/O — and stores it in [`menu_cache`](Self::menu_cache), so
+    /// the macOS tray's `menu()` serves a cache instead of running git on the GUI
+    /// event loop. Idempotent, and a no-op outside a tokio runtime (mirroring the
+    /// Snowflake keep-alive heartbeat), so unit tests that build a bare service
+    /// keep computing the menu inline.
+    pub fn start_menu_refresh(&self) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            tracing::debug!("no tokio runtime; worktrees menu refresh not started");
+            return;
+        }
+        let mut guard = self.refresh.lock().unwrap_or_else(PoisonError::into_inner);
+        if guard.is_some() {
+            return;
+        }
+        let token = CancellationToken::new();
+        let loop_token = token.clone();
+        let registry = self.registry.clone();
+        let cache = self.menu_cache.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                // Snapshot the registry (a cheap lock), then build the menu —
+                // which opens repos and parses git config — on a blocking thread,
+                // never on this async worker or the tray's main thread.
+                let entries = registry.list();
+                if let Ok(items) =
+                    tokio::task::spawn_blocking(move || menu_items_for(&entries)).await
+                {
+                    *cache.lock().unwrap_or_else(PoisonError::into_inner) = Some(items);
+                }
+                tokio::select! {
+                    () = loop_token.cancelled() => break,
+                    () = tokio::time::sleep(MENU_REFRESH_INTERVAL) => {}
+                }
+            }
+        });
+        *guard = Some(RefreshTask { token, handle });
     }
 }
 
@@ -90,14 +165,18 @@ impl DaemonService for WorktreesService {
     }
 
     fn menu(&self) -> MenuSnapshot {
-        let entries = self.registry.list();
-        let items = if entries.is_empty() {
-            vec![MenuItem::Label("No open windows".to_string())]
-        } else {
-            window_menu_items(&entries)
-        };
+        // Serve the snapshot the background task maintains off the main thread;
+        // fall back to a one-off inline compute only before the first refresh
+        // lands (or with no runtime — the unit tests). Never blocks on git here
+        // in the daemon, honouring the trait's "cheap, must not block" contract.
+        let cached = self
+            .menu_cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        let items = cached.unwrap_or_else(|| menu_items_for(&self.registry.list()));
         MenuSnapshot {
-            title: "Worktrees".to_string(),
+            title: SUBMENU_TITLE.to_string(),
             items,
         }
     }
@@ -130,7 +209,18 @@ impl DaemonService for WorktreesService {
     }
 
     async fn shutdown(&self) {
-        // In-memory only; nothing to drain or persist.
+        // Stop the background menu-refresh task; the registry itself is in-memory
+        // with nothing to drain or persist. Take the task out from under the lock
+        // first so the `std::Mutex` is never held across the `.await`.
+        let task = self
+            .refresh
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take();
+        if let Some(task) = task {
+            task.token.cancel();
+            let _ = task.handle.await;
+        }
     }
 }
 
@@ -315,6 +405,18 @@ const REPO_SEP: char = '·';
 /// Separator marking a **linked worktree** (a git "fork" glyph), so a worktree
 /// line is distinguishable at a glance from its parent repo's main checkout.
 const WORKTREE_SEP: char = '⑂';
+
+/// The full tray item list for a window set: the "No open windows" placeholder
+/// when empty, else one line per window via [`window_menu_items`]. Does the git
+/// enrichment (blocking disk I/O), so it runs on a blocking thread from the
+/// background refresh task — and inline only as a cold-start fallback in `menu`.
+fn menu_items_for(entries: &[WindowEntry]) -> Vec<MenuItem> {
+    if entries.is_empty() {
+        vec![MenuItem::Label("No open windows".to_string())]
+    } else {
+        window_menu_items(entries)
+    }
+}
 
 /// Builds the tray items for a non-empty window list: **one clickable line per
 /// window** whose label carries the live git state and whose click focuses that
@@ -681,6 +783,52 @@ mod tests {
             .collect();
         assert!(action_ids.contains(&"focus:w1"));
         assert!(action_ids.contains(&"focus:w2"));
+    }
+
+    #[test]
+    fn start_menu_refresh_is_a_noop_outside_a_runtime() {
+        // With no tokio runtime, the background task is never spawned, so the
+        // bare service keeps computing `menu()` inline (what the tests rely on).
+        let svc = WorktreesService::new();
+        svc.start_menu_refresh();
+        assert!(svc.refresh.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn start_menu_refresh_populates_cache_and_shutdown_stops_it() {
+        let svc = WorktreesService::new();
+        svc.handle("register", register_payload("w1", Some("repo-a"), "/tmp/a"))
+            .await
+            .unwrap();
+        // Before the task runs, `menu()` computes inline from an empty cache.
+        assert!(svc.menu_cache.lock().unwrap().is_none());
+
+        svc.start_menu_refresh();
+        // Idempotent: a second call does not start a second task.
+        svc.start_menu_refresh();
+
+        // The task fills the cache off the main thread; poll briefly for it.
+        let mut filled = false;
+        for _ in 0..100 {
+            if svc.menu_cache.lock().unwrap().is_some() {
+                filled = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(filled, "background refresh should populate the menu cache");
+
+        // `menu()` now serves the cache: one clickable line for the window.
+        let menu = svc.menu();
+        assert_eq!(menu.title, "Worktrees");
+        assert!(menu
+            .items
+            .iter()
+            .any(|i| matches!(i, MenuItem::Action(a) if a.id == "focus:w1")));
+
+        // Shutdown cancels and joins the task, clearing the handle.
+        svc.shutdown().await;
+        assert!(svc.refresh.lock().unwrap().is_none());
     }
 
     #[tokio::test]

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -11,10 +11,11 @@
 //! secret persisted.
 //!
 //! The adapter also computes the **per-worktree git enrichment** (current
-//! branch, ahead/behind counts) on read via `git2` (#1186), keeping the
-//! companion a thin reporter of raw folder paths (ADR-0040). The engine stores
-//! only what the companion sends; disk I/O for the enrichment lives here,
-//! alongside the launcher, never under the registry lock.
+//! branch, ahead/behind counts, and the parent repository a linked worktree
+//! belongs to) on read via `git2` (#1186), keeping the companion a thin reporter
+//! of raw folder paths (ADR-0040). The engine stores only what the companion
+//! sends; disk I/O for the enrichment lives here, alongside the launcher, never
+//! under the registry lock.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -163,6 +164,24 @@ struct GitStatus {
     /// Commits the branch is behind its upstream (`None` without an upstream).
     #[serde(skip_serializing_if = "Option::is_none")]
     behind: Option<usize>,
+    /// The main repository's directory name — the parent repo for a linked
+    /// worktree, the checkout's own directory otherwise. Derived from git's
+    /// common dir so a worktree names the repo it belongs to rather than its
+    /// worktree-folder basename. `None` when not in a repo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    main_repo: Option<String>,
+    /// Whether the enriched folder is a **linked** git worktree rather than the
+    /// repository's main working tree. Omitted (false) for a normal checkout.
+    #[serde(skip_serializing_if = "is_false")]
+    is_worktree: bool,
+}
+
+/// `skip_serializing_if` predicate for a `bool` defaulting to `false`, so the
+/// field is dropped on the wire unless set — keeping older clients byte-identical
+/// (the protocol's forward-compatibility convention).
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// Computes the [`GitStatus`] of `folder` by discovering the repository that
@@ -173,9 +192,16 @@ fn git_status(folder: &Path) -> GitStatus {
     let Ok(repo) = Repository::discover(folder) else {
         return GitStatus::default();
     };
+    // Repo identity applies even when HEAD is unborn or detached, so a worktree
+    // still names its parent repo (and is flagged as a worktree) in those states.
+    let base = GitStatus {
+        main_repo: main_repo_name(repo.commondir()),
+        is_worktree: repo.is_worktree(),
+        ..GitStatus::default()
+    };
     let Ok(head) = repo.head() else {
         // An unborn branch (fresh repo, no commits) or an unreadable HEAD.
-        return GitStatus::default();
+        return base;
     };
     // A branch HEAD has a UTF-8 shorthand; anything else — a detached HEAD
     // (mid-rebase or a checked-out tag/commit), or the rare non-UTF-8 branch
@@ -186,7 +212,7 @@ fn git_status(folder: &Path) -> GitStatus {
         .filter(|_| head.is_branch())
         .map(str::to_string)
     else {
-        return GitStatus::default();
+        return base;
     };
     let branch = git2::Branch::wrap(head);
     let (ahead, behind) = match upstream_ahead_behind(&repo, &branch) {
@@ -197,6 +223,31 @@ fn git_status(folder: &Path) -> GitStatus {
         branch: Some(name),
         ahead,
         behind,
+        ..base
+    }
+}
+
+/// The main repository's directory name from git's common dir. For the usual
+/// `<repo>/.git` layout — shared by a checkout and all its linked worktrees —
+/// that is the working-tree directory's name; for a bare repo (`<name>.git`) it
+/// is that directory with a trailing `.git` stripped. Best-effort: `None` when
+/// no name can be derived.
+fn main_repo_name(commondir: &Path) -> Option<String> {
+    let file_name = commondir.file_name()?.to_string_lossy().into_owned();
+    if file_name == ".git" {
+        // Normal layout: the repo is the directory that contains `.git`.
+        commondir
+            .parent()
+            .and_then(Path::file_name)
+            .map(|n| n.to_string_lossy().into_owned())
+    } else {
+        // A bare repo: use its own directory name, without any `.git` suffix.
+        Some(
+            file_name
+                .strip_suffix(".git")
+                .unwrap_or(&file_name)
+                .to_string(),
+        )
     }
 }
 
@@ -259,48 +310,67 @@ fn display_name(entry: &WindowEntry) -> String {
     "(no folder)".to_string()
 }
 
-/// Builds the tray items for a non-empty window list: a label per window, a
-/// separator, then a "Focus" action per window that has a folder to open. The
-/// labels carry live git state, so this reads each worktree from disk — cheap
-/// for a realistic window count and consistent with reap-on-read.
+/// Separator between the repo name and branch for a normal working tree.
+const REPO_SEP: char = '·';
+/// Separator marking a **linked worktree** (a git "fork" glyph), so a worktree
+/// line is distinguishable at a glance from its parent repo's main checkout.
+const WORKTREE_SEP: char = '⑂';
+
+/// Builds the tray items for a non-empty window list: **one clickable line per
+/// window** whose label carries the live git state and whose click focuses that
+/// window. A window with no workspace folder has nothing for `code` to open, so
+/// it stays a non-clickable status line. The labels read each worktree from disk
+/// (via [`window_label`]) — cheap for a realistic window count and consistent
+/// with reap-on-read.
 fn window_menu_items(entries: &[WindowEntry]) -> Vec<MenuItem> {
-    let mut items = Vec::new();
-    for entry in entries {
-        items.push(MenuItem::Label(window_label(entry)));
-    }
-    items.push(MenuItem::Separator);
-    for entry in entries {
-        // No folder means nothing for `code` to open, so omit the action.
-        if !entry.folders.is_empty() {
-            items.push(MenuItem::Action(MenuAction {
-                id: format!("focus:{}", entry.key),
-                label: format!("Focus {}", display_name(entry)),
-                enabled: true,
-            }));
-        }
-    }
-    items
+    entries
+        .iter()
+        .map(|entry| {
+            let label = window_label(entry);
+            if entry.folders.is_empty() {
+                MenuItem::Label(label)
+            } else {
+                MenuItem::Action(MenuAction {
+                    id: format!("focus:{}", entry.key),
+                    label,
+                    enabled: true,
+                })
+            }
+        })
+        .collect()
 }
 
-/// The tray label for one window: its display name, then live branch state
-/// (`repo · branch (+2 -1)`) when the primary folder is a git worktree,
-/// otherwise the reported title if it adds anything the name does not.
+/// The tray label for one window: the **main repository** name, then live branch
+/// state (`omni-dev · branch (+2 -1)`) when the primary folder is a git repo. A
+/// linked worktree is set off with the [`WORKTREE_SEP`] fork glyph
+/// (`omni-dev ⑂ branch`) so it reads distinctly from the main checkout; a folder
+/// that is not a repo falls back to its reported title.
 fn window_label(entry: &WindowEntry) -> String {
-    let name = display_name(entry);
     let status = entry
         .folders
         .first()
         .map(|folder| git_status(folder))
         .unwrap_or_default();
+    // Prefer the git-derived main repo so a linked worktree names its parent
+    // repository rather than its worktree-folder basename.
+    let name = status
+        .main_repo
+        .clone()
+        .unwrap_or_else(|| display_name(entry));
     if let Some(branch) = &status.branch {
+        let sep = if status.is_worktree {
+            WORKTREE_SEP
+        } else {
+            REPO_SEP
+        };
         return match sync_indicator(status.ahead, status.behind) {
-            Some(sync) => format!("{name} · {branch} {sync}"),
-            None => format!("{name} · {branch}"),
+            Some(sync) => format!("{name} {sep} {branch} {sync}"),
+            None => format!("{name} {sep} {branch}"),
         };
     }
     // No git branch (not a repo / detached): fall back to the reported title.
     match &entry.title {
-        Some(title) if title != &name => format!("{name} · {title}"),
+        Some(title) if title != &name => format!("{name} {REPO_SEP} {title}"),
         _ => name,
     }
 }
@@ -520,10 +590,11 @@ mod tests {
     }
 
     #[test]
-    fn window_menu_items_label_omits_redundant_title_and_skips_folderless_actions() {
+    fn window_menu_items_merge_stats_and_focus_into_one_clickable_line() {
         let now = Utc::now();
         let entries = vec![
-            // Title differs from the repo name → "name · title".
+            // A folder-bearing, non-repo window: one clickable Action whose label
+            // is the stats line ("name · title", since /tmp is not a git repo).
             WindowEntry {
                 key: "k1".to_string(),
                 folders: vec![PathBuf::from("/tmp/a")],
@@ -532,8 +603,8 @@ mod tests {
                 pid: None,
                 last_seen: now,
             },
-            // Title equals the display name → label is just the name (the
-            // `_ => name` arm), and no folder means no Focus action.
+            // A folderless window has nothing to focus, so it stays a plain
+            // Label; a title equal to the name collapses to just the name.
             WindowEntry {
                 key: "k2".to_string(),
                 folders: vec![],
@@ -544,6 +615,23 @@ mod tests {
             },
         ];
         let items = window_menu_items(&entries);
+        // Exactly one item per window — no duplicate label, no separator.
+        assert_eq!(items.len(), 2);
+        assert!(!items.iter().any(|i| matches!(i, MenuItem::Separator)));
+
+        // The folder-bearing window is a single clickable action carrying the
+        // stats label (the old label + Focus action, merged).
+        let action = items
+            .iter()
+            .find_map(|i| match i {
+                MenuItem::Action(a) => Some(a),
+                _ => None,
+            })
+            .expect("a focus action");
+        assert_eq!(action.id, "focus:k1");
+        assert_eq!(action.label, "repo · a branch");
+
+        // The folderless window is a non-clickable label (not "solo · solo").
         let labels: Vec<&str> = items
             .iter()
             .filter_map(|i| match i {
@@ -551,18 +639,7 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert!(labels.contains(&"repo · a branch"));
-        assert!(labels.contains(&"solo")); // not "solo · solo"
-
-        let action_ids: Vec<&str> = items
-            .iter()
-            .filter_map(|i| match i {
-                MenuItem::Action(a) => Some(a.id.as_str()),
-                _ => None,
-            })
-            .collect();
-        // Only the folder-bearing window gets a Focus action.
-        assert_eq!(action_ids, vec!["focus:k1"]);
+        assert_eq!(labels, vec!["solo"]);
     }
 
     #[tokio::test]
@@ -591,8 +668,9 @@ mod tests {
         assert_eq!(status.summary, "2 window(s) across 1 repo(s)");
 
         let menu = svc.menu();
-        // Two labels + a separator + two focus actions.
-        assert!(menu.items.iter().any(|i| matches!(i, MenuItem::Separator)));
+        // One clickable item per window — no separator, no duplicate label.
+        assert_eq!(menu.items.len(), 2);
+        assert!(!menu.items.iter().any(|i| matches!(i, MenuItem::Separator)));
         let action_ids: Vec<&str> = menu
             .items
             .iter()
@@ -752,15 +830,30 @@ mod tests {
         assert_eq!(status.branch.as_deref(), Some("main"));
         assert_eq!(status.ahead, Some(1));
         assert_eq!(status.behind, Some(1));
+        // A normal checkout names itself and is not flagged a worktree.
+        assert_eq!(
+            status.main_repo.as_deref(),
+            dir.path().file_name().and_then(|n| n.to_str())
+        );
+        assert!(!status.is_worktree);
     }
 
     #[test]
     fn git_status_empty_repo_is_unborn() {
         // A repo with no commits has an unborn HEAD, so `head()` errors and the
-        // status degrades to empty rather than panicking.
+        // branch/sync fields stay empty rather than panicking — but the repo
+        // identity is still resolved from the common dir.
         let dir = tempfile::tempdir().unwrap();
         init_repo(dir.path());
-        assert_eq!(git_status(dir.path()), GitStatus::default());
+        let status = git_status(dir.path());
+        assert_eq!(status.branch, None);
+        assert_eq!(status.ahead, None);
+        assert_eq!(status.behind, None);
+        assert_eq!(
+            status.main_repo.as_deref(),
+            dir.path().file_name().and_then(|n| n.to_str())
+        );
+        assert!(!status.is_worktree);
     }
 
     #[test]
@@ -777,17 +870,26 @@ mod tests {
     }
 
     #[test]
-    fn git_status_non_repo_and_detached_are_empty() {
-        // A plain directory that is not a git repo.
+    fn git_status_non_repo_is_empty_detached_reports_repo_without_branch() {
+        // A plain directory that is not a git repo yields nothing at all.
         let plain = tempfile::tempdir().unwrap();
         assert_eq!(git_status(plain.path()), GitStatus::default());
 
-        // A detached HEAD reports no branch (and thus no sync).
+        // A detached HEAD reports no branch (and thus no sync), but the repo
+        // identity is still resolved from the common dir.
         let dir = tempfile::tempdir().unwrap();
         let repo = init_repo(dir.path());
         let a = empty_commit(&repo, Some("refs/heads/main"), &[], "A");
         repo.set_head_detached(a).unwrap();
-        assert_eq!(git_status(dir.path()), GitStatus::default());
+        let status = git_status(dir.path());
+        assert_eq!(status.branch, None);
+        assert_eq!(status.ahead, None);
+        assert_eq!(status.behind, None);
+        assert_eq!(
+            status.main_repo.as_deref(),
+            dir.path().file_name().and_then(|n| n.to_str())
+        );
+        assert!(!status.is_worktree);
     }
 
     #[test]
@@ -823,8 +925,13 @@ mod tests {
         // No upstream configured → the ahead/behind keys are absent, not zero.
         assert!(windows[0].get("ahead").is_none());
         assert!(windows[0].get("behind").is_none());
+        // The main repo name is enriched onto the entry.
+        assert_eq!(
+            windows[0].get("main_repo").and_then(Value::as_str),
+            dir.path().file_name().and_then(|n| n.to_str())
+        );
 
-        // A non-repo folder is still listed, just without a branch.
+        // A non-repo folder is still listed, just without a branch or main repo.
         let plain = tempfile::tempdir().unwrap();
         svc.handle(
             "register",
@@ -838,6 +945,7 @@ mod tests {
             .find(|w| w.get("key").and_then(Value::as_str) == Some("w2"))
             .unwrap();
         assert!(w2.get("branch").is_none());
+        assert!(w2.get("main_repo").is_none());
     }
 
     #[test]
@@ -846,17 +954,19 @@ mod tests {
         let repo = init_repo(dir.path());
         empty_commit(&repo, Some("refs/heads/main"), &[], "A");
         repo.set_head("refs/heads/main").unwrap();
+        let repo_name = dir.path().file_name().unwrap().to_str().unwrap();
         let entry = WindowEntry {
             key: "k".to_string(),
             folders: vec![dir.path().to_path_buf()],
-            repo: Some("my-repo".to_string()),
+            // Both the companion `repo` and `title` are overridden by the
+            // git-derived main repo name and computed branch.
+            repo: Some("companion-repo".to_string()),
             title: Some("ignored title".to_string()),
             pid: None,
             last_seen: Utc::now(),
         };
-        // The computed branch wins over the reported title; with no upstream
-        // there is no sync suffix.
-        assert_eq!(window_label(&entry), "my-repo · main");
+        // Main checkout: `repo · branch`, and with no upstream there is no sync.
+        assert_eq!(window_label(&entry), format!("{repo_name} · main"));
     }
 
     #[tokio::test]
@@ -886,15 +996,103 @@ mod tests {
     fn window_label_includes_sync_for_tracking_branch() {
         let dir = tempfile::tempdir().unwrap();
         let _repo = diverging_repo(dir.path());
+        let repo_name = dir.path().file_name().unwrap().to_str().unwrap();
         let entry = WindowEntry {
             key: "k".to_string(),
             folders: vec![dir.path().to_path_buf()],
-            repo: Some("my-repo".to_string()),
+            repo: Some("companion-repo".to_string()),
             title: None,
             pid: None,
             last_seen: Utc::now(),
         };
         // A tracking branch appends the `(+ahead -behind)` sync indicator.
-        assert_eq!(window_label(&entry), "my-repo · main (+1 -1)");
+        assert_eq!(window_label(&entry), format!("{repo_name} · main (+1 -1)"));
+    }
+
+    /// Adds a linked worktree of `repo` at `wt_path` checked out on a new
+    /// `branch` pointed at `base`, mirroring `git worktree add -b <branch>
+    /// <wt_path>`.
+    fn add_worktree(repo: &Repository, base: git2::Oid, wt_path: &Path, branch: &str) {
+        let commit = repo.find_commit(base).unwrap();
+        repo.branch(branch, &commit, false).unwrap();
+        let reference = repo
+            .find_reference(&format!("refs/heads/{branch}"))
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(&reference));
+        repo.worktree(branch, wt_path, Some(&opts)).unwrap();
+    }
+
+    #[test]
+    fn git_status_marks_linked_worktree_and_names_parent_repo() {
+        let main_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(main_dir.path());
+        let a = empty_commit(&repo, Some("refs/heads/main"), &[], "A");
+        repo.set_head("refs/heads/main").unwrap();
+
+        // A linked worktree checked out on a new `feature` branch, in a
+        // directory whose basename is deliberately *not* the repo name.
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("feature-wt");
+        add_worktree(&repo, a, &wt_path, "feature");
+
+        let status = git_status(&wt_path);
+        assert!(status.is_worktree);
+        assert_eq!(status.branch.as_deref(), Some("feature"));
+        // The worktree names its *parent* repo, not its worktree-folder basename.
+        assert_eq!(
+            status.main_repo.as_deref(),
+            main_dir.path().file_name().and_then(|n| n.to_str())
+        );
+
+        // The main checkout resolves the same repo name and is not a worktree.
+        let main_status = git_status(main_dir.path());
+        assert!(!main_status.is_worktree);
+        assert_eq!(main_status.main_repo, status.main_repo);
+    }
+
+    #[test]
+    fn window_label_marks_worktree_with_fork_glyph() {
+        let main_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(main_dir.path());
+        let a = empty_commit(&repo, Some("refs/heads/main"), &[], "A");
+        repo.set_head("refs/heads/main").unwrap();
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("feature-wt");
+        add_worktree(&repo, a, &wt_path, "feature");
+
+        let repo_name = main_dir.path().file_name().unwrap().to_str().unwrap();
+        let entry = WindowEntry {
+            key: "k".to_string(),
+            folders: vec![wt_path],
+            repo: Some("feature-wt".to_string()),
+            title: None,
+            pid: None,
+            last_seen: Utc::now(),
+        };
+        // A worktree line: parent repo, the fork glyph, then the branch (no
+        // upstream here, so no sync suffix).
+        assert_eq!(window_label(&entry), format!("{repo_name} ⑂ feature"));
+    }
+
+    #[test]
+    fn main_repo_name_derives_from_common_dir() {
+        // Normal layout: the repo is the directory that contains `.git`.
+        assert_eq!(
+            main_repo_name(Path::new("/home/me/omni-dev/.git")).as_deref(),
+            Some("omni-dev")
+        );
+        // A trailing slash on the common dir does not change the answer.
+        assert_eq!(
+            main_repo_name(Path::new("/home/me/omni-dev/.git/")).as_deref(),
+            Some("omni-dev")
+        );
+        // A bare repo: its own directory name, without the `.git` suffix.
+        assert_eq!(
+            main_repo_name(Path::new("/srv/git/omni-dev.git")).as_deref(),
+            Some("omni-dev")
+        );
+        // A `.git` at the filesystem root has no parent name to use.
+        assert_eq!(main_repo_name(Path::new("/.git")), None);
     }
 }

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -695,6 +695,18 @@ mod tests {
     fn window_menu_items_merge_stats_and_focus_into_one_clickable_line() {
         let now = Utc::now();
         let entries = vec![
+            // A folderless window has nothing to focus, so it stays a plain
+            // Label; a title equal to the name collapses to just the name. It
+            // leads the list so the focus-action lookup below is exercised
+            // against a leading non-Action item it has to skip.
+            WindowEntry {
+                key: "k2".to_string(),
+                folders: vec![],
+                repo: Some("solo".to_string()),
+                title: Some("solo".to_string()),
+                pid: None,
+                last_seen: now,
+            },
             // A folder-bearing, non-repo window: one clickable Action whose label
             // is the stats line ("name · title", since /tmp is not a git repo).
             WindowEntry {
@@ -702,16 +714,6 @@ mod tests {
                 folders: vec![PathBuf::from("/tmp/a")],
                 repo: Some("repo".to_string()),
                 title: Some("a branch".to_string()),
-                pid: None,
-                last_seen: now,
-            },
-            // A folderless window has nothing to focus, so it stays a plain
-            // Label; a title equal to the name collapses to just the name.
-            WindowEntry {
-                key: "k2".to_string(),
-                folders: vec![],
-                repo: Some("solo".to_string()),
-                title: Some("solo".to_string()),
                 pid: None,
                 last_seen: now,
             },
@@ -759,19 +761,26 @@ mod tests {
         assert!(status.healthy);
         assert_eq!(status.summary, "0 window(s) across 0 repo(s)");
 
-        // With two windows in the same repo.
+        // Two folder-bearing windows in the same repo, plus one folderless
+        // window that shares the repo but has nothing for `code` to open.
         svc.handle("register", register_payload("w1", Some("repo-a"), "/tmp/a"))
             .await
             .unwrap();
         svc.handle("register", register_payload("w2", Some("repo-a"), "/tmp/b"))
             .await
             .unwrap();
+        svc.handle(
+            "register",
+            json!({ "key": "w3", "repo": "repo-a", "folders": [] }),
+        )
+        .await
+        .unwrap();
         let status = svc.status().await;
-        assert_eq!(status.summary, "2 window(s) across 1 repo(s)");
+        assert_eq!(status.summary, "3 window(s) across 1 repo(s)");
 
         let menu = svc.menu();
-        // One clickable item per window — no separator, no duplicate label.
-        assert_eq!(menu.items.len(), 2);
+        // One line per window — no separator, no duplicate label.
+        assert_eq!(menu.items.len(), 3);
         assert!(!menu.items.iter().any(|i| matches!(i, MenuItem::Separator)));
         let action_ids: Vec<&str> = menu
             .items
@@ -781,8 +790,11 @@ mod tests {
                 _ => None,
             })
             .collect();
+        // The two folder-bearing windows are clickable; the folderless one is a
+        // plain Label, so it never yields a focus action.
         assert!(action_ids.contains(&"focus:w1"));
         assert!(action_ids.contains(&"focus:w2"));
+        assert!(!action_ids.contains(&"focus:w3"));
     }
 
     #[test]

--- a/src/daemon/tray.rs
+++ b/src/daemon/tray.rs
@@ -28,6 +28,11 @@ use crate::daemon::server::{self, DaemonOptions};
 use crate::daemon::service::{MenuItem as ServiceMenuItem, MenuSnapshot};
 use crate::daemon::{build_default_registry, DaemonRunConfig};
 
+/// How often the tray re-polls each service's `menu()` and rebuilds/refreshes
+/// the tray. Bounds the per-service `menu()` work to ~1 Hz regardless of how
+/// often the OS invokes the event-loop callback (which can be many times a
+/// second) — otherwise those `menu()` calls churn a core.
+const MENU_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// Menu id of the daemon-level Quit item.
 const QUIT_ID: &str = "omni-dev:quit";
 /// Separator between a service name and its action id inside a tray menu id.
@@ -238,28 +243,39 @@ fn event_loop(
 
     let menu_rx = MenuEvent::receiver();
     let mut clipboard: Option<Clipboard> = None;
+    // The initial menu was just built, so the first re-poll is one interval away.
+    let mut last_poll = Instant::now();
 
     event_loop.run_return(move |_event, _target, control_flow| {
-        // Wake at least once per second to refresh the live menu state.
-        *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_secs(1));
+        // Wake at least once per interval to refresh the live menu state.
+        *control_flow = ControlFlow::WaitUntil(Instant::now() + MENU_POLL_INTERVAL);
 
         // Close the tray when the daemon is stopped by a signal or `daemon stop`.
+        // This cheap check runs on every callback so shutdown is observed
+        // promptly, even though the menu re-poll below is throttled.
         if shutdown.is_cancelled() {
             *control_flow = ControlFlow::Exit;
             return;
         }
 
-        let snaps = snapshots(&registry);
-        let sig = signature(&snaps);
-        if sig != last_sig {
-            // Update item text/enabled in place so an open menu isn't closed;
-            // only a structural change (sessions added/removed) rebuilds it.
-            if !update_in_place(&handles, &snaps) {
-                let (menu, new_handles) = build_menu(&snaps);
-                tray.set_menu(Some(Box::new(menu)));
-                handles = new_handles;
+        // Re-poll each service's `menu()` at most once per interval rather than on
+        // every OS callback (which fires many times a second) — the callback is
+        // invoked far more often than the WaitUntil timer, and recomputing the
+        // snapshots every time needlessly burns CPU.
+        if last_poll.elapsed() >= MENU_POLL_INTERVAL {
+            last_poll = Instant::now();
+            let snaps = snapshots(&registry);
+            let sig = signature(&snaps);
+            if sig != last_sig {
+                // Update item text/enabled in place so an open menu isn't closed;
+                // only a structural change (sessions added/removed) rebuilds it.
+                if !update_in_place(&handles, &snaps) {
+                    let (menu, new_handles) = build_menu(&snaps);
+                    tray.set_menu(Some(Box::new(menu)));
+                    handles = new_handles;
+                }
+                last_sig = sig;
             }
-            last_sig = sig;
         }
 
         while let Ok(event) = menu_rx.try_recv() {


### PR DESCRIPTION
## Summary

Enhances the worktrees service to compute and expose the **parent repository name** and **worktree status** for each open window, improving clarity in the tray menu and CLI list output. A linked worktree now displays its parent repo name (not its folder basename) and is visually distinguished with a fork glyph (⑂). Also moves git enrichment for the tray menu off the macOS GUI thread to fix a shutdown-stall regression.

## Changes

**Parent-repo tracking & worktree distinction** (`bd8c0dfd`)
- Add `main_repo` (parent repository directory name) and `is_worktree` fields to `GitStatus`, derived from git's common dir
- `main_repo_name()` extracts repo identity from git's common dir (normal `.git` subdirectory and bare `.git`-suffixed layouts)
- `git_status()` computes repo identity even for unborn/detached HEAD, so worktrees always name their parent repo
- `window_menu_items()` merges the stats label and focus action into a single clickable line per window
- `window_label()` prefers the daemon-computed `main_repo` and inserts `·` for normal checkouts or `⑂` for linked worktrees
- CLI `render_windows()` uses a new `repo_name()` helper that prefers `main_repo`

**Off-thread tray menu refresh** (`564ab55b`) — fixes the #1186 regression where git ops on the main thread pegged a core and stalled daemon shutdown
- The service holds the registry behind an `Arc` and caches a menu snapshot rebuilt by a background tokio task every 2s
- `menu()` serves the cached snapshot; `shutdown()` cancels and joins the refresh task
- Tray event loop throttles service polling to at most once per second

**Tests** (`e1359176`) — folderless-window coverage in the worktrees menu rendering, plus new tests for parent-repo derivation and worktree labelling.

Updates ADR-0040 and `docs/worktrees-service.md` to document the new fields and behavior.
