### PR TITLE
feat(cli, daemon): implement worktrees tree command for repository enumeration

### DIFF
--- a/src/cli/worktrees.rs
+++ b/src/cli/worktrees.rs
@@ -2,7 +2,8 @@
 //! registry.
 //!
 //! Lifecycle stays on `omni-dev daemon` (`start`/`stop`/`status`/`restart`);
-//! this command only sends the `worktrees` service's read op (`list`) over the
+//! this command only sends the `worktrees` service's read ops (`list` for the
+//! open windows, `tree` for the repos-and-all-their-worktrees view) over the
 //! daemon's Unix control socket. The companion VS Code extension is what *feeds*
 //! the registry (`register`/`heartbeat`/`unregister`), talking to the same
 //! socket directly from each window.
@@ -36,6 +37,8 @@ pub struct WorktreesCommand {
 pub enum WorktreesSubcommands {
     /// List the repos/worktrees currently open across all windows.
     List(ListCommand),
+    /// Show every repository and all its worktrees, grouped by repository.
+    Tree(TreeCommand),
 }
 
 impl WorktreesCommand {
@@ -43,6 +46,7 @@ impl WorktreesCommand {
     pub async fn execute(self) -> Result<()> {
         match self.command {
             WorktreesSubcommands::List(cmd) => cmd.execute().await,
+            WorktreesSubcommands::Tree(cmd) => cmd.execute().await,
         }
     }
 }
@@ -73,6 +77,32 @@ impl ListCommand {
         match self.output {
             TableOrJson::Json => println!("{}", serde_json::to_string_pretty(&result)?),
             TableOrJson::Table => println!("{}", render_windows(&result)),
+        }
+        Ok(())
+    }
+}
+
+/// Shows every repository and all of its worktrees (open or not), grouped by
+/// repository — the daemon's `tree` op, which derives the repos from the open
+/// windows and enumerates each repo's worktrees.
+#[derive(Parser)]
+pub struct TreeCommand {
+    /// Control-socket path. Defaults to the per-user runtime location.
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+    /// Output format.
+    #[arg(short = 'o', long, value_enum, default_value_t = TableOrJson::Table)]
+    pub output: TableOrJson,
+}
+
+impl TreeCommand {
+    /// Executes the tree command.
+    pub async fn execute(self) -> Result<()> {
+        let socket = server::resolve_socket(self.socket)?;
+        let result = call(&socket, "tree", Value::Null).await?;
+        match self.output {
+            TableOrJson::Json => println!("{}", serde_json::to_string_pretty(&result)?),
+            TableOrJson::Table => println!("{}", render_tree(&result)),
         }
         Ok(())
     }
@@ -128,6 +158,84 @@ fn render_windows(result: &Value) -> String {
         ));
     }
     out
+}
+
+/// Renders a `tree` reply as a repo-grouped view: a header line per repository
+/// (its name, GitHub `owner/name` when present, and root path), then one indented
+/// row per worktree — a `*` marks the main working tree, followed by the branch,
+/// its `+ahead -behind` sync state, an `open` flag when a live window has it open,
+/// and the worktree path. Returns a placeholder when no repository is open.
+fn render_tree(result: &Value) -> String {
+    let repos = result
+        .get("repos")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    if repos.is_empty() {
+        return "No repositories open.".to_string();
+    }
+    let mut out = String::new();
+    for (i, repo) in repos.iter().enumerate() {
+        // A blank line separates repositories (but not before the first).
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&repo_header(repo));
+        for worktree in repo
+            .get("worktrees")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+        {
+            out.push('\n');
+            out.push_str(&worktree_row(worktree));
+        }
+    }
+    out
+}
+
+/// The header line for one repo in the tree view: `<name>  (github: owner/name)
+/// <root>`, with the GitHub clause omitted for a non-GitHub repo.
+fn repo_header(repo: &Value) -> String {
+    let name = sanitize(repo.get("main_repo").and_then(Value::as_str).unwrap_or("-"));
+    let root = sanitize(repo.get("root").and_then(Value::as_str).unwrap_or(""));
+    match github_summary(repo) {
+        Some(github) => format!("{name}  ({github})  {root}"),
+        None => format!("{name}  {root}"),
+    }
+}
+
+/// A `github: owner/name` summary for a repo, or `None` when it has no GitHub
+/// identity (a non-GitHub or remote-less repo).
+fn github_summary(repo: &Value) -> Option<String> {
+    let owner = repo.pointer("/github/owner").and_then(Value::as_str)?;
+    let name = repo.pointer("/github/name").and_then(Value::as_str)?;
+    Some(format!("github: {}/{}", sanitize(owner), sanitize(name)))
+}
+
+/// One indented worktree row: a `*` for the main working tree, the branch, the
+/// `+ahead -behind` sync state, an `open` flag when a window has it open, and the
+/// worktree path.
+fn worktree_row(worktree: &Value) -> String {
+    let marker = if worktree.get("is_main").and_then(Value::as_bool) == Some(true) {
+        '*'
+    } else {
+        ' '
+    };
+    let branch = sanitize(
+        worktree
+            .get("branch")
+            .and_then(Value::as_str)
+            .unwrap_or("-"),
+    );
+    let sync = sync_summary(worktree);
+    let open = if worktree.get("open").and_then(Value::as_bool) == Some(true) {
+        "open"
+    } else {
+        ""
+    };
+    let path = sanitize(worktree.get("path").and_then(Value::as_str).unwrap_or(""));
+    format!("  {marker} {branch:<24} {sync:<9} {open:<5} {path}")
 }
 
 /// The repo name to show for a window: the daemon-computed `main_repo` (which
@@ -204,15 +312,28 @@ mod tests {
         Wrapper::try_parse_from(full).unwrap().cmd
     }
 
