### PR TITLE
docs(docs): add ADR-0048 for worktrees tree view and push subscriptions

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -71,3 +71,4 @@ by Michael Nygard.
 | [ADR-0045](adr-0045.md)  | ✅ Accepted                              | 2026-07-07 | Isolated Named Credential Profiles for Multi-Tenant Configuration                           |
 | [ADR-0046](adr-0046.md)  | ✅ Accepted                              | 2026-07-07 | Unified `-o/--output <format>` Convention with Dedicated `--out-file` for File Destinations |
 | [ADR-0047](adr-0047.md)  | ✅ Accepted                              | 2026-07-07 | Remote-First Default Base-Branch Resolution That Fails Closed                               |
+| [ADR-0048](adr-0048.md)  | ✅ Accepted                              | 2026-07-10 | Repo/Worktree Tree View Fed by a Daemon Push Subscription                                   |

--- a/docs/adrs/adr-0048.md
+++ b/docs/adrs/adr-0048.md
@@ -1,0 +1,243 @@
+# ADR-0048: Repo/Worktree Tree View Fed by a Daemon Push Subscription
+
+## Status
+
+✅ Accepted (2026-07-10)
+
+## Context
+
+[ADR-0040](adr-0040.md) added the `worktrees` daemon service: an in-memory,
+TTL-reaped registry of the VS Code windows open across the machine, served to the
+CLI, the tray, and a thin companion extension that only *reports* its own window.
+That models the **union of currently-open windows**. It does not model what a
+*Git Worktree Manager*–style view needs: the **repositories** in play and **all**
+of each repository's git worktrees — open in a window or not — with "is a window
+open on it?" as a per-worktree attribute rather than the primary key.
+
+Growing the service into that tree view ran into three structural facts about the
+starting point:
+
+1. **No worktree enumeration.** The daemon only ever inspected the folders a
+   window reported open; it never ran the equivalent of `git worktree list`, so it
+   could not show a repo's *other* worktrees.
+2. **No GitHub-remote awareness.** Nothing in the service parsed a remote URL, so
+   a repo could not be labelled with its `owner/repo` identity.
+3. **The control socket cannot push.** `handle_connection` reads one line →
+   `dispatch` returns one `Value` → writes one reply. There was no path for a
+   service to emit asynchronous events, so a live view could only be built by
+   polling. (The browser bridge streams over a *separate* WebSocket plane —
+   [ADR-0036](adr-0036.md) — not this socket.)
+
+The companion also had **no UI**: it was a ~50-line register/heartbeat/unregister
+reporter, contributing only settings to `package.json`.
+
+The design goal was a tree view — repositories at the top level (GitHub icon +
+`owner/repo` where applicable), every worktree as a child with its branch and
+`↑ahead ↓behind` and an open-window badge — that **updates itself live** as
+windows open and close and as branches move, where **double-clicking** a worktree
+focuses its window (or opens one). Four decisions were locked before the work
+([#1264](https://github.com/rust-works/omni-dev/issues/1264)):
+
+- **Which repos appear:** all git repos, GitHub ones enriched with `owner/repo`;
+  non-GitHub repos still listed.
+- **Repos with no open window (v1):** **open-window-derived** — repos are
+  discovered from currently-open windows and a repo leaves the tree when its last
+  window closes. This keeps the daemon's no-persistence property. Configured repo
+  roots (so a repo shows with zero windows open) are a deliberate follow-up.
+- **Live updates:** a **true push subscription** over the control socket, not
+  polling.
+- **Activation:** **double-click** via a manual click-timer, because the VS Code
+  TreeView API has no native double-click event (single click only selects).
+
+The constraints from ADR-0040 still bind: reuse the daemon's transport and trust
+model unchanged (a `0600` socket in a `0700` directory), persist no secret and no
+state, keep the engine's `Mutex`-never-across-`.await` invariant
+([ADR-0039](adr-0039.md)), and stay wire-compatible with older clients through the
+protocol's `#[serde(skip_serializing_if = …)]` convention.
+
+## Decision
+
+Grow the `worktrees` service along four coordinated axes — a new read op that
+inverts the data model, a socket op that focuses a window, the control socket's
+first streaming path, and the companion's first real UI — while leaving `list`,
+the tray, and the reporter lifecycle byte-for-byte unchanged.
+
+### 1. Invert the data model on read: the `tree` op
+
+The open-window registry
+([`src/worktrees.rs`](../../src/worktrees.rs)) stays exactly as ADR-0040 defined
+it — it remains the **liveness source** (which worktrees are open, and the window
+`key` a focus action resolves). The engine gains one read,
+[`open_folders`](../../src/worktrees.rs), that snapshots the distinct
+workspace folders across all live windows (reaping first, under the same lock,
+pure CPU). That is the only engine change the `tree` op needs; the repo/worktree
+derivation is disk I/O and lives entirely in the **adapter**
+([`src/daemon/services/worktrees.rs`](../../src/daemon/services/worktrees.rs)),
+off the registry lock, on a blocking thread — the engine/adapter split from
+[ADR-0039](adr-0039.md).
+
+The adapter's new `tree` op:
+
+1. derives the **distinct repositories** by resolving each open folder to its git
+   common dir (`Repository::discover`), deduped by common dir via a `BTreeMap` for
+   deterministic order;
+2. enumerates **all** of each repo's worktrees — the main working tree (the common
+   dir's parent) plus every linked worktree (`Repository::worktrees` /
+   `find_worktree`), sorted by path;
+3. **enriches** each worktree by reusing the existing `git_status` building block
+   (branch, ahead/behind, `is_main`);
+4. tags the repo's **GitHub identity** by parsing `origin` (then the first
+   `github.com` remote) — handling `https://`, `http://`, `ssh://`, `git://`, and
+   the SCP-like `git@github.com:` forms, `None` for any non-GitHub host; and
+5. **joins the open windows back on** by canonicalized path, so each worktree
+   carries `open: bool` and, when open, the `window_key` for the focus action.
+
+The reply is `{ repos: [ { main_repo, github?, root, worktrees: [ { path,
+branch?, ahead?, behind?, is_main, open, window_key? } ] } ] }`. It is **additive**:
+`list` is untouched and every new field follows the `skip_serializing_if`
+convention, so an older client never sees a byte it does not expect. The CLI gains
+a read-only `omni-dev worktrees tree [-o table|json]` rendering the grouped view.
+
+This is the "open-window-derived (v1)" decision made concrete: because the repo
+set is derived from open windows each time, a repo with no open window simply is
+not in the tree — no persistence, no configured roots, nothing to reconcile across
+a daemon restart.
+
+### 2. Focus a window over the socket: the `open` op
+
+ADR-0040's tray "focus" action spawns the VS Code CLI (`code <path>`) on a
+window's folder. The companion cannot do this itself — its sandbox cannot see, let
+alone focus, a sibling window — so double-click needs the **daemon** to launch
+`code`. Rather than duplicate launcher logic in TypeScript, the adapter exposes the
+tray's exact launcher path as a control-socket **`open` op** (payload `{ path }`):
+it reuses `focus_window_with`'s guard (an **existing absolute directory**) and
+launcher resolution (`OMNI_DEV_VSCODE_BIN` → well-known absolute paths → bare
+`code`). `code <path>` uniformly focuses an already-open window or opens a new one,
+so one op serves both open and not-open worktrees.
+
+This is a small but real **escalation of the ADR-0040 threat model**, carried into
+the Consequences below: before it, only the human clicking the tray could make the
+daemon spawn `code`; now any *writer* of the socket can. It is bounded exactly as
+everything on this socket is — writing already requires being the owning local
+user (`0600`) — and the absolute-existing-directory guard both keeps it to real
+local folders and blocks a `-`-leading path from being parsed by `code` as a flag
+(argument injection). The guard is defense-in-depth, not a trust boundary.
+
+### 3. The control socket's first streaming path: push subscriptions
+
+The socket was strictly request→one-reply. Rather than bolt polling onto the
+client, we taught the socket to **push**, as an opt-in that leaves every existing
+op untouched:
+
+- **Engine change-notify.** The registry gains a `tokio::sync::watch<u64>` version
+  counter, bumped **only when the visible set changes** — a `register`, a removing
+  `unregister`, or a mutation-path reap that actually drops a stale entry. A plain
+  heartbeat (frequent) does **not** bump; a no-op unregister does not bump. `watch`
+  needs no runtime and never blocks, so it fits the engine's no-async-setup
+  posture, and every bump happens *after* the map guard is dropped, preserving the
+  `Mutex`-never-across-`.await` (and never-nested-locks) invariant. A burst
+  coalesces into a single wake because `watch` only tracks the newest version.
+- **An optional trait capability.** `DaemonService` gains
+  `fn subscribe(&self, op, payload) -> Option<Box<dyn ServiceStream>>`, defaulting
+  to `None`. A `ServiceStream` exposes just `changed()` (resolves when state *may*
+  have changed) and `snapshot()` (the current payload). Every existing service
+  inherits the default and is unchanged.
+- **A server drive loop.** When a line's op resolves to a stream, the server
+  switches that connection to streaming mode (`run_stream`): it sends the initial
+  `tree` snapshot, then `select!`s over { the engine change-notify, a periodic
+  `STREAM_TICK` (3 s, so purely **on-disk** git changes — a branch switch, a new
+  commit — that fire *no* registry event are still picked up), the framed read (an
+  inbound line is an explicit cancel; `None`/`Err` is disconnect), and the shutdown
+  `CancellationToken` }. Every wake re-samples and **diffs against the last-sent
+  snapshot**, pushing only a real delta — so identical frames are never duplicated.
+  This mirrors the browser bridge's `start_stream` coalescing shape, but on the
+  control socket.
+- **No new wire type.** Each pushed line is an ordinary `DaemonReply::ok(payload)`.
+  A reader distinguishes a subscription only by continuing to read lines instead of
+  stopping after one. The one subscription today is `worktrees` / `subscribe`,
+  yielding the same `{ repos: [...] }` snapshot the `tree` op returns.
+
+Back-compat is total: an older client never sends `subscribe`, so it only ever
+sees the classic one-reply exchange.
+
+### 4. The companion's first real UI
+
+The companion ([`editors/vscode/`](../../editors/vscode/)) grows from a headless
+reporter into a tree view, **alongside** the unchanged register/heartbeat/
+unregister reporter lifecycle:
+
+- an activity-bar `viewsContainer` + `views` tree, `commands` (open, refresh), and
+  `menus`, activating on the view;
+- a `TreeDataProvider<Node>` mapping a `tree` payload to repo nodes (a GitHub
+  `ThemeIcon` + `owner/repo` label for GitHub repos, a `repo` icon otherwise) and
+  worktree children (branch as the label, `↑ahead ↓behind` as the description, a
+  three-way **open badge** — a blue tick for the worktree open in *this* window, a
+  green dot for one open in *another*, the plain branch glyph otherwise — and a
+  `contextValue` that marks the open/current state and gates the menu), firing
+  `onDidChangeTreeData` on each pushed snapshot. The "current window" distinction
+  (#1274) is a pure client-side consumer of the per-worktree `window_key` the
+  `tree` payload already carries — matched against the window's own registry key —
+  so it needed no daemon or protocol change;
+- a **persistent subscribe connection** (`subscription.ts`) that reads pushed
+  NDJSON lines and **reconnects with exponential backoff + jitter** (500 ms → 10 s)
+  when the daemon drops or is absent, degrading to a hint message rather than an
+  error dialog. The socket module stays `vscode`-free so it is unit-tested with
+  `node --test`;
+- a **manual double-click timer** in the click handler (a second click on the same
+  item within 400 ms opens it; otherwise the click is recorded and native
+  selection stands), calling the daemon `open` op — commented clearly that the
+  TreeView API has no double-click event.
+
+## Consequences
+
+- **The view is a derived projection, not new stored state.** The repo/worktree
+  tree is recomputed from the open-window registry (the ADR-0040 liveness source)
+  plus the on-disk git state on every read and every pushed frame. No repo list,
+  no worktree list, and no GitHub identity is persisted or cached across reads, so
+  the daemon keeps its no-persistence property: nothing to reconcile on restart,
+  and a repo leaves the tree the instant its last window closes.
+- **Enumeration and enrichment are disk I/O, kept off the lock and off the async
+  workers.** `tree` (and each subscription snapshot) opens repositories, walks
+  worktrees, and parses git config on a **blocking thread**, never under the
+  registry `Mutex` and never on an async worker — the same discipline ADR-0040 set
+  for `list`/`status` enrichment. The registry lock still only ever guards
+  pure-CPU work.
+- **The socket now has two shapes, but only for opt-in ops.** A connection is
+  either the classic request→one-reply or — when and only when its op resolves to a
+  `ServiceStream` — a long-lived push stream. There is no new wire type and no
+  change to any existing op, so every prior client (and every non-worktrees
+  service) is byte-for-byte unaffected. The subscription tears down cleanly on
+  client disconnect, an explicit cancel line, or daemon shutdown (the shutdown
+  token is a `select!` arm).
+- **Threat model: the `open` op is a deliberate, bounded escalation.** ADR-0040's
+  residual exposure was "read the socket → enumerate open repo *paths*; write it →
+  inject fake entries". This adds one capability to a *writer*: spawn `code` on a
+  supplied path. It is same-user-bounded (the `0600` socket already requires the
+  owning local user — no new principal gains anything), and the
+  absolute-existing-directory guard confines it to real local folders while
+  blocking argument injection. The subscription adds **no** new exposure beyond
+  `tree` itself — it streams exactly what a reader could already pull — so the only
+  new capability on the whole surface is the `open` spawn, and it is defense-in-
+  depth, not a trust boundary. The companion is still the daemon's only non-omni-dev
+  client, now reading a richer payload and holding a long-lived connection, but
+  over the same socket with the same ownership gate.
+- **GitHub enrichment is best-effort and never load-bearing.** A repo with no
+  GitHub remote (or an unparseable URL) is still listed, just without the `github`
+  field — the tree degrades exactly like the per-field git enrichment, adding no
+  error path and staying wire-compatible.
+- **Two known v1 limits, both deliberate.** A repo shows only while at least one of
+  its windows is open (configured repo roots are a follow-up), and live updates use
+  push with a 3 s safety tick rather than a filesystem watcher — so an on-disk
+  branch change is reflected within the tick interval, not instantly. A polling
+  fallback was explicitly *not* built (push was chosen); the tick already covers
+  the on-disk-change case the change-notify cannot see.
+- **Still Unix-only.** The service, CLI, and companion socket path remain
+  `#[cfg(unix)]` / unix-socket-only; Windows support is tracked with the broader
+  daemon work ([#1237](https://github.com/rust-works/omni-dev/issues/1237)).
+  Marketplace/Open VSX publishing of the companion remains a follow-up.
+
+This supersedes nothing: it extends ADR-0040 in place. See
+[ADR-0039](adr-0039.md) for the daemon framework, [ADR-0040](adr-0040.md) for the
+worktrees service this grows, [ADR-0036](adr-0036.md) for the bridge's separate
+streaming plane, and [docs/worktrees-service.md](../worktrees-service.md) for the
+operator guide and the companion's full wire contract.

--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -5,6 +5,15 @@ authoritative set of repositories and git worktrees open across **every** VS Cod
 window, fed by a small first-party companion extension that reports from each
 window. It is the daemon's third service, after the browser bridge and Snowflake.
 
+Beyond the open-window `list`, the service exposes a **`tree`** view — every
+repository and **all** of its git worktrees (open in a window or not), grouped by
+repo and enriched with GitHub identity — and pushes it live to subscribers over
+the control socket (the **`subscribe`** op). The companion extension renders that
+tree in a Git Worktree Manager–style activity-bar view where **double-clicking** a
+worktree focuses (or opens) its VS Code window via the **`open`** op. See
+[ADR-0040](adrs/adr-0040.md) for the original service and
+[ADR-0048](adrs/adr-0048.md) for the tree/subscription/UI expansion.
+
 ## Why a resident service
 
 A VS Code extension host is **sandboxed per window**: each window's extension can
@@ -26,25 +35,47 @@ the view correct over time. See [ADR-0040](adrs/adr-0040.md).
 - `src/worktrees.rs` — the `WorktreesRegistry` engine: the in-memory `HashMap`
   of open windows behind a `std::sync::Mutex` (never held across an `.await`),
   the TTL reaping and entry cap/eviction, and the
-  register/heartbeat/unregister/list/first-folder operations. A standalone
-  `crate::worktrees` module, matching the browser bridge (`src/browser/`) and
-  Snowflake (`src/snowflake/`) engine/adapter split.
+  register/heartbeat/unregister/list/first-folder operations. It also snapshots
+  the distinct open **folders** (`open_folders`, the seed the `tree` op resolves
+  to repos) and carries a `tokio::sync::watch` **change-notify** counter
+  (`subscribe_changes`) bumped whenever the visible set changes, which drives the
+  push subscription. A standalone `crate::worktrees` module, matching the browser
+  bridge (`src/browser/`) and Snowflake (`src/snowflake/`) engine/adapter split.
 - `src/daemon/services/worktrees.rs` — `WorktreesService`, a thin `DaemonService`
-  adapter over that engine: it routes control-socket ops to the registry,
-  renders the tray menu/status, and drives the VS Code launcher. Cheap to
-  construct; persists nothing.
-- `src/cli/worktrees.rs` — the read-only `omni-dev worktrees list` client.
+  adapter over that engine: it routes control-socket ops to the registry, renders
+  the tray menu/status, drives the VS Code launcher, computes the git enrichment,
+  builds the repo/worktree **`tree`** (enumerating each repo's worktrees with
+  `git2` and tagging its GitHub identity), and backs the **`subscribe`** stream.
+  Cheap to construct; persists nothing. All the git disk I/O runs on a blocking
+  thread, never under the registry lock.
+- `src/daemon/service.rs` + `src/daemon/server.rs` — the streaming machinery
+  shared by all services: the `ServiceStream` trait capability (an optional
+  `subscribe` on `DaemonService`) and the server's `run_stream` drive loop that
+  pushes an initial snapshot, then a fresh one on each change-notify or periodic
+  tick, diffing so identical frames are never re-sent.
+- `src/cli/worktrees.rs` — the read-only `omni-dev worktrees list` and
+  `omni-dev worktrees tree` clients.
 - The companion VS Code extension in [`editors/vscode/`](../editors/vscode/) —
-  the **writer**: it `register`s on activation, `heartbeat`s every ~10 s, and
-  `unregister`s on deactivation, talking to the daemon socket directly from each
-  window.
+  both a **writer** and a **reader**. As a writer it `register`s on activation,
+  `heartbeat`s every ~10 s, and `unregister`s on deactivation. As a reader it
+  holds a long-lived `subscribe` connection and renders the pushed `tree`
+  snapshots as an activity-bar tree view (see [Tree view](#tree-view-companion-ui)),
+  talking to the daemon socket directly from each window.
 
 ### Data flow
 
+The open-window registrations are the liveness source; the `tree` view is derived
+from them (each open folder → its repo → all that repo's worktrees) and pushed live
+to subscribers:
+
 ```
-VS Code window A ─┐
-VS Code window B ─┼─►  omni-dev daemon (worktrees service)  ──►  CLI / tray / extension UI
-VS Code window C ─┘     live registry, keyed by per-window key
+                         registrations                         list / tree (pull)
+VS Code window A ─┐  (register/heartbeat/    ┌─────────────────────────►  CLI / tray
+VS Code window B ─┼──── unregister) ────────►│ omni-dev daemon         │
+VS Code window C ─┘                          │ (worktrees service)     ├── subscribe ──►  companion
+                                             │ registry + git2 enrich  │   (push tree)    tree view
+      ▲                                      └─────────────────────────┘                     │
+      └──────────────────  open op: focus/open a worktree's window (code <path>)  ◄──────────┘
 ```
 
 ### Liveness
@@ -94,6 +125,27 @@ The companion extension feeds the registry; the CLI only reads it. If the daemon
 is not running, `worktrees list` reports the connection failure (the companion, by
 contrast, no-ops silently).
 
+`worktrees tree` shows the same live data inverted into the repo/worktree view —
+every repository derived from the open windows, and **all** of each repo's
+worktrees (open or not):
+
+```bash
+# Every repository and all its worktrees, grouped by repository.
+omni-dev worktrees tree
+
+# Machine-readable JSON (byte-identical to the on-socket `tree` payload).
+omni-dev worktrees tree -o json
+```
+
+The table prints a header line per repository — its **main-repo name**, its GitHub
+`owner/name` (when `origin` is a `github.com` remote), and its root path — then one
+indented row per worktree: a `*` marks the **main working tree**, followed by the
+branch, its `+ahead -behind` sync state, an `open` flag when a live window has that
+worktree open, and the worktree path. A repo with no open window contributes no
+rows, so the tree lists exactly the repos currently in play (the open-window-derived
+v1 model — [ADR-0048](adrs/adr-0048.md)). `-o json` is the raw `tree` payload
+described under [the contract](#companion-contract-for-the-extension-and-other-clients).
+
 ## Tray
 
 On a macOS `menu-bar` build the service contributes a **"Worktrees" submenu**:
@@ -123,6 +175,46 @@ Focusing is **best-effort**. The launcher is resolved in this order:
 
 If none works, the failure is logged and the rest of the tray keeps working.
 
+## Tree view (companion UI)
+
+The companion extension contributes a **"Worktrees" activity-bar view** — a
+*Git Worktree Manager*–style tree, but fed live by the daemon and consistent across
+every window (no per-window curation). It renders the `tree` payload:
+
+```
+▸ omni-dev            (github: rust-works/omni-dev)
+    ● main            ↑2 ↓0        ← window open (badge), main working tree
+      issue-1300      ↑1 ↓3        ← linked worktree, no window open
+    ● issue-1250      ↑0 ↓0
+▸ some-other-repo
+      main
+```
+
+- **Top level: repositories.** A GitHub repo shows a GitHub icon and its
+  `owner/repo`; a non-GitHub repo is still listed by its main-repo name.
+- **Children: worktrees.** Every worktree of that repo (main + linked), labelled
+  by its branch with `↑ahead ↓behind` as the row description, and a three-way
+  **open badge** icon (#1274): a **blue tick** on the worktree open in *this*
+  window, a **green dot** on one open in *another* window, and the plain branch
+  glyph on a worktree with no live window. The current-window distinction comes
+  from matching a worktree's `window_key` against this window's own key.
+- **Double-click to focus/open.** Because the VS Code TreeView API has **no** native
+  double-click event (a single click only selects), the companion implements it with
+  a manual click-timer: a second click on the same worktree within ~400 ms sends the
+  daemon `open` op, which runs `code <path>` — focusing the already-open window or
+  opening a new one. Uniform for open and not-open worktrees.
+- **Live.** The view updates itself as windows open and close and as branches or
+  commits change, driven by the [push subscription](#push-subscription) — no manual
+  refresh. A **Refresh** title-bar action does a one-shot `tree` fetch as a fallback
+  when the subscription is momentarily down.
+- **Daemon-down degrades gracefully.** When the daemon is not running, the view
+  shows a hint ("start it with `omni-dev daemon start`") rather than an error dialog,
+  and the subscription reconnects with exponential backoff (500 ms → 10 s) once the
+  daemon returns. An empty-but-connected daemon shows "No worktrees are open…".
+
+The tree view runs **alongside** the reporter lifecycle (register/heartbeat/
+unregister): every window is both a reporter and, if it has the view open, a reader.
+
 ## Status
 
 `omni-dev daemon status` includes the service:
@@ -146,12 +238,15 @@ companion's thin-reporter contract ([ADR-0040](adrs/adr-0040.md)): the ~50-line
 extension never runs git.
 
 - **Computed on read.** Enrichment happens each time the registry is read
-  (`list`, `status`, and the tray menu), from the worktree on disk, so the branch
-  shown is always current — not a snapshot frozen at registration. `list` and
-  `status` run it on a blocking thread (`git2` is synchronous disk I/O) and never
-  under the registry lock.
-- **Primary folder only.** Only the first workspace folder of each window is
-  enriched — it is the one the table shows and the "Focus" action opens.
+  (`list`, `status`, the tray menu, and every `tree` / `subscribe` snapshot), from
+  the worktree on disk, so the branch shown is always current — not a snapshot
+  frozen at registration. Every path but the sync tray `menu` runs it on a blocking
+  thread (`git2` is synchronous disk I/O) and never under the registry lock.
+- **`list` enriches the primary folder; `tree` enriches every worktree.** For a
+  window entry (`list`/`status`), only the first workspace folder is enriched — it
+  is the one the table shows and the "Focus" action opens. For the `tree` view the
+  same building blocks are applied to **every** worktree the daemon enumerates for
+  each repository, whether or not a window has it open.
 - **Best-effort and degrading.** Discovery tolerates a folder inside a
   subdirectory or a linked worktree. A folder that is not a git repo, a detached
   HEAD, or a branch with no upstream is still listed — just without the fields it
@@ -174,12 +269,25 @@ user, and only on an **existing absolute directory** (which also blocks a
 `-`-leading path from being parsed by `code` as a flag). The focus action and the
 `open` op share that same guard before spawning `code`. Registry strings
 (`repo`/`folders`, and the companion `title`) are writer-influenced metadata, so
-the `worktrees list` table strips control characters (C0, DEL, C1) from the
-strings it renders before writing to the terminal — a registered entry cannot
-inject ANSI escape sequences into the operator's TTY (#1137). The daemon-computed
-`branch` is a git ref name (which cannot contain control bytes) but is sanitized
-on the same path as defense-in-depth. Native tray menus do not interpret ANSI,
-and the `-o json` output escapes control bytes via JSON encoding.
+the `worktrees list` and `worktrees tree` tables strip control characters (C0,
+DEL, C1) from the strings they render before writing to the terminal — a
+registered entry (or a worktree path / GitHub identity) cannot inject ANSI escape
+sequences into the operator's TTY (#1137). The daemon-computed `branch` is a git
+ref name (which cannot contain control bytes) but is sanitized on the same path as
+defense-in-depth. Native tray menus do not interpret ANSI, and the `-o json`
+output escapes control bytes via JSON encoding.
+
+The **`tree`** op and the **`subscribe`** stream add **no new exposure** beyond the
+existing reads. `tree` enumerates the worktrees of repositories the socket owner
+already has windows open on, and reveals repo/worktree *paths* and the GitHub
+`owner/name` of `origin` — all derivable by the same owner from those open folders.
+`subscribe` streams exactly that same snapshot on a schedule; a subscriber learns
+nothing a repeated `tree` poll would not. The stream is bounded and self-limiting:
+it lives on one `0600` connection, coalesces bursts, diffs to suppress duplicate
+frames, and is torn down on client disconnect, an explicit cancel line, or daemon
+shutdown. So the only capability the whole expansion adds to a socket *writer* is
+the `open` spawn described above; see [ADR-0048](adrs/adr-0048.md) for the full
+threat-model note.
 
 ## Companion contract (for the extension and other clients)
 
@@ -198,13 +306,22 @@ The service is reachable directly over the daemon's Unix control socket
 
 Ops:
 
-| op           | payload                                          | success payload                |
-|--------------|--------------------------------------------------|--------------------------------|
-| `register`   | `{ key, folders[], repo?, title?, pid? }`        | `{ ok: true }`                 |
-| `heartbeat`  | `{ key }`                                         | `{ known: <bool> }`            |
-| `unregister` | `{ key }`                                         | `{ removed: <bool> }`          |
-| `list`       | `null`                                            | `{ windows: [entry, …] }`      |
-| `open`       | `{ path }`                                       | `{ ok: true }`                 |
+| op           | payload                                    | success payload            |
+|--------------|--------------------------------------------|----------------------------|
+| `register`   | `{ key, folders[], repo?, title?, pid? }`  | `{ ok: true }`             |
+| `heartbeat`  | `{ key }`                                  | `{ known: <bool> }`        |
+| `unregister` | `{ key }`                                  | `{ removed: <bool> }`      |
+| `list`       | `null`                                     | `{ windows: [entry, …] }`  |
+| `tree`       | `null`                                     | `{ repos: [repo, …] }`     |
+| `open`       | `{ path }`                                 | `{ ok: true }`             |
+| `subscribe`  | `null`                                     | *(stream — see below)*     |
+
+The first six ops are strictly **request → one reply**. `subscribe` is the one
+**streaming** op (see [Push subscription](#push-subscription)): the reply is a
+sequence of `{ ok: true, payload: { repos: … } }` lines on the same connection —
+an initial snapshot, then a fresh one each time the view changes — not a single
+reply. It uses no new wire type, so a client that only ever sends the other ops is
+wire-identical to the ADR-0040 contract.
 
 Where:
 
@@ -221,6 +338,24 @@ Where:
   guard (#1266), so a client (the companion, on double-click) never duplicates
   that logic. A relative or non-existent `path` is rejected with a clear error
   before anything is spawned (see [Security](#security)).
+- A `tree` `repo` is
+  `{ main_repo, github?, root, worktrees: [worktree, …] }`, where `github` is
+  `{ owner, name }` present only when `origin` (or the first `github.com` remote)
+  is a GitHub URL, and `root` is the absolute path of the main working tree. Repos
+  are **derived from the open windows** (each open folder → its git common dir →
+  repo root) and deduped, so a repo appears only while at least one of its windows
+  is open (the v1 model — [ADR-0048](adrs/adr-0048.md)).
+- A `tree` `worktree` is
+  `{ path, branch?, ahead?, behind?, is_main, open, window_key? }`. The main
+  working tree comes first (`is_main: true`), then linked worktrees sorted by path.
+  `open` is `true` when a live window currently has that worktree open, and
+  `window_key` (the open window's registry `key`, the handle a focus action
+  resolves) is present only then. `branch`/`ahead`/`behind` are the same
+  daemon-computed, independently-degrading git fields as on a `list` entry (see
+  [Git enrichment](#git-enrichment)).
+- `subscribe` streams the `tree` payload live; see
+  [Push subscription](#push-subscription) for the framing, coalescing, and
+  teardown semantics.
 - A `list` `entry` is
   `{ key, folders[], repo?, title?, pid?, branch?, ahead?, behind?, main_repo?,
   is_worktree?, last_seen }` with `last_seen` as an RFC 3339 timestamp; consumers
@@ -239,13 +374,16 @@ Where:
   optional fields like these follow the protocol's `#[serde(skip_serializing_if)]`
   convention, so an older client simply ignores them.
 
-Companion lifecycle, per window:
+Companion lifecycle, per window. The reporter half (register/heartbeat/
+unregister) is unchanged from ADR-0040; the tree-view half opens one long-lived
+`subscribe` connection alongside it:
 
 ```text
 activate():    connect(socket) → {service:"worktrees", op:"register",
                                    payload:{key, folders, repo, title, pid}}
+               connect(socket) → {service:"worktrees", op:"subscribe"}   // long-lived, reads pushed snapshots
 heartbeat:     every ~10s → {op:"heartbeat", key}     // re-register if {known:false}
-deactivate():  {op:"unregister", key}
+deactivate():  {op:"unregister", key}   + close the subscribe socket
 ```
 
 Example exchange:
@@ -255,21 +393,61 @@ Example exchange:
 ← {"ok":true,"payload":{"ok":true}}
 → {"service":"worktrees","op":"list"}
 ← {"ok":true,"payload":{"windows":[{"key":"3f1c…","folders":["/home/me/omni-dev"],"repo":"omni-dev","title":"omni-dev — main","pid":4321,"branch":"main","ahead":2,"behind":0,"main_repo":"omni-dev","last_seen":"2026-06-23T01:20:00Z"}]}}
+→ {"service":"worktrees","op":"tree"}
+← {"ok":true,"payload":{"repos":[{"main_repo":"omni-dev","github":{"owner":"rust-works","name":"omni-dev"},"root":"/home/me/omni-dev","worktrees":[{"path":"/home/me/omni-dev","branch":"main","ahead":2,"behind":0,"is_main":true,"open":true,"window_key":"3f1c…"},{"path":"/home/me/wt/issue-1300","branch":"issue-1300","ahead":1,"behind":3,"is_main":false,"open":false}]}]}}
 ```
 
 The companion sends no `branch`/`ahead`/`behind` on `register`; the daemon adds
-them to `list`/`status` replies.
+them to `list`/`status`/`tree` replies.
+
+### Push subscription
+
+A client that sends `{ "service": "worktrees", "op": "subscribe" }` switches that
+connection to **push mode**: the daemon replies with an initial `tree` snapshot,
+then pushes a fresh `{ ok: true, payload: { repos: … } }` line each time the view
+changes — a window registers or unregisters, an entry ages out, or (via a periodic
+~3 s re-sample) an on-disk branch/commit change that fires no registry event. The
+semantics a client can rely on:
+
+- **No new wire type.** Every pushed line is an ordinary `DaemonReply::ok(payload)`.
+  A reader tells a subscription apart from a one-shot op only by continuing to read
+  lines rather than stopping after the first.
+- **Coalesced and de-duplicated.** A burst of changes collapses into one wake, and
+  the daemon diffs each snapshot against the last one it sent, so **two identical
+  frames are never pushed in a row**. Treat each line as the current full state, not
+  a delta.
+- **Teardown.** The stream ends when the client sends **any** further line (an
+  explicit cancel), disconnects, or the daemon shuts down — all three close the
+  connection cleanly. Use a **dedicated** connection for `subscribe`; do not
+  multiplex other ops onto it.
+- **Reconnect is the client's job.** The daemon does not persist subscriptions;
+  after a daemon restart or a dropped socket the client reconnects and re-subscribes.
+  The companion does this with exponential backoff + jitter (500 ms → 10 s) and
+  treats an absent daemon as a silent no-op, never an error dialog.
+
+Back-compat is total: a client that never sends `subscribe` only ever sees the
+classic one-reply exchange. See [ADR-0048](adrs/adr-0048.md) for the design.
 
 ## Scope and follow-ups
 
 - The companion extension lives in [`editors/vscode/`](../editors/vscode/): a
-  small TypeScript reporter that speaks the contract above, bundled with esbuild
-  and packaged as a `.vsix` by its own path-filtered CI workflow. Publishing to
-  the VS Code Marketplace / Open VSX is a follow-up (it needs a publisher account
-  and CI secrets); until then, install the `.vsix` built by CI with
-  `code --install-extension`.
+  TypeScript reporter **and** tree-view UI that speaks the contract above, bundled
+  with esbuild and packaged as a `.vsix` by its own path-filtered CI workflow.
+  Publishing to the VS Code Marketplace / Open VSX is a follow-up (it needs a
+  publisher account and CI secrets); until then, install the `.vsix` built by CI
+  with `code --install-extension`.
 - Git enrichment lives in Rust (#1186): the companion reports raw folder paths
   and the daemon computes per-worktree branch and ahead/behind state with `git2`
   (see [Git enrichment](#git-enrichment)), keeping the companion thin.
 - The service and CLI are Unix-only (`#[cfg(unix)]`), like the rest of the daemon;
   Windows support is tracked with the broader daemon work (#1237).
+- **Open-window-derived repos (v1):** a repository appears in the `tree` only while
+  at least one of its windows is open. **Configured repo roots** — so a repo shows
+  with zero windows open — are a deliberate follow-up ([ADR-0048](adrs/adr-0048.md),
+  #1264); they would be the first state the service persists.
+- **Push, not poll:** live updates use the change-notify plus a ~3 s safety tick
+  for on-disk changes, so a branch move is reflected within the tick rather than
+  instantly. A polling fallback and a filesystem watcher were both considered and
+  deferred.
+- The tree view is **view + focus only**; worktree *management* actions
+  (add/remove/prune) are out of scope for this iteration.


### PR DESCRIPTION
## Description

This PR adds ADR-0048 and substantially expands `docs/worktrees-service.md` to document the repo/worktree tree view feature built on top of the worktrees daemon service ([ADR-0040](docs/adrs/adr-0040.md)). The ADR records four coordinated design decisions: a new `tree` op that inverts the open-window registry into a grouped repo/worktree view; an `open` op that lets the companion focus or open a worktree window via the daemon; the control socket's first streaming path (push `subscribe`); and the companion VS Code extension's first real activity-bar tree UI.

The operator guide (`docs/worktrees-service.md`) is updated to match: it documents the new ops in the wire contract table, explains push-subscription framing and reconnect semantics, describes the companion's three-way open-badge iconography, updates the data-flow diagram, and expands the security section to cover the threat-model implications of the new `open` spawn capability and the `subscribe` stream.

## Type of Change

- [x] Documentation update

## Related Issue

Relates to #1269
Relates to #1264

## Changes Made

**Documentation:**
- Added `docs/adrs/adr-0048.md` (243 lines): comprehensive ADR covering all four design axes — the `tree` op (data-model inversion), the `open` op (focus/open escalation with absolute-existing-directory guard), the control socket's first streaming path (`subscribe` with `tokio::sync::watch` change-notify + 3 s tick + diff-before-push coalescing), and the companion's activity-bar tree UI (three-way open-badge, double-click timer, exponential-backoff reconnect)
- Updated `docs/adrs/README.md`: added index entry for ADR-0048 (Accepted, 2026-07-10)
- Updated `docs/worktrees-service.md`: expanded introductory overview; revised source-layout section to document `open_folders`, the `watch` change-notify counter, and the `ServiceStream` trait; added a revised data-flow ASCII diagram that shows the push-subscription path; added the `tree` CLI usage section; added the "Tree view (companion UI)" section with rendered tree example and three-way badge description; updated the companion contract op-table to include `tree`, `subscribe`, and the updated `open`; added the "Push subscription" section documenting wire semantics, coalescing, teardown, and reconnect; expanded the security section to cover `tree`/`subscribe` exposure and the `open`-op threat-model note; updated scope and follow-ups with v1 limits and planned follow-ons

**Testing:**
- Documentation-only PR; no code changes and no test changes required

## Testing

**Automated Testing:**
- [x] All existing tests pass (no code changed)

**Manual Testing:**
- [x] Reviewed all three documents for internal consistency (op tables, ADR cross-references, data-flow diagram)
- [x] Verified ADR-0048 cross-references to ADR-0039, ADR-0040, and ADR-0036 are correct
- [x] Confirmed wire contract examples in `worktrees-service.md` match the payload shapes described in ADR-0048

### Test Commands
```bash
# No code changes — documentation review only
cargo fmt --check
cargo clippy -- -D warnings
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — ADR-0048 §Consequences documents the `open` op threat-model note (same-user-bounded, absolute-existing-directory guard); reviewers should verify the reasoning is sound
- [x] Architecture changes — the ADR formalises the control socket's first streaming path and the `DaemonService::subscribe` optional trait capability; check the design is consistent with ADR-0039 and ADR-0040
- [x] Backward compatibility — the ADR and operator guide both claim total back-compat (clients that never send `subscribe` see an unmodified one-reply exchange); verify this claim is clearly stated

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact (documentation-only change)

## Security Considerations

- [x] No security implications for this PR itself (the security analysis is *documented* in ADR-0048 and `worktrees-service.md`, but no security-relevant code is introduced here)

## Deployment Notes

- [x] No special deployment requirements

## Additional Notes

**Future Enhancements (documented in ADR-0048 and worktrees-service.md):**
- Configured repo roots so a repository appears in the tree even when no window is open (first persisted state the service would hold)
- Worktree management actions (add/remove/prune) — explicitly out of scope for v1
- VS Code Marketplace / Open VSX publishing of the companion extension
- Windows daemon support (#1237)

**Known Limitations (v1, documented in ADR-0048):**
- Repos appear only while at least one window is open (open-window-derived model)
- Live updates use a ~3 s safety tick rather than an instant filesystem watcher for on-disk branch changes

**Alternatives Considered (per ADR-0048):**
- Polling instead of push subscription — deferred; the change-notify + tick already covers the on-disk-change case
- Filesystem watcher for instant on-disk branch updates — deferred to a follow-up