### PR TITLE
feat(cli): add window key to worktree current badge identification

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -145,7 +145,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
  * pushed onto `context.subscriptions` so it tears down cleanly on deactivate.
  */
 function setupTreeView(context: vscode.ExtensionContext): void {
-  const treeProvider = new WorktreesTreeDataProvider();
+  // `windowKey` is assigned in `activate()` before this runs, so the provider can
+  // mark this window's own worktree distinctly from those open in other windows.
+  const treeProvider = new WorktreesTreeDataProvider(windowKey);
   provider = treeProvider;
   const view = vscode.window.createTreeView<Node>(TREE_VIEW_ID, {
     treeDataProvider: treeProvider,

--- a/editors/vscode/src/tree.test.ts
+++ b/editors/vscode/src/tree.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   TreeRepoPayload,
+  isCurrentWindow,
   nodeId,
   repoLabel,
   reposToNodes,
@@ -90,7 +91,26 @@ test("worktreeDescription formats the sync counts, omitting absent sides", () =>
   assert.equal(worktreeDescription({ path: "/x", is_main: true, open: false, behind: 5 }), "↓5");
 });
 
-test("worktreeContextValue marks the open badge under a shared `worktree` prefix", () => {
+test("isCurrentWindow matches only the open worktree whose key is this window's", () => {
+  // Open here: the open worktree's key equals this window's key.
+  assert.equal(isCurrentWindow(REPOS[0].worktrees[0], "w1"), true);
+  // Open, but in another window (keys differ).
+  assert.equal(isCurrentWindow(REPOS[0].worktrees[0], "w2"), false);
+  // Closed worktree never matches, whatever the key.
+  assert.equal(isCurrentWindow(REPOS[0].worktrees[1], "w1"), false);
+  // An unknown window key (e.g. before assignment) never matches an open worktree.
+  assert.equal(isCurrentWindow(REPOS[0].worktrees[0], undefined), false);
+  // Degenerate: open with no key and an absent window key must not match.
+  assert.equal(isCurrentWindow({ path: "/x", is_main: true, open: true }, undefined), false);
+});
+
+test("worktreeContextValue marks current, other-window, and closed under a shared `worktree` prefix", () => {
+  // This window's own worktree gets the distinct `worktree.current`.
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[0], "w1"), "worktree.current");
+  // Open elsewhere → `worktree.open`; closed → `worktree`.
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[0], "w2"), "worktree.open");
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[1], "w1"), "worktree");
+  // Without a window key, an open worktree is still just `worktree.open`.
   assert.equal(worktreeContextValue(REPOS[0].worktrees[0]), "worktree.open");
   assert.equal(worktreeContextValue(REPOS[0].worktrees[1]), "worktree");
 });
@@ -108,9 +128,22 @@ test("worktreeTooltip carries path, kind, parent repo, sync, and open state", ()
   assert.match(tip, /\/home\/me\/omni-dev/);
   assert.match(tip, /main working tree of rust-works\/omni-dev/);
   assert.match(tip, /main {2}↑2 ↓0/);
+  // No window key supplied → the generic open line, not the current-window one.
   assert.match(tip, /● window open/);
 
   const closed = worktreeTooltip(REPOS[0].worktrees[1], REPOS[0]);
   assert.match(closed, /linked worktree of rust-works\/omni-dev/);
   assert.match(closed, /no window open/);
+});
+
+test("worktreeTooltip distinguishes the current window's open line", () => {
+  // Matching key → `● this window`.
+  const here = worktreeTooltip(REPOS[0].worktrees[0], REPOS[0], "w1");
+  assert.match(here, /● this window/);
+  assert.doesNotMatch(here, /● window open/);
+
+  // Non-matching key → the generic `● window open`.
+  const elsewhere = worktreeTooltip(REPOS[0].worktrees[0], REPOS[0], "w2");
+  assert.match(elsewhere, /● window open/);
+  assert.doesNotMatch(elsewhere, /● this window/);
 });

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -75,6 +75,17 @@ export function repoLabel(repo: TreeRepoPayload): string {
 }
 
 /**
+ * Whether this worktree is the one open in **the current** VS Code window — the
+ * leaf whose registry `window_key` matches this window's own `windowKey`. Used to
+ * mark it distinctly (a blue tick) from worktrees open in *other* windows. Stays
+ * `vscode`-free so it is unit-testable. An absent `windowKey` (or a worktree with
+ * no live window) never matches.
+ */
+export function isCurrentWindow(wt: TreeWorktreePayload, windowKey?: string): boolean {
+  return wt.open && windowKey !== undefined && wt.window_key === windowKey;
+}
+
+/**
  * A worktree's primary label: its branch, or the folder basename when detached
  * or unborn (no branch reported).
  */
@@ -98,22 +109,38 @@ export function worktreeDescription(wt: TreeWorktreePayload): string {
   return parts.join(" ");
 }
 