+    fn parse_list(args: &[&str]) -> ListCommand {
+        match parse(args) {
+            WorktreesSubcommands::List(cmd) => cmd,
+            WorktreesSubcommands::Tree(_) => panic!("expected the list subcommand"),
+        }
+    }
+
+    fn parse_tree(args: &[&str]) -> TreeCommand {
+        match parse(args) {
+            WorktreesSubcommands::Tree(cmd) => cmd,
+            WorktreesSubcommands::List(_) => panic!("expected the tree subcommand"),
+        }
+    }
+
     #[test]
     fn list_parses_flags_and_defaults() {
-        let WorktreesSubcommands::List(cmd) = parse(&["list"]);
+        let cmd = parse_list(&["list"]);
         assert_eq!(cmd.output, TableOrJson::Table);
         assert!(!cmd.json);
         assert!(cmd.socket.is_none());
 
-        let WorktreesSubcommands::List(cmd) =
-            parse(&["list", "-o", "json", "--socket", "/tmp/d.sock"]);
+        let cmd = parse_list(&["list", "-o", "json", "--socket", "/tmp/d.sock"]);
         assert_eq!(cmd.output, TableOrJson::Json);
         assert_eq!(cmd.socket.as_deref(), Some(Path::new("/tmp/d.sock")));
     }
