### PR TITLE
feat(daemon): add open op to worktrees service for socket-driven code launches

### DIFF
--- a/docs/adrs/adr-0040.md
+++ b/docs/adrs/adr-0040.md
@@ -78,7 +78,7 @@ disk.
 
 The companion talks the daemon's existing wire protocol
 ([`protocol.rs`](../../src/daemon/protocol.rs)) — a `DaemonEnvelope { service:
-"worktrees", op, payload }` per line — with four ops:
+"worktrees", op, payload }` per line — with five ops:
 
 | Op | Payload | Reply | Meaning |
 |---|---|---|---|
@@ -86,6 +86,7 @@ The companion talks the daemon's existing wire protocol
 | `heartbeat` | `{ key }` | `{ known: bool }` | Refreshes `last_seen`; `known: false` means the daemon has no such entry. |
 | `unregister` | `{ key }` | `{ removed: bool }` | Removes the window (fired on `deactivate()`). |
 | `list` | — | `{ windows: [entry, …] }` | The live cross-window set, sorted by `(repo, key)`. |
+| `open` | `{ path }` | `{ ok: true }` | Focuses/opens `path` in VS Code (`code <path>`); `path` must be an existing **absolute** directory. Shares the tray's launcher path (#1266). |
 
 `heartbeat → { known: false }` is the **resync signal**: because the registry is
 in-memory, a window that was open before the daemon started — or that survives a
@@ -125,6 +126,14 @@ logged, not fatal. The folder is required to be an existing **absolute** directo
 before spawning, which also rules out a path beginning with `-` being parsed as a
 flag.
 
+The same launcher path is exposed as a control-socket **`open` op** (payload
+`{ path }`, #1266) so the companion — which cannot see a sibling window and so
+must ask the daemon to focus one on double-click — reuses the daemon's tested
+guard and launcher resolution rather than duplicating them in TypeScript. `open`
+takes an arbitrary client-supplied path (not a registered window `key`), so the
+absolute-existing-directory guard is a real check there, not just a
+workspace-folder assertion; see the threat-model consequence below.
+
 A new read-only client, `omni-dev worktrees list [--json]`
 ([`src/cli/worktrees.rs`](../../src/cli/worktrees.rs)), prints the same live view
 as a table (or JSON for machines). It is Unix-only (`#[cfg(unix)]`), like the
@@ -154,10 +163,15 @@ repo's main checkout.
   ([ADR-0036](adr-0036.md)) and Snowflake's models are untouched. The residual
   exposure is narrow and bounded by socket ownership: anything that can read the
   socket can enumerate your open repo **paths** (`list`), and anything that can
