### PR TITLE
fix(ci,vscode): fix VS Code extension release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
+      # Crate releases only. The '!vscode-*' exclusion keeps the extension's own
+      # `vscode-v*` tags (handled by vscode-extension-release.yml) from also
+      # matching 'v*' and misfiring a crate release + cargo publish.
       - 'v*'
+      - '!vscode-*'
 
 permissions:
   contents: write

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -14,8 +14,10 @@ name: VS Code extension release
 #      both registries.
 #
 # One-time prerequisites (maintainer, not code): an Azure DevOps publisher whose
-# id matches `"publisher": "rust-works"`, the `rust-works` Open VSX namespace,
-# and the repo secrets VSCE_PAT + OVSX_PAT. See editors/vscode/README.md.
+# id matches `"publisher": "rust-works"` and the repo secret VSCE_PAT (required).
+# OVSX_PAT and the `rust-works` Open VSX namespace are optional — set them to also
+# publish to Open VSX; without OVSX_PAT that publish is skipped, not failed. See
+# editors/vscode/README.md.
 on:
   push:
     tags:
@@ -45,19 +47,25 @@ jobs:
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
 
-      # Fail loudly and early if either PAT is absent, rather than getting most
-      # of the way through a publish and dying (or, worse, silently skipping).
+      # Require the Marketplace token up front (fail fast if absent) rather than
+      # dying most of the way through a publish. The Open VSX token is optional:
+      # when unset we skip that publish (see the step's `if`) so a Marketplace-only
+      # release is still green; the boolean output gates it.
       - name: Verify required secrets are present
+        id: secrets
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
-          missing=()
-          [ -z "$VSCE_PAT" ] && missing+=("VSCE_PAT")
-          [ -z "$OVSX_PAT" ] && missing+=("OVSX_PAT")
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required repo secret(s): ${missing[*]}. Add them under Settings → Secrets and variables → Actions before releasing. See editors/vscode/README.md."
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::error::Missing required repo secret VSCE_PAT. Add it under Settings → Secrets and variables → Actions before releasing. See editors/vscode/README.md."
             exit 1
+          fi
+          if [ -n "$OVSX_PAT" ]; then
+            echo "has_ovsx=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_ovsx=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OVSX_PAT is not set — skipping the Open VSX publish. Set it to also publish to Open VSX. See editors/vscode/README.md."
           fi
 
       # On a tag push, the tag is the source of truth for what we intend to
@@ -109,6 +117,7 @@ jobs:
         run: npm run publish:vsce -- --packagePath "${{ steps.vsix.outputs.path }}"
 
       - name: Publish to Open VSX
+        if: steps.secrets.outputs.has_ovsx == 'true'
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: npm run publish:ovsx -- "${{ steps.vsix.outputs.path }}"

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -98,9 +98,14 @@ To cut a release:
 3. Tag the merge commit `vscode-v<version>` (e.g. `vscode-v0.2.1`) and push the
    tag. The release workflow verifies the tag matches `package.json`, re-runs
    typecheck/build/test/package, then publishes the same `.vsix` to both
-   registries.
+   registries (Open VSX is skipped when `OVSX_PAT` is unset — see below).
 
