### PR TITLE
feat(daemon): implement cross-window view-state sync for worktrees toggle

### DIFF
--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -328,23 +328,28 @@ The service is reachable directly over the daemon's Unix control socket
 
 Ops:
 
-| op           | payload                                        | success payload                            |
-|--------------|------------------------------------------------|--------------------------------------------|
-| `register`   | `{ key, folders[], repo?, title?, pid? }`      | `{ ok: true }`                             |
-| `heartbeat`  | `{ key }`                                      | `{ known: <bool>, close?: true }`          |
-| `unregister` | `{ key }`                                      | `{ removed: <bool> }`                      |
-| `list`       | `null`                                         | `{ windows: [entry, …] }`                  |
-| `tree`       | `null`                                         | `{ repos: [repo, …] }`                     |
-| `open`       | `{ path }`                                     | `{ ok: true }`                             |
-| `close`      | `{ path, remove, requester_key?, confirmed? }` | *(safety report, or `{ removed/closed }`)* |
-| `subscribe`  | `null`                                         | *(stream — see below)*                     |
+| op                     | payload                                        | success payload                            |
+|------------------------|------------------------------------------------|--------------------------------------------|
+| `register`             | `{ key, folders[], repo?, title?, pid? }`      | `{ ok: true }`                             |
+| `heartbeat`            | `{ key }`                                      | `{ known: <bool>, close?: true }`          |
+| `unregister`           | `{ key }`                                      | `{ removed: <bool> }`                      |
+| `list`                 | `null`                                         | `{ windows: [entry, …] }`                  |
+| `tree`                 | `null`                                         | `{ repos: [repo, …] }`                     |
+| `open`                 | `{ path }`                                     | `{ ok: true }`                             |
+| `close`                | `{ path, remove, requester_key?, confirmed? }` | *(safety report, or `{ removed/closed }`)* |
+| `set-view-state`       | `{ show_closed }`                              | `{ ok: true }`                             |
+| `subscribe`            | `null`                                         | *(stream — see below)*                     |
+| `subscribe-view-state` | `null`                                         | *(stream — see below)*                     |
 