@@ -220,9 +341,20 @@ mod tests {
     #[test]
     fn list_deprecated_json_flag_still_parses() {
         // `--json` is captured separately; `execute` folds it into `output`.
-        let WorktreesSubcommands::List(cmd) = parse(&["list", "--json"]);
+        let cmd = parse_list(&["list", "--json"]);
         assert!(cmd.json);
         assert_eq!(cmd.output, TableOrJson::Table);
+    }
+
+    #[test]
+    fn tree_parses_flags_and_defaults() {
+        let cmd = parse_tree(&["tree"]);
+        assert_eq!(cmd.output, TableOrJson::Table);
+        assert!(cmd.socket.is_none());
+
+        let cmd = parse_tree(&["tree", "-o", "json", "--socket", "/tmp/d.sock"]);
+        assert_eq!(cmd.output, TableOrJson::Json);
+        assert_eq!(cmd.socket.as_deref(), Some(Path::new("/tmp/d.sock")));
     }
 
     #[test]
@@ -343,6 +475,97 @@ mod tests {
         assert_eq!(age_secs(None), 0);
         assert_eq!(age_secs(Some("not-a-timestamp")), 0);
         assert!(age_secs(Some("2000-01-01T00:00:00Z")) > 0);
+    }
+
+    #[test]
+    fn render_tree_handles_empty_replies() {
+        assert_eq!(
+            render_tree(&json!({ "repos": [] })),
+            "No repositories open."
+        );
+        assert_eq!(render_tree(&json!({})), "No repositories open.");
+    }
+
+    #[test]
+    fn render_tree_groups_repos_and_worktrees() {
+        let result = json!({ "repos": [{
+            "main_repo": "omni-dev",
+            "github": { "owner": "rust-works", "name": "omni-dev" },
+            "root": "/home/me/omni-dev",
+            "worktrees": [
+                { "path": "/home/me/omni-dev", "branch": "main", "ahead": 2, "behind": 0,
+                  "is_main": true, "open": true, "window_key": "w1" },
+                { "path": "/home/me/wt/issue-1300", "branch": "issue-1300", "ahead": 1, "behind": 3,
+                  "is_main": false, "open": false },
+            ],
+        }]});
+        let out = render_tree(&result);
+        // Repo header carries the GitHub identity and root.
+        let header = out.lines().next().unwrap();
+        assert!(header.contains("omni-dev"), "{out}");
+        assert!(header.contains("github: rust-works/omni-dev"), "{out}");
+        assert!(header.contains("/home/me/omni-dev"), "{out}");
+        // The main working tree is marked with `*`, its sync, and `open`.
+        assert!(
+            out.lines()
+                .any(|l| l.contains("* main") && l.contains("+2 -0") && l.contains("open")),
+            "{out}"
+        );
+        // The linked worktree is unmarked and not flagged open.
+        let linked = out
+            .lines()
+            .find(|l| l.contains("issue-1300"))
+            .unwrap_or_default();
+        assert!(!linked.contains('*'), "{linked}");
+        assert!(!linked.contains("open"), "{linked}");
+        assert!(linked.contains("+1 -3"), "{linked}");
+        // Header + two worktree rows.
+        assert_eq!(out.lines().count(), 3, "{out}");
+    }
+
+    #[test]
+    fn render_tree_omits_github_for_non_github_repo() {
+        let result = json!({ "repos": [{
+            "main_repo": "internal",
+            "root": "/srv/internal",
+            "worktrees": [
+                { "path": "/srv/internal", "branch": "main", "is_main": true, "open": false },
+            ],
+        }]});
+        let out = render_tree(&result);
+        assert!(!out.contains("github:"), "{out}");
+        assert!(out.lines().next().unwrap().contains("internal"), "{out}");
+    }
+
+    #[test]
+    fn render_tree_strips_control_bytes() {
+        // Control bytes in the repo name, github identity, branch, and path must
+        // not reach the terminal (#1137), matching the `list` renderer.
+        let result = json!({ "repos": [{
+            "main_repo": "evil\x1b[31mrepo",
+            "github": { "owner": "ow\x07ner", "name": "na\u{9b}2Jme" },
+            "root": "/tmp/r\x1b]0;x\x07oot",
+            "worktrees": [
+                { "path": "/tmp/w\rt", "branch": "br\x1b[2Janch", "is_main": true, "open": true },
+            ],
+        }]});
+        let out = render_tree(&result);
+        assert!(
+            !out.contains(|c: char| c.is_control() && c != '\n'),
+            "{out:?}"
+        );
+        // Embedded CR/LF cannot forge extra lines: header plus one worktree row.
+        assert_eq!(out.lines().count(), 2, "{out:?}");
+    }
+
+    #[test]
+    fn github_summary_needs_both_owner_and_name() {
+        assert_eq!(
+            github_summary(&json!({ "github": { "owner": "o", "name": "n" } })).as_deref(),
+            Some("github: o/n")
+        );
+        assert_eq!(github_summary(&json!({ "github": { "owner": "o" } })), None);
+        assert_eq!(github_summary(&json!({})), None);
     }
 
     #[test]

--- a/src/cli/worktrees.rs
+++ b/src/cli/worktrees.rs
@@ -176,9 +176,10 @@ fn render_tree(result: &Value) -> String {
     }
     let mut out = String::new();
     for (i, repo) in repos.iter().enumerate() {
-        // A blank line separates repositories (but not before the first).
+        // A blank line separates repositories (but not before the first): the
+        // previous worktree row has no trailing newline, so two are needed.
         if i > 0 {
-            out.push('\n');
+            out.push_str("\n\n");
         }
         out.push_str(&repo_header(repo));
         for worktree in repo
@@ -312,28 +313,18 @@ mod tests {
         Wrapper::try_parse_from(full).unwrap().cmd
     }
 
-    fn parse_list(args: &[&str]) -> ListCommand {
-        match parse(args) {
-            WorktreesSubcommands::List(cmd) => cmd,
-            WorktreesSubcommands::Tree(_) => panic!("expected the list subcommand"),
-        }
-    }
-
-    fn parse_tree(args: &[&str]) -> TreeCommand {
-        match parse(args) {
-            WorktreesSubcommands::Tree(cmd) => cmd,
-            WorktreesSubcommands::List(_) => panic!("expected the tree subcommand"),
-        }
-    }
-
     #[test]
     fn list_parses_flags_and_defaults() {
-        let cmd = parse_list(&["list"]);
+        // Routing: `worktrees list` maps to the List variant.
+        assert!(matches!(parse(&["list"]), WorktreesSubcommands::List(_)));
+        // Flags, via the leaf parser (clap treats argv[0] as the command name).
+        let cmd = ListCommand::try_parse_from(["list"]).unwrap();
         assert_eq!(cmd.output, TableOrJson::Table);
         assert!(!cmd.json);
         assert!(cmd.socket.is_none());
 
-        let cmd = parse_list(&["list", "-o", "json", "--socket", "/tmp/d.sock"]);
+        let cmd =
+            ListCommand::try_parse_from(["list", "-o", "json", "--socket", "/tmp/d.sock"]).unwrap();
         assert_eq!(cmd.output, TableOrJson::Json);
         assert_eq!(cmd.socket.as_deref(), Some(Path::new("/tmp/d.sock")));
     }
@@ -341,18 +332,21 @@ mod tests {
     #[test]
     fn list_deprecated_json_flag_still_parses() {
         // `--json` is captured separately; `execute` folds it into `output`.
-        let cmd = parse_list(&["list", "--json"]);
+        let cmd = ListCommand::try_parse_from(["list", "--json"]).unwrap();
         assert!(cmd.json);
         assert_eq!(cmd.output, TableOrJson::Table);
     }
 
     #[test]
     fn tree_parses_flags_and_defaults() {
-        let cmd = parse_tree(&["tree"]);
+        // Routing: `worktrees tree` maps to the Tree variant.
+        assert!(matches!(parse(&["tree"]), WorktreesSubcommands::Tree(_)));
+        let cmd = TreeCommand::try_parse_from(["tree"]).unwrap();
         assert_eq!(cmd.output, TableOrJson::Table);
         assert!(cmd.socket.is_none());
 
-        let cmd = parse_tree(&["tree", "-o", "json", "--socket", "/tmp/d.sock"]);
+        let cmd =
+            TreeCommand::try_parse_from(["tree", "-o", "json", "--socket", "/tmp/d.sock"]).unwrap();
         assert_eq!(cmd.output, TableOrJson::Json);
         assert_eq!(cmd.socket.as_deref(), Some(Path::new("/tmp/d.sock")));
     }
@@ -521,6 +515,36 @@ mod tests {
         assert!(linked.contains("+1 -3"), "{linked}");
         // Header + two worktree rows.
         assert_eq!(out.lines().count(), 3, "{out}");
+    }
+
+    #[test]
+    fn render_tree_separates_multiple_repos_with_blank_line() {
+        let result = json!({ "repos": [
+            {
+                "main_repo": "alpha",
+                "root": "/r/alpha",
+                "worktrees": [
+                    { "path": "/r/alpha", "branch": "main", "is_main": true, "open": false },
+                ],
+            },
+            {
+                "main_repo": "beta",
+                "root": "/r/beta",
+                "worktrees": [
+                    { "path": "/r/beta", "branch": "main", "is_main": true, "open": false },
+                ],
+            },
+        ]});
+        let out = render_tree(&result);
+        // Two headers, two worktree rows, and one blank separator between repos.
+        assert!(
+            out.contains("\n\nbeta"),
+            "repos not blank-separated: {out:?}"
+        );
+        let alpha = out.find("alpha").unwrap();
+        let beta = out.find("beta").unwrap();
+        assert!(alpha < beta, "repo order not preserved: {out}");
+        assert_eq!(out.lines().count(), 5, "{out:?}");
     }
 
     #[test]

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -506,14 +506,13 @@ fn remote_github_identity(repo: &Repository) -> Option<GithubIdentity> {
     // drops the (per-name) errors, the second the non-UTF-8 `None`s. `names` is
     // bound so `iter()` can borrow it (only `&StringArray` is `IntoIterator`).
     let names = repo.remotes().ok();
-    for name in names.iter().flat_map(|arr| arr.iter()).flatten().flatten() {
-        if let Ok(remote) = repo.find_remote(name) {
-            if let Some(id) = remote.url().ok().and_then(github_identity) {
-                return Some(id);
-            }
-        }
-    }
-    None
+    names
+        .iter()
+        .flat_map(|arr| arr.iter())
+        .flatten()
+        .flatten()
+        .filter_map(|name| repo.find_remote(name).ok())
+        .find_map(|remote| remote.url().ok().and_then(github_identity))
 }
 
 /// Canonicalizes a path for stable comparison (resolving symlinks and `..`),
@@ -1588,6 +1587,14 @@ mod tests {
             remote_github_identity(&repo),
             github("rust-works", "omni-dev")
         );
+
+        // Origin non-GitHub but another remote is GitHub: the fallback loop over
+        // the remaining remotes finds it.
+        repo.remote_set_url("origin", "https://gitlab.com/o/r.git")
+            .unwrap();
+        repo.remote("upstream", "https://github.com/other/proj.git")
+            .unwrap();
+        assert_eq!(remote_github_identity(&repo), github("other", "proj"));
     }
 
     #[tokio::test]

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -1,8 +1,8 @@
 //! The worktrees daemon service.
 //!
 //! A thin adapter that hosts the cross-window [`WorktreesRegistry`] under the
-//! daemon's lifecycle and exposes register/heartbeat/unregister/list over the
-//! control socket, plus a tray submenu with a per-window "focus" action.
+//! daemon's lifecycle and exposes register/heartbeat/unregister/list/tree over
+//! the control socket, plus a tray submenu with a per-window "focus" action.
 //!
 //! All registry state and liveness logic (the `Mutex<HashMap>`, TTL reaping, the
 //! entry cap/eviction) lives in [`crate::worktrees`]; this adapter only routes
@@ -16,8 +16,17 @@
 //! of raw folder paths (ADR-0040). The engine stores only what the companion
 //! sends; disk I/O for the enrichment lives here, alongside the launcher, never
 //! under the registry lock.
+//!
+//! The `tree` op (#1265) inverts the data model for the companion's tree view:
+//! from the open windows the adapter derives the **distinct repositories**, then
+//! enumerates **all** of each repo's worktrees (main working tree +
+//! [`Repository::worktrees`]), enriches each (reusing [`git_status`]), tags the
+//! GitHub identity of `origin`, and joins the open windows back on by
+//! canonicalized path. The open-window registry stays the liveness source;
+//! "is a window open on it?" becomes a per-worktree attribute. All of this is
+//! git disk I/O, so it runs on a blocking thread, never under the registry lock.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -160,6 +169,16 @@ impl DaemonService for WorktreesService {
                 Ok(json!({ "removed": self.registry.unregister(key) }))
             }
             "list" => Ok(json!({ "windows": enriched_windows(self.registry.list()).await })),
+            "tree" => {
+                // Two cheap registry locks: the seed folders to derive repos
+                // from, and the live windows to join back on. The tree is
+                // best-effort, so minor skew between the two snapshots is
+                // immaterial; the git enumeration/enrichment runs off-lock on a
+                // blocking thread.
+                let folders = self.registry.open_folders();
+                let windows = self.registry.list();
+                Ok(json!({ "repos": tree_repos(folders, windows).await }))
+            }
             other => bail!("unknown worktrees op: {other}"),
         }
     }