-A one-time account + secrets setup is required before the first publish (an
-Azure DevOps publisher whose id matches `"publisher": "rust-works"`, the
-`rust-works` Open VSX namespace, and the repo secrets `VSCE_PAT` + `OVSX_PAT`) —
-see [#1279](https://github.com/rust-works/omni-dev/issues/1279).
+A one-time account + secrets setup is required before the first publish:
+
+- **VS Code Marketplace (required):** an Azure DevOps publisher whose id matches
+  `"publisher": "rust-works"` and the repo secret `VSCE_PAT`.
+- **Open VSX (optional):** the `rust-works` Open VSX namespace and the repo secret
+  `OVSX_PAT`. If `OVSX_PAT` is unset the workflow publishes to the Marketplace only
+  and skips Open VSX (rather than failing), so you can add it later.
+
+See [#1279](https://github.com/rust-works/omni-dev/issues/1279).


### PR DESCRIPTION
## Description

This PR fixes two CI/CD bugs in the VS Code extension release workflow that prevented a maintainer from successfully cutting a release without both publisher tokens, and caused VS Code extension tags to spuriously trigger the crate release workflow.

**Problem 1 — Open VSX publish was mandatory:** The `vscode-extension-release.yml` workflow required both `VSCE_PAT` and `OVSX_PAT` to be set, failing fast if either was absent. A maintainer who only had a VS Code Marketplace token could not cut any release at all, even for Marketplace-only distribution.

**Problem 2 — Extension tags misfired the crate release:** `release.yml` triggered on `v*` tags. Because GitHub's `*` glob matches everything except `/`, the extension's own `vscode-v*` tags also matched, causing a spurious crate release run and a `cargo publish` attempt whenever an extension tag was pushed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] CI/CD changes

## Related Issue

Closes #1287

## Changes Made

**CI/CD Fixes:**
- Modified `.github/workflows/vscode-extension-release.yml`: changed the secret-check step to only fail-fast on missing `VSCE_PAT`; `OVSX_PAT` is now optional — the step emits a `has_ovsx` boolean output and the Open VSX publish step is gated on `steps.secrets.outputs.has_ovsx == 'true'`, so an unset `OVSX_PAT` skips that publish with a `::notice::` rather than failing the run
- Modified `.github/workflows/release.yml`: added `!vscode-*` to the tag filter so only crate `vX.Y.Z` tags trigger the crate release workflow; extension `vscode-v*` tags remain exclusively handled by `vscode-extension-release.yml`

**Documentation:**
- Updated `editors/vscode/README.md` Releasing section to document the required/optional split: `VSCE_PAT` is listed as required, `OVSX_PAT` as optional with a note that the workflow publishes to the Marketplace only when it is unset

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new automated tests needed — changes are entirely in GitHub Actions workflow YAML and documentation

**Manual Testing:**
- [x] Workflow YAML syntax verified
- [x] Conditional logic for `has_ovsx` output reviewed — `true` branch publishes to both registries, `false` branch skips Open VSX and emits a notice
- [x] Tag filter exclusion `!vscode-*` confirmed to prevent extension tags from matching `v*` in `release.yml`

### Test Commands
```bash
# Code quality checks (no Rust changes in this PR)
cargo clippy -- -D warnings
cargo fmt --check

# Validate workflow YAML syntax
# (requires actionlint or similar)
actionlint .github/workflows/vscode-extension-release.yml
actionlint .github/workflows/release.yml
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Error handling — the `::error::` vs `::notice::` distinction for required vs optional secrets
- [x] Backward compatibility — existing releases using both `VSCE_PAT` and `OVSX_PAT` are unaffected; the workflow publishes to both registries when both secrets are set

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the [PR Guidelines](../.omni-dev/pr-guidelines.md)

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications — secret handling logic is simplified but the secrets themselves are still consumed only via GitHub Actions secret injection and never exposed in logs

## Breaking Changes

None. Repositories that already have both `VSCE_PAT` and `OVSX_PAT` set will continue to publish to both registries unchanged. The only behavioral change is that a missing `OVSX_PAT` now skips the Open VSX step instead of failing the workflow.

## Deployment Notes

- [x] No special deployment requirements

The changes take effect immediately on the next tag push. No secret rotation or configuration changes are required.

## Additional Notes

**Future Enhancements:**
- Additional registry targets (e.g., a future third extension marketplace) can be added following the same optional-secret pattern introduced here.

**Alternatives Considered:**
- Making `VSCE_PAT` optional as well (rejected — the Marketplace is the primary distribution channel and a publish with no targets is not useful)
- Using a separate workflow job for Open VSX (rejected — unnecessary complexity for a single conditional step)