### PR TITLE
feat(vscode,ci): implement VS Code extension release pipeline

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -1,0 +1,122 @@
+name: VS Code extension release
+
+# Publishes the companion extension in editors/vscode/ to the VS Code
+# Marketplace (vsce) and Open VSX (ovsx). Deliberately kept separate from
+# vscode-extension.yml (which runs the PR/main checks): this file only ever
+# runs on a dedicated `vscode-v*` tag or a manual dispatch — NEVER on a `main`
+# push — so a routine merge can never publish.
+#
+# Release flow (extension version is independent of the Rust crate):
+#   1. bump `version` in editors/vscode/package.json (and package-lock.json)
+#   2. commit, then tag the merge commit `vscode-v<version>` (e.g. vscode-v0.2.1)
+#   3. push the tag — this workflow verifies tag == package.json version,
+#      re-runs typecheck/build/test/package, then publishes the same .vsix to
+#      both registries.
+#
+# One-time prerequisites (maintainer, not code): an Azure DevOps publisher whose
+# id matches `"publisher": "rust-works"`, the `rust-works` Open VSX namespace,
+# and the repo secrets VSCE_PAT + OVSX_PAT. See editors/vscode/README.md.
+on:
+  push:
+    tags:
+      - 'vscode-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never let two publishes race for the same version.
+concurrency:
+  group: vscode-extension-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      # Fail loudly and early if either PAT is absent, rather than getting most
+      # of the way through a publish and dying (or, worse, silently skipping).
+      - name: Verify required secrets are present
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          missing=()
+          [ -z "$VSCE_PAT" ] && missing+=("VSCE_PAT")
+          [ -z "$OVSX_PAT" ] && missing+=("OVSX_PAT")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required repo secret(s): ${missing[*]}. Add them under Settings → Secrets and variables → Actions before releasing. See editors/vscode/README.md."
+            exit 1
+          fi
+
+      # On a tag push, the tag is the source of truth for what we intend to
+      # ship; refuse to publish if package.json disagrees. Skipped for a manual
+      # dispatch (no tag), which publishes whatever version is on the ref.
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/vscode-v')
+        run: |
+          tag_version="${GITHUB_REF#refs/tags/vscode-v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag vscode-v${tag_version} does not match editors/vscode/package.json version ${pkg_version}. Bump the version and retag."
+            exit 1
+          fi
+          echo "Releasing omni-dev-worktrees ${pkg_version} (tag vscode-v${tag_version})"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Package .vsix
+        run: npm run package
+
+      # Resolve the single packaged artifact so both registries get the exact
+      # same bytes (rather than each re-packaging independently).
+      - name: Resolve packaged .vsix
+        id: vsix
+        run: |
+          shopt -s nullglob
+          files=(*.vsix)
+          if [ ${#files[@]} -ne 1 ]; then
+            echo "::error::Expected exactly one .vsix, found ${#files[@]}: ${files[*]}"
+            exit 1
+          fi
+          echo "path=${files[0]}" >> "$GITHUB_OUTPUT"
+          echo "Packaged ${files[0]}"
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npm run publish:vsce -- --packagePath "${{ steps.vsix.outputs.path }}"
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npm run publish:ovsx -- "${{ steps.vsix.outputs.path }}"
+
+      # Keep the exact published artifact for provenance / manual re-install.
+      - name: Upload published .vsix artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: omni-dev-worktrees-vsix-${{ github.ref_name }}
+          path: editors/vscode/*.vsix
+          if-no-files-found: error

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,8 +1,10 @@
 name: VS Code extension
 
 # Scoped to the companion extension only — the Rust CI in ci.yml is untouched
-# and never descends into editors/. No committed lockfile yet, so this uses
-# `npm install` and does not enable the npm cache (which needs a lock file).
+# and never descends into editors/. A committed package-lock.json backs a
+# reproducible `npm ci` build with the npm cache enabled. Publishing to the
+# Marketplace / Open VSX lives in the sibling vscode-extension-release.yml,
+# which only runs on a `vscode-v*` tag — never on this file's push/PR triggers.
 on:
   push:
     branches: [main]
@@ -31,9 +33,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Type-check
         run: npm run typecheck

--- a/docs/adrs/adr-0040.md
+++ b/docs/adrs/adr-0040.md
@@ -52,8 +52,9 @@ companion VS Code extension (a separate deliverable) feeds it from each window.
 > **Implementation note (#1111):** the companion extension now ships in-repo at
 > [`editors/vscode/`](../../editors/vscode/) — a thin TypeScript reporter
 > speaking the contract below, kept isolated from the Rust build (excluded from
-> the crate; its own path-filtered CI). Marketplace/Open VSX publishing remains
-> a follow-up.
+> the crate; its own path-filtered CI). Marketplace/Open VSX publishing is wired
+> on a `vscode-v*` tag via a sibling release workflow (#1279), pending a one-time
+> publisher/namespace + PAT-secrets setup.
 
 ### In-memory registry keyed by a companion-owned key
 

--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -478,9 +478,12 @@ classic one-reply exchange. See [ADR-0048](adrs/adr-0048.md) for the design.
 - The companion extension lives in [`editors/vscode/`](../editors/vscode/): a
   TypeScript reporter **and** tree-view UI that speaks the contract above, bundled
   with esbuild and packaged as a `.vsix` by its own path-filtered CI workflow.
-  Publishing to the VS Code Marketplace / Open VSX is a follow-up (it needs a
-  publisher account and CI secrets); until then, install the `.vsix` built by CI
-  with `code --install-extension`.
+  A sibling
+  [`vscode-extension-release.yml`](../.github/workflows/vscode-extension-release.yml)
+  publishes it to the VS Code Marketplace and Open VSX on a `vscode-v*` tag
+  (#1279); it needs a one-time publisher/namespace + `VSCE_PAT`/`OVSX_PAT`
+  secrets setup before the first publish. Until published, install the `.vsix`
+  built by CI with `code --install-extension`.
 - Git enrichment lives in Rust (#1186): the companion reports raw folder paths
   and the daemon computes per-worktree branch and ahead/behind state with `git2`
   (see [Git enrichment](#git-enrichment)), keeping the companion thin.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -48,16 +48,12 @@ never surfaces an error or blocks the window.
 ## Development
 
 ```bash
-npm install         # no committed lockfile yet — see note below
+npm ci              # reproducible install from the committed package-lock.json
 npm run typecheck   # tsc --noEmit
 npm run build       # esbuild → dist/extension.js
 npm test            # tsc → out/, then node --test
 npm run package     # vsce package → omni-dev-worktrees-<version>.vsix
 ```
-
-> No `package-lock.json` is committed yet, so CI and local builds use
-> `npm install`. Run `npm install` once and commit the generated lockfile to
-> switch to reproducible `npm ci` builds (and enable the npm cache in CI).
 
 Install a local build with:
 
@@ -65,5 +61,23 @@ Install a local build with:
 code --install-extension omni-dev-worktrees-*.vsix
 ```
 
-Publishing to the VS Code Marketplace / Open VSX is not yet wired up (it needs a
-publisher account and CI secrets) — see the tracking issue for that follow-up.
+## Releasing
+
+The extension is published to the **VS Code Marketplace** (Microsoft VS Code)
+and **Open VSX** (VSCodium / Cursor / Windsurf / Gitpod / code-server) by
+[`.github/workflows/vscode-extension-release.yml`](../../.github/workflows/vscode-extension-release.yml).
+Its `version` is independent of the Rust crate's `Cargo.toml`.
+
+To cut a release:
+
+1. Bump `version` in [`package.json`](package.json) and run `npm install` to
+   refresh `package-lock.json`; commit both.
+2. Tag the merge commit `vscode-v<version>` (e.g. `vscode-v0.2.1`) and push the
+   tag. The release workflow verifies the tag matches `package.json`, re-runs
+   typecheck/build/test/package, then publishes the same `.vsix` to both
+   registries.
+
+A one-time account + secrets setup is required before the first publish (an
+Azure DevOps publisher whose id matches `"publisher": "rust-works"`, the
+`rust-works` Open VSX namespace, and the repo secrets `VSCE_PAT` + `OVSX_PAT`) —
+see [#1279](https://github.com/rust-works/omni-dev/issues/1279).

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -13,6 +13,7 @@
         "@types/vscode": "^1.75.0",
         "@vscode/vsce": "^3.2.0",
         "esbuild": "^0.24.0",
+        "ovsx": "^0.10.12",
         "typescript": "^5.6.0"
       },
       "engines": {
@@ -227,6 +228,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -654,6 +689,287 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/crc32": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.10.6.tgz",
+      "integrity": "sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/crc32-android-arm-eabi": "1.10.6",
+        "@node-rs/crc32-android-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-x64": "1.10.6",
+        "@node-rs/crc32-freebsd-x64": "1.10.6",
+        "@node-rs/crc32-linux-arm-gnueabihf": "1.10.6",
+        "@node-rs/crc32-linux-arm64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-arm64-musl": "1.10.6",
+        "@node-rs/crc32-linux-x64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-x64-musl": "1.10.6",
+        "@node-rs/crc32-wasm32-wasi": "1.10.6",
+        "@node-rs/crc32-win32-arm64-msvc": "1.10.6",
+        "@node-rs/crc32-win32-ia32-msvc": "1.10.6",
+        "@node-rs/crc32-win32-x64-msvc": "1.10.6"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm-eabi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
+      "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
+      "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
+      "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
+      "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-freebsd-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
+      "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
+      "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
+      "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
+      "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
+      "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
+      "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-wasm32-wasi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
+      "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
+      "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
+      "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
+      "integrity": "sha512-5B1vXosIIBw1m2Rcnw62IIfH7W9s9f7H7Ma0rRuhT8HR4Xh8QCgw6NJSI2S2MCngsGktYnAhyUvs81b7efTyQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -961,6 +1277,17 @@
       "license": "MIT",
       "dependencies": {
         "@textlint/ast-node-types": "15.7.1"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/node": {
@@ -1568,6 +1895,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cockatiel": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
@@ -1727,6 +2061,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -1738,6 +2090,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -2085,6 +2455,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -2213,6 +2604,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
@@ -2262,6 +2670,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -2454,6 +2875,19 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -2520,6 +2954,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-it-type": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/is-it-type/-/is-it-type-5.1.3.tgz",
+      "integrity": "sha512-AX2uU0HW+TxagTgQXOJY7+2fbFHemC7YFBwN1XqD8qQMKdtfbOC8OC3fUb4s5NU59a3662Dzwto8tWDdZYRXxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalthis": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-number": {
@@ -3084,6 +3531,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3112,6 +3569,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ovsx": {
+      "version": "0.10.12",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.12.tgz",
+      "integrity": "sha512-WwMj1iQDvCk02029oxPnkFXsPrHZ+WzmoNW5pJ8JGepHtL30i2JE4s3C3wqzQqj6a35vx2hp0gV3TdfefGmvMg==",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@vscode/vsce": "^3.7.1",
+        "commander": "^6.2.1",
+        "follow-redirects": "^1.16.0",
+        "is-ci": "^2.0.0",
+        "leven": "^3.1.0",
+        "semver": "^7.6.0",
+        "tmp": "^0.2.3",
+        "yauzl-promise": "^4.0.0"
+      },
+      "bin": {
+        "ovsx": "bin/ovsx"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ovsx/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/p-map": {
@@ -3732,6 +4222,16 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-invariant": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/simple-invariant/-/simple-invariant-2.0.1.tgz",
+      "integrity": "sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -4303,6 +4803,21 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-4.0.0.tgz",
+      "integrity": "sha512-/HCXpyHXJQQHvFq9noqrjfa/WpQC2XYs3vI7tBiAi4QiIU1knvYhZGaO1QPjwIVMdqflxbmwgMXtYeaRiAE0CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@node-rs/crc32": "^1.7.0",
+        "is-it-type": "^5.1.2",
+        "simple-invariant": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/yazl": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -139,13 +139,16 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "compile-tests": "tsc -p tsconfig.json",
     "test": "npm run compile-tests && node --test out/",
-    "package": "vsce package --no-dependencies"
+    "package": "vsce package --no-dependencies",
+    "publish:vsce": "vsce publish --no-dependencies",
+    "publish:ovsx": "ovsx publish"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/vscode": "^1.75.0",
     "@vscode/vsce": "^3.2.0",
     "esbuild": "^0.24.0",
+    "ovsx": "^0.10.12",
     "typescript": "^5.6.0"
   }
 }


### PR DESCRIPTION
## Description

This PR implements a complete automated release pipeline for the companion VS Code extension, enabling deliberate, controlled publishing to both the **VS Code Marketplace** (via `vsce`) and **Open VSX** (via `ovsx`). The extension version is managed independently of the Rust crate's `Cargo.toml`.

Previously, publishing the extension was a manual follow-up with no automation. This PR wires up a dedicated `vscode-extension-release.yml` workflow triggered exclusively by `vscode-v*` tags — it can never run on a routine `main` push — and documents the full release process for maintainers.

The workflow enforces strict preconditions before publishing: it validates that required secrets (`VSCE_PAT`, `OVSX_PAT`) are present, verifies that the pushed tag matches the `package.json` version, re-runs the full typecheck/build/test/package pipeline to ensure artifact integrity, and uploads the published `.vsix` as a GitHub Actions artifact for provenance and manual re-installation.

Closes #1279

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] CI/CD changes
- [x] Dependency update

## Related Issue

Fixes #1279

## Changes Made

**CI/CD — Release Workflow (`.github/workflows/vscode-extension-release.yml`):**
- Added new workflow triggered only on `vscode-v*` tags or manual `workflow_dispatch` — never on `main` branch pushes
- Enforces `concurrency` group `vscode-extension-release-${{ github.ref }}` with `cancel-in-progress: false` to prevent races
- Added "Verify required secrets are present" step that fails loudly if `VSCE_PAT` or `OVSX_PAT` are absent before any publish attempt
- Added "Verify tag matches package.json version" step that refuses to publish if the tag and `package.json` version disagree
- Re-runs `npm ci`, `typecheck`, `build`, `test`, and `package` steps in the workflow to ensure artifact integrity
- Resolves the single packaged `.vsix` artifact and publishes the same bytes to both registries (no independent re-packaging)
- Publishes to VS Code Marketplace via `npm run publish:vsce` with `VSCE_PAT`
- Publishes to Open VSX via `npm run publish:ovsx` with `OVSX_PAT`
- Uploads the published `.vsix` as a named artifact (`omni-dev-worktrees-vsix-<ref_name>`) for provenance

**CI/CD — PR/Main Check Workflow (`.github/workflows/vscode-extension.yml`):**
- Switched from `npm install` to `npm ci` for reproducible builds backed by the committed `package-lock.json`
- Enabled npm caching with `cache-dependency-path: editors/vscode/package-lock.json`
- Updated workflow comment to clarify that publishing lives in the sibling `vscode-extension-release.yml`

**Package Configuration (`editors/vscode/package.json`):**
- Added `ovsx` v0.10.12 as a dev dependency for Open VSX publishing
- Added `publish:vsce` npm script: `vsce publish --no-dependencies`
- Added `publish:ovsx` npm script: `ovsx publish`

**Dependencies (`editors/vscode/package-lock.json`):**
- Committed `package-lock.json` updated with transitive dependencies for `ovsx`: `@emnapi/*`, `@napi-rs/wasm-runtime`, `@node-rs/crc32` (all platform variants), `@tybys/wasm-util`, `ci-info`, `define-data-property`, `define-properties`, `follow-redirects`, `globalthis`, `has-property-descriptors`, `is-ci`, `is-it-type`, `object-keys`, `simple-invariant`, `yauzl-promise`

**Documentation (`editors/vscode/README.md`):**
- Removed stale note about `npm install` and the absence of a committed lockfile
- Added full "Releasing" section documenting the tag-based release flow:
  1. Bump `version` in `package.json`, run `npm install` to refresh `package-lock.json`, commit both
  2. Tag the merge commit `vscode-v<version>` and push — the workflow verifies the tag and publishes
- Documents one-time prerequisites: Azure DevOps publisher account, `rust-works` Open VSX namespace, and `VSCE_PAT`/`OVSX_PAT` repo secrets

**Documentation (`docs/adrs/adr-0040.md`, `docs/worktrees-service.md`):**
- Updated both documents to reflect that Marketplace/Open VSX publishing is now wired via the `vscode-v*` tag workflow (#1279), replacing "publishing remains a follow-up"

## Testing

**Automated Testing:**
- [x] All existing tests pass (no changes to Rust source or extension TypeScript logic)
- [x] The `vscode-extension.yml` CI now uses reproducible `npm ci` builds

**Manual Testing:**
- [x] Verified workflow YAML syntax is valid
- [x] Confirmed secret-validation step logic (missing PAT detection via bash array)
- [x] Confirmed tag-version-matching logic against `package.json` via `node -p`
- [x] Verified `.vsix` artifact resolution logic handles the single-file case correctly

### Test Commands

```bash
# Install extension dependencies (reproducible)
cd editors/vscode && npm ci

# Type-check
npm run typecheck

# Build
npm run build

# Run tests
npm test

# Package locally
npm run package

# Dry-run publish to VS Code Marketplace (add --dry-run flag manually)
# VSCE_PAT=<pat> npm run publish:vsce

# Dry-run publish to Open VSX
# OVSX_PAT=<pat> npm run publish:ovsx
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications — PAT secrets are only passed as env vars to the specific publish steps; early-exit validation prevents secrets from leaking into logs
- [x] Error handling — workflow fails loudly (with `::error::` annotations) on missing secrets or tag/version mismatches before any publish attempt
- [x] Architecture changes — release workflow is deliberately separate from the PR/main check workflow to prevent accidental publishes on routine merges

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement (describe below)

PAT secrets (`VSCE_PAT`, `OVSX_PAT`) are validated for presence before any build or publish step runs, failing with a descriptive error rather than silently skipping or exposing partial state. Secrets are scoped to individual steps via `env:` blocks, not exported globally. The `concurrency` group with `cancel-in-progress: false` prevents two release jobs from racing to publish the same version.

## Breaking Changes

None. This is a purely additive change. The existing CI workflow continues to work identically for PRs and main branch pushes. The `npm ci` switch requires the now-committed `package-lock.json`, which is included in this PR.

## Deployment Notes

- [x] Environment variable changes required

Before the first release, a one-time setup is required:
1. Create an Azure DevOps publisher account with id `rust-works`
2. Create the `rust-works` namespace on Open VSX
3. Add `VSCE_PAT` and `OVSX_PAT` as repository secrets under **Settings → Secrets and variables → Actions**

No deployment action is required to merge this PR. The release workflow only activates when a maintainer pushes a `vscode-v*` tag.

## Additional Notes

**Release flow summary for maintainers:**
1. Bump `version` in `editors/vscode/package.json`
2. Run `npm install` to refresh `package-lock.json`
3. Commit both files
4. Tag the merge commit `vscode-v<version>` (e.g. `vscode-v0.2.1`) and push the tag
5. The `vscode-extension-release.yml` workflow validates, builds, and publishes automatically

**Known Limitations:**
- The one-time publisher/namespace and PAT-secrets setup must be completed before the first publish; the workflow will fail early with a clear error message if secrets are missing.

**Alternatives Considered:**
- Triggering on main branch pushes was rejected to prevent accidental publishes on every merge; the `vscode-v*` tag model ensures releases are always deliberate.