@@ -383,6 +402,242 @@ async fn enriched_windows(entries: Vec<WindowEntry>) -> Vec<Value> {
     tokio::task::spawn_blocking(move || entries.iter().map(enriched_entry).collect())
         .await
         .unwrap_or_default()
+}
+
+// --- Repo/worktree tree (#1265) ----------------------------------------------
+
+/// A GitHub `owner/name` identity parsed from a repository's `origin` remote.
+/// Present on a repo in the `tree` payload only for `github.com` remotes; a
+/// non-GitHub (or remote-less) repo omits it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GithubIdentity {
+    /// The repository owner (user or org) — the first path segment.
+    owner: String,
+    /// The repository name, with any `.git` suffix stripped.
+    name: String,
+}
+
+/// One worktree of a repository in the `tree` payload: its path, live git state,
+/// whether it is the main working tree, and whether a VS Code window currently
+/// has it open (with that window's key, for the focus action). Optional git
+/// fields degrade independently, exactly like [`GitStatus`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TreeWorktree {
+    /// Absolute path to the worktree's working directory.
+    path: String,
+    /// The checked-out branch, or `None` when detached or unborn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    /// Commits ahead of the branch's upstream (`None` without an upstream).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ahead: Option<usize>,
+    /// Commits behind the branch's upstream (`None` without an upstream).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    behind: Option<usize>,
+    /// Whether this is the repository's main working tree (vs a linked worktree).
+    is_main: bool,
+    /// Whether a live VS Code window currently has this worktree open.
+    open: bool,
+    /// The open window's registry key, when `open` — the handle a focus action
+    /// resolves. Absent for a worktree with no open window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    window_key: Option<String>,
+}
+
+/// One repository (with **all** its worktrees) in the `tree` payload. Repos are
+/// derived from the distinct open windows; a repo leaves the tree when its last
+/// window closes (the open-window-derived model, ADR-0040 / #1264).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TreeRepo {
+    /// The main repository's directory name (see [`main_repo_name`]).
+    main_repo: String,
+    /// The GitHub identity of `origin`, when it is a `github.com` remote.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    github: Option<GithubIdentity>,
+    /// Absolute path to the main working tree — the repo's root.
+    root: String,
+    /// Every worktree of the repo: the main working tree first, then linked
+    /// worktrees sorted by path.
+    worktrees: Vec<TreeWorktree>,
+}
+
+/// Parses a git remote URL into its GitHub `owner/name`, or `None` for any
+/// non-GitHub host. Handles the common forms: `https://github.com/o/r(.git)`,
+/// `http://…`, `ssh://git@github.com/o/r(.git)`, `git://github.com/o/r(.git)`,
+/// and the SCP-like `git@github.com:o/r(.git)`. A trailing `.git` and trailing
+/// slashes are stripped; anything with an empty or extra path segment is
+/// rejected (best-effort, never panics).
+fn github_identity(url: &str) -> Option<GithubIdentity> {
+    let url = url.trim();
+    // Reduce every supported form to the `owner/name…` tail after the host.
+    let rest = [
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+        "git://github.com/",
+        "git@github.com:",
+    ]
+    .iter()
+    .find_map(|prefix| url.strip_prefix(prefix))?;
+    let rest = rest.strip_suffix(".git").unwrap_or(rest);
+    let rest = rest.trim_end_matches('/');
+    let mut parts = rest.splitn(2, '/');
+    let owner = parts.next()?.trim();
+    let name = parts.next()?.trim();
+    // A well-formed identity has exactly two non-empty segments.
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        return None;
+    }
+    Some(GithubIdentity {
+        owner: owner.to_string(),
+        name: name.to_string(),
+    })
+}
+
+/// The GitHub identity of `repo`: `origin`'s URL first, else the first
+/// `github.com` remote found. `None` when no remote is a GitHub remote.
+fn remote_github_identity(repo: &Repository) -> Option<GithubIdentity> {
+    if let Ok(origin) = repo.find_remote("origin") {
+        if let Some(id) = origin.url().ok().and_then(github_identity) {
+            return Some(id);
+        }
+    }
+    // `remotes()` yields `Result<Option<&str>, _>` per name; the first flatten
+    // drops the (per-name) errors, the second the non-UTF-8 `None`s. `names` is
+    // bound so `iter()` can borrow it (only `&StringArray` is `IntoIterator`).
+    let names = repo.remotes().ok();
+    for name in names.iter().flat_map(|arr| arr.iter()).flatten().flatten() {
+        if let Ok(remote) = repo.find_remote(name) {
+            if let Some(id) = remote.url().ok().and_then(github_identity) {
+                return Some(id);
+            }
+        }
+    }
+    None
+}
+
+/// Canonicalizes a path for stable comparison (resolving symlinks and `..`),
+/// falling back to the path as-given when it cannot be canonicalized (e.g. it
+/// no longer exists) so the join still degrades gracefully.
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Indexes the open windows by canonicalized workspace-folder path → window key,
+/// so a worktree path can be joined back to the window (if any) that has it open.
+/// The first window wins a shared folder; `entries` arrive in a deterministic
+/// (repo, key) order, so the choice is stable.
+fn open_window_index(entries: &[WindowEntry]) -> HashMap<PathBuf, String> {
+    let mut index = HashMap::new();
+    for entry in entries {
+        for folder in &entry.folders {
+            index
+                .entry(canonical(folder))
+                .or_insert_with(|| entry.key.clone());
+        }
+    }
+    index
+}
+
+/// Builds a [`TreeWorktree`] for `path`: reuses [`git_status`] for the live git
+/// state and joins the open-window index for `open`/`window_key`. `is_main` is
+/// set by the caller from the enumeration (main working tree vs linked).
+fn worktree_entry(
+    path: &Path,
+    is_main: bool,
+    open_index: &HashMap<PathBuf, String>,
+) -> TreeWorktree {
+    let status = git_status(path);
+    let window_key = open_index.get(&canonical(path)).cloned();
+    TreeWorktree {
+        path: path.display().to_string(),
+        branch: status.branch,
+        ahead: status.ahead,
+        behind: status.behind,
+        is_main,
+        open: window_key.is_some(),
+        window_key,
+    }
+}
+
+/// Enumerates a repository and all its worktrees into a [`TreeRepo`], given a
+/// handle discovered from one of its folders. Opens the **main** repo from the
+/// shared common dir's parent so the main working tree and every linked worktree
+/// are enumerated regardless of which one seeded the discovery. `None` for a
+/// bare or otherwise root-less repo (no working tree to show).
+fn repo_tree(discovered: &Repository, open_index: &HashMap<PathBuf, String>) -> Option<TreeRepo> {
+    // The common dir (`…/<root>/.git`) is shared by the main checkout and all
+    // linked worktrees; its parent is the main working tree.
+    let commondir = canonical(discovered.commondir());
+    let main_root = commondir.parent()?.to_path_buf();
+    let main_repo = Repository::open(&main_root).ok()?;
+
+    // Main working tree first.
+    let mut worktrees = vec![worktree_entry(&main_root, true, open_index)];
+    // Then every linked worktree, sorted by path for deterministic output. The
+    // `StringArray` of names is bound so `iter()` can borrow it (only
+    // `&StringArray` is `IntoIterator`); a name that no longer resolves to a
+    // worktree is skipped.
+    let names = main_repo.worktrees().ok();
+    let mut linked: Vec<PathBuf> = names
+        .iter()
+        .flat_map(|arr| arr.iter())
+        .flatten() // Result<Option<&str>, _> → Option<&str> (drop per-name errors)
+        .flatten() // Option<&str> → &str (drop non-UTF-8 names)
+        .filter_map(|name| main_repo.find_worktree(name).ok())
+        .map(|wt| wt.path().to_path_buf())
+        .collect();
+    linked.sort();
+    worktrees.extend(
+        linked
+            .iter()
+            .map(|path| worktree_entry(path, false, open_index)),
+    );
+
+    Some(TreeRepo {
+        main_repo: main_repo_name(&commondir)?,
+        github: remote_github_identity(&main_repo),
+        root: main_root.display().to_string(),
+        worktrees,
+    })
+}
+
+/// Resolves the seed `folders` to their distinct repositories and enumerates
+/// each repo's worktrees. Dedupes repos by their common dir (shared across a
+/// repo's worktrees) via a `BTreeMap` for deterministic ordering; a folder that
+/// is not in a git repo is skipped. Pure blocking git I/O — call it via
+/// [`tree_repos`], never under the registry lock.
+fn build_tree(folders: Vec<PathBuf>, windows: Vec<WindowEntry>) -> Vec<TreeRepo> {
+    let open_index = open_window_index(&windows);
+    let mut repos: BTreeMap<PathBuf, TreeRepo> = BTreeMap::new();
+    for folder in &folders {
+        let Ok(repo) = Repository::discover(folder) else {
+            continue;
+        };
+        let key = canonical(repo.commondir());
+        if repos.contains_key(&key) {
+            continue;
+        }
+        if let Some(tree) = repo_tree(&repo, &open_index) {
+            repos.insert(key, tree);
+        }
+    }
+    repos.into_values().collect()
+}
+
+/// Enumerates and enriches the repo/worktree tree on a blocking thread (`git2`
+/// does synchronous disk I/O and this runs inside the async control-socket
+/// handler), returning the serialized `repos` array. A join failure degrades to
+/// an empty list rather than erroring, matching [`enriched_windows`].
+async fn tree_repos(folders: Vec<PathBuf>, windows: Vec<WindowEntry>) -> Vec<Value> {
+    tokio::task::spawn_blocking(move || {
+        build_tree(folders, windows)
+            .iter()
+            .map(|repo| serde_json::to_value(repo).unwrap_or_else(|_| json!({})))
+            .collect()
+    })
+    .await
+    .unwrap_or_default()
 }
 
 /// A short human name for a window: its repo, else its first folder's basename,
