### PR TITLE
feat(snowflake): expose disconnect --id / --all via socket and CLI

### DIFF
--- a/docs/snowflake-service.md
+++ b/docs/snowflake-service.md
@@ -97,8 +97,15 @@ omni-dev snowflake query --account MYACCT --user me -o csv --out-file rows.csv "
 
 # List / evict multiplexed sessions.
 omni-dev snowflake sessions          # table; -o json for machines
-omni-dev snowflake disconnect --account MYACCT --user me
+omni-dev snowflake disconnect --account MYACCT --user me   # one pool by identity
+omni-dev snowflake disconnect --id 3                       # one pool by id (from `sessions`)
+omni-dev snowflake disconnect --all                        # every pool
 ```
+
+`disconnect` takes exactly one selector — the `--account`/`--user` pair, `--id`
+(the numeric pool id shown by `sessions`), or `--all`. The by-id and bulk forms
+were previously reachable only from the macOS tray, so non-macOS operators had to
+restart the daemon to bulk-evict sessions (#1228).
 
 `query` returns a self-describing payload:
 
@@ -331,7 +338,13 @@ Ops:
 |--------------|--------------------------------------------------------------------|--------------------------------------------------------|
 | `query`      | `{ account?, user?, warehouse?, role?, database?, schema?, sql }`  | `{ columns: [...], rows: [...] }`                      |
 | `sessions`   | `null`                                                             | `{ sessions: [<pool>] }` — one entry per pool, see below |
-| `disconnect` | `{ account, user }`                                                | `{ disconnected: <bool> }`                             |
+| `disconnect` | `{ account, user }` \| `{ id }` \| `{ all: true }`                 | `{ disconnected: <bool>, count: <n> }`                |
+
+`disconnect` accepts three mutually-exclusive selectors: the `(account, user)`
+pair (the original contract), `id` (a numeric pool id from `sessions`), or
+`all: true` (every pool). `count` is the number of pools evicted (`0` or `1` for
+the pair/id forms); `disconnected` is `count > 0`, preserved for callers written
+against the pre-#1228 reply.
 
 Each `<pool>` entry in the `sessions` reply describes one `(account, user)`
 session pool, including its live members (the CLI and tray render all of these

--- a/src/cli/snowflake.rs
+++ b/src/cli/snowflake.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use serde_json::{json, Value};
 
 use crate::cli::format::TableOrJson;
@@ -41,7 +41,8 @@ pub enum SnowflakeSubcommands {
     Query(QueryCommand),
     /// List active multiplexed sessions.
     Sessions(SessionsCommand),
-    /// Disconnect (evict) one session.
+    /// Disconnect (evict) sessions: one `(account, user)` pool, a pool by id, or
+    /// all pools.
     Disconnect(DisconnectCommand),
 }
 
@@ -255,15 +256,28 @@ fn render_member(member: &Value) -> String {
     format!("#{mid} {context} · {state} · {qc} queries")
 }
 
-/// Evicts a single multiplexed session.
+/// Evicts multiplexed sessions: one `(account, user)` pool, a pool by numeric id
+/// (from `sessions`), or every pool. Exactly one selector is required — the
+/// `--account`/`--user` pair, `--id`, or `--all`.
 #[derive(Parser)]
+#[command(group(
+    ArgGroup::new("target")
+        .required(true)
+        .args(["account", "id", "all"]),
+))]
 pub struct DisconnectCommand {
-    /// Account of the session to evict.
+    /// Account of the pool to evict (requires `--user`).
+    #[arg(long, requires = "user")]
+    pub account: Option<String>,
+    /// User of the pool to evict (requires `--account`).
+    #[arg(long, requires = "account")]
+    pub user: Option<String>,
+    /// Numeric id of the pool to evict (as shown by `sessions`).
     #[arg(long)]
-    pub account: String,
-    /// User of the session to evict.
+    pub id: Option<u64>,
+    /// Evict every pool.
     #[arg(long)]
-    pub user: String,
+    pub all: bool,
     /// Control-socket path. Defaults to the per-user runtime location.
     #[arg(long, value_name = "PATH")]
     pub socket: Option<PathBuf>,
@@ -271,24 +285,54 @@ pub struct DisconnectCommand {
 
 impl DisconnectCommand {
     /// Executes the disconnect command.
-    pub async fn execute(self) -> Result<()> {
-        let socket = server::resolve_socket(self.socket)?;
-        let payload = json!({ "account": self.account, "user": self.user });
+    pub async fn execute(mut self) -> Result<()> {
+        let payload = self.payload();
+        let socket = server::resolve_socket(self.socket.take())?;
         let result = call(&socket, "disconnect", payload).await?;
+        println!("{}", self.message(&result));
+        Ok(())
+    }
+
+    /// Builds the socket payload for whichever selector was chosen. Exactly one
+    /// is present (enforced by the `target` arg group), so the `--account`/
+    /// `--user` fallthrough always has both.
+    fn payload(&self) -> Value {
+        if self.all {
+            json!({ "all": true })
+        } else if let Some(id) = self.id {
+            json!({ "id": id })
+        } else {
+            json!({ "account": self.account, "user": self.user })
+        }
+    }
+
+    /// The line printed after the socket call, matched to the selector and the
+    /// number of pools the daemon actually evicted (`count`).
+    fn message(&self, result: &Value) -> String {
+        let count = result.get("count").and_then(Value::as_u64).unwrap_or(0);
         let disconnected = result
             .get("disconnected")
             .and_then(Value::as_bool)
-            .unwrap_or(false);
-        println!(
-            "{}",
-            disconnect_message(disconnected, &self.account, &self.user)
-        );
-        Ok(())
+            .unwrap_or(count > 0);
+        if self.all {
+            format!("Disconnected {count} session pool(s).")
+        } else if let Some(id) = self.id {
+            if disconnected {
+                format!("Disconnected session pool #{id}.")
+            } else {
+                format!("No active session pool with id {id}.")
+            }
+        } else {
+            // The arg group guarantees the pair when neither --all nor --id.
+            let account = self.account.as_deref().unwrap_or_default();
+            let user = self.user.as_deref().unwrap_or_default();
+            disconnect_message(disconnected, account, user)
+        }
     }
 }
 
-/// The message printed after a `disconnect`, depending on whether a session was
-/// actually evicted.
+/// The message printed after a `(account, user)` disconnect, depending on whether
+/// a session pool was actually evicted.
 fn disconnect_message(disconnected: bool, account: &str, user: &str) -> String {
     if disconnected {
         format!("Disconnected {account} / {user}.")
@@ -493,9 +537,13 @@ mod tests {
     }
 
     fn parse(args: &[&str]) -> SnowflakeSubcommands {
+        try_parse(args).unwrap().cmd
+    }
+
+    fn try_parse(args: &[&str]) -> Result<Wrapper, clap::Error> {
         let mut full = vec!["omni-dev"];
         full.extend_from_slice(args);
-        Wrapper::try_parse_from(full).unwrap().cmd
+        Wrapper::try_parse_from(full)
     }
 
     #[test]
@@ -644,18 +692,77 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_requires_account_and_user() {
+    fn disconnect_pair_parses_and_pairs_are_required_together() {
         let SnowflakeSubcommands::Disconnect(cmd) =
             parse(&["disconnect", "--account", "ACCT", "--user", "me"])
         else {
             panic!("expected disconnect");
         };
-        assert_eq!(cmd.account, "ACCT");
-        assert_eq!(cmd.user, "me");
+        assert_eq!(cmd.account.as_deref(), Some("ACCT"));
+        assert_eq!(cmd.user.as_deref(), Some("me"));
+        assert!(cmd.id.is_none());
+        assert!(!cmd.all);
+        assert_eq!(cmd.payload(), json!({ "account": "ACCT", "user": "me" }));
 
-        // Missing required flags is a parse error.
-        let mut full = vec!["omni-dev", "disconnect", "--account", "ACCT"];
-        assert!(Wrapper::try_parse_from(std::mem::take(&mut full)).is_err());
+        // --account without --user (and vice versa) is a parse error.
+        assert!(try_parse(&["disconnect", "--account", "ACCT"]).is_err());
+        assert!(try_parse(&["disconnect", "--user", "me"]).is_err());
+    }
+
+    #[test]
+    fn disconnect_by_id_and_all_selectors_parse() {
+        let SnowflakeSubcommands::Disconnect(cmd) = parse(&["disconnect", "--id", "7"]) else {
+            panic!("expected disconnect");
+        };
+        assert_eq!(cmd.id, Some(7));
+        assert_eq!(cmd.payload(), json!({ "id": 7 }));
+
+        let SnowflakeSubcommands::Disconnect(cmd) = parse(&["disconnect", "--all"]) else {
+            panic!("expected disconnect");
+        };
+        assert!(cmd.all);
+        assert_eq!(cmd.payload(), json!({ "all": true }));
+    }
+
+    #[test]
+    fn disconnect_requires_and_conflicts_selectors() {
+        // No selector at all is an error (the `target` group is required).
+        assert!(try_parse(&["disconnect"]).is_err());
+        // Selectors are mutually exclusive.
+        assert!(try_parse(&["disconnect", "--all", "--id", "1"]).is_err());
+        assert!(try_parse(&["disconnect", "--account", "A", "--user", "u", "--all"]).is_err());
+        assert!(try_parse(&["disconnect", "--id", "1", "--account", "A", "--user", "u"]).is_err());
+    }
+
+    #[test]
+    fn disconnect_message_reflects_selector_and_count() {
+        let all = DisconnectCommand {
+            account: None,
+            user: None,
+            id: None,
+            all: true,
+            socket: None,
+        };
+        assert_eq!(
+            all.message(&json!({ "disconnected": true, "count": 3 })),
+            "Disconnected 3 session pool(s)."
+        );
+
+        let by_id = DisconnectCommand {
+            account: None,
+            user: None,
+            id: Some(5),
+            all: false,
+            socket: None,
+        };
+        assert_eq!(
+            by_id.message(&json!({ "disconnected": true, "count": 1 })),
+            "Disconnected session pool #5."
+        );
+        assert_eq!(
+            by_id.message(&json!({ "disconnected": false, "count": 0 })),
+            "No active session pool with id 5."
+        );
     }
 
     #[test]

--- a/src/daemon/services/snowflake.rs
+++ b/src/daemon/services/snowflake.rs
@@ -37,6 +37,34 @@ impl SnowflakeService {
         engine.start_heartbeat();
         Self { engine }
     }
+
+    /// Handles the `disconnect` op's three mutually-exclusive selectors — every
+    /// pool (`{ all: true }`), a pool by numeric id (`{ id }`), or the
+    /// `(account, user)` pair (`{ account, user }`, the original contract). The
+    /// bulk and by-id forms were previously reachable only from the macOS tray
+    /// (#1228). Every reply carries `count` (pools evicted) plus `disconnected`
+    /// (`count > 0`), so the by-id and pair forms stay wire-compatible with the
+    /// pre-#1228 `{ disconnected }` reply.
+    fn handle_disconnect(&self, payload: &Value) -> Result<Value> {
+        if payload.get("all").and_then(Value::as_bool) == Some(true) {
+            let count = self.engine.disconnect_all();
+            return Ok(json!({ "disconnected": count > 0, "count": count }));
+        }
+        if let Some(id) = payload.get("id").and_then(Value::as_u64) {
+            let removed = self.engine.disconnect_by_id(id);
+            return Ok(json!({ "disconnected": removed, "count": u64::from(removed) }));
+        }
+        let account = payload
+            .get("account")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("`disconnect` requires `account`, `id`, or `all`"))?;
+        let user = payload
+            .get("user")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("`disconnect` requires `user`"))?;
+        let removed = self.engine.disconnect(account, user);
+        Ok(json!({ "disconnected": removed, "count": u64::from(removed) }))
+    }
 }
 
 #[async_trait]
@@ -56,17 +84,7 @@ impl DaemonService for SnowflakeService {
                 self.engine.query(req).await
             }
             "sessions" => Ok(json!({ "sessions": self.engine.sessions() })),
-            "disconnect" => {
-                let account = payload
-                    .get("account")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow!("`disconnect` requires `account`"))?;
-                let user = payload
-                    .get("user")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow!("`disconnect` requires `user`"))?;
-                Ok(json!({ "disconnected": self.engine.disconnect(account, user) }))
-            }
+            "disconnect" => self.handle_disconnect(&payload),
             other => bail!("unknown snowflake op: {other}"),
         }
     }
@@ -219,7 +237,21 @@ mod tests {
             .handle("disconnect", json!({ "account": "ACCT", "user": "me" }))
             .await
             .unwrap();
-        assert_eq!(payload, json!({ "disconnected": false }));
+        assert_eq!(payload, json!({ "disconnected": false, "count": 0 }));
+    }
+
+    #[tokio::test]
+    async fn disconnect_by_id_and_all_selectors() {
+        let svc = offline_service();
+        // Nothing to evict on an empty engine, but both bulk forms succeed and
+        // report a zero count.
+        let by_id = svc.handle("disconnect", json!({ "id": 7 })).await.unwrap();
+        assert_eq!(by_id, json!({ "disconnected": false, "count": 0 }));
+        let all = svc
+            .handle("disconnect", json!({ "all": true }))
+            .await
+            .unwrap();
+        assert_eq!(all, json!({ "disconnected": false, "count": 0 }));
     }
 
     #[tokio::test]

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -3259,7 +3259,7 @@ Usage: snowflake <COMMAND>
 Commands:
   query       Run SQL (from an argument or stdin) through a multiplexed session
   sessions    List active multiplexed sessions
-  disconnect  Disconnect (evict) one session
+  disconnect  Disconnect (evict) sessions: one `(account, user)` pool, a pool by id, or all pools
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3268,15 +3268,17 @@ Options:
 
 ================================================================================
 
-omni-dev snowflake disconnect - Disconnect (evict) one session
+omni-dev snowflake disconnect - Disconnect (evict) sessions: one `(account, user)` pool, a pool by id, or all pools
 
-Disconnect (evict) one session
+Disconnect (evict) sessions: one `(account, user)` pool, a pool by id, or all pools
 
-Usage: disconnect [OPTIONS] --account <ACCOUNT> --user <USER>
+Usage: disconnect [OPTIONS] <--account <ACCOUNT>|--id <ID>|--all>
 
 Options:
-      --account <ACCOUNT>  Account of the session to evict
-      --user <USER>        User of the session to evict
+      --account <ACCOUNT>  Account of the pool to evict (requires `--user`)
+      --user <USER>        User of the pool to evict (requires `--account`)
+      --id <ID>            Numeric id of the pool to evict (as shown by `sessions`)
+      --all                Evict every pool
       --socket <PATH>      Control-socket path. Defaults to the per-user runtime location
   -h, --help               Print help
 


### PR DESCRIPTION
## Description

This PR exposes bulk and by-id session disconnection capabilities through both the socket API and CLI, previously only accessible from the macOS tray. The `omni-dev snowflake disconnect` command now supports three mutually-exclusive selectors:

- `--account <ACCOUNT> --user <USER>` - Original behavior, disconnect a specific pool by identity
- `--id <ID>` - Disconnect a pool by numeric id (as shown by `sessions` command)
- `--all` - Disconnect every pool at once

This resolves the operational gap where non-macOS users had to restart the daemon to bulk-evict sessions, as the engine already had `disconnect_all()` and `disconnect_by_id()` methods that weren't exposed.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Fixes #1228

## Changes Made

**Core Changes:**
- Added `handle_disconnect()` method to `SnowflakeService` in `src/daemon/services/snowflake.rs` to route three mutually-exclusive selectors (`all`, `id`, or `account`/`user` pair) to appropriate engine methods
- Updated socket `disconnect` operation to support `{ all: true }`, `{ id }`, and `{ account, user }` payloads with unified response format including `count` alongside `disconnected` for wire compatibility
- Enhanced `DisconnectCommand` in `src/cli/snowflake.rs` with clap `ArgGroup` enforcing exactly one selector:
  - Changed `account` and `user` from required `String` to `Option<String>` with mutual `requires` constraints
  - Added `id: Option<u64>` for pool selection by numeric id
  - Added `all: bool` flag for bulk disconnection
- Implemented `payload()` method to construct appropriate socket JSON based on selected selector
- Implemented `message()` method to generate context-aware output messages that reflect the selector type and pool count evicted

**Documentation:**
- Updated `docs/snowflake-service.md` with examples of all three disconnect forms and their use cases
- Added explanation that by-id and bulk forms resolve #1228 operational limitation
- Updated socket API documentation to show mutually-exclusive selector options and new `count` field in responses
- Clarified that `disconnected` field is preserved for backward compatibility with pre-#1228 callers

**Testing:**
- Expanded disconnect tests in `src/cli/snowflake.rs`:
  - `disconnect_pair_parses_and_pairs_are_required_together()` verifies pair selection and mutual requirements
  - `disconnect_by_id_and_all_selectors_parse()` validates id and all selector parsing and payload generation
  - `disconnect_requires_and_conflicts_selectors()` ensures exactly one selector is required and conflicts are detected
  - `disconnect_message_reflects_selector_and_count()` validates output messages for all selector types
- Added daemon service test `disconnect_by_id_and_all_selectors()` in `src/daemon/services/snowflake.rs` validating socket-level behavior
- Updated help snapshot in `tests/snapshots/integration_test__help_all_output.snap` reflecting new CLI surface

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (5 new test cases covering selector combinations)
- [x] Integration tests updated (help snapshot regenerated)
- [x] Comprehensive coverage of arg parsing, payload generation, and message formatting

**Manual Testing:**
- [x] Tested `disconnect --account ACCT --user me` - original pair form works
- [x] Tested `disconnect --id <ID>` - new by-id selector
- [x] Tested `disconnect --all` - new bulk form
- [x] Verified mutually-exclusive selector enforcement (errors on conflicting flags, no selector)
- [x] Verified backward compatibility with existing (account, user) socket callers

**Test Coverage:**
- New code coverage: Comprehensive unit and integration tests for all code paths
- Overall project coverage: Maintained existing test baseline

### Test Commands
```bash
cargo test snowflake
cargo test disconnect
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Backward compatibility - socket reply format now includes `count` field alongside existing `disconnected` field; callers written against pre-#1228 reply continue to work via `disconnected` (preserved as `count > 0`)
- [x] Error handling - proper validation of mutually-exclusive selectors at both CLI and daemon layers
- [x] CLI argument constraints - clap `ArgGroup` with `requires` constraints properly enforces selector requirements (account/user pair, id, or all)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact
- [x] No performance impact

## Security Considerations
- [x] No security implications

## Breaking Changes
None. The socket API response includes an additional `count` field but preserves the existing `disconnected` field for complete backward compatibility.

## Deployment Notes
- [x] No special deployment requirements

## Additional Notes

**Future Enhancements:**
- Additional selector types (e.g., by warehouse, by role) could leverage the same mutually-exclusive pattern

**Known Limitations:**
- None

**Alternatives Considered:**
- Making separate subcommands (`disconnect-all`, `disconnect-by-id`) was considered but would create API surface bloat; the mutually-exclusive selector pattern is cleaner and more maintainable