### PR TITLE
feat(claude): expand provider inference to recognize OpenAI and Gemini models

### DIFF
--- a/src/claude/model_config.rs
+++ b/src/claude/model_config.rs
@@ -460,9 +460,28 @@ impl ModelRegistry {
     }
 
     /// Infers the provider from a model identifier.
+    ///
+    /// Consulted only as a fallback when an identifier does not match any
+    /// known [`ModelSpec`]: the inferred provider selects which provider's
+    /// [`DefaultConfig`] (from [`ProviderConfig::defaults`]) supplies the
+    /// fallback limits. Recognised identifier shapes:
+    ///
+    /// - `claude`: starts with `claude`, or contains `anthropic` (covers the
+    ///   Bedrock/AWS region-prefixed forms).
+    /// - `openai`: starts with `gpt` or `chatgpt`, or is an `o<N>` reasoning
+    ///   identifier (`o1-mini`, `o3`, `o4-mini`, …).
+    /// - `gemini`: starts with `gemini`.
+    ///
+    /// Returns `None` when the provider cannot be inferred, in which case the
+    /// caller applies the ultimate hard-coded fallback.
     fn infer_provider(&self, api_identifier: &str) -> Option<String> {
-        if api_identifier.starts_with("claude") || api_identifier.contains("anthropic") {
+        let id = api_identifier;
+        if id.starts_with("claude") || id.contains("anthropic") {
             Some("claude".to_string())
+        } else if id.starts_with("gpt") || id.starts_with("chatgpt") || is_openai_reasoning_id(id) {
+            Some("openai".to_string())
+        } else if id.starts_with("gemini") {
+            Some("gemini".to_string())
         } else {
             None
         }
@@ -591,6 +610,16 @@ impl ModelRegistry {
         }
         self.get_input_context(api_identifier)
     }
+}
+
+/// Returns `true` for OpenAI reasoning-series identifiers: a leading `o`
+/// immediately followed by a digit (`o1-mini`, `o3`, `o4-mini`, and any
+/// future `o<N>` variant). Kept separate from the `gpt`/`chatgpt` prefixes so
+/// the reasoning family is matched without also swallowing unrelated
+/// identifiers that merely begin with `o`.
+fn is_openai_reasoning_id(id: &str) -> bool {
+    let mut chars = id.chars();
+    chars.next() == Some('o') && chars.next().is_some_and(|c| c.is_ascii_digit())
 }
 
 /// Default project-local catalog path: `<cwd>/.omni-dev/models.yaml`.
@@ -875,6 +904,39 @@ mod tests {
             registry.get_input_context("totally-unknown-vendor-x"),
             FALLBACK_INPUT_CONTEXT
         );
+    }
+
+    #[test]
+    fn unknown_openai_model_uses_openai_provider_defaults() {
+        let registry = embedded_only();
+
+        // Brand-new OpenAI identifiers the embedded catalog has not caught up
+        // to yet resolve to the `openai` provider defaults (16384/128000), not
+        // the ultimate hard-coded fallback. Covers the gpt-, chatgpt-, and
+        // o<N>-reasoning identifier shapes.
+        for id in ["gpt-6-ultra", "chatgpt-6-latest", "o5-preview"] {
+            assert_eq!(
+                registry.get_max_output_tokens(id),
+                16384,
+                "max_output_tokens for {id}"
+            );
+            assert_eq!(
+                registry.get_input_context(id),
+                128_000,
+                "input_context for {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_gemini_model_uses_gemini_provider_defaults() {
+        let registry = embedded_only();
+
+        // Unknown Gemini identifier resolves to the `gemini` provider defaults
+        // (8192/1048576) rather than the ultimate hard-coded fallback.
+        let id = "gemini-9-pro";
+        assert_eq!(registry.get_max_output_tokens(id), 8192);
+        assert_eq!(registry.get_input_context(id), 1_048_576);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR enhances the model registry's provider inference logic to correctly identify unknown models from OpenAI and Gemini based on their identifier patterns. Previously, unknown models from these providers would fall back to hard-coded universal limits (4096/8192 tokens), losing provider-specific capabilities. Now they intelligently resolve to the appropriate provider's default token limits.

The enhancement enables better handling of newly released models that haven't yet been added to the embedded catalog, ensuring they receive reasonable defaults based on their provider rather than conservative universal fallbacks.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Relates to #1119 - Provider token defaults

## Changes Made

**Core Changes:**
- Enhanced `infer_provider()` method in `src/claude/model_config.rs` to recognize OpenAI models via `gpt-`, `chatgpt-`, and `o<N>-reasoning` identifier patterns
- Added support for Gemini model detection via `gemini-` prefix
- Implemented `is_openai_reasoning_id()` helper function to precisely match OpenAI's reasoning series (`o1`, `o3`, `o5`, etc.) without false positives on unrelated identifiers starting with 'o'
- Expanded `infer_provider()` documentation with detailed explanation of fallback behavior and all supported identifier shapes

**Testing:**
- Added `test_unknown_openai_model_uses_openai_provider_defaults()` to verify unknown OpenAI models resolve to correct provider defaults (16384/128000 tokens)
- Added `test_unknown_gemini_model_uses_gemini_provider_defaults()` to verify unknown Gemini models resolve to correct provider defaults (8192/1048576 tokens)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Tests verify OpenAI model detection across gpt-, chatgpt-, and o<N>-reasoning patterns
- [x] Tests verify Gemini model detection with gemini- prefix
- [x] Tests confirm fallback to provider defaults instead of hard-coded universal limits

**Manual Testing:**
- [x] Verified provider inference for various unknown model identifiers
- [x] Tested edge cases for reasoning model pattern matching (ensures `o1-mini`, `o3`, `o4-mini` etc. match correctly)
- [x] Confirmed backward compatibility with existing known models

### Test Commands
```bash
# Run full test suite
cargo test

# Run model config specific tests
cargo test model_config

# Run with all warnings treated as errors
cargo clippy -- -D warnings

# Format check
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Logic correctness for the `is_openai_reasoning_id()` helper function (ensures no false positives)
- [x] Identifier pattern matching for all three provider types (claude, openai, gemini)
- [x] Documentation clarity on fallback behavior and supported identifier shapes
- [x] Test coverage for edge cases in reasoning model detection

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No performance impact
The provider inference enhancement uses simple string prefix matching and character inspection, with negligible computational overhead.

## Security Considerations
- [x] No security implications
This change affects only internal model configuration and token limit determination, with no impact on authentication or external API interactions.

## Breaking Changes
None. This is a purely additive feature that improves handling of unknown models without changing behavior for existing known models.

## Deployment Notes
- [x] No special deployment requirements
This change is self-contained within the model configuration system and requires no database migrations, environment variables, or configuration changes.

## Additional Notes

**Token Limit Impact:**
- Unknown OpenAI models now receive 16384/128000 (max_output/input_context) tokens from the OpenAI provider config, a significant increase from the previous hard-coded fallback of 4096/8192
- Unknown Gemini models now receive 8192/1048576 from the Gemini provider config, substantially better than the previous fallback
- Unknown Claude models continue to resolve to Claude defaults when the `claude` provider is inferred

**Future Enhancements:**
- Additional provider detection patterns can be easily added by extending `infer_provider()` and adding corresponding test cases
- Provider identifier patterns could be externalized to configuration if more flexible provider recognition becomes needed