### PR TITLE
docs(docs): formalize service engine/adapter split architecture in ADRs 0039 and 0040

### DIFF
--- a/docs/adrs/adr-0039.md
+++ b/docs/adrs/adr-0039.md
@@ -4,7 +4,8 @@
 
 ✅ Accepted (2026-06-18; amended 2026-06-29 to adopt launchd socket activation as
 the macOS spawn model, #1081; amended 2026-07-05 to add a mirrored Linux systemd
-user unit, #1174)
+user unit, #1174; amended 2026-07-07 to formalize the service engine/adapter
+split, #1218)
 
 ## Context
 
@@ -66,6 +67,38 @@ pub trait DaemonService: Send + Sync {
 The `ServiceRegistry` ([`registry.rs`](../../src/daemon/registry.rs)) holds the
 services and routes by the request envelope's `service` field; it also iterates
 them for `status`, menu snapshots, and shutdown.
+
+### Service structure: engine vs. adapter
+
+A non-trivial service is factored into **two** parts, and the `DaemonService`
+implementation is only the thinner one:
+
+- an **engine** — a standalone module at the crate root
+  ([`src/browser/`](../../src/browser/), [`src/snowflake/`](../../src/snowflake/),
+  [`src/worktrees.rs`](../../src/worktrees.rs)) that owns the domain logic and
+  the in-memory state (the bridge's dual planes and correlator, the Snowflake
+  session pools, the worktrees registry). It knows nothing of the control socket
+  or the tray, so it is unit-testable **without a running daemon** and reusable
+  outside it.
+- an **adapter** — the `DaemonService` impl under
+  [`src/daemon/services/`](../../src/daemon/services/) (`bridge.rs`,
+  `snowflake.rs`, `worktrees.rs`). It holds no domain logic: it deserializes the
+  op payload, calls into the engine, renders the `menu()`/`status()` snapshots the
+  tray and `daemon status` consume, and drives the side-effects that are the
+  daemon's job rather than the engine's (persisting the bridge session token,
+  spawning `code` for a worktree `focus`).
+
+The trivial in-tree `echo` service is the deliberate exception — it is the
+framework's test fixture and has no engine. Worktrees started fused and had its
+engine split out explicitly in #1154, aligning it with the bridge and Snowflake;
+this two-part shape is now the prescribed way to add a service.
+
+Because the engine owns the state, the **load-bearing concurrency invariant lives
+at the engine**: any `std::sync::Mutex` guarding that state is **never held across
+an `.await`** — locked only for pure-CPU work, then dropped before any await
+point. This is the rule [ADR-0040](adr-0040.md) previously called "the Snowflake
+rule"; naming it here makes this ADR its single owner, since the invariant now
+spans the engine module and its adapter.
 
 ### Unix-domain control socket, NDJSON framing
 
@@ -264,6 +297,13 @@ menu actions (copy key/snippet/request command) are handled in the tray via
   shutdown, status aggregation, and the macOS menu bar **once**; a new capability
   becomes a long-lived service by implementing a single trait and registering it,
   rather than re-deriving a foreground-process harness.
+- Splitting each service into a crate-root **engine** and a thin `DaemonService`
+  **adapter** keeps domain logic testable and reusable without a running daemon,
+  keeps adapters uniform and thin, and makes this ADR the single source of truth
+  for how to add a service. The cost is an extra module boundary and re-export
+  surface per service, and the never-hold-a-lock-across-`.await` invariant now
+  spans two modules — so it is restated at the engine (above) rather than left
+  implicit in the adapter.
 - The trust boundaries stay cleanly separated: the operator/tray control plane is
   a `0600` Unix socket gated by filesystem permission, while each service keeps
   its own network authentication. The browser bridge's ADR-0036 model — loopback

--- a/docs/adrs/adr-0040.md
+++ b/docs/adrs/adr-0040.md
@@ -57,9 +57,11 @@ companion VS Code extension (a separate deliverable) feeds it from each window.
 
 ### In-memory registry keyed by a companion-owned key
 
-The service holds an in-memory map of open windows behind a `std::sync::Mutex`
-that is **never held across an `.await`** (the Snowflake rule from
-[ADR-0039](adr-0039.md)). Each entry is
+The **engine** ([`src/worktrees.rs`](../../src/worktrees.rs), the crate-root
+`WorktreesRegistry` split out in #1154) holds an in-memory map of open windows
+behind a `std::sync::Mutex` that is **never held across an `.await`** — the
+engine/adapter concurrency invariant defined in [ADR-0039](adr-0039.md); the
+`WorktreesService` adapter only routes ops to it. Each entry is
 `{ key, folders, repo, title, pid, last_seen }`.
 
 The map is keyed by a **companion-owned `key`** — a UUID the extension generates
@@ -168,8 +170,9 @@ computed.
 - Git enrichment lives in Rust, not the extension: the companion reports raw
   folder paths (keeping it ~50 lines), and the richer per-worktree git data
   (current branch, ahead/behind) is computed by the daemon with the `git2`
-  dependency it already has (#1186). The service adapter — not the pure registry
-  engine — computes it **on read** from the primary folder's on-disk state, off
+  dependency it already has (#1186). The **adapter** — not the pure registry
+  **engine**, per the engine/adapter split in [ADR-0039](adr-0039.md) — computes
+  it **on read** from the primary folder's on-disk state, off
   the registry lock (on a blocking thread for `list`/`status`, inline for the
   sync tray `menu`), so the values are always live rather than a registration-time
   snapshot. Each field is optional and degrades independently (no `branch` for a


### PR DESCRIPTION
## Description

This PR formalizes the service engine/adapter split architecture by amending ADRs 0039 and 0040 to document the prescribed two-part service structure pattern. The changes establish a clear architectural contract that separates domain logic (engine) from daemon-specific concerns (adapter) and consolidates the load-bearing concurrency invariant at the engine level.

The engine module (at crate root) owns domain logic and in-memory state and is unit-testable without a running daemon. The adapter is a thin `DaemonService` implementation that deserializes operations, calls the engine, renders snapshots, and handles daemon-specific side effects. This pattern replaces implicit understanding with explicit documentation, making it the single source of truth for adding new services.

Establishes the critical concurrency invariant: any `std::sync::Mutex` guarding engine state must never be held across an `.await`. This replaces the previous Snowflake-specific formulation and becomes the universally applicable rule across all services.

Closes #1218

## Type of Change
- [x] Documentation update

## Related Issue
Closes #1218

## Changes Made

**ADR-0039 (Daemon as long-lived control-plane process):**
- Added amendment date (2026-07-07) and #1218 reference to status section
- Added new "Service structure: engine vs. adapter" section explaining:
  - Engine: crate-root module owning domain logic and in-memory state (testable without daemon)
  - Adapter: thin `DaemonService` impl deserializing ops, calling engine, handling daemon-specific side effects
- Documented the load-bearing concurrency invariant at engine level: `std::sync::Mutex` never held across `.await`
- Clarified that `echo` service is deliberate exception (test fixture, no engine)
- Noted worktrees engine split in #1154 as alignment with bridge and Snowflake patterns
- Added rationale bullet explaining benefits (testability, reusability, uniform adapters, single source of truth) and costs (extra module boundary, re-export surface, invariant spans two modules)

**ADR-0040 (Worktrees registry):**
- Clarified that the **engine** (`WorktreesRegistry` at crate root) holds the in-memory map and `std::sync::Mutex`
- Updated concurrency invariant reference from "Snowflake rule" to "engine/adapter concurrency invariant" defined in ADR-0039
- Clarified that `WorktreesService` adapter only routes operations to engine
- Distinguished adapter vs. engine responsibilities in git enrichment section:
  - Adapter computes git data on read (not engine)
  - Adapter does this off the registry lock and on blocking thread for list/status operations
- Added explicit reference to engine/adapter split pattern in ADR-0039

## Testing

**Documentation Testing:**
- [x] Documentation changes reviewed for clarity and accuracy
- [x] Cross-references between ADRs (0039 and 0040) verified
- [x] Architecture pattern consistency validated across existing services

No automated tests are required as this is a documentation-only change. The changes clarify existing architectural patterns already implemented in the codebase (browser bridge, Snowflake service, worktrees engine split in #1154).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. This is a documentation-only amendment that formalizes existing architectural patterns without changing any code behavior.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Architecture Consolidation:**
This PR consolidates the architectural understanding across three key ADRs:
- ADR-0036: Bridge architecture (existing engine/adapter pattern)
- ADR-0039: Daemon process design (now explicitly documents engine/adapter pattern)
- ADR-0040: Worktrees registry (now clarified as engine with adapter routing)

The engine/adapter split is now the prescribed pattern for new services, with the load-bearing concurrency invariant made explicit and unified across all implementations.

**Related Work:**
- #1154: Worktrees engine split (implementation that aligns with this formalization)
- #1081: macOS spawn model amendment
- #1174: Linux systemd user unit amendment