-  write it can inject fake entries or trigger a `focus` that spawns `code` on a
-  path it supplied — but writing the socket already requires being the owning
-  local user. The absolute-existing-directory check on the focus path is
-  defense-in-depth against argument injection, not a trust boundary.
+  write it can inject fake entries or invoke the **`open` op** (#1266) to spawn
+  `code` on a path it supplied. That op is a small, deliberate escalation over the
+  original tray-only focus: previously only the human clicking the tray could
+  spawn `code` (the tray's `menu_action` is not reachable over the socket), whereas
+  a socket *writer* now can. It is bounded the same way everything on this socket
+  is — writing it already requires being the owning local user — and the launcher
+  only ever runs on an **existing absolute directory**, which keeps it to real
+  local folders and blocks a `-`-leading path from being parsed by `code` as a
+  flag (argument injection). That guard is defense-in-depth, not a trust boundary.
 - The companion extension is the daemon's **first non-omni-dev client**, so the
   four-op contract above is the stable surface it depends on. New optional fields
   follow the protocol's existing `#[serde(default, skip_serializing_if = …)]`

--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -166,9 +166,13 @@ extension never runs git.
 daemon's existing `0600` Unix control socket in its `0700` directory; no secret is
 persisted; everything is loopback/filesystem-local. The residual exposure is
 bounded by socket ownership — reading the socket reveals your open repo *paths*,
-and writing it (already requiring the owning local user) could inject entries or
-trigger a focus. The focus action additionally requires the target to be an
-existing absolute directory before spawning `code`. Registry strings
+and writing it (already requiring the owning local user) could inject entries or,
+via the **`open` op** (#1266), spawn `code` on a supplied path. That op is a
+small, deliberate escalation: before it, only the human clicking the tray could
+spawn `code`; now a socket *writer* can too — but still only as the owning local
+user, and only on an **existing absolute directory** (which also blocks a
+`-`-leading path from being parsed by `code` as a flag). The focus action and the
+`open` op share that same guard before spawning `code`. Registry strings
 (`repo`/`folders`, and the companion `title`) are writer-influenced metadata, so
 the `worktrees list` table strips control characters (C0, DEL, C1) from the
 strings it renders before writing to the terminal — a registered entry cannot
@@ -200,6 +204,7 @@ Ops:
 | `heartbeat`  | `{ key }`                                         | `{ known: <bool> }`            |
 | `unregister` | `{ key }`                                         | `{ removed: <bool> }`          |
 | `list`       | `null`                                            | `{ windows: [entry, …] }`      |
+| `open`       | `{ path }`                                       | `{ ok: true }`                 |
 
 Where:
 
@@ -210,6 +215,12 @@ Where:
   it evicts the longest-silent entry rather than rejecting, so the companion
   needs no retry logic (an evicted window re-registers off its next heartbeat).
 - `folders` — absolute workspace-folder paths.
+- `open` — `path` must be an existing **absolute** directory; the daemon then
+  spawns `code <path>`, which focuses the already-open window for that folder or
+  opens a new one. It shares the tray focus action's launcher resolution and
+  guard (#1266), so a client (the companion, on double-click) never duplicates
+  that logic. A relative or non-existent `path` is rejected with a clear error
+  before anything is spawned (see [Security](#security)).
 - A `list` `entry` is
   `{ key, folders[], repo?, title?, pid?, branch?, ahead?, behind?, main_repo?,
   is_worktree?, last_seen }` with `last_seen` as an RFC 3339 timestamp; consumers

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -1,8 +1,12 @@
 //! The worktrees daemon service.
 //!
 //! A thin adapter that hosts the cross-window [`WorktreesRegistry`] under the
-//! daemon's lifecycle and exposes register/heartbeat/unregister/list/tree over
-//! the control socket, plus a tray submenu with a per-window "focus" action.
+//! daemon's lifecycle and exposes register/heartbeat/unregister/list/tree/open
+//! over the control socket, plus a tray submenu with a per-window "focus" action.
+//! The `open` op (#1266) focuses/opens an arbitrary worktree folder in VS Code
+//! through the **same** launcher path the tray uses, so a socket client (the
+//! companion's double-click) shares the tested guard and launcher resolution
+//! rather than duplicating them.
 //!
 //! All registry state and liveness logic (the `Mutex<HashMap>`, TTL reaping, the
 //! entry cap/eviction) lives in [`crate::worktrees`]; this adapter only routes
@@ -161,11 +165,11 @@ impl DaemonService for WorktreesService {
                 Ok(json!({ "ok": true }))
             }
             "heartbeat" => {
-                let key = require_key(&payload, "heartbeat")?;
+                let key = require_str(&payload, "key", "heartbeat")?;
                 Ok(json!({ "known": self.registry.heartbeat(key) }))
             }
             "unregister" => {
-                let key = require_key(&payload, "unregister")?;
+                let key = require_str(&payload, "key", "unregister")?;
                 Ok(json!({ "removed": self.registry.unregister(key) }))
             }
             "list" => Ok(json!({ "windows": enriched_windows(self.registry.list()).await })),
@@ -178,6 +182,19 @@ impl DaemonService for WorktreesService {
                 let folders = self.registry.open_folders();
                 let windows = self.registry.list();
                 Ok(json!({ "repos": tree_repos(folders, windows).await }))
+            }
+            "open" => {
+                // Focus (or open — VS Code reuses an already-open window) an
+                // arbitrary worktree folder supplied by a socket client, reusing
+                // the tray's launcher path: `focus_window` resolves the launcher
+                // (`OMNI_DEV_VSCODE_BIN` → well-known paths → `code`) and applies
+                // the absolute-existing-directory guard (which also blocks a
+                // `-`-leading path being parsed by `code` as a flag). This is the
+                // one op a socket *writer* can use to spawn `code`; see the
+                // ADR-0040 threat model (#1266).
+                let path = require_str(&payload, "path", "open")?;
+                focus_window(Path::new(path))?;
+                Ok(json!({ "ok": true }))
             }
             other => bail!("unknown worktrees op: {other}"),
         }
@@ -243,13 +260,14 @@ impl DaemonService for WorktreesService {
     }
 }
 
-/// Extracts a required string `key` from an op payload, erroring with the op
-/// name when it is absent or not a string.
-fn require_key<'a>(payload: &'a Value, op: &str) -> Result<&'a str> {
+/// Extracts a required string `field` from an op payload, erroring with the op
+/// name when it is absent or not a string. Shared by `heartbeat`/`unregister`
+/// (`key`) and `open` (`path`).
+fn require_str<'a>(payload: &'a Value, field: &str, op: &str) -> Result<&'a str> {
     payload
-        .get("key")
+        .get(field)
         .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("`{op}` requires `key`"))
+        .ok_or_else(|| anyhow!("`{op}` requires `{field}`"))
 }
 
 /// The live git state of a worktree folder: the checked-out branch and how far