@@ -1254,5 +1509,212 @@ mod tests {
         );
         // A `.git` at the filesystem root has no parent name to use.
         assert_eq!(main_repo_name(Path::new("/.git")), None);
+    }
+
+    // --- Repo/worktree tree (#1265) ----------------------------------------
+
+    /// Pulls the `repos` array out of a `tree` payload (owned, so it survives a
+    /// temporary payload).
+    fn repos_of(payload: &Value) -> Vec<Value> {
+        payload
+            .get("repos")
+            .and_then(Value::as_array)
+            .expect("repos array")
+            .clone()
+    }
+
+    fn github(owner: &str, name: &str) -> Option<GithubIdentity> {
+        Some(GithubIdentity {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+
+    #[test]
+    fn github_identity_parses_supported_forms() {
+        // https / http, with and without the `.git` suffix.
+        assert_eq!(
+            github_identity("https://github.com/rust-works/omni-dev.git"),
+            github("rust-works", "omni-dev")
+        );
+        assert_eq!(
+            github_identity("https://github.com/rust-works/omni-dev"),
+            github("rust-works", "omni-dev")
+        );
+        assert_eq!(github_identity("http://github.com/o/r"), github("o", "r"));
+        // SCP-like and ssh:// / git:// forms.
+        assert_eq!(
+            github_identity("git@github.com:rust-works/omni-dev.git"),
+            github("rust-works", "omni-dev")
+        );
+        assert_eq!(
+            github_identity("ssh://git@github.com/o/r.git"),
+            github("o", "r")
+        );
+        assert_eq!(github_identity("git://github.com/o/r"), github("o", "r"));
+        // A trailing slash and surrounding whitespace are tolerated.
+        assert_eq!(
+            github_identity("  https://github.com/o/r/  "),
+            github("o", "r")
+        );
+    }
+
+    #[test]
+    fn github_identity_rejects_non_github_and_malformed() {
+        // Non-GitHub hosts.
+        assert_eq!(github_identity("https://gitlab.com/o/r.git"), None);
+        assert_eq!(github_identity("git@example.com:o/r.git"), None);
+        // Missing or extra path segments.
+        assert_eq!(github_identity("https://github.com/onlyowner"), None);
+        assert_eq!(github_identity("https://github.com/o/r/extra"), None);
+        assert_eq!(github_identity("https://github.com/"), None);
+        // Not a URL at all.
+        assert_eq!(github_identity("not a url"), None);
+    }
+
+    #[test]
+    fn remote_github_identity_reads_origin_then_falls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(dir.path());
+        // No remotes → None.
+        assert_eq!(remote_github_identity(&repo), None);
+        // A non-GitHub origin is not a match.
+        repo.remote("origin", "https://gitlab.com/o/r.git").unwrap();
+        assert_eq!(remote_github_identity(&repo), None);
+        // A GitHub origin resolves to its identity.
+        repo.remote_set_url("origin", "git@github.com:rust-works/omni-dev.git")
+            .unwrap();
+        assert_eq!(
+            remote_github_identity(&repo),
+            github("rust-works", "omni-dev")
+        );
+    }
+
+    #[tokio::test]
+    async fn tree_is_empty_with_no_windows_and_skips_non_repos() {
+        let svc = WorktreesService::new();
+        // No windows → an empty repo set (not an error).
+        assert_eq!(
+            svc.handle("tree", Value::Null).await.unwrap(),
+            json!({ "repos": [] })
+        );
+        // A plain non-repo folder is skipped rather than sinking the op.
+        let plain = tempfile::tempdir().unwrap();
+        svc.handle(
+            "register",
+            json!({ "key": "w1", "folders": [plain.path()], "repo": "plain" }),
+        )
+        .await
+        .unwrap();
+        assert!(repos_of(&svc.handle("tree", Value::Null).await.unwrap()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn tree_enumerates_main_and_linked_with_open_join_and_github() {
+        let main_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(main_dir.path());
+        let a = empty_commit(&repo, Some("refs/heads/main"), &[], "A");
+        repo.set_head("refs/heads/main").unwrap();
+        // A GitHub origin so the repo carries an identity in the payload.
+        repo.remote("origin", "git@github.com:rust-works/omni-dev.git")
+            .unwrap();
+
+        // A linked worktree on a new `feature` branch, in a directory whose
+        // basename is deliberately not the repo name.
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("feature-wt");
+        add_worktree(&repo, a, &wt_path, "feature");
+
+        let svc = WorktreesService::new();
+        // A window open on the main checkout and one on the linked worktree —
+        // two windows, but one repo (they must dedupe).
+        svc.handle(
+            "register",
+            json!({ "key": "wm", "folders": [main_dir.path()], "repo": "omni-dev" }),
+        )
+        .await
+        .unwrap();
+        svc.handle(
+            "register",
+            json!({ "key": "wf", "folders": [wt_path], "repo": "feature-wt" }),
+        )
+        .await
+        .unwrap();
+
+        let repos = repos_of(&svc.handle("tree", Value::Null).await.unwrap());
+        assert_eq!(
+            repos.len(),
+            1,
+            "two worktrees of one repo dedupe: {repos:?}"
+        );
+        let repo0 = &repos[0];
+        // Repo identity is the parent-repo name (not a worktree-folder basename).
+        assert_eq!(
+            repo0.get("main_repo").and_then(Value::as_str),
+            main_dir.path().file_name().and_then(|n| n.to_str())
+        );
+        assert_eq!(
+            repo0.pointer("/github/owner").and_then(Value::as_str),
+            Some("rust-works")
+        );
+        assert_eq!(
+            repo0.pointer("/github/name").and_then(Value::as_str),
+            Some("omni-dev")
+        );
+        assert!(repo0.get("root").and_then(Value::as_str).is_some());
+
+        let worktrees = repo0.get("worktrees").and_then(Value::as_array).unwrap();
+        assert_eq!(worktrees.len(), 2);
+        // Main working tree first: is_main, open, with the main window's key.
+        let main_wt = &worktrees[0];
+        assert_eq!(main_wt.get("is_main").and_then(Value::as_bool), Some(true));
+        assert_eq!(main_wt.get("open").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            main_wt.get("window_key").and_then(Value::as_str),
+            Some("wm")
+        );
+        assert_eq!(main_wt.get("branch").and_then(Value::as_str), Some("main"));
+        // Linked worktree: not main, open via the feature window.
+        let linked = &worktrees[1];
+        assert_eq!(linked.get("is_main").and_then(Value::as_bool), Some(false));
+        assert_eq!(linked.get("open").and_then(Value::as_bool), Some(true));
+        assert_eq!(linked.get("window_key").and_then(Value::as_str), Some("wf"));
+        assert_eq!(
+            linked.get("branch").and_then(Value::as_str),
+            Some("feature")
+        );
+    }
+
+    #[tokio::test]
+    async fn tree_marks_unopened_linked_worktree_closed_and_omits_github() {
+        let main_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(main_dir.path());
+        let a = empty_commit(&repo, Some("refs/heads/main"), &[], "A");
+        repo.set_head("refs/heads/main").unwrap();
+        // No remote at all → the repo carries no `github` identity.
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("feature-wt");
+        add_worktree(&repo, a, &wt_path, "feature");
+
+        let svc = WorktreesService::new();
+        // Only the main checkout has a window; the linked worktree has none.
+        svc.handle(
+            "register",
+            json!({ "key": "wm", "folders": [main_dir.path()], "repo": "omni-dev" }),
+        )
+        .await
+        .unwrap();
+
+        let repos = repos_of(&svc.handle("tree", Value::Null).await.unwrap());
+        assert_eq!(repos.len(), 1);
+        assert!(repos[0].get("github").is_none(), "no remote → no github");
+        let worktrees = repos[0].get("worktrees").and_then(Value::as_array).unwrap();
+        let linked = worktrees
+            .iter()
+            .find(|w| w.get("is_main").and_then(Value::as_bool) == Some(false))
+            .expect("the linked worktree");
+        // Enumerated even though no window has it open, and marked closed.
+        assert_eq!(linked.get("open").and_then(Value::as_bool), Some(false));
+        assert!(linked.get("window_key").is_none());
     }
 }

--- a/src/worktrees.rs
+++ b/src/worktrees.rs
@@ -180,6 +180,28 @@ impl WorktreesRegistry {
         let windows = self.lock();
         windows.get(key).and_then(|e| e.folders.first().cloned())
     }
+
+    /// Snapshots the distinct workspace folders across all live windows — the
+    /// seed set the adapter resolves to repositories (each folder → its git
+    /// common dir → repo root) to enumerate every worktree per repo (#1265).
+    ///
+    /// Reaps stale entries first, then returns the folders sorted and
+    /// deduplicated. Like [`list`](Self::list) it is pure CPU under the lock:
+    /// the git resolution the "distinct repos" derivation needs is disk I/O and
+    /// stays in the adapter, off the registry lock, honouring the
+    /// `Mutex`-never-across-`.await` invariant.
+    pub fn open_folders(&self) -> Vec<PathBuf> {
+        let now = Utc::now();
+        let mut windows = self.lock();
+        reap(&mut windows, self.ttl, now);
+        let mut folders: Vec<PathBuf> = windows
+            .values()
+            .flat_map(|e| e.folders.iter().cloned())
+            .collect();
+        folders.sort();
+        folders.dedup();
+        folders
+    }
 }
 
 impl Default for WorktreesRegistry {
@@ -297,6 +319,63 @@ mod tests {
             pid: None,
         });
         assert!(reg.first_folder("w2").is_none());
+    }
+
+    #[test]
+    fn open_folders_dedups_and_sorts_across_windows() {
+        let reg = WorktreesRegistry::new();
+        assert!(reg.open_folders().is_empty());
+        // Two windows sharing a folder, plus a multi-folder window: the shared
+        // path collapses and the result is sorted.
+        reg.register(register_request("w1", Some("repo-a"), "/tmp/shared"));
+        reg.register(RegisterRequest {
+            key: "w2".to_string(),
+            folders: vec![PathBuf::from("/tmp/shared"), PathBuf::from("/tmp/b")],
+            repo: Some("repo-a".to_string()),
+            title: None,
+            pid: None,
+        });
+        reg.register(register_request("w3", Some("repo-b"), "/tmp/a"));
+        assert_eq!(
+            reg.open_folders(),
+            vec![
+                PathBuf::from("/tmp/a"),
+                PathBuf::from("/tmp/b"),
+                PathBuf::from("/tmp/shared"),
+            ]
+        );
+    }
+
+    #[test]
+    fn open_folders_reaps_stale_windows() {
+        let reg = WorktreesRegistry::new();
+        {
+            let mut windows = reg.lock();
+            windows.insert(
+                "fresh".to_string(),
+                WindowEntry {
+                    key: "fresh".to_string(),
+                    folders: vec![PathBuf::from("/tmp/fresh")],
+                    repo: None,
+                    title: None,
+                    pid: None,
+                    last_seen: Utc::now(),
+                },
+            );
+            windows.insert(
+                "stale".to_string(),
+                WindowEntry {
+                    key: "stale".to_string(),
+                    folders: vec![PathBuf::from("/tmp/stale")],
+                    repo: None,
+                    title: None,
+                    pid: None,
+                    last_seen: Utc::now() - chrono::Duration::seconds(120),
+                },
+            );
+        }
+        // The stale window's folder is reaped out of the snapshot.
+        assert_eq!(reg.open_folders(), vec![PathBuf::from("/tmp/fresh")]);
     }
 
     #[test]

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -34,7 +34,7 @@ use tokio::sync::Notify;
 
 use clap::Parser as _;
 use omni_dev::cli::format::TableOrJson;
-use omni_dev::cli::worktrees::{ListCommand, WorktreesCommand, WorktreesSubcommands};
+use omni_dev::cli::worktrees::{ListCommand, TreeCommand, WorktreesCommand, WorktreesSubcommands};
 use omni_dev::cli::Cli;
 use omni_dev::daemon::client::DaemonClient;
 use omni_dev::daemon::protocol::{DaemonEnvelope, DaemonReply, MAX_LINE_BYTES};
@@ -333,6 +333,103 @@ async fn worktrees_cli_list_against_live_daemon() {
         socket: Some(missing),
         output: TableOrJson::Table,
         json: false,
+    }
+    .execute()
+    .await
+    .is_err());
+}
+
+/// Drives the real `omni-dev worktrees tree` CLI command struct against a live
+/// daemon: the table path, the JSON path, the subcommand wrapper, the top-level
+/// `Cli` dispatch, and the daemon-down error path. Like the `list` variant this
+/// is the only way to cover the `tree` command's socket-connecting code, which
+/// cannot run in the lib unit-test binary (it must not bind sockets). The
+/// registered folder is not a git repo, so `tree` returns an empty repo set —
+/// enough to exercise both render branches; populated rendering is unit-tested.
+#[tokio::test]
+async fn worktrees_cli_tree_against_live_daemon() {
+    let _gate = UMASK_GATE.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("d.sock");
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(WorktreesService::new()));
+    let handle = tokio::spawn(run(
+        registry,
+        DaemonOptions {
+            socket_path: socket.clone(),
+        },
+    ));
+
+    let client = DaemonClient::new(&socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Seed a window so `tree` derives (and skips) a non-repo folder rather than
+    // taking the trivially-empty path.
+    client
+        .request(DaemonEnvelope::service(
+            "worktrees",
+            "register",
+            json!({ "key": "k1", "folders": [dir.path()], "repo": "p" }),
+        ))
+        .await
+        .unwrap();
+
+    // Table path and JSON path.
+    TreeCommand {
+        socket: Some(socket.clone()),
+        output: TableOrJson::Table,
+    }
+    .execute()
+    .await
+    .unwrap();
+    TreeCommand {
+        socket: Some(socket.clone()),
+        output: TableOrJson::Json,
+    }
+    .execute()
+    .await
+    .unwrap();
+
+    // Through the subcommand wrapper (covers the `Tree` dispatch arm).
+    WorktreesCommand {
+        command: WorktreesSubcommands::Tree(TreeCommand {
+            socket: Some(socket.clone()),
+            output: TableOrJson::Table,
+        }),
+    }
+    .execute()
+    .await
+    .unwrap();
+
+    // Through the top-level CLI parse + dispatch.
+    let sock_str = socket.to_str().unwrap();
+    Cli::try_parse_from([
+        "omni-dev",
+        "worktrees",
+        "tree",
+        "--socket",
+        sock_str,
+        "-o",
+        "json",
+    ])
+    .unwrap()
+    .execute()
+    .await
+    .unwrap();
+
+    client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+
+    // With the daemon down, the CLI surfaces the connection failure.
+    let missing = dir.path().join("absent.sock");
+    assert!(TreeCommand {
+        socket: Some(missing),
+        output: TableOrJson::Table,
     }
     .execute()
     .await

--- a/tests/snapshots/integration_test__help_all_output.snap
+++ b/tests/snapshots/integration_test__help_all_output.snap
@@ -3476,6 +3476,7 @@ Usage: worktrees <COMMAND>
 
 Commands:
   list  List the repos/worktrees currently open across all windows
+  tree  Show every repository and all its worktrees, grouped by repository
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3489,6 +3490,20 @@ omni-dev worktrees list - List the repos/worktrees currently open across all win
 List the repos/worktrees currently open across all windows
 
 Usage: list [OPTIONS]
+
+Options:
+      --socket <PATH>    Control-socket path. Defaults to the per-user runtime location
+  -o, --output <OUTPUT>  Output format [default: table] [possible values: table, json]
+  -h, --help             Print help (see more with '--help')
+
+
+================================================================================
+
+omni-dev worktrees tree - Show every repository and all its worktrees, grouped by repository
+
+Show every repository and all its worktrees, grouped by repository
+
+Usage: tree [OPTIONS]
 
 Options:
       --socket <PATH>    Control-socket path. Defaults to the per-user runtime location


### PR DESCRIPTION
## Description

Adds a new `omni-dev worktrees tree` subcommand that displays **every repository and all of its worktrees** (open in a window or not), grouped by repository — complementing the existing `list` command, which shows only open windows. This is Phase 1 of the worktrees tree-view feature (#1264): the daemon-side data model and the `tree` op the companion UI later consumes.

The repos are **derived from open windows** (each open folder → its git common dir → repo root), and each repo's worktrees — including closed/linked ones — are enumerated and enriched with live git state, so the view stays consistent with the daemon's no-persistence, open-window-centric model (ADR-0040).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Closes #1265
Relates to #1264

## Changes Made

**Core Changes:**
- **Registry (`src/worktrees.rs`)** — new `open_folders()` snapshots the distinct workspace folders across all live windows, the seed set for repo discovery. Preserves the `Mutex`-never-across-`.await` invariant.
- **Daemon service (`src/daemon/services/worktrees.rs`)** — new `tree` op derives distinct repositories from open-window folders, enumerates all worktrees per repo (`git2`), enriches each with branch/ahead/behind/`is_main`, tags GitHub identity from `origin`, and joins open windows back on by canonicalized path. All git I/O runs on a blocking thread, off the registry lock.
- **CLI (`src/cli/worktrees.rs`)** — new `worktrees tree [-o table|json]`: repo-grouped rendering with indented worktree rows (`*` marks the main working tree; branch, `+ahead -behind` sync, open flag, path). Terminal output strips control bytes, matching the `list` renderer.

**Design notes:**
- The tree enumerates **all** worktrees of a repo, not just open ones, giving visibility into closed linked worktrees.
- GitHub identity is derived from `origin`; non-GitHub (or remote-less) repos omit the `github` field.
- Empty replies and non-repo folders degrade gracefully without error.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Integration tests updated/added

Coverage added for: `tree` argument parsing; rendering of empty/multi-repo trees and control-byte sanitization; GitHub URL parsing across forms (https, ssh, git://, SCP-like); end-to-end tree enumeration with open-window joins and GitHub tagging; and edge cases (unopened linked worktrees, non-GitHub remotes, canonicalization fallback). The `help_all` golden snapshot was updated for the new subcommand.