-/** A multi-line hover tooltip: path, main/linked, branch+sync, parent repo, open state. */
-export function worktreeTooltip(wt: TreeWorktreePayload, repo: TreeRepoPayload): string {
+/**
+ * A multi-line hover tooltip: path, main/linked, branch+sync, parent repo, open
+ * state. The open line distinguishes the current window (`● this window`) from a
+ * worktree merely open elsewhere (`● window open`) when `windowKey` is supplied.
+ */
+export function worktreeTooltip(
+  wt: TreeWorktreePayload,
+  repo: TreeRepoPayload,
+  windowKey?: string,
+): string {
   const kind = wt.is_main ? "main working tree" : "linked worktree";
   const branch = wt.branch ?? "(detached)";
   const sync = worktreeDescription(wt);
   const branchLine = sync ? `${branch}  ${sync}` : branch;
-  const openLine = wt.open ? "● window open" : "no window open";
+  const openLine = isCurrentWindow(wt, windowKey)
+    ? "● this window"
+    : wt.open
+      ? "● window open"
+      : "no window open";
   return [wt.path, `${kind} of ${repoLabel(repo)}`, branchLine, openLine].join("\n");
 }
 
 /**
  * The `contextValue` used to gate context-menu items and mark the open badge.
- * Both start with `worktree` so a single `viewItem =~ /worktree/` menu `when`
- * matches open and closed alike.
+ * All three start with `worktree` so a single `viewItem =~ /worktree/` menu
+ * `when` matches current, other-window, and closed alike; `worktree.current`
+ * additionally gates any current-window-only menu items.
  */
-export function worktreeContextValue(wt: TreeWorktreePayload): string {
+export function worktreeContextValue(wt: TreeWorktreePayload, windowKey?: string): string {
+  if (isCurrentWindow(wt, windowKey)) {
+    return "worktree.current";
+  }
   return wt.open ? "worktree.open" : "worktree";
 }
 

--- a/editors/vscode/src/treeDataProvider.ts
+++ b/editors/vscode/src/treeDataProvider.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import {
   Node,
   TreeRepoPayload,
+  isCurrentWindow,
   nodeId,
   repoLabel,
   reposToNodes,
@@ -30,6 +31,12 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
   private repos: TreeRepoPayload[] = [];
   private readonly emitter = new vscode.EventEmitter<Node | undefined | null | void>();
   readonly onDidChangeTreeData = this.emitter.event;
+
+  /**
+   * @param windowKey this window's own registry key, so the leaf whose
+   * `window_key` matches can be marked distinctly from worktrees open elsewhere.
+   */
+  constructor(private readonly windowKey?: string) {}
 
   /** Replaces the snapshot and refreshes the whole tree. */
   update(repos: TreeRepoPayload[]): void {
@@ -63,13 +70,16 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
     );
     item.id = nodeId(node);
     item.description = worktreeDescription(node.wt);
-    item.tooltip = worktreeTooltip(node.wt, node.repo);
-    item.contextValue = worktreeContextValue(node.wt);
-    // The open badge: a green dot for a worktree with a live window, else the
-    // plain branch glyph.
-    item.iconPath = node.wt.open
-      ? new vscode.ThemeIcon("circle-filled", new vscode.ThemeColor("charts.green"))
-      : new vscode.ThemeIcon("git-branch");
+    item.tooltip = worktreeTooltip(node.wt, node.repo, this.windowKey);
+    item.contextValue = worktreeContextValue(node.wt, this.windowKey);
+    // The open badge, three-way: a blue tick for the worktree open in *this*
+    // window, a green dot for one open in another window, else the plain branch
+    // glyph for a worktree with no live window.
+    item.iconPath = isCurrentWindow(node.wt, this.windowKey)
+      ? new vscode.ThemeIcon("check", new vscode.ThemeColor("charts.blue"))
+      : node.wt.open
+        ? new vscode.ThemeIcon("circle-filled", new vscode.ThemeColor("charts.green"))
+        : new vscode.ThemeIcon("git-branch");
     item.command = {
       command: ITEM_CLICKED_COMMAND,
       title: "Open Worktree",


### PR DESCRIPTION
## Description

Adds a **three-way visual distinction** for worktree open-state in the companion's VS Code tree view: a **blue tick** marks the worktree open in *the current* window, a **green dot** marks worktrees open in *other* windows, and the branch glyph marks a worktree with no live window. This lets a user tell at a glance which worktree they are actively working in across multiple concurrent windows.

The window's own `windowKey` (assigned at activation) is threaded into `WorktreesTreeDataProvider` and compared against each worktree's registry `window_key` — so this is a pure **client-side consumer** of a field the `tree` payload already carries, needing no daemon or protocol change.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Closes #1274
Relates to #1264

## Changes Made

**Core Changes (`editors/vscode/`):**
- New `isCurrentWindow(wt, windowKey)` helper — true when a worktree is open and its `window_key` matches this window's key.
- `WorktreesTreeDataProvider` now takes `windowKey` in its constructor (passed from `activate()`).
- `worktreeContextValue()` returns `worktree.current` for the current window's worktree (gating window-specific context-menu items), else `worktree.open` / `worktree`.
- `worktreeTooltip()` distinguishes `● this window` from `● window open`.
- Icon selection updated to render the blue tick / green dot / branch glyph.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality

Unit tests (`node --test`) added for `isCurrentWindow`, the three-way `contextValue`, and the tooltip's current-window line, including edge cases (undefined keys, closed worktrees, mismatched window keys).