@@ -762,8 +780,10 @@ fn focus_window(folder: &Path) -> Result<()> {
 /// Best-effort and non-blocking: the spawned child is reaped on a detached
 /// thread so a long-lived daemon does not accumulate zombies one per focus.
 fn focus_window_with(program: &Path, folder: &Path) -> Result<()> {
-    // Workspace-folder paths are absolute; requiring it also rules out a path
-    // that begins with `-` being parsed by `code` as a flag.
+    // The tray path passes an absolute workspace folder, but the socket `open`
+    // op (#1266) passes an arbitrary client-supplied path, so this guard is a
+    // real check there, not just an assertion: requiring an absolute path also
+    // rules out a `-`-leading path being parsed by `code` as a flag.
     if !folder.is_absolute() {
         bail!(
             "refusing to focus a non-absolute folder path: {}",
@@ -905,7 +925,7 @@ mod tests {
             .handle("register", json!({ "key": "  " }))
             .await
             .is_err());
-        // heartbeat/unregister require the key via `require_key`.
+        // heartbeat/unregister require the key via `require_str`.
         assert!(svc.handle("heartbeat", json!({})).await.is_err());
         assert!(svc.handle("unregister", json!({})).await.is_err());
     }
@@ -1113,9 +1133,12 @@ mod tests {
         svc.shutdown().await;
     }
 
-    /// Restores `OMNI_DEV_VSCODE_BIN` on drop. Only this test reads the variable
-    /// (via `resolve_code_binary` → `focus_window`), so there is no cross-test
-    /// race despite the process-global mutation.
+    /// Restores `OMNI_DEV_VSCODE_BIN` on drop. The two spawn tests that read the
+    /// variable (via `resolve_code_binary` → `focus_window`) —
+    /// `menu_action_focus_resolves_folder_and_spawns` and
+    /// `open_focuses_an_existing_absolute_dir` — both point the launcher at the
+    /// same harmless `/bin/sh`, and no test asserts the variable is *unset*, so a
+    /// transient overlap under the harness's test parallelism is benign.
     struct VscodeBinGuard(Option<std::ffi::OsString>);
     impl Drop for VscodeBinGuard {
         fn drop(&mut self) {
@@ -1142,6 +1165,49 @@ mod tests {
         let _g = VscodeBinGuard(std::env::var_os(VSCODE_BIN_ENV));
         std::env::set_var(VSCODE_BIN_ENV, "/bin/sh");
         svc.menu_action("focus:w1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn open_rejects_missing_relative_or_nonexistent_path() {
+        let svc = WorktreesService::new();
+        // A missing `path` is a payload error.
+        assert!(svc.handle("open", json!({})).await.is_err());
+        assert!(svc.handle("open", json!({ "path": 42 })).await.is_err());
+        // A relative path is rejected before any spawn — this is also what
+        // blocks a `-`-leading argument from reaching `code` as a flag.
+        assert!(svc
+            .handle("open", json!({ "path": "relative/dir" }))
+            .await
+            .is_err());
+        assert!(svc
+            .handle("open", json!({ "path": "-flag" }))
+            .await
+            .is_err());
+        // An absolute path that does not exist is rejected before any spawn, so
+        // no launcher is needed for these guard cases.
+        assert!(svc
+            .handle("open", json!({ "path": "/no/such/abs/dir/xyzzy" }))
+            .await
+            .is_err());
+        svc.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn open_focuses_an_existing_absolute_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = WorktreesService::new();
+        // Pin the launcher to a harmless binary so the spawn deterministically
+        // succeeds whether or not `code` is installed. Unlike the tray `focus`
+        // path, `open` takes the folder straight from the payload — no prior
+        // `register` is required.
+        let _g = VscodeBinGuard(std::env::var_os(VSCODE_BIN_ENV));
+        std::env::set_var(VSCODE_BIN_ENV, "/bin/sh");
+        let reply = svc
+            .handle("open", json!({ "path": dir.path() }))
+            .await
+            .unwrap();
+        assert_eq!(reply, json!({ "ok": true }));
+        svc.shutdown().await;
     }
 
     #[test]


### PR DESCRIPTION
## Description

Exposes a new `open` operation on the worktrees control socket so socket clients (notably the companion VS Code extension, on double-click) can focus or open an arbitrary worktree folder in VS Code. It **reuses the tray's tested launcher path resolution and absolute-existing-directory guard**, so clients never duplicate that launcher/guard logic. This is Phase 2 of the worktrees tree-view feature (#1264).

`code <path>` uniformly focuses an already-open window or opens a new one, so one op serves both open and not-open worktrees.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Closes #1266
Relates to #1264

## Changes Made

**Core Changes:**
- Added the `open` op (payload `{ path }`) to the worktrees wire protocol (five ops total), sharing launcher resolution with the tray's focus action via `focus_window()`.
- Refactored `require_key()` into a generic `require_str()` field extractor.
- The `open` handler validates the path is **absolute and an existing directory** before spawning.

**Documentation:**
- Updated ADR-0040 with the threat-model analysis for socket-driven `code` spawning.
- Updated `docs/worktrees-service.md` with the `open` op specification, and refreshed module docs.

## Security

This is a small, **deliberate escalation** of the original tray-only focus action: previously only the human clicking the tray could make the daemon spawn `code`; a socket *writer* now can too. It is bounded by socket ownership (writing already requires the owning local user, `0600`) and the absolute-existing-directory guard — which also blocks a `-`-leading path from being parsed by `code` as a flag (argument injection). The shared launcher keeps this security logic in one tested place.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality

Added coverage for missing/relative/non-existent paths (all rejected before any spawn) and a positive test opening an existing absolute directory.