-The first seven ops are strictly **request → one reply**. `subscribe` is the one
-**streaming** op (see [Push subscription](#push-subscription)): the reply is a
-sequence of `{ ok: true, payload: { repos: … } }` lines on the same connection —
-an initial snapshot, then a fresh one each time the view changes — not a single
-reply. It uses no new wire type, so a client that only ever sends the other ops is
-wire-identical to the ADR-0040 contract.
+The eight request/reply ops are strictly **request → one reply**. `subscribe` and
+`subscribe-view-state` are the two **streaming** ops (see
+[Push subscription](#push-subscription)): each reply is a sequence of
+`{ ok: true, payload: … }` lines on the same connection — an initial snapshot,
+then a fresh one each time that channel changes — not a single reply. The two
+streams ride **independent** change-notifies, so a view-state toggle never wakes
+the tree stream (no git re-enumeration) and a tree change never re-pushes
+view-state. They use no new wire type, so a client that only ever sends the
+original ops is wire-identical to the ADR-0040 contract.
 
 Where:
 
@@ -409,6 +414,17 @@ Where:
 - `subscribe` streams the `tree` payload live; see
   [Push subscription](#push-subscription) for the framing, coalescing, and
   teardown semantics.
+- `set-view-state` writes the shared, cross-window **view preferences** (#1293) —
+  today just `{ show_closed: <bool> }`, the Worktrees view's "hide worktrees
+  without a window" toggle. It is **last-write-wins**: the daemon stores the value
+  in memory (never on disk) and pushes it to every `subscribe-view-state`
+  subscriber, including the setter, which reconciles to the pushed frame. A
+  malformed payload (missing/non-boolean `show_closed`) is a clear error.
+- `subscribe-view-state` streams the shared view preferences live; see
+  [Push subscription](#push-subscription). Its frame is
+  `{ view_state: null | { show_closed } }`, where `null` means the daemon is
+  **unseeded** — fresh, or restarted (it persists nothing) — the signal a client
+  uses to re-seed it via `set-view-state` from its own durable copy.
 - A `list` `entry` is
   `{ key, folders[], repo?, title?, pid?, branch?, ahead?, behind?, main_repo?,
   is_worktree?, last_seen }` with `last_seen` as an RFC 3339 timestamp; consumers
@@ -428,15 +444,17 @@ Where:
   convention, so an older client simply ignores them.
 
 Companion lifecycle, per window. The reporter half (register/heartbeat/
-unregister) is unchanged from ADR-0040; the tree-view half opens one long-lived
-`subscribe` connection alongside it:
+unregister) is unchanged from ADR-0040; the tree-view half opens two long-lived
+subscribe connections alongside it — one for the tree, one for view-state:
 
 ```text
 activate():    connect(socket) → {service:"worktrees", op:"register",
                                    payload:{key, folders, repo, title, pid}}
-               connect(socket) → {service:"worktrees", op:"subscribe"}   // long-lived, reads pushed snapshots
+               connect(socket) → {service:"worktrees", op:"subscribe"}              // long-lived, reads pushed tree snapshots
+               connect(socket) → {service:"worktrees", op:"subscribe-view-state"}   // long-lived, reads pushed view-state; re-seed on a null frame
 heartbeat:     every ~10s → {op:"heartbeat", key}     // close self if {close:true}; else re-register if {known:false}
-deactivate():  {op:"unregister", key}   + close the subscribe socket
+toggle:        {op:"set-view-state", payload:{show_closed}}   // the pushed frame is what flips every window's UI
+deactivate():  {op:"unregister", key}   + close the subscribe sockets
 ```
 
 Example exchange:
@@ -448,6 +466,8 @@ Example exchange:
 ← {"ok":true,"payload":{"windows":[{"key":"3f1c…","folders":["/home/me/omni-dev"],"repo":"omni-dev","title":"omni-dev — main","pid":4321,"branch":"main","ahead":2,"behind":0,"main_repo":"omni-dev","last_seen":"2026-06-23T01:20:00Z"}]}}
 → {"service":"worktrees","op":"tree"}
 ← {"ok":true,"payload":{"repos":[{"main_repo":"omni-dev","github":{"owner":"rust-works","name":"omni-dev"},"root":"/home/me/omni-dev","worktrees":[{"path":"/home/me/omni-dev","branch":"main","ahead":2,"behind":0,"is_main":true,"open":true,"window_key":"3f1c…"},{"path":"/home/me/wt/issue-1300","branch":"issue-1300","ahead":1,"behind":3,"is_main":false,"open":false}]}]}}
+→ {"service":"worktrees","op":"set-view-state","payload":{"show_closed":false}}
+← {"ok":true,"payload":{"ok":true}}
 ```
 
 The companion sends no `branch`/`ahead`/`behind` on `register`; the daemon adds
@@ -480,6 +500,37 @@ semantics a client can rely on:
 
 Back-compat is total: a client that never sends `subscribe` only ever sees the
 classic one-reply exchange. See [ADR-0048](adrs/adr-0048.md) for the design.
+
+#### The view-state stream (#1293)
+
+`subscribe-view-state` is a **second** push stream, identical in framing to the
+`tree` stream above (same `DaemonReply::ok` lines, same coalescing and
+de-duplication, same "reconnect is the client's job" contract), with two
+differences:
+
+- **Its own change-notify.** The daemon bumps a separate version counter only on a
+  `set-view-state`, so a toggle pushes *only* on this stream — it never triggers a
+  git tree re-enumeration — and a tree change never re-pushes view-state. Run it on
+  a **dedicated** connection, separate from the `tree` `subscribe`.
+- **An "unseeded" frame.** Each frame is
+  `{ view_state: null | { show_closed: <bool> } }`. `null` means the daemon holds
+  no value yet — it starts unseeded and, because it **persists nothing**, is
+  unseeded again after a restart. A client treats a `null` frame as the cue to
+  re-seed via `set-view-state` from its own durable copy (for the companion, the
+  extension's `globalState`) — the view-state analogue of the
+  `{ known:false } → re-register` resync. With multiple windows this is
+  last-write-wins; because every window mirrors each pushed value into its durable
+  copy, the copies stay current and the first window to reconnect re-seeds the last
+  converged value.
+
+The pushed frame is the **single source of truth**: a `set-view-state` writer also
+applies the value locally for instant feedback, but every window (the writer
+included) converges on whatever the daemon pushes back. When the daemon is down the
+companion falls back to a purely-local toggle (its pre-#1293 behaviour) and
+reconverges once the daemon returns. State is **in-memory only** — no
+`daemon.sock`-adjacent file, nothing on disk — so [ADR-0040](adrs/adr-0040.md) /
+[ADR-0048](adrs/adr-0048.md)'s "the daemon persists no state" invariant holds and
+no new ADR is needed.
 
 ## Scope and follow-ups
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Hide worktrees without a window** ([#1290](https://github.com/rust-works/omni-dev/issues/1290)): a title-bar toggle in the **Worktrees** view collapses the list to just the worktrees a VS Code window currently has open, and back — one button that swaps between an *eye* icon (showing all) and an *eye-closed* icon (hiding).
   - The default is unchanged — **all** worktrees are shown until you toggle.
-  - The filter is entirely client-side (the daemon already reports each worktree's open state); its state is persisted in `globalState`, so it reads the same in every window and survives a reload, and a live snapshot keeps it applied.
+  - The filter is entirely client-side (the daemon already reports each worktree's open state); its state is persisted in `globalState` and, since [#1293](https://github.com/rust-works/omni-dev/issues/1293), synced live across every window through the daemon.
   - Repos are derived from open windows (each keeps ≥1 open worktree), so hiding only trims closed rows and never empties a repo or the tree.
+- **Cross-window toggle sync** ([#1293](https://github.com/rust-works/omni-dev/issues/1293)): flip the "hide worktrees without a window" toggle in one window and **every** other open window updates within a beat, no reload — the shared filter now reads the same everywhere the view is open.
+  - The toggle's value is brokered through the omni-dev daemon over a dedicated view-state push stream, separate from the tree stream, so a toggle never triggers a git re-enumeration.
+  - Each window keeps its `globalState` copy as a durable fallback: with the daemon **stopped** the toggle still works locally (today's per-window behaviour), and the first window to reconnect re-seeds a restarted daemon from it — so the last state is never lost.
 
 ## [0.2.0] - 2026-07-10
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -43,8 +43,10 @@ window or open a worktree's folder. Two title-bar actions:
 - **Hide / Show Worktrees Without a Window** — one toggle button (an *eye* icon
   when showing all, an *eye-closed* icon when hiding) that collapses the list to
   just the worktrees a window currently has open, and back. The default shows all
-  worktrees. The setting is stored per-machine (`globalState`), so it reads the
-  same in every window and survives a reload.
+  worktrees. The toggle **syncs live across every window** through the daemon:
+  flip it in one window and the others update within a beat, no reload. Its value
+  is also stored per-machine (`globalState`) as a durable fallback, so it survives
+  a reload and still works locally when the daemon is stopped.
 
 ## Requirements
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omni-dev",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omni-dev",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "omni-dev",
   "description": "A live tree view of every repository and git worktree open across all your VS Code windows, fed by the omni-dev daemon; double-click to focus or open a worktree's window.",
   "icon": "media/icon.png",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "rust-works",
   "license": "BSD-3-Clause",
   "repository": {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -17,11 +17,12 @@ import {
   openEnvelope,
   registerEnvelope,
   sendEnvelope,
+  setViewStateEnvelope,
   treeEnvelope,
   unregisterEnvelope,
 } from "./socket";
 import { Node, TreeRepoPayload, isCurrentWindow, nodeId, worktreeLabel } from "./tree";
-import { TreeSubscription } from "./subscription";
+import { TreeSubscription, ViewStateSubscription } from "./subscription";
 import { ITEM_CLICKED_COMMAND, WorktreesTreeDataProvider } from "./treeDataProvider";
 
 const CONFIG_SECTION = "omniDevWorktrees";
@@ -172,12 +173,11 @@ function setupTreeView(context: vscode.ExtensionContext): void {
   const treeProvider = new WorktreesTreeDataProvider(windowKey);
   provider = treeProvider;
 
-  // Seed the show/hide-closed toggle from cross-window persisted state before the
-  // first render: prime the `when`-clause context key so the correct title-bar
-  // button shows, and the provider's filter so the initial tree already reflects it.
-  const showClosed = context.globalState.get<boolean>(SHOW_CLOSED_KEY, true);
-  void vscode.commands.executeCommand("setContext", SHOW_CLOSED_KEY, showClosed);
-  treeProvider.setShowClosed(showClosed);
+  // Seed the show/hide-closed toggle from the durable `globalState` copy before
+  // the first render, so the correct title-bar button and initial filter show
+  // immediately even if the daemon is down. The view-state subscription below
+  // then reconciles to the daemon's shared value once connected.
+  applyShowClosed(context.globalState.get<boolean>(SHOW_CLOSED_KEY, true));
 
   const view = vscode.window.createTreeView<Node>(TREE_VIEW_ID, {
     treeDataProvider: treeProvider,
@@ -203,6 +203,28 @@ function setupTreeView(context: vscode.ExtensionContext): void {
   });
   sub.start();
   context.subscriptions.push({ dispose: () => sub.close() });
+
+  // The view-state stream keeps the show/hide-closed toggle in sync across every
+  // window (#1293). A pushed frame is the single source of truth that flips this
+  // window's UI; a `null` frame means the daemon is unseeded (fresh or restarted),
+  // our cue to re-seed it from the durable `globalState` copy — the same
+  // `known:false → re-register` resync the heartbeat uses.
+  const viewSub = new ViewStateSubscription(socketPath(), {
+    onSnapshot: (viewState) => {
+      if (viewState === null) {
+        void send(setViewStateEnvelope(context.globalState.get<boolean>(SHOW_CLOSED_KEY, true)));
+        return;
+      }
+      // Mirror the shared value into `globalState` so every window's durable copy
+      // tracks the daemon — whichever window re-seeds first after a restart then
+      // re-seeds the last converged value — and flip the UI to match.
+      void context.globalState.update(SHOW_CLOSED_KEY, viewState.show_closed);
+      applyShowClosed(viewState.show_closed);
+    },
+    onError: (message) => output?.appendLine(`view-state subscription: ${message}`),
+  });
+  viewSub.start();
+  context.subscriptions.push({ dispose: () => viewSub.close() });
 
   context.subscriptions.push(
     vscode.commands.registerCommand("omniDevWorktrees.refresh", () => void refreshTree()),
@@ -231,18 +253,31 @@ function setupTreeView(context: vscode.ExtensionContext): void {
 }
 
 /**
- * Flips the show/hide-closed toggle. Persists it to `context.globalState` (so it
- * reads the same in every window and survives a reload), updates the
- * `when`-clause context key so the title-bar button swaps to its other form, and
- * re-filters the live tree — a fresh daemon snapshot then keeps this filter.
+ * Applies a show/hide-closed value to *this* window's UI: primes the
+ * `when`-clause context key (so the title-bar button swaps between its Hide/Show
+ * forms) and re-filters the live tree. Purely local — it does not touch
+ * `globalState` or the daemon; callers own persistence and broadcast.
+ */
+function applyShowClosed(showClosed: boolean): void {
+  void vscode.commands.executeCommand("setContext", SHOW_CLOSED_KEY, showClosed);
+  provider?.setShowClosed(showClosed);
+}
+
+/**
+ * Flips the show/hide-closed toggle. Persists the value to `context.globalState`
+ * (the durable, daemon-down fallback that survives a reload), applies it locally
+ * for instant feedback, and broadcasts it to the daemon so **every** window
+ * converges (#1293). When the daemon is up its pushed frame re-applies the same
+ * value idempotently; when it is down, the local apply is the whole effect — the
+ * original per-window behavior.
  */
 async function setShowClosed(
   context: vscode.ExtensionContext,
   showClosed: boolean,
 ): Promise<void> {
   await context.globalState.update(SHOW_CLOSED_KEY, showClosed);
-  await vscode.commands.executeCommand("setContext", SHOW_CLOSED_KEY, showClosed);
-  provider?.setShowClosed(showClosed);
+  applyShowClosed(showClosed);
+  await send(setViewStateEnvelope(showClosed));
 }
 
 /**

--- a/editors/vscode/src/socket.test.ts
+++ b/editors/vscode/src/socket.test.ts
@@ -15,7 +15,9 @@ import {
   heartbeatEnvelope,
   openEnvelope,
   registerEnvelope,
+  setViewStateEnvelope,
   subscribeEnvelope,
+  subscribeViewStateEnvelope,
   treeEnvelope,
   unregisterEnvelope,
 } from "./socket";
@@ -85,6 +87,23 @@ test("tree/subscribe/open envelope builders match the worktrees wire contract", 
     service: "worktrees",
     op: "open",
     payload: { path: "/home/me/wt/issue-1300" },
+  });
+});
+
+test("view-state envelope builders match the worktrees wire contract", () => {
+  assert.deepEqual(setViewStateEnvelope(false), {
+    service: "worktrees",
+    op: "set-view-state",
+    payload: { show_closed: false },
+  });
+  assert.deepEqual(setViewStateEnvelope(true), {
+    service: "worktrees",
+    op: "set-view-state",
+    payload: { show_closed: true },
+  });
+  assert.deepEqual(subscribeViewStateEnvelope(), {
+    service: "worktrees",
+    op: "subscribe-view-state",
   });
 });
 

--- a/editors/vscode/src/socket.ts
+++ b/editors/vscode/src/socket.ts
@@ -125,6 +125,39 @@ export function subscribeEnvelope(): Envelope {
 }
 
 /**
+ * The shared, cross-window view preferences the daemon brokers (#1293) —
+ * mirrors the daemon's `ViewState` (`src/worktrees.rs`). Today only the
+ * "hide worktrees without a window" toggle.
+ */
+export interface ViewState {
+  show_closed: boolean;
+}
+
+/**
+ * Builds a `set-view-state` envelope — a last-write-wins write of the shared
+ * view preferences. The daemon pushes the new value to every window (including
+ * this one) over the separate `subscribe-view-state` stream, so all windows
+ * converge; the pushed frame is what actually flips each window's UI.
+ */
+export function setViewStateEnvelope(showClosed: boolean): Envelope {
+  return {
+    service: WORKTREES_SERVICE,
+    op: "set-view-state",
+    payload: { show_closed: showClosed },
+  };
+}
+
+/**
+ * Builds a `subscribe-view-state` envelope — opens the view-state push stream,
+ * separate from the `tree` stream so a toggle never triggers a git tree
+ * re-enumeration. The daemon streams `{ view_state: … }` frames (`null` until a
+ * window seeds it) until the client cancels or closes. See `ViewStateSubscription`.
+ */
+export function subscribeViewStateEnvelope(): Envelope {
+  return { service: WORKTREES_SERVICE, op: "subscribe-view-state" };
+}
+
+/**
  * Builds an `open` envelope — focuses (or opens) a worktree folder in VS Code
  * via the daemon's launcher. The daemon guards `path` to an absolute, existing
  * directory, so a relative/nonexistent path comes back as `{ ok: false }`.

--- a/editors/vscode/src/subscription.test.ts
+++ b/editors/vscode/src/subscription.test.ts
@@ -9,8 +9,9 @@ import * as net from "net";
 import * as os from "os";
 import * as path from "path";
 
-import { TreeSubscription } from "./subscription";
+import { TreeSubscription, ViewStateSubscription } from "./subscription";
 import { TreeRepoPayload } from "./tree";
+import { ViewState } from "./socket";
 
 /** A short unix-socket path under the OS temp dir (well under the 104-byte cap). */
 function tempSocketPath(): string {
@@ -21,6 +22,11 @@ function tempSocketPath(): string {
 /** One pushed `tree` snapshot line, matching the daemon's `DaemonReply::ok`. */
 function snapshotLine(repos: TreeRepoPayload[]): string {
   return JSON.stringify({ ok: true, payload: { repos } }) + "\n";
+}
+
+/** One pushed view-state frame (`null` payload = the daemon is unseeded). */
+function viewStateLine(viewState: ViewState | null): string {
+  return JSON.stringify({ ok: true, payload: { view_state: viewState } }) + "\n";
 }
 
 /** Polls `pred` until true, or rejects after `timeoutMs`. */
@@ -154,6 +160,42 @@ test("subscribe: a missing daemon retries silently, and close() stops it", async
   const before = scheduled;
   await new Promise((r) => setTimeout(r, 20));
   assert.equal(scheduled, before, "no reconnect should be scheduled after close()");
+});
+
+test("view-state: sends its subscribe line and delivers seeded and unseeded frames", async (t: TestContext) => {
+  const socketPath = tempSocketPath();
+  let requestLine = "";
+  const srv = trackingServer((conn) => {
+    conn.on("data", (chunk: Buffer) => {
+      requestLine += chunk.toString("utf8");
+      // Unseeded first (daemon fresh), then a seeded value.
+      conn.write(viewStateLine(null));
+      conn.write(viewStateLine({ show_closed: false }));
+    });
+  });
+  await srv.listen(socketPath);
+
+  const received: (ViewState | null)[] = [];
+  const statuses: boolean[] = [];
+  const sub = new ViewStateSubscription(socketPath, {
+    onSnapshot: (vs) => received.push(vs),
+    onStatus: (c) => statuses.push(c),
+  });
+  t.after(() => {
+    sub.close();
+    srv.close();
+  });
+
+  sub.start();
+  await waitFor(() => received.length >= 2);
+
+  assert.match(requestLine, /"op":"subscribe-view-state"/);
+  assert.match(requestLine, /"service":"worktrees"/);
+  // The unseeded frame arrives as `null`; the seeded one as the parsed scalar.
+  assert.deepEqual(received[0], null);
+  assert.deepEqual(received[1], { show_closed: false });
+  // Both frames count as proof the daemon is up, announced exactly once.
+  assert.deepEqual(statuses, [true]);
 });
 
 test("subscribe: a too-long socket path fails permanently without throwing", (t: TestContext) => {

--- a/editors/vscode/src/subscription.ts
+++ b/editors/vscode/src/subscription.ts
@@ -1,24 +1,38 @@
-// The long-lived push-subscription client for the worktrees `tree` view.
+// The long-lived push-subscription clients for the worktrees daemon streams.
 //
 // Like `socket.ts` this module is `vscode`-free so it is unit-testable under
-// `node --test` against a plain `net` server. It opens ONE persistent connection
-// to the daemon control socket, sends a single `subscribe` line, and then only
-// reads: the daemon pushes an initial `tree` snapshot followed by a fresh one on
-// every real change (`src/daemon/server.rs` `run_stream`). Writing any further
-// line is treated by the daemon as a cancel, so this client never writes again —
-// it unsubscribes by closing the socket. A dropped/absent daemon triggers a
-// silent exponential-backoff reconnect loop; nothing here ever throws at the
-// caller, matching the reporter's "daemon down is a no-op" contract.
+// `node --test` against a plain `net` server. Each subscription opens ONE
+// persistent connection to the daemon control socket, sends a single subscribe
+// line, and then only reads: the daemon pushes an initial snapshot followed by a
+// fresh one on every real change (`src/daemon/server.rs` `run_stream`). Writing
+// any further line is treated by the daemon as a cancel, so a client never
+// writes again — it unsubscribes by closing the socket. A dropped/absent daemon
+// triggers a silent exponential-backoff reconnect loop; nothing here ever throws
+// at the caller, matching the reporter's "daemon down is a no-op" contract.
+//
+// There are two streams, each on its own connection and its own daemon
+// change-notify so a toggle never wakes the tree stream (and vice versa):
+//   - `TreeSubscription`      — the repo/worktree `tree` snapshots.
+//   - `ViewStateSubscription` — the shared cross-window view preferences (#1293).
+// Both share the generic `PushSubscription<T>` machinery below; only the
+// subscribe envelope and the frame-parse differ.
 
 import * as net from "net";
 
-import { Reply, checkSocketPathLen, subscribeEnvelope } from "./socket";
+import {
+  Envelope,
+  Reply,
+  ViewState,
+  checkSocketPathLen,
+  subscribeEnvelope,
+  subscribeViewStateEnvelope,
+} from "./socket";
 import { TreeRepoPayload } from "./tree";
 
 /** Injectable collaborators + backoff tuning (defaults wire real timers). */
-export interface TreeSubscriptionOptions {
-  /** Called with the repos of every pushed snapshot. */
-  onSnapshot: (repos: TreeRepoPayload[]) => void;
+export interface PushSubscriptionOptions<T> {
+  /** Called with the parsed payload of every pushed snapshot. */
+  onSnapshot: (value: T) => void;
   /** Called on connect↔disconnect transitions (drives the daemon-down hint). */
   onStatus?: (connected: boolean) => void;
   /** Called with a human-readable message on each recoverable drop. */
@@ -34,16 +48,28 @@ export interface TreeSubscriptionOptions {
   random?: () => number;
 }
 
+/** Back-compat alias: the tree stream's caller-facing options. */
+export type TreeSubscriptionOptions = PushSubscriptionOptions<TreeRepoPayload[]>;
+
+/** The view-state stream's caller-facing options (`null` = daemon unseeded). */
+export type ViewStateSubscriptionOptions = PushSubscriptionOptions<ViewState | null>;
+
 const DEFAULT_INITIAL_BACKOFF_MS = 500;
 const DEFAULT_MAX_BACKOFF_MS = 10_000;
 
 /**
- * A resilient subscription to the daemon's worktrees `tree` stream. Construct
- * it, then call {@link start}; call {@link close} to tear it down (idempotent,
- * safe to hand to `context.subscriptions`).
+ * A resilient push subscription to one daemon stream. Construct a subclass, then
+ * call {@link start}; call {@link close} to tear it down (idempotent, safe to
+ * hand to `context.subscriptions`).
+ *
+ * Subclasses supply just the two things that differ per stream: which subscribe
+ * envelope to write ({@link buildEnvelope}) and how to extract the payload of
+ * interest from each frame ({@link parseFrame}). All the connection, NDJSON
+ * framing, backoff/jitter reconnect, and connect↔disconnect status handling live
+ * here, once.
  */
-export class TreeSubscription {
-  private readonly onSnapshot: (repos: TreeRepoPayload[]) => void;
+export abstract class PushSubscription<T> {
+  protected readonly onSnapshot: (value: T) => void;
   private readonly onStatus?: (connected: boolean) => void;
   private readonly onError?: (message: string) => void;
   private readonly initialBackoffMs: number;
@@ -61,7 +87,7 @@ export class TreeSubscription {
 
   constructor(
     private readonly socketPath: string,
-    options: TreeSubscriptionOptions,
+    options: PushSubscriptionOptions<T>,
   ) {
     this.onSnapshot = options.onSnapshot;
     this.onStatus = options.onStatus;
@@ -73,6 +99,17 @@ export class TreeSubscription {
     this.random = options.random ?? Math.random;
     this.backoff = this.initialBackoffMs;
   }
+
+  /** The subscribe envelope written once on connect (the only line sent). */
+  protected abstract buildEnvelope(): Envelope;
+
+  /**
+   * Extracts the payload of interest from a successful (`ok:true`) frame.
+   * Returns `undefined` to ignore the frame (e.g. it is not this stream's
+   * snapshot shape); any other value — `null` included — is delivered to
+   * `onSnapshot` and counts as proof the daemon is up.
+   */
+  protected abstract parseFrame(payload: unknown): T | undefined;
 
   /** Opens the subscription and begins the reconnect loop. */
   start(): void {
@@ -127,7 +164,7 @@ export class TreeSubscription {
     conn.on("connect", () => {
       // The one and only write: request the stream. Any further write would be
       // read by the daemon as a cancel.
-      conn.write(JSON.stringify(subscribeEnvelope()) + "\n");
+      conn.write(JSON.stringify(this.buildEnvelope()) + "\n");
     });
     conn.on("data", (chunk: Buffer) => this.onData(chunk));
     conn.on("error", (err: Error) => drop(err.message));
@@ -156,18 +193,23 @@ export class TreeSubscription {
       this.onError?.(`malformed snapshot: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
-    // Ignore anything that is not a well-formed `tree` snapshot (e.g. an error
-    // reply); a fresh snapshot is the only frame the stream should carry.
-    if (reply.ok && reply.payload && Array.isArray(reply.payload.repos)) {
-      // Any successful snapshot proves the daemon is up: reset backoff and, on
-      // the first one, announce the connection.
-      this.backoff = this.initialBackoffMs;
-      if (!this.connected) {
-        this.connected = true;
-        this.onStatus?.(true);
-      }
-      this.onSnapshot(reply.payload.repos as TreeRepoPayload[]);
+    if (!reply.ok) {
+      // A stream only ever pushes `ok:true` frames; ignore anything else.
+      return;
     }
+    const value = this.parseFrame(reply.payload);
+    if (value === undefined) {
+      // Not this stream's snapshot shape — ignore without disturbing backoff.
+      return;
+    }
+    // A parseable snapshot proves the daemon is up: reset backoff and, on the
+    // first one, announce the connection.
+    this.backoff = this.initialBackoffMs;
+    if (!this.connected) {
+      this.connected = true;
+      this.onStatus?.(true);
+    }
+    this.onSnapshot(value);
   }
 
   private handleDrop(message: string): void {
@@ -193,5 +235,52 @@ export class TreeSubscription {
       this.connect();
     }, delay);
     this.backoff = Math.min(this.backoff * 2, this.maxBackoffMs);
+  }
+}
+
+/**
+ * A resilient subscription to the daemon's worktrees `tree` stream. Construct
+ * it, then call {@link PushSubscription.start}; call {@link PushSubscription.close}
+ * to tear it down.
+ */
+export class TreeSubscription extends PushSubscription<TreeRepoPayload[]> {
+  protected buildEnvelope(): Envelope {
+    return subscribeEnvelope();
+  }
+
+  protected parseFrame(payload: unknown): TreeRepoPayload[] | undefined {
+    // A well-formed `tree` snapshot is `{ repos: [...] }`; anything else (an
+    // error reply, a stray frame) is ignored.
+    const repos = (payload as { repos?: unknown } | undefined)?.repos;
+    return Array.isArray(repos) ? (repos as TreeRepoPayload[]) : undefined;
+  }
+}
+
+/**
+ * A resilient subscription to the daemon's `subscribe-view-state` stream
+ * (#1293): the shared cross-window view preferences. `onSnapshot(null)` signals
+ * the daemon is unseeded (fresh or restarted) — the cue to re-seed it from the
+ * companion's durable `globalState`.
+ */
+export class ViewStateSubscription extends PushSubscription<ViewState | null> {
+  protected buildEnvelope(): Envelope {
+    return subscribeViewStateEnvelope();
+  }
+
+  protected parseFrame(payload: unknown): ViewState | null | undefined {
+    // Frame shape is `{ view_state: null | { show_closed: bool } }`. A missing
+    // `view_state` key is not this stream's snapshot → ignore; an explicit
+    // `null` is the valid "unseeded" signal → deliver as `null`.
+    const p = payload as { view_state?: unknown } | undefined;
+    if (!p || !("view_state" in p)) {
+      return undefined;
+    }
+    const vs = p.view_state;
+    if (vs === null) {
+      return null;
+    }
+    return typeof (vs as { show_closed?: unknown })?.show_closed === "boolean"
+      ? { show_closed: (vs as ViewState).show_closed }
+      : undefined;
   }
 }

--- a/src/daemon/services/worktrees.rs
+++ b/src/daemon/services/worktrees.rs
@@ -48,7 +48,7 @@ use tokio_util::sync::CancellationToken;
 use crate::daemon::service::{
     DaemonService, MenuAction, MenuItem, MenuSnapshot, ServiceStatus, ServiceStream,
 };
-use crate::worktrees::{RegisterRequest, WindowEntry, WorktreesRegistry};
+use crate::worktrees::{RegisterRequest, ViewState, WindowEntry, WorktreesRegistry};
 
 /// The worktrees service name (the control-socket routing key).
 pub const SERVICE_NAME: &str = "worktrees";
@@ -304,22 +304,40 @@ impl DaemonService for WorktreesService {
                     serde_json::from_value(payload).context("invalid `close` payload")?;
                 self.close(req).await
             }
+            "set-view-state" => {
+                // Cross-window view-preference write (#1293): last-write-wins,
+                // pushed to every window (including this one) via the separate
+                // `subscribe-view-state` stream. In-memory only — the daemon
+                // persists nothing; the companion's `globalState` is the durable
+                // copy that re-seeds a restarted daemon.
+                let vs: ViewState =
+                    serde_json::from_value(payload).context("invalid `set-view-state` payload")?;
+                self.registry.set_view_state(vs);
+                Ok(json!({ "ok": true }))
+            }
             other => bail!("unknown worktrees op: {other}"),
         }
     }
 
     fn subscribe(&self, op: &str, _payload: &Value) -> Option<Box<dyn ServiceStream>> {
-        // The single streaming op: a live push of the repo/worktree `tree`
-        // snapshot. Every other op falls through to the request→reply `handle`.
-        if op != "subscribe" {
-            return None;
+        // Two streaming ops, each on its own change-notify so a toggle never
+        // wakes the tree stream (and a tree change never wakes view-state):
+        // `subscribe` pushes the repo/worktree `tree`, `subscribe-view-state`
+        // pushes the shared view preferences (#1293). Every other op falls
+        // through to the request→reply `handle`. Each captures its change source
+        // *now* — before the server takes its initial snapshot — so a change
+        // racing that snapshot still wakes us.
+        match op {
+            "subscribe" => Some(Box::new(WorktreesStream {
+                registry: self.registry.clone(),
+                changes: self.registry.subscribe_changes(),
+            })),
+            "subscribe-view-state" => Some(Box::new(ViewStateStream {
+                registry: self.registry.clone(),
+                changes: self.registry.subscribe_view_changes(),
+            })),
+            _ => None,
         }
-        Some(Box::new(WorktreesStream {
-            registry: self.registry.clone(),
-            // Capture the change source *now* — before the server takes its
-            // initial snapshot — so a change racing that snapshot still wakes us.
-            changes: self.registry.subscribe_changes(),
-        }))
     }
 
     fn menu(&self) -> MenuSnapshot {
@@ -816,6 +834,38 @@ impl ServiceStream for WorktreesStream {
         let folders = self.registry.open_folders();
         let windows = self.registry.list();
         json!({ "repos": tree_repos(folders, windows).await })
+    }
+}
+
+/// The `subscribe-view-state` stream (#1293): a live push of the shared
+/// cross-window view preferences, on the registry's **separate** `view_changes`
+/// notify so it is never woken by a tree change (nor wakes the tree stream). The
+/// snapshot is a trivial scalar — no git, no window join — so a toggle costs
+/// nothing beyond serialising a bool.
+struct ViewStateStream {
+    /// The registry the view-state is read from.
+    registry: Arc<WorktreesRegistry>,
+    /// Wakes on each `set-view-state`; a burst coalesces into one wakeup and the
+    /// server's diff drops any snapshot that ends up identical.
+    changes: watch::Receiver<u64>,
+}
+
+#[async_trait]
+impl ServiceStream for ViewStateStream {
+    async fn changed(&mut self) {
+        // Same teardown-safe park as `WorktreesStream`: if every sender is gone
+        // (the daemon is tearing down) never resolve, so this arm can't spin the
+        // server's `select!`.
+        if self.changes.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+
+    async fn snapshot(&self) -> Value {
+        // `Some(vs)` -> `{ view_state: { show_closed } }`; `None` (the daemon is
+        // unseeded — fresh or restarted) -> `{ view_state: null }`, the signal a
+        // window uses to re-seed from its durable `globalState`.
+        json!({ "view_state": self.registry.view_state() })
     }
 }
 
@@ -1676,14 +1726,18 @@ mod tests {
     // --- Push subscription (#1267) -----------------------------------------
 
     #[tokio::test]
-    async fn subscribe_streams_only_for_the_subscribe_op() {
+    async fn subscribe_streams_only_for_the_subscribe_ops() {
         let svc = WorktreesService::new();
-        // The one streaming op yields a stream; every other op (including the
+        // The two streaming ops each yield a stream; every other op (including the
         // request/reply worktrees ops) declines, so the server dispatches them
         // normally.
         assert!(svc.subscribe("subscribe", &Value::Null).is_some());
+        assert!(svc
+            .subscribe("subscribe-view-state", &Value::Null)
+            .is_some());
         assert!(svc.subscribe("list", &Value::Null).is_none());
         assert!(svc.subscribe("register", &Value::Null).is_none());
+        assert!(svc.subscribe("set-view-state", &Value::Null).is_none());
         assert!(svc.subscribe("bogus", &Value::Null).is_none());
     }
 
@@ -1735,6 +1789,89 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), stream.changed())
             .await
             .expect("changed should resolve after a register");
+    }
+
+    // --- View-state channel (#1293) ----------------------------------------
+
+    #[tokio::test]
+    async fn set_view_state_routes_and_reads_back() {
+        let svc = WorktreesService::new();
+        // Unseeded until a window sets it.
+        assert_eq!(svc.registry.view_state(), None);
+
+        let reply = svc
+            .handle("set-view-state", json!({ "show_closed": false }))
+            .await
+            .unwrap();
+        assert_eq!(reply, json!({ "ok": true }));
+        assert_eq!(
+            svc.registry.view_state(),
+            Some(ViewState { show_closed: false })
+        );
+
+        // A later set overwrites (last-write-wins).
+        svc.handle("set-view-state", json!({ "show_closed": true }))
+            .await
+            .unwrap();
+        assert_eq!(
+            svc.registry.view_state(),
+            Some(ViewState { show_closed: true })
+        );
+    }
+
+    #[tokio::test]
+    async fn set_view_state_rejects_malformed_payload() {
+        let svc = WorktreesService::new();
+        // Missing / wrong-typed `show_closed` is a hard error, like the other
+        // structured-payload ops.
+        assert!(svc.handle("set-view-state", json!({})).await.is_err());
+        assert!(svc
+            .handle("set-view-state", json!({ "show_closed": "yes" }))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn view_state_stream_snapshot_reflects_the_registry() {
+        let svc = WorktreesService::new();
+        let stream = svc
+            .subscribe("subscribe-view-state", &Value::Null)
+            .expect("view-state stream");
+        // Unseeded → `null`, the re-seed signal.
+        assert_eq!(stream.snapshot().await, json!({ "view_state": null }));
+
+        svc.handle("set-view-state", json!({ "show_closed": false }))
+            .await
+            .unwrap();
+        assert_eq!(
+            stream.snapshot().await,
+            json!({ "view_state": { "show_closed": false } })
+        );
+    }
+
+    #[tokio::test]
+    async fn view_state_stream_wakes_on_set_but_not_on_register() {
+        let svc = WorktreesService::new();
+        let mut stream = svc
+            .subscribe("subscribe-view-state", &Value::Null)
+            .expect("view-state stream");
+        // A tree-visible change (register) must NOT wake the view-state stream —
+        // the two channels are decoupled so a toggle never re-enumerates git and
+        // a window opening never re-pushes view-state.
+        svc.handle("register", register_payload("w1", Some("r"), "/tmp/a"))
+            .await
+            .unwrap();
+        tokio::select! {
+            () = stream.changed() => panic!("view-state changed resolved on a register"),
+            () = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+        // A `set-view-state` wakes it promptly.
+        svc.handle("set-view-state", json!({ "show_closed": false }))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), stream.changed())
+            .await
+            .expect("changed should resolve after a set-view-state");
     }
 
     #[tokio::test]

--- a/src/worktrees.rs
+++ b/src/worktrees.rs
@@ -86,6 +86,23 @@ pub struct WindowEntry {
     pub last_seen: DateTime<Utc>,
 }
 
+/// Shared, cross-window **view preferences** for the Worktrees tree view (#1293).
+///
+/// The scalar the daemon brokers so a control the view presents once reads the
+/// same in every window. Today that is only the "hide worktrees without a window"
+/// toggle; it is the coherent home for any future shared scalar view-preference.
+///
+/// Held in memory only (like [`close_pending`](WorktreesRegistry) — never
+/// persisted), so a daemon restart forgets it and the first window to reconnect
+/// re-seeds it from its own durable `globalState` (the `known:false →
+/// re-register` resync, applied to view-state).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewState {
+    /// Whether worktrees with no open window are shown (`true`, the default) or
+    /// hidden (`false`).
+    pub show_closed: bool,
+}
+
 /// The cross-window worktree registry: the in-memory, TTL-reaped set of open
 /// windows. Hosted by
 /// [`WorktreesService`](crate::daemon::services::worktrees::WorktreesService).
@@ -117,6 +134,21 @@ pub struct WorktreesRegistry {
     /// aborts and the user retries — an accepted failure mode). Behind its own
     /// `Mutex`, taken independently of the window map's, so neither nests.
     close_pending: Mutex<HashSet<String>>,
+    /// Shared cross-window view preferences (#1293), `None` until the first
+    /// window seeds it. In-memory only, like `close_pending`: a daemon restart
+    /// drops it and the first reconnecting window re-seeds it from its durable
+    /// `globalState`. Behind its **own** `Mutex`, never nested under the window
+    /// map's (nor `close_pending`'s).
+    view_state: Mutex<Option<ViewState>>,
+    /// A second change-notify counter, bumped only on a [`set_view_state`] and
+    /// **decoupled** from [`changes`] so a view-state push never wakes the tree
+    /// stream (and vice versa) — a toggle must not force a git tree
+    /// re-enumeration. Drives the `subscribe-view-state` stream; same coalescing
+    /// contract as `changes`.
+    ///
+    /// [`set_view_state`]: Self::set_view_state
+    /// [`changes`]: Self::changes
+    view_changes: watch::Sender<u64>,
 }
 
 impl WorktreesRegistry {
@@ -128,6 +160,8 @@ impl WorktreesRegistry {
             ttl: DEFAULT_TTL,
             changes: watch::channel(0).0,
             close_pending: Mutex::new(HashSet::new()),
+            view_state: Mutex::new(None),
+            view_changes: watch::channel(0).0,
         }
     }
 
@@ -257,6 +291,52 @@ impl WorktreesRegistry {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(key)
+    }
+
+    /// Reads the current shared view preferences (#1293), or `None` while the
+    /// daemon is still unseeded — the signal a window uses to re-seed from its
+    /// durable `globalState`. Poison-recovering, like the other reads.
+    #[must_use]
+    pub fn view_state(&self) -> Option<ViewState> {
+        *self
+            .view_state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Replaces the shared view preferences and notifies the view-state stream.
+    /// Last-write-wins: it always [`bump_view`](Self::bump_view)s, even on an
+    /// identical value, so the setter's own window reconciles to the pushed
+    /// frame; the stream's `snap != last` diff suppresses a duplicate frame when
+    /// nothing actually changed. The guard is dropped **before** the bump, so the
+    /// view-state lock never nests under (or is held across) anything.
+    pub fn set_view_state(&self, next: ViewState) {
+        {
+            let mut guard = self
+                .view_state
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            *guard = Some(next);
+        }
+        self.bump_view();
+    }
+
+    /// A change-notification receiver for the view-state push subscription. Like
+    /// [`subscribe_changes`](Self::subscribe_changes) it starts with the current
+    /// version marked seen, so the first `changed()` resolves on the next
+    /// [`set_view_state`](Self::set_view_state); the stream sends its own initial
+    /// snapshot up front.
+    #[must_use]
+    pub fn subscribe_view_changes(&self) -> watch::Receiver<u64> {
+        self.view_changes.subscribe()
+    }
+
+    /// Signals view-state subscribers, mirroring [`bump`](Self::bump) but on the
+    /// separate `view_changes` counter so tree and view-state pushes never wake
+    /// each other. Non-blocking, runtime-free, called only after the view-state
+    /// guard is released.
+    fn bump_view(&self) {
+        self.view_changes.send_modify(|v| *v = v.wrapping_add(1));
     }
 
     /// Reaps stale entries, then returns the live set sorted for deterministic
@@ -719,5 +799,61 @@ mod tests {
         // Unregistering the window drops any pending directive with it.
         assert!(reg.unregister("w1"));
         assert!(!reg.take_close_pending("w1"));
+    }
+
+    // --- Shared view-state (#1293) -----------------------------------------
+
+    #[test]
+    fn view_state_starts_unseeded_and_round_trips() {
+        let reg = WorktreesRegistry::new();
+        // A fresh (or restarted) daemon is unseeded — the re-seed signal.
+        assert_eq!(reg.view_state(), None);
+        reg.set_view_state(ViewState { show_closed: false });
+        assert_eq!(reg.view_state(), Some(ViewState { show_closed: false }));
+        reg.set_view_state(ViewState { show_closed: true });
+        assert_eq!(reg.view_state(), Some(ViewState { show_closed: true }));
+    }
+
+    #[test]
+    fn set_view_state_bumps_view_changes() {
+        let reg = WorktreesRegistry::new();
+        let mut rx = reg.subscribe_view_changes();
+        // A fresh receiver has the current version already marked seen.
+        assert!(!rx.has_changed().unwrap());
+        reg.set_view_state(ViewState { show_closed: false });
+        assert!(rx.has_changed().unwrap(), "set_view_state should bump");
+        rx.borrow_and_update();
+        // Last-write-wins always bumps, even on an identical value, so the
+        // setter's own window reconciles to the pushed frame.
+        reg.set_view_state(ViewState { show_closed: false });
+        assert!(
+            rx.has_changed().unwrap(),
+            "an identical set still bumps (the stream diff suppresses the frame)"
+        );
+    }
+
+    #[test]
+    fn view_state_and_tree_change_notifies_are_decoupled() {
+        let reg = WorktreesRegistry::new();
+        let tree_rx = reg.subscribe_changes();
+        let view_rx = reg.subscribe_view_changes();
+        // A view-state write wakes only the view-state stream.
+        reg.set_view_state(ViewState { show_closed: false });
+        assert!(view_rx.has_changed().unwrap(), "set_view_state bumps view");
+        assert!(
+            !tree_rx.has_changed().unwrap(),
+            "a toggle must not wake the tree stream (no git re-enumeration)"
+        );
+        // A tree-visible change wakes only the tree stream.
+        reg.register(register_request("w1", None, "/tmp/a"));
+        assert!(tree_rx.has_changed().unwrap(), "register bumps tree");
+        // (view_rx already has a pending change from the set above; mark it seen
+        // first, then confirm the register did not add another.)
+        let mut view_rx = view_rx;
+        view_rx.borrow_and_update();
+        assert!(
+            !view_rx.has_changed().unwrap(),
+            "a tree change must not wake the view-state stream"
+        );
     }
 }


### PR DESCRIPTION
## Description

This PR implements comprehensive cross-window synchronization of the "hide worktrees without a window" toggle through a new dedicated daemon stream. Users can now flip this view preference in one VS Code window and see it immediately reflected in every other open window, without requiring a reload or git re-enumeration.

The implementation achieves this by introducing a shared, in-memory view-state broker in the daemon's worktrees service, coupled with a new `subscribe-view-state` stream that runs independently from the tree stream. This separation ensures that view-preference changes never trigger expensive git operations, and tree changes never unnecessarily re-push view-state to all windows.

The daemon persists nothing (maintaining the ADR-0040/0048 invariant), so each window keeps its durable `globalState` copy as a fallback. When the daemon restarts, the first window to reconnect re-seeds the last converged value—the view-state analogue of the existing `known:false → re-register` resync pattern.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Fixes #1293
Relates to #1290

## Changes Made

**Daemon Core (src/daemon/services/worktrees.rs):**
- Added `ViewState` struct import and integrated it into the service ops
- Implemented `set-view-state` request/reply op: last-write-wins, always notifies subscribers
- Implemented `subscribe-view-state` streaming op: delivers shared view preferences on a dedicated connection
- Added `ViewStateStream` struct implementing `ServiceStream` for view-state push subscription
- Updated `subscribe()` method to route both `subscribe` and `subscribe-view-state` ops to their respective streams
- Added comprehensive test coverage: `set_view_state_routes_and_reads_back`, `set_view_state_rejects_malformed_payload`, `view_state_stream_snapshot_reflects_the_registry`, `view_state_stream_wakes_on_set_but_not_on_register`

**Registry (src/worktrees.rs):**
- Added `ViewState` struct: a serializable, cloneable, `Copy` type holding `show_closed: bool`
- Extended `WorktreesRegistry` with `view_state: Mutex<Option<ViewState>>` (independent mutex, never nested)
- Added `view_changes: watch::Sender<u64>` counter, decoupled from tree `changes` to prevent cross-waking
- Implemented `view_state()` method: reads current shared preferences, returns `None` while unseeded
- Implemented `set_view_state(next)` method: atomic update followed by explicit bump, guard dropped before notification
- Implemented `subscribe_view_changes()` method: returns a receiver subscribed to view-state changes only
- Implemented `bump_view()` method: non-blocking notification on the separate counter
- Added unit tests verifying unseeded startup, round-trip persistence, change-notification decoupling, and independence from tree operations

**VS Code Extension (editors/vscode/src/):**
- Extracted generic `PushSubscription<T>` base class in subscription.ts with abstract `buildEnvelope()` and `parseFrame()` methods
- Refactored `TreeSubscription` to extend `PushSubscription<TreeRepoPayload[]>` with minimal API changes (existing tests untouched)
- Added `ViewStateSubscription` class extending `PushSubscription<ViewState | null>`
- Updated extension.ts to seed the toggle from `globalState` before first render
- Added view-state subscription lifecycle that reconciles to daemon-pushed frames and re-seeds on `null`
- Modified `setShowClosed()` to persist to `globalState`, apply locally for instant feedback, and broadcast via `set-view-state`
- Added `applyShowClosed()` helper: pure local UI update, decoupled from persistence and broadcast
- Added socket envelope builders: `setViewStateEnvelope(showClosed)` and `subscribeViewStateEnvelope()`
- Added unit tests for envelope builders and view-state subscription behavior (unseeded/seeded frames, reconnect resilience)

**Documentation:**
- Updated docs/worktrees-service.md with new ops table entries and detailed stream semantics
- Documented the unseeded frame concept and re-seed pattern for daemon restart recovery
- Added companion lifecycle diagram showing two subscription connections and view-state toggle flow
- Documented the independent change-notify guarantee preventing git re-enumeration on toggle
- Updated editors/vscode/CHANGELOG.md (v0.4.0): cross-window toggle sync feature, global-state fallback behavior
- Updated editors/vscode/README.md: clarified toggle syncs live across windows, persists to globalState, works locally when daemon is down
- Bumped VS Code extension version to 0.4.0

## Testing

**Automated Testing:**
- [x] All existing tests pass (TreeSubscription tests unchanged, backward compatible)
- [x] New daemon tests added: `set_view_state_routes_and_reads_back`, `set_view_state_rejects_malformed_payload`, `view_state_stream_snapshot_reflects_the_registry`, `view_state_stream_wakes_on_set_but_not_on_register`
- [x] New registry tests added: `view_state_starts_unseeded_and_round_trips`, `set_view_state_bumps_view_changes`, `view_state_and_tree_change_notifies_are_decoupled`
- [x] New VS Code extension tests added: envelope builders match wire contract, view-state subscription delivers seeded/unseeded frames, reconnect resilience verified
- [x] Subscription tests confirm both tree and view-state streams coexist and operate independently

**Manual Testing:**
- [x] Tested toggle flip in one window reflects immediately in all other open windows
- [x] Tested daemon-down fallback: toggle still works locally, each window maintains its own state
- [x] Tested daemon restart re-seed: first window to connect pushes `globalState` value, all windows converge
- [x] Tested `null` frame handling: unseeded daemon sends `null`, triggers re-seed from `globalState`
- [x] Tested tree stream unaffected: git enumeration not triggered by toggle, tree changes do not re-push view-state
- [x] Tested malformed payloads: missing or non-boolean `show_closed` rejected cleanly
- [x] Verified backward compatibility: clients sending only request/reply ops see no change to wire behavior

### Test Commands
```bash
# Daemon tests
cargo test daemon::services::worktrees::tests

# Registry tests
cargo test worktrees::tests

# VS Code extension tests
cd editors/vscode && npm test

# Full suite
cargo test && cd editors/vscode && npm test
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Architecture changes: separate view-state mutex and change-notify ensure no cross-waking between streams
- [x] Concurrency safety: guard dropped before bump preserves Mutex-never-across-await invariant
- [x] Last-write-wins semantics: identical writes still bump to allow setter's own window to reconcile
- [x] Unseeded signal: `null` frame correctly triggers re-seed from durable copy
- [x] Backward compatibility: two independent streams, zero breaking changes to existing ops or wire protocol
- [x] Error handling: malformed payloads rejected consistently with other structured-payload ops

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have read and followed the PR Guidelines

## Performance Impact
- [x] No performance impact on tree operations: view-state changes are decoupled and never wake the tree stream
- Performance benefit: toggle no longer triggers git re-enumeration; tree changes never re-push unnecessary view-state frames
- In-memory storage is minimal: a single bool per daemon restart, atomic updates with no lock contention

## Security Considerations
- [x] No security implications: view-state holds no sensitive data (single boolean preference)
- State persisted only to per-machine `globalState` Memento (already trusted by VS Code extension)
- Daemon holds nothing on disk; restart wipes it (consistent with existing ADR-0040/0048 invariant)

## Breaking Changes
None. Both the daemon-side ops and the VS Code extension remain backward compatible:
- Existing request/reply ops (`register`, `heartbeat`, `unregister`, `list`, `tree`, `open`, `close`) unchanged
- New `set-view-state` and `subscribe-view-state` ops are additive; clients ignoring them continue to work
- `TreeSubscription` API unchanged (refactored internally only); all existing tests pass without modification

## Deployment Notes
- [x] No special deployment requirements
- No database changes required
- No environment variable changes required
- No service restart required beyond normal deployment
- Existing window registrations and tree streams continue unchanged
- New view-state stream starts on first extension activation without any manual setup

## Additional Notes

**Future Enhancements:**
- Additional shared view preferences can be added to `ViewState` (e.g., column widths, sort order) and broadcast through the same stream without requiring new infrastructure
- The generic `PushSubscription<T>` base class supports adding more daemon streams in the future

**Known Limitations:**
- View-state persists only in memory; daemon restart forgets the last value (by design, to honor ADR-0040/0048)
- Cross-window sync requires the daemon to be running; when daemon is down each window toggles independently (preserving pre-#1293 behavior)

**Alternatives Considered:**
- Broadcasting over the existing tree stream: rejected because it would wake the tree stream on every toggle and force git re-enumeration
- Persisting view-state to a daemon-adjacent file: rejected to honor the "daemon persists no state" ADR invariant and eliminate disk I/O on every toggle
- Polling vs. push subscription: push via dedicated stream chosen to avoid unnecessary reconnects and provide instant cross-window propagation