### PR TITLE
feat(daemon): implement push subscriptions for worktrees service (#1267)

### DIFF
--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -4,6 +4,25 @@
 //! [`DaemonEnvelope`] request per line, one [`DaemonReply`] response per line.
 //! New optional fields use `#[serde(default, skip_serializing_if = ...)]` so
 //! older peers stay byte-compatible on the wire.
+//!
+//! ## Subscriptions (streaming replies)
+//!
+//! Most ops are strictly request→one-reply. A **subscription** op is the one
+//! exception (#1267): when a service recognises the op as streaming (via
+//! [`DaemonService::subscribe`](super::service::DaemonService::subscribe)) the
+//! server switches that connection to push mode and emits **many**
+//! [`DaemonReply`] lines on the same connection — an initial snapshot, then a
+//! fresh snapshot each time the service's state changes (coalesced, and diffed
+//! so two identical frames are never sent in a row). Each pushed line is an
+//! ordinary `DaemonReply::ok(payload)`; there is **no** new wire type, so a
+//! reader distinguishes a subscription only by continuing to read lines instead
+//! of stopping after one. The stream ends when the client sends any further line
+//! (an explicit cancel), disconnects, or the daemon shuts down.
+//!
+//! The only subscription today is `worktrees` / `subscribe`, whose payload is
+//! the `{ "repos": [...] }` tree snapshot. Back-compat is total: an older client
+//! never sends a subscription op, so it only ever sees the classic one-reply
+//! exchange.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/daemon/registry.rs
+++ b/src/daemon/registry.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 
-use super::service::{DaemonService, ServiceStatus};
+use super::service::{DaemonService, ServiceStatus, ServiceStream};
 
 /// Holds the daemon's registered services and routes control-socket envelopes
 /// to them by [`name`](DaemonService::name).
@@ -50,6 +50,19 @@ impl ServiceRegistry {
             .get(service)
             .ok_or_else(|| anyhow!("unknown service: {service}"))?;
         svc.handle(op, payload).await
+    }
+
+    /// Opens a push subscription on the named service for a streaming `op`, or
+    /// `None` when the service is unknown or does not stream that op — in which
+    /// case the caller falls back to the normal [`dispatch`](Self::dispatch)
+    /// request→reply path (#1267).
+    pub fn subscribe(
+        &self,
+        service: &str,
+        op: &str,
+        payload: &Value,
+    ) -> Option<Box<dyn ServiceStream>> {
+        self.get(service)?.subscribe(op, payload)
     }
 
     /// Collects status from every service, in registration order.

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -17,6 +17,7 @@ use super::lifecycle;
 use super::paths;
 use super::protocol::{DaemonEnvelope, DaemonReply, StatusReport, DAEMON_SERVICE, MAX_LINE_BYTES};
 use super::registry::ServiceRegistry;
+use super::service::ServiceStream;
 use super::single_instance;
 
 /// How long to wait for accepted-but-unfinished connections to drain on
@@ -24,6 +25,12 @@ use super::single_instance;
 /// in-flight dispatch+reply, bounded so a stuck or idle client cannot hang
 /// shutdown indefinitely (a service manager would `SIGKILL` us eventually).
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often a push subscription re-samples and diffs its snapshot even without
+/// a change notification, so purely on-disk state changes (a branch switch, new
+/// commits) — which fire **no** registry event — are still reflected within the
+/// interval. Kept in the issue's 2–5 s band (#1267).
+const STREAM_TICK: Duration = Duration::from_secs(3);
 
 /// Configuration for a [`run`] invocation.
 #[derive(Debug, Clone)]
@@ -201,10 +208,14 @@ async fn drain_connections(conns: &mut JoinSet<()>, timeout: Duration) {
 /// Serves one client connection: decode each NDJSON line, dispatch it, and
 /// write back one reply line, until the client hangs up or a read/write error.
 ///
-/// There is deliberately no `shutdown.cancelled()` arm here: an accepted line
-/// always finishes its dispatch+reply, and shutdown is handled by the server
-/// draining these tasks (see [`drain_connections`]). `shutdown` is still
-/// threaded through for the built-in `shutdown` op (see [`handle_builtin`]).
+/// The normal request→one-reply path has deliberately no `shutdown.cancelled()`
+/// arm: an accepted line always finishes its dispatch+reply, and shutdown is
+/// handled by the server draining these tasks (see [`drain_connections`]). A
+/// **subscription** op is the exception — it takes over the connection via
+/// [`run_stream`], which *does* select on `shutdown` so a long-lived stream is
+/// torn down promptly on drain rather than waiting out [`DRAIN_TIMEOUT`].
+/// `shutdown` is threaded through for both (also the built-in `shutdown` op, see
+/// [`handle_builtin`]).
 async fn handle_connection(
     stream: UnixStream,
     registry: Arc<ServiceRegistry>,
@@ -212,13 +223,8 @@ async fn handle_connection(
 ) {
     let mut framed = Framed::new(stream, LinesCodec::new_with_max_length(MAX_LINE_BYTES));
     while let Some(line) = framed.next().await {
-        match line {
-            Ok(line) => {
-                let reply = dispatch_line(&line, &registry, &shutdown).await;
-                if !send_reply(&mut framed, reply).await {
-                    break;
-                }
-            }
+        let line = match line {
+            Ok(line) => line,
             Err(e) => {
                 // A decode error ends the `Framed` stream (the next poll yields
                 // `None`), so there is nothing more to serve on this connection:
@@ -235,6 +241,93 @@ async fn handle_connection(
                 let _ = send_reply(&mut framed, DaemonReply::err(msg)).await;
                 break;
             }
+        };
+
+        // Parse once, so a subscription op can be detected before it is
+        // dispatched as a normal one-reply op. A malformed envelope replies with
+        // an error but keeps the connection open, matching the pre-#1267 path.
+        let envelope: DaemonEnvelope = match serde_json::from_str(&line) {
+            Ok(envelope) => envelope,
+            Err(e) => {
+                if !send_reply(
+                    &mut framed,
+                    DaemonReply::err(format!("invalid envelope: {e}")),
+                )
+                .await
+                {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        // A streaming op takes over the connection for its whole lifetime: it
+        // never returns a single reply, so once `run_stream` finishes (client
+        // gone or daemon shutting down) the connection is done.
+        if let Some(name) = envelope.service.as_deref() {
+            if name != DAEMON_SERVICE {
+                if let Some(stream) = registry.subscribe(name, &envelope.op, &envelope.payload) {
+                    run_stream(&mut framed, stream, &shutdown).await;
+                    return;
+                }
+            }
+        }
+
+        let reply = dispatch_envelope(envelope, &registry, &shutdown).await;
+        if !send_reply(&mut framed, reply).await {
+            break;
+        }
+    }
+}
+
+/// Drives a push subscription over `framed` until the client goes away or the
+/// daemon shuts down. Sends an initial snapshot, then re-samples the stream on
+/// each change notification and on a periodic [`STREAM_TICK`], pushing **only**
+/// snapshots that differ from the last one sent — so identical frames are never
+/// duplicated (the acceptance criterion). Mirrors the browser bridge's
+/// `start_stream` coalescing shape, but on the control socket.
+///
+/// The subscription owns the connection for its lifetime: any further inbound
+/// line is treated as an explicit cancel and ends the stream, matching the
+/// one-op-per-connection the companion uses (a dedicated subscribe socket).
+async fn run_stream(
+    framed: &mut Framed<UnixStream, LinesCodec>,
+    mut stream: Box<dyn ServiceStream>,
+    shutdown: &CancellationToken,
+) {
+    // Initial snapshot up front. The stream's change source was captured when it
+    // was built (before this snapshot), so the loop below only pushes deltas —
+    // and any change racing this initial sample is caught by the first wakeup.
+    let mut last = stream.snapshot().await;
+    if !send_reply(framed, DaemonReply::ok(last.clone())).await {
+        return;
+    }
+
+    // `interval` fires immediately on the first `tick()`; consume that so the
+    // periodic re-sample starts one full interval out.
+    let mut tick = tokio::time::interval(STREAM_TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    tick.tick().await;
+
+    loop {
+        tokio::select! {
+            () = stream.changed() => {}
+            _ = tick.tick() => {}
+            // Reading `framed` serves double duty and every outcome ends the
+            // stream: an inbound line is an explicit cancel, `None` is the client
+            // hanging up, and an `Err` is a read/decode error. `Framed`'s decode
+            // buffer lives in the codec, not this future, so cancelling this arm
+            // mid-poll loses no buffered bytes.
+            _ = framed.next() => break,
+            () = shutdown.cancelled() => break,
+        }
+        // Any wakeup means "maybe changed": re-sample and push only a real delta.
+        let snap = stream.snapshot().await;
+        if snap != last {
+            if !send_reply(framed, DaemonReply::ok(snap.clone())).await {
+                break;
+            }
+            last = snap;
         }
     }
 }
@@ -256,16 +349,14 @@ async fn send_reply(framed: &mut Framed<UnixStream, LinesCodec>, reply: DaemonRe
     true
 }
 
-/// Parses one NDJSON request line and produces its reply.
-async fn dispatch_line(
-    line: &str,
+/// Produces the one-reply response for a (already-parsed, non-streaming)
+/// request envelope. Streaming ops are peeled off earlier in
+/// [`handle_connection`]; everything else routes here.
+async fn dispatch_envelope(
+    envelope: DaemonEnvelope,
     registry: &ServiceRegistry,
     shutdown: &CancellationToken,
 ) -> DaemonReply {
-    let envelope: DaemonEnvelope = match serde_json::from_str(line) {
-        Ok(envelope) => envelope,
-        Err(e) => return DaemonReply::err(format!("invalid envelope: {e}")),
-    };
     match envelope.service.as_deref() {
         None | Some(DAEMON_SERVICE) => handle_builtin(&envelope.op, registry, shutdown).await,
         Some(name) => {
@@ -373,5 +464,228 @@ mod tests {
         let result = js.join_next().await.unwrap();
         assert!(result.is_err());
         note_reaped(result);
+    }
+
+    // --- Push-subscription streaming (#1267) --------------------------------
+    //
+    // `UnixStream::pair()` is an unbound, connected socket pair — no `bind`, so
+    // no umask mutation — so these `run_stream` tests stay here (in-process)
+    // rather than in the socket-binding `tests/daemon_socket.rs` binary.
+
+    use std::sync::Mutex as StdMutex;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::sync::watch;
+
+    /// A controllable [`ServiceStream`] for driving `run_stream` directly: the
+    /// test bumps `tx` to wake it and swaps `snap` to change what it reports.
+    struct FakeStream {
+        rx: watch::Receiver<u64>,
+        snap: Arc<StdMutex<serde_json::Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceStream for FakeStream {
+        async fn changed(&mut self) {
+            // Mirror the real impl: park (rather than spin) once the sender drops.
+            if self.rx.changed().await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+        async fn snapshot(&self) -> serde_json::Value {
+            self.snap.lock().unwrap().clone()
+        }
+    }
+
+    /// Reads one NDJSON reply line from the client end, asserting it is not EOF.
+    /// Generic over the reader so it works on both an owned `BufReader<UnixStream>`
+    /// and one wrapping a `&mut UnixStream` (test 2 keeps the stream to write to).
+    async fn read_reply<R: tokio::io::AsyncBufRead + Unpin>(reader: &mut R) -> DaemonReply {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await.unwrap();
+        assert!(n > 0, "expected a reply line, got EOF");
+        serde_json::from_str(line.trim_end()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn run_stream_pushes_initial_then_deltas_and_dedupes() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let (tx, rx) = watch::channel(0u64);
+        let snap = Arc::new(StdMutex::new(json!({ "n": 0 })));
+        let fake = FakeStream {
+            rx,
+            snap: snap.clone(),
+        };
+        let shutdown = CancellationToken::new();
+        let server_shutdown = shutdown.clone();
+
+        let server_task = tokio::spawn(async move {
+            let mut framed = Framed::new(server, LinesCodec::new_with_max_length(MAX_LINE_BYTES));
+            run_stream(&mut framed, Box::new(fake), &server_shutdown).await;
+        });
+
+        let mut reader = BufReader::new(client);
+
+        // 1) The initial snapshot is pushed up front.
+        let initial = read_reply(&mut reader).await;
+        assert!(initial.ok);
+        assert_eq!(initial.payload, json!({ "n": 0 }));
+
+        // 2) A wake whose snapshot is unchanged is NOT re-sent (the diff dedupes).
+        //    Then a real change is. Because the next frame we read is the changed
+        //    one, a spurious duplicate of `{n:0}` would fail this assertion.
+        tx.send(1).unwrap(); // wake; snapshot still {n:0} → suppressed
+        *snap.lock().unwrap() = json!({ "n": 1 });
+        tx.send(2).unwrap(); // wake; snapshot now {n:1} → pushed
+        let delta = read_reply(&mut reader).await;
+        assert_eq!(delta.payload, json!({ "n": 1 }));
+
+        // 3) Shutdown tears the stream down cleanly: the client hits EOF.
+        shutdown.cancel();
+        let mut tail = String::new();
+        let n = reader.read_line(&mut tail).await.unwrap();
+        assert_eq!(n, 0, "stream should close cleanly on shutdown");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_stream_ends_when_client_sends_a_line() {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let (_tx, rx) = watch::channel(0u64);
+        let snap = Arc::new(StdMutex::new(json!({ "n": 0 })));
+        let fake = FakeStream { rx, snap };
+        let shutdown = CancellationToken::new();
+        let server_shutdown = shutdown.clone();
+
+        let server_task = tokio::spawn(async move {
+            let mut framed = Framed::new(server, LinesCodec::new_with_max_length(MAX_LINE_BYTES));
+            run_stream(&mut framed, Box::new(fake), &server_shutdown).await;
+        });
+
+        let mut reader = BufReader::new(&mut client);
+        let _initial = read_reply(&mut reader).await;
+        // Release the borrow of `client` so it can be written to below.
+        drop(reader);
+
+        // Any inbound line is a cancel: the stream ends and the task completes
+        // even though shutdown was never signalled.
+        client.write_all(b"cancel\n").await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .expect("run_stream should end after a client line")
+            .unwrap();
+    }
+
+    /// `handle_connection`'s parse/route path: a malformed envelope replies with
+    /// an error but keeps the connection open, and a well-formed non-subscribe op
+    /// then falls through the streaming check to the normal one-reply dispatch.
+    #[tokio::test]
+    async fn handle_connection_rejects_bad_envelope_then_serves_normal_op() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client, server) = UnixStream::pair().unwrap();
+        let mut registry = ServiceRegistry::new();
+        registry.register(Arc::new(
+            crate::daemon::services::worktrees::WorktreesService::new(),
+        ));
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(handle_connection(server, Arc::new(registry), shutdown));
+
+        let (read_half, mut write_half) = client.into_split();
+        let mut reader = BufReader::new(read_half);
+
+        // 1) A syntactically invalid line → error reply; the connection stays up.
+        write_half.write_all(b"not json\n").await.unwrap();
+        let bad = read_reply(&mut reader).await;
+        assert!(!bad.ok);
+        assert!(bad.error.unwrap().contains("invalid envelope"));
+
+        // 2) A well-formed non-subscribe op is served on the same connection
+        //    (the streaming check declines `list`, so it dispatches normally).
+        let env = serde_json::to_string(&DaemonEnvelope::service(
+            "worktrees",
+            "list",
+            serde_json::Value::Null,
+        ))
+        .unwrap();
+        write_half.write_all(env.as_bytes()).await.unwrap();
+        write_half.write_all(b"\n").await.unwrap();
+        let listed = read_reply(&mut reader).await;
+        assert!(listed.ok);
+        assert!(listed.payload.get("windows").is_some());
+
+        // Client hangs up → the handler task ends cleanly.
+        drop(write_half);
+        drop(reader);
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("handler should end after the client hangs up")
+            .unwrap();
+    }
+
+    /// `handle_connection` routes a `subscribe` op into streaming mode: the
+    /// client gets the pushed initial snapshot, and daemon shutdown ends both the
+    /// stream and the handler task.
+    #[tokio::test]
+    async fn handle_connection_enters_streaming_for_subscribe() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client, server) = UnixStream::pair().unwrap();
+        let mut registry = ServiceRegistry::new();
+        registry.register(Arc::new(
+            crate::daemon::services::worktrees::WorktreesService::new(),
+        ));
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(handle_connection(
+            server,
+            Arc::new(registry),
+            shutdown.clone(),
+        ));
+
+        let (read_half, mut write_half) = client.into_split();
+        let mut reader = BufReader::new(read_half);
+        let env = serde_json::to_string(&DaemonEnvelope::service(
+            "worktrees",
+            "subscribe",
+            serde_json::Value::Null,
+        ))
+        .unwrap();
+        write_half.write_all(env.as_bytes()).await.unwrap();
+        write_half.write_all(b"\n").await.unwrap();
+
+        // The subscription pushes an initial snapshot (no windows → empty repos).
+        let initial = read_reply(&mut reader).await;
+        assert!(initial.ok);
+        assert_eq!(initial.payload, json!({ "repos": [] }));
+
+        // Shutdown ends the stream and the handler task.
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("shutdown should end the streaming handler")
+            .unwrap();
+    }
+
+    /// `run_stream` returns immediately when even the initial snapshot cannot be
+    /// sent (the client is already gone) rather than entering the select loop.
+    #[tokio::test]
+    async fn run_stream_returns_when_initial_send_fails() {
+        let (client, server) = UnixStream::pair().unwrap();
+        // Close the peer before `run_stream` writes, so the first send fails.
+        drop(client);
+        let (_tx, rx) = watch::channel(0u64);
+        let fake = FakeStream {
+            rx,
+            snap: Arc::new(StdMutex::new(json!({ "n": 0 }))),
+        };
+        let shutdown = CancellationToken::new();
+        let mut framed = Framed::new(server, LinesCodec::new_with_max_length(MAX_LINE_BYTES));
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            run_stream(&mut framed, Box::new(fake), &shutdown),
+        )
+        .await
+        .expect("run_stream should return promptly when the initial send fails");
     }
 }

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -26,6 +26,26 @@ pub trait DaemonService: Send + Sync {
     /// Handles an operation routed to this service, returning a JSON payload.
     async fn handle(&self, op: &str, payload: Value) -> Result<Value>;
 
+    /// Opens a **push subscription** for a streaming op, or returns `None` when
+    /// `op` is not one this service streams (the default for every service).
+    ///
+    /// When the server sees a `Some`, it switches that connection to streaming
+    /// mode ([`server::run_stream`](super::server)): it sends the stream's
+    /// initial [`snapshot`](ServiceStream::snapshot), then pushes a fresh
+    /// snapshot each time [`ServiceStream::changed`] (or the server's own
+    /// periodic tick) wakes it and the payload differs from the last one sent,
+    /// until the client disconnects or the daemon shuts down. A `None` op falls
+    /// through to the normal request→one-reply [`handle`](Self::handle) path, so
+    /// the request/reply contract is unchanged for every existing service and op
+    /// (#1267).
+    ///
+    /// Kept synchronous and cheap: building a stream should only clone the
+    /// handles it needs. `payload` is borrowed so the non-streaming path retains
+    /// ownership for [`handle`](Self::handle).
+    fn subscribe(&self, _op: &str, _payload: &Value) -> Option<Box<dyn ServiceStream>> {
+        None
+    }
+
     /// Cheap snapshot of the service's tray submenu, polled by the menu-bar
     /// shell. Must not block.
     fn menu(&self) -> MenuSnapshot;
@@ -40,6 +60,32 @@ pub trait DaemonService: Send + Sync {
     /// Gracefully stops the service, draining in-flight work. Called once on
     /// daemon shutdown.
     async fn shutdown(&self);
+}
+
+/// A live push stream a service exposes for a subscription op.
+///
+/// See [`DaemonService::subscribe`]. The server owns the drive loop: it awaits
+/// [`changed`](Self::changed) (alongside its own periodic tick, so purely
+/// on-disk state changes are still caught), then calls
+/// [`snapshot`](Self::snapshot) and pushes the payload only when it differs from
+/// the last one sent — so the implementation never has to schedule, diff, or
+/// write anything itself (#1267).
+#[async_trait]
+pub trait ServiceStream: Send {
+    /// Resolves when the service's visible state *may* have changed since the
+    /// previous call. Collapsing a burst of changes into one wakeup (coalescing)
+    /// is the implementation's job; a spurious wakeup is harmless because the
+    /// server diffs the resulting snapshot. It must **not** resolve in a tight
+    /// loop when there is nothing to report (e.g. once the change source is gone,
+    /// park rather than return repeatedly), or it would spin the server's
+    /// `select!`.
+    async fn changed(&mut self);
+
+    /// The current snapshot payload, sent verbatim as
+    /// [`DaemonReply::ok`](super::protocol::DaemonReply::ok). May perform
+    /// blocking work (offloaded to a blocking thread); the server awaits it
+    /// between wakeups.
+    async fn snapshot(&self) -> Value;
 }
 
 /// Structured per-service status, aggregated by the built-in `status` op and

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -41,10 +41,13 @@ use async_trait::async_trait;
 use git2::Repository;
 use serde::Serialize;
 use serde_json::{json, Value};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::daemon::service::{DaemonService, MenuAction, MenuItem, MenuSnapshot, ServiceStatus};
+use crate::daemon::service::{
+    DaemonService, MenuAction, MenuItem, MenuSnapshot, ServiceStatus, ServiceStream,
+};
 use crate::worktrees::{RegisterRequest, WindowEntry, WorktreesRegistry};
 
 /// The worktrees service name (the control-socket routing key).
@@ -198,6 +201,20 @@ impl DaemonService for WorktreesService {
             }
             other => bail!("unknown worktrees op: {other}"),
         }
+    }
+
+    fn subscribe(&self, op: &str, _payload: &Value) -> Option<Box<dyn ServiceStream>> {
+        // The single streaming op: a live push of the repo/worktree `tree`
+        // snapshot. Every other op falls through to the request→reply `handle`.
+        if op != "subscribe" {
+            return None;
+        }
+        Some(Box::new(WorktreesStream {
+            registry: self.registry.clone(),
+            // Capture the change source *now* — before the server takes its
+            // initial snapshot — so a change racing that snapshot still wakes us.
+            changes: self.registry.subscribe_changes(),
+        }))
     }
 
     fn menu(&self) -> MenuSnapshot {
@@ -655,6 +672,46 @@ async fn tree_repos(folders: Vec<PathBuf>, windows: Vec<WindowEntry>) -> Vec<Val
     })
     .await
     .unwrap_or_default()
+}
+
+// --- Push subscription (#1267) -----------------------------------------------
+
+/// The [`ServiceStream`] backing the worktrees `subscribe` op: a live push of
+/// the same `{ repos: [...] }` snapshot the `tree` op returns (#1265). The
+/// server drives it — awaiting [`changed`](ServiceStream::changed) plus its own
+/// periodic tick, then diffing [`snapshot`](ServiceStream::snapshot) — so this
+/// type only has to (a) relay the registry's change-notify and (b) recompute the
+/// tree on demand.
+struct WorktreesStream {
+    /// The cross-window registry the snapshot is computed from.
+    registry: Arc<WorktreesRegistry>,
+    /// Wakes on each visible-set change (a `register`, a removing `unregister`,
+    /// or a mutation-driven reap). A burst coalesces into one wakeup; the
+    /// server's diff drops any snapshot that ends up identical.
+    changes: watch::Receiver<u64>,
+}
+
+#[async_trait]
+impl ServiceStream for WorktreesStream {
+    async fn changed(&mut self) {
+        // `watch::Receiver::changed` marks the newest version seen, so a burst of
+        // bumps collapses into a single wakeup. If every sender is gone (the
+        // registry — and thus the daemon — is tearing down) it returns `Err`;
+        // park instead of returning, so this arm can never spin the server's
+        // `select!` (the tick and shutdown arms still drive teardown).
+        if self.changes.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+
+    async fn snapshot(&self) -> Value {
+        // Identical to the `tree` op: two cheap registry locks (the seed folders
+        // to derive repos from, and the live windows to join on), then the git
+        // enumeration/enrichment off the lock on a blocking thread.
+        let folders = self.registry.open_folders();
+        let windows = self.registry.list();
+        json!({ "repos": tree_repos(folders, windows).await })
+    }
 }
 
 /// A short human name for a window: its repo, else its first folder's basename,
@@ -1122,6 +1179,70 @@ mod tests {
         let svc = WorktreesService::default();
         let payload = svc.handle("list", Value::Null).await.unwrap();
         assert_eq!(payload, json!({ "windows": [] }));
+    }
+
+    // --- Push subscription (#1267) -----------------------------------------
+
+    #[tokio::test]
+    async fn subscribe_streams_only_for_the_subscribe_op() {
+        let svc = WorktreesService::new();
+        // The one streaming op yields a stream; every other op (including the
+        // request/reply worktrees ops) declines, so the server dispatches them
+        // normally.
+        assert!(svc.subscribe("subscribe", &Value::Null).is_some());
+        assert!(svc.subscribe("list", &Value::Null).is_none());
+        assert!(svc.subscribe("register", &Value::Null).is_none());
+        assert!(svc.subscribe("bogus", &Value::Null).is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_snapshot_matches_the_tree_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = init_repo(dir.path());
+        empty_commit(&repo, Some("refs/heads/main"), &[], "A");
+        repo.set_head("refs/heads/main").unwrap();
+
+        let svc = WorktreesService::new();
+        let stream = svc
+            .subscribe("subscribe", &Value::Null)
+            .expect("subscribe stream");
+        // No windows yet → no repos derived.
+        assert_eq!(stream.snapshot().await, json!({ "repos": [] }));
+
+        // A window opens on the repo → the snapshot carries it, byte-identical to
+        // what the `tree` op returns for the same registry state.
+        svc.handle(
+            "register",
+            json!({ "key": "w1", "folders": [dir.path()], "repo": "r" }),
+        )
+        .await
+        .unwrap();
+        let snap = stream.snapshot().await;
+        let tree = svc.handle("tree", Value::Null).await.unwrap();
+        assert_eq!(snap, tree);
+        let repos = snap["repos"].as_array().expect("repos array");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0]["worktrees"][0]["branch"], json!("main"));
+    }
+
+    #[tokio::test]
+    async fn subscribe_changed_wakes_on_register() {
+        let svc = WorktreesService::new();
+        let mut stream = svc
+            .subscribe("subscribe", &Value::Null)
+            .expect("subscribe stream");
+        // Idle: `changed()` must not resolve without a registry change.
+        tokio::select! {
+            () = stream.changed() => panic!("changed resolved with no registry change"),
+            () = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+        // A register bumps the change-notify → `changed()` resolves promptly.
+        svc.handle("register", register_payload("w1", Some("r"), "/tmp/a"))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), stream.changed())
+            .await
+            .expect("changed should resolve after a register");
     }
 
     #[tokio::test]

--- a/src/worktrees.rs
+++ b/src/worktrees.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
 
 /// How long a window may go silent before it ages out of the registry. Three
 /// missed ~10s heartbeats; a window that crashed without firing `unregister`
@@ -93,6 +94,20 @@ pub struct WorktreesRegistry {
     windows: Mutex<HashMap<String, WindowEntry>>,
     /// How long an entry survives without a heartbeat.
     ttl: Duration,
+    /// A monotonically-bumped version counter, incremented whenever the visible
+    /// set of windows changes (a `register`, a removing `unregister`, or a
+    /// mutation-driven reap that drops a stale entry). A push-subscription
+    /// consumer holds a [`watch::Receiver`] from
+    /// [`subscribe_changes`](Self::subscribe_changes) and wakes on each bump to
+    /// re-snapshot (#1267). The counter's *value* is immaterial —
+    /// only that it changed — so a burst coalesces into one wake and the
+    /// subscriber diffs the resulting snapshot to suppress duplicate frames.
+    ///
+    /// `watch` needs no runtime and never blocks, so it fits this engine's
+    /// no-async-setup posture; every [`bump`](Self::bump) happens *after* the map
+    /// guard is dropped, so the `std::Mutex`-never-across-`.await` rule is intact
+    /// (and the watch's own internal lock is never nested under the map lock).
+    changes: watch::Sender<u64>,
 }
 
 impl WorktreesRegistry {
@@ -102,7 +117,31 @@ impl WorktreesRegistry {
         Self {
             windows: Mutex::new(HashMap::new()),
             ttl: DEFAULT_TTL,
+            changes: watch::channel(0).0,
         }
+    }
+
+    /// A change-notification receiver for the push subscription: it observes a
+    /// new value each time the visible window set changes (see [`changes`] and
+    /// [`bump`]). Created with the current version already marked seen, so the
+    /// first [`watch::Receiver::changed`] resolves on the *next* change — the
+    /// subscriber sends its own initial snapshot up front and then waits for
+    /// deltas (#1267).
+    ///
+    /// [`changes`]: Self::changes
+    /// [`bump`]: Self::bump
+    #[must_use]
+    pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes.subscribe()
+    }
+
+    /// Signals subscribers that the visible window set changed. Non-blocking and
+    /// runtime-free; called only *after* the map guard is released so the two
+    /// locks never nest. A send never fails here (the sender is owned by the
+    /// registry, which outlives every receiver, and `send_modify` bumps even
+    /// with no receivers).
+    fn bump(&self) {
+        self.changes.send_modify(|v| *v = v.wrapping_add(1));
     }
 
     /// Locks the registry, recovering from a poisoned mutex (a panic in a prior
@@ -117,24 +156,31 @@ impl WorktreesRegistry {
     /// callers validate the `key` before reaching here.
     pub fn register(&self, req: RegisterRequest) {
         let now = Utc::now();
-        let mut windows = self.lock();
-        reap(&mut windows, self.ttl, now);
-        // Upserts never evict; only a genuinely new key can grow the map, and
-        // never past MAX_WINDOWS.
-        if !windows.contains_key(&req.key) && windows.len() >= MAX_WINDOWS {
-            evict_oldest(&mut windows);
+        {
+            let mut windows = self.lock();
+            reap(&mut windows, self.ttl, now);
+            // Upserts never evict; only a genuinely new key can grow the map, and
+            // never past MAX_WINDOWS.
+            if !windows.contains_key(&req.key) && windows.len() >= MAX_WINDOWS {
+                evict_oldest(&mut windows);
+            }
+            windows.insert(
+                req.key.clone(),
+                WindowEntry {
+                    key: req.key,
+                    folders: req.folders,
+                    repo: req.repo,
+                    title: req.title,
+                    pid: req.pid,
+                    last_seen: now,
+                },
+            );
         }
-        windows.insert(
-            req.key.clone(),
-            WindowEntry {
-                key: req.key,
-                folders: req.folders,
-                repo: req.repo,
-                title: req.title,
-                pid: req.pid,
-                last_seen: now,
-            },
-        );
+        // Always bump: a register is infrequent (once per companion `activate()`,
+        // not per heartbeat) and may add or alter a window's folders/repo. A
+        // no-op re-register with identical data is harmless — the subscriber
+        // diffs the snapshot and suppresses the duplicate frame.
+        self.bump();
     }
 
     /// Refreshes a window's liveness. Returns whether the key was known: a
@@ -143,28 +189,51 @@ impl WorktreesRegistry {
     /// has no record of it.
     pub fn heartbeat(&self, key: &str) -> bool {
         let now = Utc::now();
-        let mut windows = self.lock();
-        reap(&mut windows, self.ttl, now);
-        match windows.get_mut(key) {
-            Some(entry) => {
-                entry.last_seen = now;
-                true
-            }
-            None => false,
+        let (known, reaped) = {
+            let mut windows = self.lock();
+            let reaped = reap(&mut windows, self.ttl, now);
+            let known = match windows.get_mut(key) {
+                Some(entry) => {
+                    entry.last_seen = now;
+                    true
+                }
+                None => false,
+            };
+            (known, reaped)
+        };
+        // A heartbeat is frequent (~every 10 s per window); a pure liveness
+        // refresh does not change the visible set, so bump *only* when this
+        // heartbeat's inline reap actually aged a stale sibling out.
+        if reaped > 0 {
+            self.bump();
         }
+        known
     }
 
     /// Drops a window's registration. Returns whether an entry was present.
     pub fn unregister(&self, key: &str) -> bool {
         let now = Utc::now();
-        let mut windows = self.lock();
-        let removed = windows.remove(key).is_some();
-        reap(&mut windows, self.ttl, now);
+        let (removed, reaped) = {
+            let mut windows = self.lock();
+            let removed = windows.remove(key).is_some();
+            let reaped = reap(&mut windows, self.ttl, now);
+            (removed, reaped)
+        };
+        if removed || reaped > 0 {
+            self.bump();
+        }
         removed
     }
 
     /// Reaps stale entries, then returns the live set sorted for deterministic
     /// output. Holds the lock only for pure-CPU work.
+    ///
+    /// Like the other reads ([`open_folders`](Self::open_folders),
+    /// [`first_folder`](Self::first_folder)) this reaps but never
+    /// [`bump`](Self::bump)s: the only observer of a read-path reap is the push
+    /// subscription's own re-snapshot (or `status`/`menu`), and the
+    /// subscription's periodic tick already re-samples read-only staleness — so
+    /// bumping here would only make the subscription wake itself (#1267).
     pub fn list(&self) -> Vec<WindowEntry> {
         let now = Utc::now();
         let mut windows = self.lock();
@@ -210,11 +279,17 @@ impl Default for WorktreesRegistry {
     }
 }
 
-/// Removes entries last seen longer than `ttl` ago. Pure CPU; the caller holds
-/// the registry lock but never `.await`s while holding it.
-fn reap(windows: &mut HashMap<String, WindowEntry>, ttl: Duration, now: DateTime<Utc>) {
+/// Removes entries last seen longer than `ttl` ago, returning how many were
+/// dropped. Pure CPU; the caller holds the registry lock but never `.await`s
+/// while holding it. The count lets a *mutation* path
+/// ([`register`](WorktreesRegistry::register) et al.) decide whether to
+/// [`bump`](WorktreesRegistry::bump) the change-notify; read paths ignore it (see
+/// [`list`](WorktreesRegistry::list)).
+fn reap(windows: &mut HashMap<String, WindowEntry>, ttl: Duration, now: DateTime<Utc>) -> usize {
     let max_age = ttl.as_secs() as i64;
+    let before = windows.len();
     windows.retain(|_, e| (now - e.last_seen).num_seconds() <= max_age);
+    before - windows.len()
 }
 
 /// Removes the entry with the oldest `last_seen` (ties broken by lowest key
@@ -528,5 +603,64 @@ mod tests {
     fn default_constructs_an_empty_registry() {
         let reg = WorktreesRegistry::default();
         assert!(reg.lock().is_empty());
+    }
+
+    // --- Change-notify for the push subscription (#1267) --------------------
+
+    #[test]
+    fn subscribe_changes_starts_seen_and_register_bumps() {
+        let reg = WorktreesRegistry::new();
+        let mut rx = reg.subscribe_changes();
+        // A fresh receiver has the current version already marked seen.
+        assert!(!rx.has_changed().unwrap());
+        // A register changes the visible set → the receiver observes a new value.
+        reg.register(register_request("w1", None, "/tmp/a"));
+        assert!(rx.has_changed().unwrap(), "register should bump");
+        // Marking it seen clears the pending change.
+        rx.borrow_and_update();
+        assert!(!rx.has_changed().unwrap());
+    }
+
+    #[test]
+    fn unregister_bumps_only_when_it_removes() {
+        let reg = WorktreesRegistry::new();
+        reg.register(register_request("w1", None, "/tmp/a"));
+        // Subscribe *after* the register so its bump is already seen.
+        let rx = reg.subscribe_changes();
+        // Removing a missing key changes nothing (and reaps nothing) → no bump.
+        assert!(!reg.unregister("ghost"));
+        assert!(
+            !rx.has_changed().unwrap(),
+            "a no-op unregister must not bump"
+        );
+        // Removing a present key bumps.
+        assert!(reg.unregister("w1"));
+        assert!(
+            rx.has_changed().unwrap(),
+            "a removing unregister should bump"
+        );
+    }
+
+    #[test]
+    fn heartbeat_bumps_only_when_it_reaps() {
+        let reg = WorktreesRegistry::new();
+        reg.register(register_request("w1", None, "/tmp/a"));
+        let rx = reg.subscribe_changes();
+        // A plain heartbeat refreshes liveness but changes no visible state.
+        assert!(reg.heartbeat("w1"));
+        assert!(!rx.has_changed().unwrap(), "a pure heartbeat must not bump");
+        // Seed a stale sibling directly; a heartbeat that reaps it *does* bump.
+        {
+            let mut windows = reg.lock();
+            windows.insert(
+                "stale".to_string(),
+                entry_at("stale", Utc::now() - chrono::Duration::seconds(120)),
+            );
+        }
+        assert!(reg.heartbeat("w1"));
+        assert!(
+            rx.has_changed().unwrap(),
+            "a heartbeat that reaps a stale sibling should bump"
+        );
     }
 }

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -436,6 +436,128 @@ async fn worktrees_cli_tree_against_live_daemon() {
     .is_err());
 }
 
+/// Initializes a bare-minimum git repository at `path` (no commit needed: an
+/// unborn HEAD is still a repo, so the `tree`/`subscribe` snapshot lists it), so
+/// registering a window on it changes the pushed snapshot.
+fn init_git_repo(path: &std::path::Path) {
+    git2::Repository::init(path).unwrap();
+}
+
+/// Reads one pushed NDJSON [`DaemonReply`] frame from a subscription reader,
+/// asserting it is not EOF.
+async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(reader: &mut R) -> DaemonReply {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await.unwrap();
+    assert!(n > 0, "expected a pushed frame, got EOF");
+    serde_json::from_str(line.trim_end()).unwrap()
+}
+
+/// End-to-end acceptance for the push subscription (#1267): a `subscribe` client
+/// gets an initial snapshot, a fresh one after a `register` and after an
+/// `unregister`, no duplicate identical frame on an idempotent re-register, and
+/// a clean EOF when the daemon shuts down. Uses a raw socket because
+/// `DaemonClient` is one-shot request/reply; the subscription is many replies on
+/// one connection.
+#[tokio::test]
+async fn worktrees_subscribe_pushes_initial_and_updates() {
+    let _gate = UMASK_GATE.lock().await;
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("d.sock");
+    let mut registry = ServiceRegistry::new();
+    registry.register(Arc::new(WorktreesService::new()));
+    let handle = tokio::spawn(run(
+        registry,
+        DaemonOptions {
+            socket_path: socket.clone(),
+        },
+    ));
+
+    // A one-shot client for control ops (register/unregister/shutdown), plus the
+    // readiness probe.
+    let client = DaemonClient::new(&socket);
+    for _ in 0..50 {
+        if client.ping().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // A dedicated subscription connection: send `subscribe`, then read frames.
+    let sub = UnixStream::connect(&socket).await.unwrap();
+    let (read_half, mut write_half) = sub.into_split();
+    let mut reader = BufReader::new(read_half);
+    let subscribe_line = serde_json::to_string(&DaemonEnvelope::service(
+        "worktrees",
+        "subscribe",
+        Value::Null,
+    ))
+    .unwrap();
+    write_half
+        .write_all(subscribe_line.as_bytes())
+        .await
+        .unwrap();
+    write_half.write_all(b"\n").await.unwrap();
+
+    // 1) Initial snapshot: no windows registered yet → empty repo set.
+    let initial = read_frame(&mut reader).await;
+    assert!(initial.ok, "initial frame errored: {:?}", initial.error);
+    assert_eq!(initial.payload, json!({ "repos": [] }));
+
+    // 2) A window opens on a real git repo → a fresh snapshot carrying it.
+    let repo_dir = tempfile::tempdir().unwrap();
+    init_git_repo(repo_dir.path());
+    client
+        .request(DaemonEnvelope::service(
+            "worktrees",
+            "register",
+            json!({ "key": "k1", "folders": [repo_dir.path()], "repo": "r" }),
+        ))
+        .await
+        .unwrap();
+    let updated = read_frame(&mut reader).await;
+    let repos = updated.payload["repos"].as_array().unwrap();
+    assert_eq!(repos.len(), 1, "register should push the newly-opened repo");
+    assert_eq!(repos[0]["worktrees"][0]["open"], json!(true));
+
+    // 3) No duplicate identical frames + fresh frame on unregister: an idempotent
+    //    re-register bumps the change-notify but yields the *same* snapshot, so
+    //    the server's diff suppresses it. The `unregister` that follows removes
+    //    the window, so the next frame we read must be the empty set — if the
+    //    duplicate had (wrongly) been sent, we'd read the non-empty frame here.
+    client
+        .request(DaemonEnvelope::service(
+            "worktrees",
+            "register",
+            json!({ "key": "k1", "folders": [repo_dir.path()], "repo": "r" }),
+        ))
+        .await
+        .unwrap();
+    client
+        .request(DaemonEnvelope::service(
+            "worktrees",
+            "unregister",
+            json!({ "key": "k1" }),
+        ))
+        .await
+        .unwrap();
+    let removed = read_frame(&mut reader).await;
+    assert_eq!(
+        removed.payload,
+        json!({ "repos": [] }),
+        "expected the post-unregister empty frame, not a duplicate of the repo frame"
+    );
+
+    // 4) Daemon shutdown tears the stream down cleanly: the reader hits EOF.
+    client.shutdown().await.ok();
+    let mut tail = String::new();
+    let n = tokio::time::timeout(Duration::from_secs(2), reader.read_line(&mut tail))
+        .await
+        .expect("shutdown should close the subscription within the timeout")
+        .unwrap();
+    assert_eq!(n, 0, "subscription should close cleanly on daemon shutdown");
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+}
+
 #[tokio::test]
 async fn second_bind_is_refused_while_first_is_live() {
     let _gate = UMASK_GATE.lock().await;


### PR DESCRIPTION
## Description

This PR implements a streaming push subscription model for the daemon control socket, enabling clients to maintain a live connection and receive real-time state snapshots as changes occur, rather than polling via repeated requests. The subscription operation is detected before request dispatch and takes over the connection for its lifetime, transparently coalescing and diffing snapshots to prevent duplicate frames.

The implementation provides a fully backward-compatible extension to the daemon protocol. Older clients that never send subscription operations continue to work with the classic one-request-one-reply pattern, while new clients can opt into push mode for the `worktrees` service's `subscribe` operation.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #1267

## Changes Made

**Core Architecture:**
- Added `ServiceStream` trait defining the push subscription interface with `changed()` and `snapshot()` methods; implementations drive async change notifications and supply payloads on demand
- Extended `DaemonService` with optional `subscribe()` method to opt into streaming for specific operations; defaults to `None` for backward compatibility
- Refactored `handle_connection()` to parse envelopes once, detect streaming operations via `registry.subscribe()`, and route to new `run_stream()` function for subscriptions or `dispatch_envelope()` for normal operations
- Implemented `run_stream()` to drive the subscription loop: send initial snapshot, then re-sample on change notifications and periodic `STREAM_TICK` (3 seconds), pushing only when diffs differ from last sent frame (automatic deduplication)
- Added `ServiceRegistry::subscribe()` to route subscription operations to services

**Worktrees Service Implementation:**
- Wired `WorktreesRegistry` with a `watch::Sender<u64>` change-notify channel; `register()`, `unregister()`, and mutation-driven `reap()` calls bump the version to wake subscribers
- Implemented `WorktreesStream` for the worktrees `subscribe` operation, relaying the same `{ "repos": [...] }` snapshot as the `tree` operation but in push mode
- Modified `register()`, `unregister()`, and `reap()` to signal the change channel after releasing the registry lock
- Updated `heartbeat()` to only bump change-notify when it actually reaps stale entries (frequent heartbeats no longer trigger spurious wakeups)

**Protocol Documentation:**
- Added comprehensive documentation to `protocol.rs` explaining the subscription model, wire format, and backward compatibility guarantees

**Testing:**
- Added unit tests for `run_stream()` deduplication and client cancellation
- Added service-level tests for the subscribe operation and change-notification wakeups
- Added registry tests for change-notify behavior on register, unregister, and reap operations
- Added end-to-end acceptance test (`worktrees_subscribe_pushes_initial_and_updates`) verifying initial snapshot, updates, deduplication, and clean shutdown

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for subscription functionality and change notification
- [x] Unit tests for `run_stream()` deduplication logic
- [x] Unit tests for client cancellation via inbound lines
- [x] Service-level tests for subscribe operation routing
- [x] Service-level tests for changed() wakeup on registry mutations
- [x] Registry tests for change-notify on register, unregister, and reap
- [x] End-to-end acceptance test with live daemon socket

**Manual Testing:**
- [x] Tested subscription with initial snapshot delivery
- [x] Tested snapshot updates on window register/unregister
- [x] Tested deduplication (idempotent re-register suppresses duplicate frames)
- [x] Tested clean shutdown and EOF delivery to subscription clients
- [x] Verified backward compatibility (existing one-shot operations unaffected)

### Test Commands
```bash
# Core test suite
cargo test

# Daemon-specific tests
cargo test daemon

# Worktrees service tests
cargo test worktrees

# Socket integration tests
cargo test daemon_socket

# Code quality checks
cargo clippy -- -D warnings
cargo fmt --check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture: The `ServiceStream` trait design and how it integrates with the connection loop
- [x] Concurrency: Change-notify channel design, especially timing of `bump()` calls after lock release
- [x] Deduplication logic: The diff-based frame suppression in `run_stream()`
- [x] Backward compatibility: Streaming operations are opt-in; all existing operations remain unchanged
- [x] Error handling: Graceful connection teardown on client disconnect, daemon shutdown, or read errors
- [x] Performance: Periodic tick interval (3 seconds) balances responsiveness with overhead

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact
- [x] No performance impact for non-subscription operations
- [x] Minimal overhead for subscription clients: one periodic tick every 3 seconds, plus event-driven re-samples coalesced into one wakeup
- [x] Change-notify uses `tokio::sync::watch`, which is runtime-free and non-blocking

## Security Considerations
- [x] No security implications
- Subscription payloads use the same `DaemonReply::ok()` format as regular operations
- No new authentication or authorization mechanisms required
- Connection teardown on client disconnect is immediate and clean
- Daemon shutdown promptly closes all subscription streams via `CancellationToken`

## Breaking Changes
None. This is a purely additive feature with full backward compatibility. Existing clients that never send subscription operations continue to work identically.

## Deployment Notes
- [x] No special deployment requirements
- [x] No database migrations required
- [x] No environment variable changes required
- [x] No configuration updates required
- [x] No service restart required
- Can be deployed as a standard rolling update without any special handling

## Additional Notes

**Design Decisions:**
- The change-notify channel is stored directly on `WorktreesRegistry` rather than being hidden behind an async setup, maintaining the engine's no-async-setup posture and avoiding runtime initialization overhead
- Bumping is always done *after* releasing the registry lock to enforce the rule that `std::Mutex` is never held across `.await` points
- The subscription owns the connection for its lifetime; any inbound line from the client is treated as an explicit cancel, matching the one-op-per-connection pattern used by the companion application
- Deduplication happens at the `run_stream()` level, not the service level, so all services get the benefit automatically without additional boilerplate

**Wire Format Compatibility:**
- Subscription payloads are ordinary `DaemonReply::ok()` frames with no new wire type
- Readers distinguish a subscription only by continuing to read lines instead of stopping after one
- The stream ends when the client sends any further line, disconnects, or the daemon shuts down