### PR TITLE
feat(vscode): open a worktree/repo's pull request(s) as a VS Code tab

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Open Pull Request…** ([#1299](https://github.com/rust-works/omni-dev/issues/1299)): a context-menu action on the **Worktrees** view opens a repo's or worktree's pull request(s) **as a tab inside VS Code**, never a browser.
   - On a **worktree** node it finds the PR(s) whose head branch is that worktree's checked-out branch; on a **repository** node it fans out to all the repo's open PRs. No PR shows a friendly info message, one PR opens directly, and several offer a multi-select quick-pick to open any or all at once.
   - PRs are discovered with the `gh` CLI (reusing its existing auth) and open through the **GitHub Pull Requests** extension's (`GitHub.vscode-pull-request-github`) documented URI handler. When that extension is not installed, a single warning offers **Install** or **Copy PR URL** — it never silently falls back to a browser.
-  - Only repos with a `github.com` origin get the action (the daemon reports `owner/name` for those); it requires the `gh` CLI on your PATH and the GitHub Pull Requests extension.
+  - Only repos with a `github.com` origin get the action (the daemon reports `owner/name` for those); it requires the `gh` CLI and the GitHub Pull Requests extension. `gh` is resolved from your `PATH`, the usual install locations (Homebrew, `~/.local/bin`, …), or the `OMNI_DEV_GH_BIN` override, so a GUI-launched editor with a minimal `PATH` still finds it.
 
 ## [0.3.0] - 2026-07-11
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Open Pull Request…** ([#1299](https://github.com/rust-works/omni-dev/issues/1299)): a context-menu action on the **Worktrees** view opens a repo's or worktree's pull request(s) **as a tab inside VS Code**, never a browser.
+  - On a **worktree** node it finds the PR(s) whose head branch is that worktree's checked-out branch; on a **repository** node it fans out to all the repo's open PRs. No PR shows a friendly info message, one PR opens directly, and several offer a multi-select quick-pick to open any or all at once.
+  - PRs are discovered with the `gh` CLI (reusing its existing auth) and open through the **GitHub Pull Requests** extension's (`GitHub.vscode-pull-request-github`) documented URI handler. When that extension is not installed, a single warning offers **Install** or **Copy PR URL** — it never silently falls back to a browser.
+  - Only repos with a `github.com` origin get the action (the daemon reports `owner/name` for those); it requires the `gh` CLI on your PATH and the GitHub Pull Requests extension.
+
 ## [0.3.0] - 2026-07-11
 
 ### Added

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -71,10 +71,13 @@ never silently falls back to a browser.
 - **macOS or Linux only** — like the daemon, the companion is Unix-only; on
   Windows there is no daemon socket to talk to (tracked in
   [#1237](https://github.com/rust-works/omni-dev/issues/1237)).
-- For **Open Pull Request…** only: the [`gh` CLI](https://cli.github.com/) on your
-  PATH and authenticated (`gh auth login`), and the [**GitHub Pull
+- For **Open Pull Request…** only: the [`gh` CLI](https://cli.github.com/)
+  installed and authenticated (`gh auth login`), and the [**GitHub Pull
   Requests**](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
   extension (`GitHub.vscode-pull-request-github`) to render the PR in a tab.
+  `gh` is found on your `PATH` or in the usual install locations (Homebrew,
+  `~/.local/bin`, …); if a GUI-launched editor inherits a minimal `PATH` and
+  can't find it, set `OMNI_DEV_GH_BIN` to its full path.
 
 ## Settings
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -46,12 +46,35 @@ window or open a worktree's folder. Two title-bar actions:
   worktrees. The setting is stored per-machine (`globalState`), so it reads the
   same in every window and survives a reload.
 
+Right-click a leaf or repo for context-menu actions: **Close Worktree** /
+**Close Window**, and — for a `github.com` repo — **Open Pull Request…**.
+
+### Open Pull Request…
+
+Right-click a repository or worktree with a `github.com` origin and choose **Open
+Pull Request…** to open its pull request(s) **as a tab inside VS Code** (never a
+browser):
+
+- a **worktree** node opens the PR(s) whose head branch matches its checked-out
+  branch; a **repository** node fans out to all the repo's open PRs;
+- **no PR** shows a friendly info message; **one** opens directly; **several**
+  offer a multi-select quick-pick so you can open any of them or all at once.
+
+PRs are discovered with the `gh` CLI (reusing its existing auth) and opened
+through the **GitHub Pull Requests** extension's URI handler. If that extension
+is not installed, a single warning offers **Install** or **Copy PR URL** — it
+never silently falls back to a browser.
+
 ## Requirements
 
 - The omni-dev daemon running locally (`omni-dev daemon start`).
 - **macOS or Linux only** — like the daemon, the companion is Unix-only; on
   Windows there is no daemon socket to talk to (tracked in
   [#1237](https://github.com/rust-works/omni-dev/issues/1237)).
+- For **Open Pull Request…** only: the [`gh` CLI](https://cli.github.com/) on your
+  PATH and authenticated (`gh auth login`), and the [**GitHub Pull
+  Requests**](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
+  extension (`GitHub.vscode-pull-request-github`) to render the PR in a tab.
 
 ## Settings
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -72,6 +72,12 @@
         "category": "omni-dev"
       },
       {
+        "command": "omniDevWorktrees.openPullRequest",
+        "title": "Open Pull Request…",
+        "category": "omni-dev",
+        "icon": "$(git-pull-request)"
+      },
+      {
         "command": "omniDevWorktrees.hideClosedWorktrees",
         "title": "Hide Worktrees Without a Window",
         "category": "omni-dev",
@@ -100,6 +106,10 @@
         },
         {
           "command": "omniDevWorktrees.closeWindow",
+          "when": "false"
+        },
+        {
+          "command": "omniDevWorktrees.openPullRequest",
           "when": "false"
         },
         {
@@ -133,6 +143,11 @@
           "command": "omniDevWorktrees.open",
           "when": "view == omniDevWorktrees.tree && viewItem =~ /worktree/",
           "group": "inline"
+        },
+        {
+          "command": "omniDevWorktrees.openPullRequest",
+          "when": "view == omniDevWorktrees.tree && viewItem =~ /github/",
+          "group": "1_pr@1"
         },
         {
           "command": "omniDevWorktrees.closeWindow",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -20,6 +20,7 @@ import {
   treeEnvelope,
   unregisterEnvelope,
 } from "./socket";
+import { openPullRequest } from "./prCommands";
 import { Node, TreeRepoPayload, isCurrentWindow, nodeId, worktreeLabel } from "./tree";
 import { TreeSubscription } from "./subscription";
 import { ITEM_CLICKED_COMMAND, WorktreesTreeDataProvider } from "./treeDataProvider";
@@ -215,6 +216,10 @@ function setupTreeView(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(
       "omniDevWorktrees.closeWindow",
       (node?: Node) => void closeWindow(node),
+    ),
+    vscode.commands.registerCommand(
+      "omniDevWorktrees.openPullRequest",
+      (node?: Node) => void openPullRequest(node),
     ),
     // The two halves of the one title-bar toggle: exactly one is contributed at a
     // time (gated on the context key), so clicking the visible button flips the

--- a/editors/vscode/src/gh.test.ts
+++ b/editors/vscode/src/gh.test.ts
@@ -1,0 +1,35 @@
+// Unit tests for the `gh` binary resolver. The runner itself (`runGh`) spawns a
+// real subprocess and is not unit-tested; the resolution logic is pure (env +
+// an injected existence predicate) and is what actually varies by machine.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveGhBin, wellKnownGhPaths } from "./gh";
+
+test("resolveGhBin: an OMNI_DEV_GH_BIN override wins over everything", () => {
+  // The override is used even when a well-known path also exists.
+  assert.equal(resolveGhBin({ OMNI_DEV_GH_BIN: "/custom/gh" }, () => true), "/custom/gh");
+});
+
+test("resolveGhBin: a blank override is ignored", () => {
+  assert.equal(resolveGhBin({ OMNI_DEV_GH_BIN: "   " }, () => false), "gh");
+});
+
+test("resolveGhBin: returns the first well-known path that exists", () => {
+  const second = wellKnownGhPaths()[1];
+  assert.equal(
+    resolveGhBin({}, (p) => p === second),
+    second,
+  );
+});
+
+test("resolveGhBin: falls back to bare `gh` (a PATH lookup) when none exist", () => {
+  assert.equal(resolveGhBin({}, () => false), "gh");
+});
+
+test("wellKnownGhPaths covers Homebrew (both arches) and a user-local install", () => {
+  const paths = wellKnownGhPaths("/home/tester");
+  assert.ok(paths.includes("/opt/homebrew/bin/gh"));
+  assert.ok(paths.includes("/usr/local/bin/gh"));
+  assert.ok(paths.includes("/home/tester/.local/bin/gh"));
+});

--- a/editors/vscode/src/gh.ts
+++ b/editors/vscode/src/gh.ts
@@ -3,9 +3,12 @@
 // Kept separate (and `vscode`-free) so `github.ts` stays a pure, unit-tested
 // module: everything with logic worth asserting lives there behind an injected
 // runner, and this file only does the one thing that must touch the OS — spawn
-// `gh` — and turn its two failure modes into actionable errors.
+// `gh` — and turn its failure modes into actionable errors.
 
 import { execFile } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
@@ -18,14 +21,64 @@ const execFileAsync = promisify(execFile);
 const MAX_BUFFER = 16 * 1024 * 1024;
 
 /**
+ * Well-known absolute locations of the `gh` binary, in probe order. A
+ * GUI-launched VS Code (Dock/Finder) — or one spawned by the daemon under a
+ * service manager — inherits a minimal `PATH` that omits Homebrew's and
+ * user-local `bin` dirs, so a plain `gh` PATH lookup fails even when gh is
+ * installed. Probing these first is the same tactic the daemon's VS Code
+ * launcher uses to find `code`. `home` is injectable for testing.
+ */
+export function wellKnownGhPaths(home: string = os.homedir()): string[] {
+  return [
+    "/opt/homebrew/bin/gh", // macOS, Apple Silicon Homebrew
+    "/usr/local/bin/gh", // macOS Intel Homebrew, common manual installs
+    "/home/linuxbrew/.linuxbrew/bin/gh", // Linux Homebrew
+    "/usr/bin/gh", // Linux distro packages
+    path.join(home, ".local", "bin", "gh"), // user-local installs
+  ];
+}
+
+/** Whether `p` exists and is executable — the well-known-path probe predicate. */
+function isExecutableFile(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the `gh` executable to run. An explicit `OMNI_DEV_GH_BIN` override
+ * wins; otherwise the first existing {@link wellKnownGhPaths} entry; else bare
+ * `gh` — a normal `PATH` lookup, which works when VS Code was launched from a
+ * shell with a full environment. `env`/`exists` are injectable for testing.
+ */
+export function resolveGhBin(
+  env: NodeJS.ProcessEnv = process.env,
+  exists: (p: string) => boolean = isExecutableFile,
+): string {
+  const override = env.OMNI_DEV_GH_BIN?.trim();
+  if (override) {
+    return override;
+  }
+  for (const candidate of wellKnownGhPaths()) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+  return "gh";
+}
+
+/**
  * Runs `gh <args>` and resolves with its stdout. Rejects with an actionable
  * error for the two things that go wrong in practice:
- *  - `gh` not on `PATH` (`ENOENT`) → tell the user to install it;
+ *  - `gh` not found (`ENOENT`) → tell the user to install it or point us at it;
  *  - a non-zero exit → surface `gh`'s own stderr (auth prompts, unknown repo, …).
  */
 export async function runGh(args: string[]): Promise<string> {
   try {
-    const { stdout } = await execFileAsync("gh", args, {
+    const { stdout } = await execFileAsync(resolveGhBin(), args, {
       maxBuffer: MAX_BUFFER,
       encoding: "utf8",
     });
@@ -40,8 +93,10 @@ function classifyGhError(err: unknown): Error {
   const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };
   if (e?.code === "ENOENT") {
     return new Error(
-      "the GitHub CLI (`gh`) was not found on your PATH. Install it from " +
-        "https://cli.github.com/ and run `gh auth login`.",
+      "the GitHub CLI (`gh`) was not found on your PATH or in the usual install " +
+        "locations. Install it from https://cli.github.com/ and run `gh auth login`, " +
+        "or set OMNI_DEV_GH_BIN to its full path (a GUI-launched editor can inherit a " +
+        "minimal PATH).",
     );
   }
   const stderr = e?.stderr ? String(e.stderr).trim() : "";

--- a/editors/vscode/src/gh.ts
+++ b/editors/vscode/src/gh.ts
@@ -1,0 +1,52 @@
+// The real `gh` subprocess runner behind `github.ts`'s injectable `GhRunner`.
+//
+// Kept separate (and `vscode`-free) so `github.ts` stays a pure, unit-tested
+// module: everything with logic worth asserting lives there behind an injected
+// runner, and this file only does the one thing that must touch the OS — spawn
+// `gh` — and turn its two failure modes into actionable errors.
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The stdout buffer cap for a `gh pr list` call. A repo's open-PR list (capped
+ * at `--limit 100`, a handful of JSON fields each) is far under this; the bound
+ * just guards against a pathological response rather than growing unboundedly.
+ */
+const MAX_BUFFER = 16 * 1024 * 1024;
+
+/**
+ * Runs `gh <args>` and resolves with its stdout. Rejects with an actionable
+ * error for the two things that go wrong in practice:
+ *  - `gh` not on `PATH` (`ENOENT`) → tell the user to install it;
+ *  - a non-zero exit → surface `gh`'s own stderr (auth prompts, unknown repo, …).
+ */
+export async function runGh(args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("gh", args, {
+      maxBuffer: MAX_BUFFER,
+      encoding: "utf8",
+    });
+    return stdout;
+  } catch (err) {
+    throw classifyGhError(err);
+  }
+}
+
+/** Turns an `execFile` rejection into a user-facing error. */
+function classifyGhError(err: unknown): Error {
+  const e = err as NodeJS.ErrnoException & { stderr?: string | Buffer };
+  if (e?.code === "ENOENT") {
+    return new Error(
+      "the GitHub CLI (`gh`) was not found on your PATH. Install it from " +
+        "https://cli.github.com/ and run `gh auth login`.",
+    );
+  }
+  const stderr = e?.stderr ? String(e.stderr).trim() : "";
+  if (stderr) {
+    return new Error(`\`gh\` failed: ${stderr}`);
+  }
+  return e instanceof Error ? e : new Error(String(err));
+}

--- a/editors/vscode/src/github.test.ts
+++ b/editors/vscode/src/github.test.ts
@@ -1,0 +1,148 @@
+// Unit tests for the pure PR-discovery module. Nothing here imports `vscode`,
+// so it runs under a plain Node process (`node --test out/`).
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  PR_JSON_FIELDS,
+  PR_LIST_LIMIT,
+  PullRequest,
+  discoverPullRequests,
+  parsePrList,
+  prListArgsForBranch,
+  prListArgsForRepo,
+  prOverviewUri,
+  prQuickPickDescription,
+  prQuickPickLabel,
+} from "./github";
+import { TreeGithubIdentity } from "./tree";
+
+const REPO: TreeGithubIdentity = { owner: "rust-works", name: "omni-dev" };
+
+const PR: PullRequest = {
+  number: 1299,
+  title: "Open a PR from the Worktrees view",
+  url: "https://github.com/rust-works/omni-dev/pull/1299",
+  headRefName: "issue-1299-open-pr-from-worktrees-view",
+  baseRefName: "main",
+  isDraft: false,
+  state: "OPEN",
+  author: { login: "newhoggy", name: "John Ky" },
+};
+
+test("prListArgsForRepo lists all open PRs of the repo", () => {
+  assert.deepEqual(prListArgsForRepo(REPO), [
+    "pr",
+    "list",
+    "--repo",
+    "rust-works/omni-dev",
+    "--state",
+    "open",
+    "--json",
+    PR_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ]);
+});
+
+test("prListArgsForBranch scopes to the head branch with --head", () => {
+  assert.deepEqual(prListArgsForBranch(REPO, "issue-1300"), [
+    "pr",
+    "list",
+    "--repo",
+    "rust-works/omni-dev",
+    "--head",
+    "issue-1300",
+    "--state",
+    "open",
+    "--json",
+    PR_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ]);
+});
+
+test("parsePrList tolerates empty stdout and an empty array", () => {
+  assert.deepEqual(parsePrList(""), []);
+  assert.deepEqual(parsePrList("   \n"), []);
+  assert.deepEqual(parsePrList("[]"), []);
+});
+
+test("parsePrList returns the parsed PRs for a valid array", () => {
+  const prs = parsePrList(JSON.stringify([PR]));
+  assert.equal(prs.length, 1);
+  assert.equal(prs[0].number, 1299);
+  assert.equal(prs[0].headRefName, "issue-1299-open-pr-from-worktrees-view");
+});
+
+test("parsePrList throws an actionable error on malformed or non-array output", () => {
+  assert.throws(() => parsePrList("not json at all"), /could not parse/);
+  assert.throws(() => parsePrList('{"number":1}'), /expected a JSON array/);
+});
+
+test("prOverviewUri builds the GitHub PR extension webview URI", () => {
+  assert.equal(
+    prOverviewUri("vscode", "rust-works", "omni-dev", 1299),
+    "vscode://github.vscode-pull-request-github/open-pull-request-webview?owner=rust-works&repo=omni-dev&pullRequestNumber=1299",
+  );
+  // The scheme is the running product's, so the handler is reached in forks too.
+  assert.match(
+    prOverviewUri("cursor", "rust-works", "omni-dev", 42),
+    /^cursor:\/\/github\.vscode-pull-request-github\/open-pull-request-webview\?/,
+  );
+});
+
+test("prQuickPickLabel is `#<number> <title>`", () => {
+  assert.equal(prQuickPickLabel(PR), "#1299 Open a PR from the Worktrees view");
+});
+
+test("prQuickPickDescription shows head→base, then draft and author when present", () => {
+  assert.equal(
+    prQuickPickDescription(PR),
+    "issue-1299-open-pr-from-worktrees-view → main · @newhoggy",
+  );
+  assert.equal(
+    prQuickPickDescription({ ...PR, isDraft: true }),
+    "issue-1299-open-pr-from-worktrees-view → main · draft · @newhoggy",
+  );
+  // No author login → just the branch pair.
+  assert.equal(prQuickPickDescription({ ...PR, author: undefined }), "issue-1299-open-pr-from-worktrees-view → main");
+});
+
+test("discoverPullRequests lists all PRs for a repo scope", async () => {
+  const calls: string[][] = [];
+  const runner = async (args: string[]) => {
+    calls.push(args);
+    return JSON.stringify([PR]);
+  };
+  const prs = await discoverPullRequests({ kind: "repo", repo: REPO }, runner);
+  assert.equal(prs.length, 1);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], prListArgsForRepo(REPO));
+});
+
+test("discoverPullRequests scopes a worktree to its --head branch", async () => {
+  const calls: string[][] = [];
+  const runner = async (args: string[]) => {
+    calls.push(args);
+    return "[]";
+  };
+  const prs = await discoverPullRequests(
+    { kind: "worktree", repo: REPO, branch: "issue-1300" },
+    runner,
+  );
+  assert.deepEqual(prs, []);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], prListArgsForBranch(REPO, "issue-1300"));
+});
+
+test("discoverPullRequests returns [] for a detached worktree without calling gh", async () => {
+  let called = false;
+  const runner = async (_args: string[]) => {
+    called = true;
+    return JSON.stringify([PR]);
+  };
+  const prs = await discoverPullRequests({ kind: "worktree", repo: REPO }, runner);
+  assert.deepEqual(prs, []);
+  assert.equal(called, false);
+});

--- a/editors/vscode/src/github.test.ts
+++ b/editors/vscode/src/github.test.ts
@@ -80,15 +80,17 @@ test("parsePrList throws an actionable error on malformed or non-array output", 
   assert.throws(() => parsePrList('{"number":1}'), /expected a JSON array/);
 });
 
-test("prOverviewUri builds the GitHub PR extension webview URI", () => {
+test("prOverviewUri builds the webview URI with the PR url as the `uri` param", () => {
+  // The handler wants a single `uri` param holding the full github.com PR URL,
+  // URL-encoded; owner/repo/number are parsed out of it by the extension.
   assert.equal(
-    prOverviewUri("vscode", "rust-works", "omni-dev", 1299),
-    "vscode://github.vscode-pull-request-github/open-pull-request-webview?owner=rust-works&repo=omni-dev&pullRequestNumber=1299",
+    prOverviewUri("vscode", "https://github.com/rust-works/omni-dev/pull/1299"),
+    "vscode://github.vscode-pull-request-github/open-pull-request-webview?uri=https%3A%2F%2Fgithub.com%2Frust-works%2Fomni-dev%2Fpull%2F1299",
   );
   // The scheme is the running product's, so the handler is reached in forks too.
   assert.match(
-    prOverviewUri("cursor", "rust-works", "omni-dev", 42),
-    /^cursor:\/\/github\.vscode-pull-request-github\/open-pull-request-webview\?/,
+    prOverviewUri("cursor", "https://github.com/o/r/pull/42"),
+    /^cursor:\/\/github\.vscode-pull-request-github\/open-pull-request-webview\?uri=/,
   );
 });
 

--- a/editors/vscode/src/github.ts
+++ b/editors/vscode/src/github.ts
@@ -1,0 +1,182 @@
+// Pull-request discovery, formatting, and URI building for the "Open Pull
+// Request…" action on the Worktrees view.
+//
+// Like `tree.ts`/`socket.ts`, this module is deliberately free of any `vscode`
+// import so it stays pure and unit-testable under `node --test`. The real `gh`
+// subprocess runner lives in `gh.ts`; the `vscode`-facing command glue that
+// drives the quick-picks lives in `prCommands.ts`. Everything with logic worth
+// asserting — the `gh` arg arrays, the defensive JSON parse, the quick-pick
+// labels, the URI, and the scope→discovery mapping — is here behind an injected
+// runner so it can be exercised without a real `gh` or a real editor.
+
+import { TreeGithubIdentity } from "./tree";
+
+/**
+ * One open pull request, as returned by `gh pr list --json …`. Only the fields
+ * this feature requests are modelled; `gh` guarantees their presence for the
+ * `--json` keys we pass, so they are non-optional except `author` (which `gh`
+ * can report as an object with a missing `login` for some actors).
+ */
+export interface PullRequest {
+  number: number;
+  title: string;
+  url: string;
+  headRefName: string;
+  baseRefName: string;
+  isDraft: boolean;
+  state: string;
+  author?: { login?: string; name?: string };
+}
+
+/** The `--json` fields requested from `gh pr list` — mirrors {@link PullRequest}. */
+export const PR_JSON_FIELDS = "number,title,url,headRefName,baseRefName,isDraft,state,author";
+
+/** The `gh pr list --limit` cap — high enough to list a repo's open PRs in one call. */
+export const PR_LIST_LIMIT = "100";
+
+/**
+ * A `gh` invocation: given an argv (no leading `gh`), resolve with its stdout,
+ * or reject with an actionable error. The real implementation is in `gh.ts`;
+ * tests inject a fake so discovery can be exercised without a subprocess.
+ */
+export type GhRunner = (args: string[]) => Promise<string>;
+
+/**
+ * What to look for. A **repo** scope lists every open PR of the repository; a
+ * **worktree** scope lists only the PR(s) whose head branch is the worktree's
+ * checked-out branch (and yields nothing for a detached/unborn worktree, whose
+ * `branch` is absent).
+ */
+export type PrScope =
+  | { kind: "repo"; repo: TreeGithubIdentity }
+  | { kind: "worktree"; repo: TreeGithubIdentity; branch?: string };
+
+/** The `owner/name` slug `gh --repo` expects. */
+function repoSlug(repo: TreeGithubIdentity): string {
+  return `${repo.owner}/${repo.name}`;
+}
+
+/** Builds the `gh pr list` argv for **all** of a repo's open PRs. */
+export function prListArgsForRepo(repo: TreeGithubIdentity): string[] {
+  return [
+    "pr",
+    "list",
+    "--repo",
+    repoSlug(repo),
+    "--state",
+    "open",
+    "--json",
+    PR_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ];
+}
+
+/** Builds the `gh pr list` argv for the open PR(s) whose head is `branch`. */
+export function prListArgsForBranch(repo: TreeGithubIdentity, branch: string): string[] {
+  return [
+    "pr",
+    "list",
+    "--repo",
+    repoSlug(repo),
+    "--head",
+    branch,
+    "--state",
+    "open",
+    "--json",
+    PR_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ];
+}
+
+/**
+ * Parses `gh pr list --json` stdout into a `PullRequest[]`, defensively: empty
+ * stdout (never emitted by `gh`, but cheap to tolerate) is an empty list, and
+ * anything that is not a JSON array is an actionable error rather than a thrown
+ * `SyntaxError` bubbling out of the extension host.
+ */
+export function parsePrList(stdout: string): PullRequest[] {
+  const trimmed = stdout.trim();
+  if (trimmed === "") {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("could not parse `gh pr list` output as JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("unexpected `gh pr list` output: expected a JSON array");
+  }
+  return parsed as PullRequest[];
+}
+
+/**
+ * Discovers the open PR(s) in scope, running `gh` through the injected runner.
+ * A worktree with no branch (detached/unborn) can have no head-matching PR, so
+ * it resolves to `[]` **without** invoking the runner at all.
+ */
+export async function discoverPullRequests(
+  scope: PrScope,
+  runner: GhRunner,
+): Promise<PullRequest[]> {
+  let args: string[];
+  if (scope.kind === "repo") {
+    args = prListArgsForRepo(scope.repo);
+  } else {
+    if (!scope.branch) {
+      return [];
+    }
+    args = prListArgsForBranch(scope.repo, scope.branch);
+  }
+  return parsePrList(await runner(args));
+}
+
+/** The quick-pick label for a PR: `#<number> <title>`. */
+export function prQuickPickLabel(pr: PullRequest): string {
+  return `#${pr.number} ${pr.title}`;
+}
+
+/**
+ * The muted quick-pick description for a PR: `<head> → <base>`, then `draft`
+ * and the author handle when present, joined by a middot.
+ */
+export function prQuickPickDescription(pr: PullRequest): string {
+  const parts = [`${pr.headRefName} → ${pr.baseRefName}`];
+  if (pr.isDraft) {
+    parts.push("draft");
+  }
+  if (pr.author?.login) {
+    parts.push(`@${pr.author.login}`);
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * Builds the URI that asks the **GitHub Pull Requests** extension
+ * (`GitHub.vscode-pull-request-github`) to open a PR's overview as a tab:
+ *
+ * ```
+ * <scheme>://github.vscode-pull-request-github/open-pull-request-webview?owner=…&repo=…&pullRequestNumber=…
+ * ```
+ *
+ * `scheme` is the running product's URI scheme (`vscode.env.uriScheme` —
+ * `vscode`, `vscode-insiders`, `cursor`, …) so the handler is reached in every
+ * VS Code-family editor. Siblings not used here: `open-pull-request-changes`
+ * (diff tab) and `checkout-pull-request`.
+ */
+export function prOverviewUri(
+  scheme: string,
+  owner: string,
+  name: string,
+  number: number,
+): string {
+  const query = new URLSearchParams({
+    owner,
+    repo: name,
+    pullRequestNumber: String(number),
+  }).toString();
+  return `${scheme}://github.vscode-pull-request-github/open-pull-request-webview?${query}`;
+}

--- a/editors/vscode/src/github.ts
+++ b/editors/vscode/src/github.ts
@@ -159,24 +159,21 @@ export function prQuickPickDescription(pr: PullRequest): string {
  * (`GitHub.vscode-pull-request-github`) to open a PR's overview as a tab:
  *
  * ```
- * <scheme>://github.vscode-pull-request-github/open-pull-request-webview?owner=…&repo=…&pullRequestNumber=…
+ * <scheme>://github.vscode-pull-request-github/open-pull-request-webview?uri=<pr web url>
  * ```
+ *
+ * The handler (verified against v0.156.0) takes a **single** `uri` query
+ * parameter holding the PR's full `github.com` web URL and matches it against
+ * `^https?://github.com/<owner>/<repo>/pull/<n>$` — so we pass the PR's `url`
+ * verbatim (exactly that shape, straight from `gh pr list --json url`) rather
+ * than separate owner/repo/number params, which this handler does not accept.
  *
  * `scheme` is the running product's URI scheme (`vscode.env.uriScheme` —
  * `vscode`, `vscode-insiders`, `cursor`, …) so the handler is reached in every
  * VS Code-family editor. Siblings not used here: `open-pull-request-changes`
  * (diff tab) and `checkout-pull-request`.
  */
-export function prOverviewUri(
-  scheme: string,
-  owner: string,
-  name: string,
-  number: number,
-): string {
-  const query = new URLSearchParams({
-    owner,
-    repo: name,
-    pullRequestNumber: String(number),
-  }).toString();
+export function prOverviewUri(scheme: string, prWebUrl: string): string {
+  const query = new URLSearchParams({ uri: prWebUrl }).toString();
   return `${scheme}://github.vscode-pull-request-github/open-pull-request-webview?${query}`;
 }

--- a/editors/vscode/src/prCommands.ts
+++ b/editors/vscode/src/prCommands.ts
@@ -1,0 +1,150 @@
+// The `vscode`-facing "Open Pull Request…" command. It is a thin adapter: the
+// discovery, `gh` arg building, parsing, URI building, and quick-pick formatting
+// all live in the `vscode`-free, unit-tested `github.ts`; this file only wires
+// those onto the editor — a progress notification, the empty/single/multi-select
+// branches, and opening each chosen PR as a tab through the GitHub Pull Requests
+// extension's URI handler.
+
+import * as vscode from "vscode";
+
+import { runGh } from "./gh";
+import {
+  PrScope,
+  PullRequest,
+  discoverPullRequests,
+  prOverviewUri,
+  prQuickPickDescription,
+  prQuickPickLabel,
+} from "./github";
+import { Node } from "./tree";
+
+/** The extension that renders a GitHub PR as a tab; without it the URI no-ops. */
+const PR_EXTENSION_ID = "GitHub.vscode-pull-request-github";
+
+/**
+ * Opens the pull request(s) for a repo or worktree node **as a tab inside VS
+ * Code** (never a browser). Discovers via `gh` under a progress notification,
+ * then: no PR → a friendly info message; one PR → open it; several → a
+ * multi-select quick-pick to open any or all. A node with no GitHub identity is
+ * ignored (the menu is gated so it can only ever fire on a `github` item).
+ */
+export async function openPullRequest(node?: Node): Promise<void> {
+  if (!node) {
+    return;
+  }
+  const scope = prScopeForNode(node);
+  if (!scope) {
+    return;
+  }
+
+  let prs: PullRequest[];
+  try {
+    prs = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Finding pull requests for ${scopeLabel(scope)}…`,
+      },
+      () => discoverPullRequests(scope, runGh),
+    );
+  } catch (err) {
+    void vscode.window.showErrorMessage(
+      `omni-dev: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  if (prs.length === 0) {
+    void vscode.window.showInformationMessage(
+      `No open pull request for ${scopeLabel(scope)}.`,
+    );
+    return;
+  }
+
+  const selected = prs.length === 1 ? prs : await pickPullRequests(prs, scope);
+  if (!selected || selected.length === 0) {
+    return;
+  }
+
+  // The GitHub PR extension is what turns the URI into a tab; without it the
+  // `openExternal` call silently no-ops, so warn once (never fall back to a
+  // browser) before opening any of the selected PRs.
+  if (!isPrExtensionInstalled()) {
+    await warnMissingPrExtension(selected);
+    return;
+  }
+
+  for (const pr of selected) {
+    const uri = vscode.Uri.parse(
+      prOverviewUri(vscode.env.uriScheme, scope.repo.owner, scope.repo.name, pr.number),
+    );
+    await vscode.env.openExternal(uri);
+  }
+}
+
+/** The scope to search for a node, or `undefined` when it has no GitHub identity. */
+function prScopeForNode(node: Node): PrScope | undefined {
+  const github = node.repo.github;
+  if (!github) {
+    return undefined;
+  }
+  if (node.kind === "repo") {
+    return { kind: "repo", repo: github };
+  }
+  return { kind: "worktree", repo: github, branch: node.wt.branch };
+}
+
+/** A human label for the scope, used in progress and info messages. */
+function scopeLabel(scope: PrScope): string {
+  const repo = `${scope.repo.owner}/${scope.repo.name}`;
+  return scope.kind === "worktree" && scope.branch ? `${repo}@${scope.branch}` : repo;
+}
+
+/** A multi-select quick-pick over the PRs; returns the chosen ones (or `undefined`). */
+async function pickPullRequests(
+  prs: PullRequest[],
+  scope: PrScope,
+): Promise<PullRequest[] | undefined> {
+  const items = prs.map((pr) => ({
+    label: prQuickPickLabel(pr),
+    description: prQuickPickDescription(pr),
+    pr,
+  }));
+  const picks = await vscode.window.showQuickPick(items, {
+    canPickMany: true,
+    placeHolder: `Select pull request(s) to open for ${scopeLabel(scope)}`,
+  });
+  return picks?.map((p) => p.pr);
+}
+
+/** Whether the GitHub Pull Requests extension is installed in this editor. */
+function isPrExtensionInstalled(): boolean {
+  return vscode.extensions.getExtension(PR_EXTENSION_ID) !== undefined;
+}
+
+/**
+ * Warns once that the GitHub Pull Requests extension is required, offering to
+ * **Install** it or **Copy PR URL** — the latter puts the selected PR URL(s) on
+ * the clipboard so the user can open them however they like. We never silently
+ * fall back to a browser.
+ */
+async function warnMissingPrExtension(prs: PullRequest[]): Promise<void> {
+  const choice = await vscode.window.showWarningMessage(
+    "The GitHub Pull Requests extension (GitHub.vscode-pull-request-github) is required " +
+      "to open a pull request inside VS Code. Install it, or copy the PR URL.",
+    "Install",
+    "Copy PR URL",
+  );
+  if (choice === "Install") {
+    await vscode.commands.executeCommand(
+      "workbench.extensions.installExtension",
+      PR_EXTENSION_ID,
+    );
+  } else if (choice === "Copy PR URL") {
+    await vscode.env.clipboard.writeText(prs.map((pr) => pr.url).join("\n"));
+    void vscode.window.showInformationMessage(
+      prs.length === 1
+        ? "PR URL copied to the clipboard."
+        : `${prs.length} PR URLs copied to the clipboard.`,
+    );
+  }
+}

--- a/editors/vscode/src/prCommands.ts
+++ b/editors/vscode/src/prCommands.ts
@@ -74,9 +74,7 @@ export async function openPullRequest(node?: Node): Promise<void> {
   }
 
   for (const pr of selected) {
-    const uri = vscode.Uri.parse(
-      prOverviewUri(vscode.env.uriScheme, scope.repo.owner, scope.repo.name, pr.number),
-    );
+    const uri = vscode.Uri.parse(prOverviewUri(vscode.env.uriScheme, pr.url));
     await vscode.env.openExternal(uri);
   }
 }

--- a/editors/vscode/src/tree.test.ts
+++ b/editors/vscode/src/tree.test.ts
@@ -145,6 +145,34 @@ test("worktreeContextValue encodes open state and structural role under a shared
   assert.equal(worktreeContextValue(closedMain), "worktree.main");
 });
 
+test("worktreeContextValue appends `.github` only when the parent repo is on GitHub", () => {
+  // hasGithub defaults to false → the existing values are byte-for-byte unchanged.
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[0], "w1", false), "worktree.current.main");
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[1], "w1", false), "worktree.linked");
+
+  // hasGithub true → a trailing `.github` segment on top of the existing value.
+  assert.equal(
+    worktreeContextValue(REPOS[0].worktrees[0], "w1", true),
+    "worktree.current.main.github",
+  );
+  assert.equal(
+    worktreeContextValue(REPOS[0].worktrees[0], "w2", true),
+    "worktree.open.main.github",
+  );
+  assert.equal(worktreeContextValue(REPOS[0].worktrees[1], "w1", true), "worktree.linked.github");
+
+  const closedMain = { path: "/repo", is_main: true, open: false };
+  assert.equal(worktreeContextValue(closedMain, undefined, true), "worktree.main.github");
+
+  // The `.github` suffix leaves the (unanchored) close-menu regexes matching: a
+  // main tree with a window still matches Close Window, a linked one Close Worktree.
+  assert.match(worktreeContextValue(REPOS[0].worktrees[0], "w1", true), /worktree\.(current|open)\.main/);
+  assert.match(worktreeContextValue(REPOS[0].worktrees[1], "w1", true), /worktree\..*linked/);
+  // …and both GitHub variants match the new Open-PR menu's `/github/` gate.
+  assert.match(worktreeContextValue(REPOS[0].worktrees[0], "w1", true), /github/);
+  assert.match(worktreeContextValue(REPOS[0].worktrees[1], "w1", true), /github/);
+});
+
 test("nodeId is stable and distinguishes repos from worktrees", () => {
   assert.equal(nodeId({ kind: "repo", repo: REPOS[0] }), "repo:/home/me/omni-dev");
   assert.equal(

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -142,26 +142,38 @@ export function worktreeTooltip(
 
 /**
  * The `contextValue` used to gate context-menu items and mark the open badge.
- * Encodes two orthogonal facts as dotted segments:
+ * Encodes three orthogonal facts as dotted segments:
  *
  *  - **open state** — `worktree.current` (this window), `worktree.open`
  *    (another window), or bare `worktree` (no window);
- *  - **structural role** — a trailing `.main` (the repository's main working
- *    tree) or `.linked` (a linked worktree), which the daemon reports as
- *    `is_main` and which decides deletability (never the branch name).
+ *  - **structural role** — a `.main` (the repository's main working tree) or
+ *    `.linked` (a linked worktree), which the daemon reports as `is_main` and
+ *    which decides deletability (never the branch name);
+ *  - **GitHub identity** — a trailing `.github` when the parent repo has a
+ *    `github.com` origin (so the "Open Pull Request…" menu can gate on it),
+ *    appended only when `hasGithub` is set.
  *
  * So every value starts with `worktree` — the existing `viewItem =~ /worktree/`
- * "open" menu still matches all six variants — while the close menus gate on the
+ * "open" menu still matches all variants — while the close menus gate on the
  * role: **Close Window** on `/worktree\.(current|open)\.main/` (a main tree with
  * a window) and **Close Worktree** on `/worktree\..*linked/` (any linked
  * worktree). A main tree with no window matches neither, so nothing is offered.
+ * The trailing `.github` is appended last so those (unanchored) role regexes are
+ * unaffected, and `hasGithub` defaults to `false` so a non-GitHub repo's values
+ * stay byte-for-byte as before.
  */
-export function worktreeContextValue(wt: TreeWorktreePayload, windowKey?: string): string {
+export function worktreeContextValue(
+  wt: TreeWorktreePayload,
+  windowKey?: string,
+  hasGithub = false,
+): string {
   const role = wt.is_main ? "main" : "linked";
-  if (isCurrentWindow(wt, windowKey)) {
-    return `worktree.current.${role}`;
-  }
-  return wt.open ? `worktree.open.${role}` : `worktree.${role}`;
+  const base = isCurrentWindow(wt, windowKey)
+    ? `worktree.current.${role}`
+    : wt.open
+      ? `worktree.open.${role}`
+      : `worktree.${role}`;
+  return hasGithub ? `${base}.github` : base;
 }
 
 /**

--- a/editors/vscode/src/treeDataProvider.ts
+++ b/editors/vscode/src/treeDataProvider.ts
@@ -70,7 +70,9 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
       );
       item.id = nodeId(node);
       item.iconPath = new vscode.ThemeIcon(node.repo.github ? "github" : "repo");
-      item.contextValue = "repo";
+      // `.github` gates the "Open Pull Request…" menu; the plain `repo` value is
+      // unchanged for non-GitHub repos.
+      item.contextValue = node.repo.github ? "repo.github" : "repo";
       item.tooltip = node.repo.root;
       return item;
     }
@@ -82,7 +84,7 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
     item.id = nodeId(node);
     item.description = worktreeDescription(node.wt);
     item.tooltip = worktreeTooltip(node.wt, node.repo, this.windowKey);
-    item.contextValue = worktreeContextValue(node.wt, this.windowKey);
+    item.contextValue = worktreeContextValue(node.wt, this.windowKey, !!node.repo.github);
     // The open badge, three-way: a blue tick for the worktree open in *this*
     // window, a green dot for one open in another window, else the plain branch
     // glyph for a worktree with no live window.


### PR DESCRIPTION
## Description

Adds an **Open Pull Request…** context-menu action to the companion VS Code
extension's **Worktrees** view, on both repository and worktree nodes, so you can
jump from a tree node to its GitHub pull request(s) **without leaving the
editor** — the PR opens **as a tab inside VS Code, not in a browser**.

- **Worktree node** → the PR(s) whose head branch matches that worktree's
  checked-out branch.
- **Repository node** → any of the repo's open PRs.
- **No PR** → a friendly info message; **one PR** → opens directly; **several** →
  a multi-select quick-pick to open any of them or all at once.

PRs are discovered by shelling out to the `gh` CLI (reusing its existing auth)
and opened through the **GitHub Pull Requests** extension
(`GitHub.vscode-pull-request-github`) via its `open-pull-request-webview` URI
handler. When that extension is not installed, a single warning offers
**Install** or **Copy PR URL** — it never silently falls back to a browser.

**Scope:** extension-only. No daemon/Rust change, no new socket op, no change to
the daemon trust boundary — the daemon's existing `tree` payload already carries
`repo.github = {owner, name}` (github.com origins only) and per-worktree
`wt.branch`. Because this touches no Rust CLI surface, the `insta` /
`update-snapshots` rule does not apply.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Fixes #1299

## Changes Made

**New source** (the existing pure-module + thin-`vscode`-adapter split):
- `editors/vscode/src/github.ts` (`vscode`-free, unit-tested): the `PullRequest`
  shape; `prListArgsForRepo` / `prListArgsForBranch` `gh` arg builders; a
  defensive `parsePrList`; quick-pick label/description formatters; the
  `open-pull-request-webview` URI builder (`prOverviewUri(scheme, prWebUrl)`);
  and `discoverPullRequests(scope, runner)` over an injected `gh` runner (a
  detached worktree returns `[]` without shelling out).
- `editors/vscode/src/gh.ts` (`vscode`-free): the real runner via
  `execFile(resolveGhBin(), args)` (argv array, no shell). `resolveGhBin`
  resolves `gh` robustly — an `OMNI_DEV_GH_BIN` override → the first existing
  well-known absolute path (Homebrew both arches, linuxbrew, distro,
  `~/.local/bin`) → bare `gh` (a PATH lookup) — so a GUI-launched editor with a
  minimal PATH still finds it. `ENOENT` and non-zero exits (gh's stderr) become
  actionable errors.
- `editors/vscode/src/prCommands.ts` (`vscode`-facing, thin): `openPullRequest` —
  discovery under `withProgress`, the empty / single / multi-select branches, the
  missing-extension Install / Copy-PR-URL warning, and opening each selected PR
  via `prOverviewUri` + `vscode.env.openExternal`.

**Wiring:**
- `editors/vscode/src/tree.ts` — `worktreeContextValue` gains a
  `hasGithub = false` param that appends a trailing `.github` segment; the
  default keeps non-GitHub `contextValue`s byte-for-byte unchanged and the suffix
  is appended last so the unanchored close-menu regexes still match.
- `editors/vscode/src/treeDataProvider.ts` — passes `!!node.repo.github` into
  `worktreeContextValue`, and sets the repo item's `contextValue` to
  `repo.github` (vs plain `repo`).
- `editors/vscode/src/extension.ts` — registers the
  `omniDevWorktrees.openPullRequest` command.
- `editors/vscode/package.json` — contributes the command (hidden from the
  palette) and a `view/item/context` entry gated on `viewItem =~ /github/` in a
  new `1_pr@1` group above the close menus (matches both `repo.github` and the
  `.github` worktree variants).

**Documentation:**
- `editors/vscode/README.md` — a new **Open Pull Request…** section plus the
  `gh` CLI + GitHub Pull Requests extension requirements (incl. the
  `OMNI_DEV_GH_BIN` override).
- `editors/vscode/CHANGELOG.md` — an `### Added` entry under `[Unreleased]`.

**Testing:**
- `editors/vscode/src/github.test.ts` (new, `node --test`) — arg builders,
  `parsePrList` (empty / `[]` / malformed), the URI builder, the quick-pick
  formatters, and `discoverPullRequests` with a fake runner (repo = all,
  worktree = `--head`, detached = empty with no runner call).
- `editors/vscode/src/gh.test.ts` (new, `node --test`) — `resolveGhBin` (override
  wins / blank override ignored / first existing well-known path / bare-`gh`
  fallback) and `wellKnownGhPaths`.
- `editors/vscode/src/tree.test.ts` — added `.github`-variant cases for
  `worktreeContextValue` (existing assertions stay valid via the `false` default).

## Fixes applied during verification

Two issues surfaced while running the extension against a real editor and were
fixed on this branch:

1. **`gh` not found on a GUI-launched editor** (`ad92f34b`) — a VS Code launched
   from the Dock/Finder inherits a minimal `PATH` that omits Homebrew's `bin`, so
   `execFile("gh", …)` failed even though `gh` was installed. Resolved by probing
   well-known install locations (and an `OMNI_DEV_GH_BIN` override), mirroring the
   daemon's `code`-launcher tactic.
2. **Wrong PR webview URI format** (`61df57cb`) — the `?owner=&repo=&pullRequestNumber=`
   form the issue proposed is **not** accepted by the installed
   `GitHub.vscode-pull-request-github` (verified against v0.156.0), which raised
   "Invalid pull request URI". Its handler takes a single `uri` query parameter
   holding the PR's full github.com web URL (matched against
   `^https?://github.com/<owner>/<repo>/pull/<n>$`). Now passes the PR's `url`
   (straight from `gh pr list --json url`) as `?uri=<encoded pr url>`.

## Testing

**Automated Testing:**
- [x] Typecheck passes (`npm run typecheck`)
- [x] All unit tests pass (`npm test` — 40 tests across `github.test.ts`,
      `gh.test.ts`, `tree.test.ts`, `socket.test.ts`, `subscription.test.ts`)
- [x] Bundle builds (`npm run build` → `dist/extension.js`)

**Manual Testing:**
- [x] Packaged (`vsce package`) and installed into VS Code 1.128.0 with the
      omni-dev daemon running, `gh` authenticated, and
      `GitHub.vscode-pull-request-github` (v0.156.0) installed.
- [x] Confirmed a PR opens **as a webview tab inside VS Code** (not a browser)
      via the extension's `open-pull-request-webview` handler with the corrected
      `?uri=` deep link.

### Test Commands
```bash
cd editors/vscode
npm ci
npm run typecheck   # tsc --noEmit
npm test            # tsc → out/, then node --test out/
npm run build       # esbuild → dist/extension.js
```

## Review Focus Areas

**Please pay special attention to:**
- [ ] `contextValue` gating — the trailing `.github` must not break the existing
      Close Window / Close Worktree regexes (covered by new `tree.test.ts` cases).
- [ ] `gh` resolution in `gh.ts` (`resolveGhBin`) — override → well-known paths →
      bare `gh`; `execFile` with an argv array (no shell); `ENOENT` / stderr
      surfaced as actionable errors.
- [ ] The PR webview URI (`prOverviewUri`) — single `uri` param carrying the PR's
      github.com URL, URL-encoded, as the installed extension's handler requires.
- [ ] The missing-PR-extension path warns and never falls back to a browser.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`tsc` strict, `noUnusedLocals` clean)
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact
- [x] No performance impact — one `gh pr list` subprocess per invocation of the
  action (user-initiated, run under a progress notification); no work on the hot
  path of the tree view or heartbeat.

## Security Considerations
- [x] No security implications, and no new trust boundary (extension-only).
  - `gh` is invoked via `execFile` with an argv array (no shell interpolation),
    reusing the user's existing `gh` auth; the extension stores no tokens.
  - PRs open via `vscode.env.openExternal` on a `vscode://…` URI handled by the
    GitHub Pull Requests extension — no browser, no credential handling here.
  - The daemon, its socket, and its `tree` payload are unchanged.

## Breaking Changes
None. Purely additive: the action only appears on `github.com` repos, and
`worktreeContextValue`'s new parameter defaults to `false`, so existing tree
`contextValue`s (and the Close menus that gate on them) are unchanged.

## Additional Notes

**Requirements (for the action only):** the `gh` CLI installed and authenticated
(`gh auth login`) — found on `PATH`, in the usual install locations, or via the
`OMNI_DEV_GH_BIN` override — and the GitHub Pull Requests extension
(`GitHub.vscode-pull-request-github`) to render the PR in a tab.

**Future enhancements (deferred):** an optional self-contained read-only markdown
PR tab built from `gh pr view --json`, to make the feature work even without the
GitHub Pull Requests extension. The lightweight Install / Copy-PR-URL warning is
implemented; the deeper markdown-tab fallback is left as a follow-up.

**Alternatives considered and rejected** (per #1299): a custom webview PR viewer
(re-implements a PR viewer, heavier to maintain); VS Code Simple Browser
(unreliable — GitHub sends `X-Frame-Options: deny`); opening the PR in an external
browser (explicitly not wanted).
