### PR TITLE
feat(vscode): implement GitHub PR badges on worktree rows

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -73,3 +73,4 @@ by Michael Nygard.
 | [ADR-0047](adr-0047.md)  | ✅ Accepted                              | 2026-07-07 | Remote-First Default Base-Branch Resolution That Fails Closed                               |
 | [ADR-0048](adr-0048.md)  | ✅ Accepted                              | 2026-07-10 | Repo/Worktree Tree View Fed by a Daemon Push Subscription                                   |
 | [ADR-0049](adr-0049.md)  | ✅ Accepted                              | 2026-07-10 | Destructive Worktree Close over the Daemon, Guarded by Structural `is_main`                 |
+| [ADR-0050](adr-0050.md)  | ✅ Accepted                              | 2026-07-13 | Worktree PR Badges Resolved Extension-Side via `gh`, Not the Daemon                         |

--- a/docs/adrs/adr-0050.md
+++ b/docs/adrs/adr-0050.md
@@ -1,0 +1,130 @@
+# ADR-0050: Worktree PR Badges Resolved Extension-Side via `gh`, Not the Daemon
+
+## Status
+
+✅ Accepted (2026-07-13)
+
+## Context
+
+[ADR-0040](adr-0040.md) introduced the `worktrees` daemon service and
+[ADR-0048](adr-0048.md) grew it into a live repo/worktree tree view fed by a push
+subscription. Each worktree row already shows its branch and — fetched lazily on
+repo-expand (#1306) — its `↑ahead ↓behind` sync counts. The natural next fact to
+surface is the worktree's **GitHub pull request**: whether the branch has an open
+PR, and its state, so a PR can be seen (and opened) without leaving the editor
+(#1296).
+
+The tree already carries everything a PR lookup needs: the `tree` payload's
+per-repo `github: {owner, name}` identity (parsed from the `origin` remote) and
+each worktree's `branch`. A prior increment (#1299) had already added a `gh`-based
+**"Open Pull Request…"** context action to this view — a pure discovery module
+(`github.ts`) behind an injected `gh` runner (`gh.ts`), handing the PR off to the
+GitHub Pull Requests extension as a tab. So a `gh`-based PR path already existed;
+what was missing was surfacing PR *state* on the node itself.
+
+Three facts shaped the decision:
+
+1. **Where the fetch lives is a trust-boundary choice.** Resolving PRs
+   **daemon-side** would let one process cache lookups across every window — but it
+   would introduce a **GitHub token into the daemon**, directly at odds with the
+   worktrees service's load-bearing *"persists nothing / no secret"* posture
+   ([ADR-0040](adr-0040.md)): the whole design turns on the daemon holding no
+   credential and the `0600` socket exposing only local, same-owner-derivable
+   paths. Resolving **extension-side** keeps the credential out of the daemon
+   entirely.
+2. **Two auth mechanisms were available; the codebase already committed to one.**
+   The VS Code `authentication.getSession('github', ['repo'])` API would give an
+   OAuth token with no `gh` dependency, but it is a **second, parallel** PR
+   mechanism next to #1299's `gh` path — a hand-built REST/GraphQL client, its own
+   error handling and a sign-in prompt, and a token surface in the extension host.
+   The `gh` CLI is already installed-and-authed by the target user, already used by
+   the sibling action, hits the **same** 5,000-req/hr authenticated rate limit, and
+   already solves the GUI-minimal-`PATH` problem (`resolveGhBin`).
+3. **CI check state comes free from the same call.** `statusCheckRollup` is a valid
+   `gh pr list --json` field, so the checks glyph needs **one extra field on the
+   one call already made per repo** — not a per-PR `gh pr checks` invocation.
+
+The ADR-0040/0048 constraints still bind: reuse the transport and trust model
+unchanged, add no persisted secret or state, keep the streamed `tree` snapshot
+cheap (per #1306, per-worktree extras are lazy, not on every tick), and stay
+best-effort — GitHub enrichment is never load-bearing.
+
+## Decision
+
+Resolve and render the PR badge **entirely in the companion extension**, reusing
+the #1299 `gh` path, with **no daemon, protocol, or wire change**.
+
+### 1. Extension-side `gh`, one batched call per repo-expand
+
+On expanding a GitHub repo, the extension runs a single
+`gh pr list --repo <owner>/<name> --state open --json …,statusCheckRollup
+--limit 100` (a badge-specific field set, kept separate from the "Open Pull
+Request…" action's leaner one so the quick-pick does not pay for the verbose
+rollup). It matches each PR to a worktree by **head branch** (first match, per the
+issue), mirroring the lazy fetch-on-expand pattern the `ahead-behind` op already
+established — so only the repos actually looked at pay a `gh` call, and the daemon
+snapshot stays untouched. The daemon's `github {owner,name}` (already on the wire)
+is the only input; **no PR data ever flows over the socket.**
+
+### 2. A per-repo TTL cache folded into the existing cadence
+
+The push subscription re-renders expanded repos on every snapshot, so the fetch is
+guarded by a **~60 s per-`owner/name` cache**. A `gh` failure — missing binary,
+not authenticated, unknown repo — is **cached as an empty result** for the TTL and
+logged once, so a missing `gh` is not re-spawned on every snapshot. No new poll
+loop is added; PR refresh rides the same expand/subscription cadence as
+`↑ahead ↓behind`.
+
+### 3. Pure model + formatters, thin adapter
+
+The badge is a small `PrBadge { number, isDraft, checks, url }` folded onto the
+worktree node by `withPr` — the PR counterpart of `withAheadBehind` — so the
+`vscode`-free, unit-tested `tree.ts` owns all formatting: `worktreePrBadge`
+(`#65`, `#65 draft`, `#65 ✗`), its composition into the row `description` after the
+sync counts, and a tooltip PR line. The `statusCheckRollup` array (a mix of
+`CheckRun` and legacy `StatusContext` entries) is reduced to one
+`success | failure | pending | none` verdict by a pure `rollupCheckState`: any
+failing check dominates, else any still-running one, else success; skipped/neutral
+count as passing. The provider stays a thin adapter that folds the fetched badges
+in and reads `item.description`/`tooltip` unchanged.
+
+### 4. Best-effort and opt-out; the open action is unchanged
+
+A worktree with no branch, no matching PR, or on a non-GitHub repo renders exactly
+as before — no error, no noise. The `omniDevWorktrees.showPullRequests` setting
+(default on) gates the badge and its `gh` lookups entirely. Opening a PR remains
+the existing `.github`-gated "Open Pull Request…" action; the badge only surfaces
+the state, it does not overload the row click.
+
+## Consequences
+
+- **The daemon's no-secret posture is preserved exactly.** Because resolution is
+  extension-side, no GitHub token enters the daemon, the `0600` socket carries no
+  PR data, and the `tree`/`subscribe` wire contract is byte-for-byte unchanged.
+  The credential stays inside `gh`, where the user already put it. This is the
+  central reason daemon-side resolution was rejected.
+- **`gh`, not a second auth mechanism.** Reusing the #1299 `gh` path means one PR
+  mechanism, not two: no `vscode.authentication` token surface, no hand-built REST
+  client, and the checks glyph is a single extra `--json` field. The cost is a hard
+  dependency on `gh` being installed and authenticated; without it the feature
+  degrades silently (badges omitted) and the explicit action still reports the real
+  error.
+- **Best-effort and cheap.** PR state is never load-bearing — the tree renders
+  fully without it. The per-repo lazy fetch + ~60 s cache bounds `gh` spawns to
+  roughly one per expanded repo per minute; the `statusCheckRollup` verbosity noted
+  upstream only bites at extreme PR counts, far above the `--limit 100` open-PR cap.
+- **No wire, protocol, or CLI change.** The work is confined to
+  [`editors/vscode/`](../../editors/vscode/) — pure logic in `tree.ts`/`github.ts`
+  under `node --test`, thin wiring in `treeDataProvider.ts`/`extension.ts`, and one
+  `package.json` setting. No Rust, no daemon op, and so no `insta` snapshot churn.
+- **GitHub-only, view-only.** Non-GitHub forges and PR creation/review/merge stay
+  out of scope (the latter defers to the GitHub Pull Requests extension), matching
+  ADR-0048's "GitHub enrichment is best-effort and never load-bearing".
+- **Still Unix-only** on the daemon side, though the badge itself is pure
+  extension code and platform-independent.
+
+This supersedes nothing: it extends [ADR-0040](adr-0040.md) and
+[ADR-0048](adr-0048.md) in place, and is consistent with
+[ADR-0003](adr-0003.md)'s "shell out to `gh`/`git` for GitHub operations". See
+[docs/worktrees-service.md](../worktrees-service.md) for the operator guide and the
+companion's PR behavior.

--- a/docs/worktrees-service.md
+++ b/docs/worktrees-service.md
@@ -189,9 +189,9 @@ every window (no per-window curation). It renders the `tree` payload:
 
 ```
 ▸ omni-dev            (github: rust-works/omni-dev)
-    ● main            ↑2 ↓0        ← window open (badge), main working tree
-      issue-1300      ↑1 ↓3        ← linked worktree, no window open
-    ● issue-1250      ↑0 ↓0
+    ● main            ↑2 ↓0                 ← window open (badge), main working tree
+      issue-1300      ↑1 ↓3  #1300 ✗        ← linked worktree; open PR, checks failing
+    ● issue-1250      ↑0 ↓0  #1250 draft ●  ← draft PR, checks running
 ▸ some-other-repo
       main
 ```
@@ -240,6 +240,37 @@ every window (no per-window curation). It renders the `tree` payload:
 
 The tree view runs **alongside** the reporter lifecycle (register/heartbeat/
 unregister): every window is both a reporter and, if it has the view open, a reader.
+
+### Pull requests
+
+For a worktree on a **GitHub** repo whose branch has an **open pull request**, the
+row shows a muted PR badge after the sync counts — `#<number>`, a `draft` marker
+for drafts, and a CI-checks glyph (`✓` passing, `✗` failing, `●` still running;
+nothing when a PR has no checks). The badge appears on **every** worktree in the
+view — the one open in this window and those open in others (and closed worktrees
+when shown) — and the hover tooltip adds a `PR #<n> · open/draft · checks …` line.
+
+A right-click **"Open Pull Request…"** action on any GitHub worktree (or repo)
+opens its PR **as a tab inside the editor** — never a browser. It discovers the
+PR(s) via `gh` (a quick-pick when several match) and hands off to the **GitHub
+Pull Requests** extension (`GitHub.vscode-pull-request-github`); if that extension
+is absent it offers to install it or copy the PR URL.
+
+- **Resolved extension-side via `gh`, not the daemon.** Like `↑ahead ↓behind`, PR
+  state is **not** on the `tree` wire payload. The extension resolves it lazily
+  **on repo-expand** with one `gh pr list --state open --json …,statusCheckRollup`
+  per repo, matches each PR to a worktree by head branch, and caches the result
+  per repo for ~60 s so a re-render never re-spawns `gh`. This keeps the daemon's
+  **"persists nothing / no secret"** posture intact
+  ([ADR-0040](adrs/adr-0040.md), [ADR-0050](adrs/adr-0050.md)): the GitHub
+  credential lives inside `gh`, the daemon never sees a token, and the wire
+  contract is unchanged. It needs `gh` installed and `gh auth login`.
+- **Best-effort, silent.** A worktree with no branch, no matching PR, or on a
+  non-GitHub repo shows nothing extra. If `gh` is absent or not authenticated,
+  badges are simply omitted — no error dialog (the explicit "Open Pull Request…"
+  action still surfaces the real `gh` error).
+- **Opt-out.** The `omniDevWorktrees.showPullRequests` setting (default on) gates
+  the badge and its `gh` lookups entirely.
 
 ## Status
 
@@ -593,4 +624,11 @@ classic one-reply exchange. See [ADR-0048](adrs/adr-0048.md) for the design.
   instantly. A polling fallback and a filesystem watcher were both considered and
   deferred.
 - The tree view is **view + focus only**; worktree *management* actions
-  (add/remove/prune) are out of scope for this iteration.
+  (add/remove/prune) are out of scope for this iteration (except the destructive
+  **close** in [ADR-0049](adrs/adr-0049.md)).
+- **PR badges are `gh`-based and GitHub-only (#1296):** the tree resolves open PRs
+  via the GitHub CLI on repo-expand ([ADR-0050](adrs/adr-0050.md)). Other forges
+  (GitLab/Bitbucket) and PR *creation/review/merge* are out of scope — the latter
+  defers to the GitHub Pull Requests extension. A daemon-side, cross-window PR
+  cache was considered and rejected: it would put a GitHub token in the daemon,
+  breaking its no-secret posture.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -174,6 +174,11 @@
           "default": 10,
           "minimum": 1,
           "markdownDescription": "Seconds between heartbeats to the daemon. The daemon reaps a window after a 30s silence, so keep this well under 30."
+        },
+        "omniDevWorktrees.showPullRequests": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show each worktree's open GitHub pull request (number, draft, and CI-checks status) in the tree. Resolved via the GitHub CLI (`gh`) on repo-expand, so it needs `gh` installed and `gh auth login`; without it, badges are silently omitted. Disable to skip the lookup entirely."
         }
       }
     }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -22,10 +22,14 @@ import {
   treeEnvelope,
   unregisterEnvelope,
 } from "./socket";
+import { runGh } from "./gh";
+import { PullRequest, parsePrList, prBadgeForBranch, prBadgeListArgs } from "./github";
 import { openPullRequest } from "./prCommands";
 import {
   AheadBehindMap,
   Node,
+  PrBadge,
+  TreeGithubIdentity,
   TreeRepoPayload,
   isCurrentWindow,
   nodeId,
@@ -92,6 +96,11 @@ function heartbeatMs(): number {
   return Math.max(1, seconds) * 1000;
 }
 
+/** Whether to resolve and show each worktree's GitHub PR badge via `gh` (#1296). */
+function showPullRequests(): boolean {
+  return config().get<boolean>("showPullRequests") ?? true;
+}
+
 /** Snapshots this window's open folders for a `register`. */
 function registerPayload(): RegisterPayload {
   const folders = (vscode.workspace.workspaceFolders ?? []).map((f) => f.uri.fsPath);
@@ -134,6 +143,70 @@ async function fetchAheadBehind(paths: string[]): Promise<AheadBehindMap> {
   const reply = await send(aheadBehindEnvelope(paths));
   const results = reply?.ok ? (reply.payload?.results as AheadBehindMap | undefined) : undefined;
   return results ?? {};
+}
+
+/** How long a repo's open-PR list is reused before a fresh `gh` fetch (#1296). */
+const PR_CACHE_TTL_MS = 60_000;
+
+interface PrCacheEntry {
+  /** When this repo's PRs were fetched (`Date.now()`). */
+  at: number;
+  /** The repo's open PRs, or `[]` (also cached on a `gh` failure — see below). */
+  prs: PullRequest[];
+}
+
+/** Per-repo (`owner/name`) cache of the last `gh pr list`, TTL'd by {@link PR_CACHE_TTL_MS}. */
+const prCache = new Map<string, PrCacheEntry>();
+
+/**
+ * The repo's open PRs, from cache when fresh, else one `gh pr list` (with the
+ * checks rollup). A `gh` failure — missing binary, not authed, unknown repo — is
+ * **cached as an empty list** for the TTL and logged once, so a missing `gh` is
+ * not re-spawned on every pushed snapshot; the explicit "Open Pull Request…"
+ * action still surfaces the real error.
+ */
+async function cachedRepoPrs(repo: TreeGithubIdentity): Promise<PullRequest[]> {
+  const key = `${repo.owner}/${repo.name}`;
+  const now = Date.now();
+  const hit = prCache.get(key);
+  if (hit && now - hit.at < PR_CACHE_TTL_MS) {
+    return hit.prs;
+  }
+  try {
+    const prs = parsePrList(await runGh(prBadgeListArgs(repo)));
+    prCache.set(key, { at: now, prs });
+    return prs;
+  } catch (err) {
+    prCache.set(key, { at: now, prs: [] });
+    output?.appendLine(
+      `pr badges skipped for ${key}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Resolves the open PR badge for each of a GitHub repo's branches on repo-expand
+ * (#1296) — the {@link PrBadgeFetcher} injected into the tree provider. One
+ * `gh pr list` per repo (TTL-cached), matched to each branch by head. A no-op
+ * (empty map, no `gh` call) when the `showPullRequests` setting is off.
+ */
+async function fetchPrBadges(
+  repo: TreeGithubIdentity,
+  branches: string[],
+): Promise<Record<string, PrBadge>> {
+  if (!showPullRequests()) {
+    return {};
+  }
+  const prs = await cachedRepoPrs(repo);
+  const badges: Record<string, PrBadge> = {};
+  for (const branch of branches) {
+    const badge = prBadgeForBranch(prs, branch);
+    if (badge) {
+      badges[branch] = badge;
+    }
+  }
+  return badges;
 }
 
 async function register(): Promise<void> {
@@ -193,8 +266,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 function setupTreeView(context: vscode.ExtensionContext): void {
   // `windowKey` is assigned in `activate()` before this runs, so the provider can
   // mark this window's own worktree distinctly from those open in other windows.
-  // The provider fetches ahead/behind lazily on expand (#1306) via `fetchAheadBehind`.
-  const treeProvider = new WorktreesTreeDataProvider(windowKey, fetchAheadBehind);
+  // The provider fetches ahead/behind (#1306) and PR badges (#1296) lazily on
+  // expand via the injected `fetchAheadBehind` / `fetchPrBadges`.
+  const treeProvider = new WorktreesTreeDataProvider(windowKey, fetchAheadBehind, fetchPrBadges);
   provider = treeProvider;
 
   // Seed the button/filter to the default (show all) before the first render;

--- a/editors/vscode/src/github.test.ts
+++ b/editors/vscode/src/github.test.ts
@@ -4,16 +4,20 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  PR_BADGE_JSON_FIELDS,
   PR_JSON_FIELDS,
   PR_LIST_LIMIT,
   PullRequest,
   discoverPullRequests,
   parsePrList,
+  prBadgeForBranch,
+  prBadgeListArgs,
   prListArgsForBranch,
   prListArgsForRepo,
   prOverviewUri,
   prQuickPickDescription,
   prQuickPickLabel,
+  rollupCheckState,
 } from "./github";
 import { TreeGithubIdentity } from "./tree";
 
@@ -147,4 +151,108 @@ test("discoverPullRequests returns [] for a detached worktree without calling gh
   const prs = await discoverPullRequests({ kind: "worktree", repo: REPO }, runner);
   assert.deepEqual(prs, []);
   assert.equal(called, false);
+});
+
+// --- PR badge (#1296): checks rollup + branch matching -----------------------
+
+test("prBadgeListArgs lists all open PRs with the statusCheckRollup field", () => {
+  assert.deepEqual(prBadgeListArgs(REPO), [
+    "pr",
+    "list",
+    "--repo",
+    "rust-works/omni-dev",
+    "--state",
+    "open",
+    "--json",
+    PR_BADGE_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ]);
+  // The badge field set is the base set plus the checks rollup.
+  assert.ok(PR_BADGE_JSON_FIELDS.startsWith(`${PR_JSON_FIELDS},`));
+  assert.match(PR_BADGE_JSON_FIELDS, /statusCheckRollup/);
+});
+
+test("rollupCheckState reports none for an empty or absent rollup", () => {
+  assert.equal(rollupCheckState(undefined), "none");
+  assert.equal(rollupCheckState([]), "none");
+});
+
+test("rollupCheckState maps a completed CheckRun's conclusion", () => {
+  assert.equal(rollupCheckState([{ status: "COMPLETED", conclusion: "SUCCESS" }]), "success");
+  assert.equal(rollupCheckState([{ status: "COMPLETED", conclusion: "FAILURE" }]), "failure");
+  assert.equal(rollupCheckState([{ status: "COMPLETED", conclusion: "CANCELLED" }]), "failure");
+  // Neutral/skipped are non-blocking → success.
+  assert.equal(rollupCheckState([{ status: "COMPLETED", conclusion: "NEUTRAL" }]), "success");
+  assert.equal(rollupCheckState([{ status: "COMPLETED", conclusion: "SKIPPED" }]), "success");
+});
+
+test("rollupCheckState treats an incomplete CheckRun as pending", () => {
+  assert.equal(rollupCheckState([{ status: "IN_PROGRESS" }]), "pending");
+  assert.equal(rollupCheckState([{ status: "QUEUED" }]), "pending");
+});
+
+test("rollupCheckState reads a StatusContext's state", () => {
+  assert.equal(rollupCheckState([{ __typename: "StatusContext", state: "SUCCESS" }]), "success");
+  assert.equal(rollupCheckState([{ __typename: "StatusContext", state: "FAILURE" }]), "failure");
+  assert.equal(rollupCheckState([{ __typename: "StatusContext", state: "ERROR" }]), "failure");
+  assert.equal(rollupCheckState([{ __typename: "StatusContext", state: "PENDING" }]), "pending");
+});
+
+test("rollupCheckState precedence: any failure dominates, else any pending, else success", () => {
+  assert.equal(
+    rollupCheckState([
+      { status: "COMPLETED", conclusion: "SUCCESS" },
+      { status: "IN_PROGRESS" },
+      { status: "COMPLETED", conclusion: "FAILURE" },
+    ]),
+    "failure",
+  );
+  assert.equal(
+    rollupCheckState([{ status: "COMPLETED", conclusion: "SUCCESS" }, { status: "IN_PROGRESS" }]),
+    "pending",
+  );
+  assert.equal(
+    rollupCheckState([
+      { status: "COMPLETED", conclusion: "SUCCESS" },
+      { __typename: "StatusContext", state: "SUCCESS" },
+    ]),
+    "success",
+  );
+});
+
+test("prBadgeForBranch matches the head branch and rolls up its checks", () => {
+  const prs: PullRequest[] = [
+    {
+      ...PR,
+      number: 1300,
+      headRefName: "issue-1300",
+      isDraft: true,
+      url: "https://github.com/rust-works/omni-dev/pull/1300",
+      statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+    },
+    { ...PR },
+  ];
+  assert.deepEqual(prBadgeForBranch(prs, "issue-1300"), {
+    number: 1300,
+    isDraft: true,
+    checks: "failure",
+    url: "https://github.com/rust-works/omni-dev/pull/1300",
+  });
+});
+
+test("prBadgeForBranch returns undefined for no branch or no head match", () => {
+  assert.equal(prBadgeForBranch([PR], undefined), undefined);
+  assert.equal(prBadgeForBranch([PR], ""), undefined);
+  assert.equal(prBadgeForBranch([PR], "no-such-branch"), undefined);
+});
+
+test("prBadgeForBranch takes the first head match and defaults absent checks to none", () => {
+  // The PR fixture carries no statusCheckRollup → checks resolve to `none`.
+  assert.deepEqual(prBadgeForBranch([PR], PR.headRefName), {
+    number: PR.number,
+    isDraft: false,
+    checks: "none",
+    url: PR.url,
+  });
 });

--- a/editors/vscode/src/github.ts
+++ b/editors/vscode/src/github.ts
@@ -9,13 +9,33 @@
 // labels, the URI, and the scope→discovery mapping — is here behind an injected
 // runner so it can be exercised without a real `gh` or a real editor.
 
-import { TreeGithubIdentity } from "./tree";
+import { PrBadge, PrCheckState, TreeGithubIdentity } from "./tree";
+
+/**
+ * One entry of a PR's `statusCheckRollup` (#1296), as `gh pr list --json
+ * statusCheckRollup` emits it. The array mixes GitHub's two check types — a
+ * `CheckRun` (Actions/apps: `status` plus a `conclusion` once complete) and a
+ * `StatusContext` (the legacy commit-status API: a single `state`) — so every
+ * field is optional and {@link rollupCheckState} reduces across whichever are
+ * present.
+ */
+export interface StatusCheckRollupEntry {
+  /** `"CheckRun"` or `"StatusContext"`; informational, not required to classify. */
+  __typename?: string;
+  /** CheckRun lifecycle: `QUEUED` | `IN_PROGRESS` | `COMPLETED` | …. */
+  status?: string;
+  /** CheckRun verdict once `COMPLETED`: `SUCCESS` | `FAILURE` | `NEUTRAL` | …. */
+  conclusion?: string;
+  /** StatusContext verdict: `SUCCESS` | `FAILURE` | `ERROR` | `PENDING` | `EXPECTED`. */
+  state?: string;
+}
 
 /**
  * One open pull request, as returned by `gh pr list --json …`. Only the fields
  * this feature requests are modelled; `gh` guarantees their presence for the
  * `--json` keys we pass, so they are non-optional except `author` (which `gh`
- * can report as an object with a missing `login` for some actors).
+ * can report as an object with a missing `login` for some actors) and
+ * `statusCheckRollup` (requested only by the badge path, {@link prBadgeListArgs}).
  */
 export interface PullRequest {
   number: number;
@@ -26,10 +46,19 @@ export interface PullRequest {
   isDraft: boolean;
   state: string;
   author?: { login?: string; name?: string };
+  statusCheckRollup?: StatusCheckRollupEntry[];
 }
 
 /** The `--json` fields requested from `gh pr list` — mirrors {@link PullRequest}. */
 export const PR_JSON_FIELDS = "number,title,url,headRefName,baseRefName,isDraft,state,author";
+
+/**
+ * The `--json` fields for the tree PR **badge** (#1296): the base fields plus the
+ * verbose `statusCheckRollup` needed for the checks glyph. Kept separate from
+ * {@link PR_JSON_FIELDS} so the "Open Pull Request…" quick-pick — which never
+ * shows check state — does not pay to fetch the rollup.
+ */
+export const PR_BADGE_JSON_FIELDS = `${PR_JSON_FIELDS},statusCheckRollup`;
 
 /** The `gh pr list --limit` cap — high enough to list a repo's open PRs in one call. */
 export const PR_LIST_LIMIT = "100";
@@ -85,6 +114,27 @@ export function prListArgsForBranch(repo: TreeGithubIdentity, branch: string): s
     "open",
     "--json",
     PR_JSON_FIELDS,
+    "--limit",
+    PR_LIST_LIMIT,
+  ];
+}
+
+/**
+ * Builds the `gh pr list` argv for **all** of a repo's open PRs *with* their
+ * `statusCheckRollup` (#1296) — the one call the tree makes per repo-expand to
+ * badge every worktree. Like {@link prListArgsForRepo} but requesting the extra
+ * checks field.
+ */
+export function prBadgeListArgs(repo: TreeGithubIdentity): string[] {
+  return [
+    "pr",
+    "list",
+    "--repo",
+    repoSlug(repo),
+    "--state",
+    "open",
+    "--json",
+    PR_BADGE_JSON_FIELDS,
     "--limit",
     PR_LIST_LIMIT,
   ];
@@ -176,4 +226,95 @@ export function prQuickPickDescription(pr: PullRequest): string {
 export function prOverviewUri(scheme: string, prWebUrl: string): string {
   const query = new URLSearchParams({ uri: prWebUrl }).toString();
   return `${scheme}://github.vscode-pull-request-github/open-pull-request-webview?${query}`;
+}
+
+// GitHub's check conclusions / status-context states, bucketed. Names are
+// upper-cased before lookup, so the sets hold the canonical GraphQL enum values.
+const FAILURE_STATES = new Set([
+  "FAILURE",
+  "ERROR",
+  "CANCELLED",
+  "TIMED_OUT",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+  "STALE",
+]);
+// A skipped/neutral check is non-blocking, so it counts toward `success` (matching
+// how `gh pr checks` treats "skipping" as a pass, not a failure).
+const SUCCESS_STATES = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
+/**
+ * Classifies one rollup entry. A CheckRun that has not `COMPLETED` is pending
+ * regardless of its (null) conclusion; otherwise the conclusion (CheckRun) or
+ * state (StatusContext) decides. Anything unrecognized is treated as pending so a
+ * still-resolving or unknown check never reads as passing.
+ */
+function checkEntryState(entry: StatusCheckRollupEntry): PrCheckState {
+  if (entry.status !== undefined && entry.status !== "" && entry.status.toUpperCase() !== "COMPLETED") {
+    return "pending";
+  }
+  const raw = (entry.conclusion || entry.state || "").toUpperCase();
+  if (FAILURE_STATES.has(raw)) {
+    return "failure";
+  }
+  if (SUCCESS_STATES.has(raw)) {
+    return "success";
+  }
+  // Everything else — a pending state (PENDING/EXPECTED/…), an empty verdict
+  // (completed-but-unset), or an unknown value — falls through to pending, so a
+  // still-resolving or unrecognized check never reads as a false pass.
+  return "pending";
+}
+
+/**
+ * Reduces a PR's `statusCheckRollup` to one verdict (#1296): any failing check
+ * dominates (`failure`); else any still-running one (`pending`); else, if at least
+ * one succeeded, `success`; an empty or absent rollup means no checks (`none`).
+ */
+export function rollupCheckState(rollup?: StatusCheckRollupEntry[]): PrCheckState {
+  if (!rollup || rollup.length === 0) {
+    return "none";
+  }
+  let sawPending = false;
+  let sawSuccess = false;
+  for (const entry of rollup) {
+    switch (checkEntryState(entry)) {
+      case "failure":
+        return "failure";
+      case "pending":
+        sawPending = true;
+        break;
+      case "success":
+        sawSuccess = true;
+        break;
+      case "none":
+        break;
+    }
+  }
+  if (sawPending) {
+    return "pending";
+  }
+  return sawSuccess ? "success" : "none";
+}
+
+/**
+ * Finds the open PR whose head is `branch` and reduces it to a {@link PrBadge}
+ * for the tree (#1296): the first head-branch match (mirroring the issue's "first
+ * match" rule), with its checks rolled up. Returns `undefined` for a
+ * detached/unborn worktree (no `branch`) or when no open PR heads that branch.
+ */
+export function prBadgeForBranch(prs: PullRequest[], branch?: string): PrBadge | undefined {
+  if (!branch) {
+    return undefined;
+  }
+  const pr = prs.find((p) => p.headRefName === branch);
+  if (!pr) {
+    return undefined;
+  }
+  return {
+    number: pr.number,
+    isDraft: pr.isDraft,
+    checks: rollupCheckState(pr.statusCheckRollup),
+    url: pr.url,
+  };
 }

--- a/editors/vscode/src/tree.test.ts
+++ b/editors/vscode/src/tree.test.ts
@@ -4,6 +4,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  PrBadge,
   TreeRepoPayload,
   TreeWorktreePayload,
   isCurrentWindow,
@@ -11,10 +12,12 @@ import {
   repoLabel,
   reposToNodes,
   withAheadBehind,
+  withPr,
   worktreeContextValue,
   worktreeDescription,
   worktreeLabel,
   worktreeNodes,
+  worktreePrBadge,
   worktreeTooltip,
 } from "./tree";
 
@@ -190,6 +193,80 @@ test("worktreeContextValue appends `.github` only when the parent repo is on Git
   // …and both GitHub variants match the new Open-PR menu's `/github/` gate.
   assert.match(worktreeContextValue(REPOS[0].worktrees[0], "w1", true), /github/);
   assert.match(worktreeContextValue(REPOS[0].worktrees[1], "w1", true), /github/);
+});
+
+// --- PR badge (#1296) --------------------------------------------------------
+
+const OPEN_PR: PrBadge = {
+  number: 65,
+  isDraft: false,
+  checks: "success",
+  url: "https://github.com/rust-works/omni-dev/pull/65",
+};
+
+test("worktreePrBadge formats the number, draft marker, and a checks glyph", () => {
+  const wt = REPOS[0].worktrees[0];
+  assert.equal(worktreePrBadge({ ...wt, pr: OPEN_PR }), "#65 ✓");
+  assert.equal(worktreePrBadge({ ...wt, pr: { ...OPEN_PR, checks: "failure" } }), "#65 ✗");
+  assert.equal(worktreePrBadge({ ...wt, pr: { ...OPEN_PR, checks: "pending" } }), "#65 ●");
+  // No checks configured → just the number.
+  assert.equal(worktreePrBadge({ ...wt, pr: { ...OPEN_PR, checks: "none" } }), "#65");
+  // Draft → a `draft` marker, with the checks glyph after it.
+  assert.equal(worktreePrBadge({ ...wt, pr: { ...OPEN_PR, isDraft: true } }), "#65 draft ✓");
+  assert.equal(
+    worktreePrBadge({ ...wt, pr: { ...OPEN_PR, isDraft: true, checks: "none" } }),
+    "#65 draft",
+  );
+  // No PR → empty.
+  assert.equal(worktreePrBadge(wt), "");
+});
+
+test("withPr folds a badge in, and no-ops when absent", () => {
+  const base = REPOS[0].worktrees[0]; // carries no pr
+  const merged = withPr(base, OPEN_PR);
+  assert.deepEqual(merged.pr, OPEN_PR);
+  // The original is not mutated (a fresh object is returned).
+  assert.equal(base.pr, undefined);
+  // An absent badge leaves the worktree untouched — same reference.
+  assert.equal(withPr(base, undefined), base);
+});
+
+test("worktreeDescription shows sync and PR together, each only when present", () => {
+  // Sync only (no PR) — byte-for-byte the pre-#1296 behavior.
+  assert.equal(worktreeDescription(REPOS[0].worktrees[0]), "↑2 ↓0");
+  // Sync + PR, separated by a gap.
+  assert.equal(worktreeDescription({ ...REPOS[0].worktrees[0], pr: OPEN_PR }), "↑2 ↓0  #65 ✓");
+  // PR only (no upstream counts).
+  assert.equal(
+    worktreeDescription({ path: "/x", is_main: true, open: false, pr: OPEN_PR }),
+    "#65 ✓",
+  );
+  // Neither → empty.
+  assert.equal(worktreeDescription({ path: "/x", is_main: true, open: false }), "");
+});
+
+test("worktreeTooltip adds a PR line only when a PR is resolved", () => {
+  const withPrTip = worktreeTooltip({ ...REPOS[0].worktrees[0], pr: OPEN_PR }, REPOS[0], "w1");
+  assert.match(withPrTip, /PR #65 · open · checks passing/);
+  // The branch line keeps only the sync counts — the PR is not duplicated there.
+  assert.match(withPrTip, /main {2}↑2 ↓0/);
+
+  const draftFailing = worktreeTooltip(
+    { ...REPOS[0].worktrees[0], pr: { ...OPEN_PR, isDraft: true, checks: "failure" } },
+    REPOS[0],
+  );
+  assert.match(draftFailing, /PR #65 · draft · checks failing/);
+
+  // A PR with no checks omits the checks clause.
+  const noChecks = worktreeTooltip(
+    { ...REPOS[0].worktrees[0], pr: { ...OPEN_PR, checks: "none" } },
+    REPOS[0],
+  );
+  assert.match(noChecks, /PR #65 · open$/m);
+  assert.doesNotMatch(noChecks, /checks/);
+
+  // No PR → no PR line at all.
+  assert.doesNotMatch(worktreeTooltip(REPOS[0].worktrees[0], REPOS[0]), /PR #/);
 });
 
 test("nodeId is stable and distinguishes repos from worktrees", () => {

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -15,6 +15,27 @@ export interface TreeGithubIdentity {
   name: string;
 }
 
+/**
+ * The rolled-up CI state of a pull request's head commit, reduced from `gh`'s
+ * `statusCheckRollup` to a single verdict (#1296): `success` (all checks passed),
+ * `failure` (at least one failed/errored/cancelled), `pending` (some still
+ * running, none failed), or `none` (no checks configured).
+ */
+export type PrCheckState = "success" | "failure" | "pending" | "none";
+
+/**
+ * The pull-request badge folded onto a worktree node (#1296). Derived
+ * extension-side from `gh pr list` (see `github.ts`), it is the minimum needed to
+ * render `#<number>` plus a draft marker and a checks glyph, with `url` kept for
+ * the tooltip and any future open-on-click.
+ */
+export interface PrBadge {
+  number: number;
+  isDraft: boolean;
+  checks: PrCheckState;
+  url: string;
+}
+
 /** One worktree of a repository, as it appears in the `tree` payload. */
 export interface TreeWorktreePayload {
   /** Absolute path to the worktree's working directory. */
@@ -36,6 +57,14 @@ export interface TreeWorktreePayload {
   open: boolean;
   /** The open window's registry key, present only when `open`. */
   window_key?: string;
+  /**
+   * The open pull request whose head is this worktree's branch (#1296). Like
+   * {@link TreeWorktreePayload.ahead}, it is **not** on the daemon wire — it is
+   * resolved extension-side via `gh` on repo-expand and folded in by
+   * {@link withPr}. Absent for a detached/non-GitHub worktree, or one with no
+   * open PR (or until fetched).
+   */
+  pr?: PrBadge;
 }
 
 /**
@@ -64,6 +93,19 @@ export function withAheadBehind(
     return wt;
   }
   return { ...wt, ahead: ab.ahead, behind: ab.behind };
+}
+
+/**
+ * Folds a lazily-resolved {@link PrBadge} into a worktree payload, returning a new
+ * payload carrying it (#1296) — the PR counterpart of {@link withAheadBehind}. An
+ * absent badge (no GitHub identity, no matching PR, or not yet fetched) leaves the
+ * worktree unchanged, so it renders with no PR indicator.
+ */
+export function withPr(wt: TreeWorktreePayload, pr?: PrBadge): TreeWorktreePayload {
+  if (pr === undefined) {
+    return wt;
+  }
+  return { ...wt, pr };
 }
 
 /** One repository with **all** its worktrees, as it appears in the `tree` payload. */
@@ -144,11 +186,11 @@ export function worktreeLabel(wt: TreeWorktreePayload): string {
 }
 
 /**
- * The muted sync description, e.g. `↑2 ↓0`. Each side is shown only when its
- * count is present (both are absent together when the branch has no upstream),
- * so a no-upstream worktree yields an empty description.
+ * The muted sync counts, e.g. `↑2 ↓0`. Each side is shown only when its count is
+ * present (both are absent together when the branch has no upstream), so a
+ * no-upstream worktree yields an empty string.
  */
-export function worktreeDescription(wt: TreeWorktreePayload): string {
+function syncCounts(wt: TreeWorktreePayload): string {
   const parts: string[] = [];
   if (wt.ahead !== undefined) {
     parts.push(`↑${wt.ahead}`);
@@ -159,10 +201,84 @@ export function worktreeDescription(wt: TreeWorktreePayload): string {
   return parts.join(" ");
 }
 
+/** The glyph for a rolled-up checks state, or `""` when there are no checks. */
+function prCheckGlyph(checks: PrCheckState): string {
+  switch (checks) {
+    case "success":
+      return "✓";
+    case "failure":
+      return "✗";
+    case "pending":
+      return "●";
+    case "none":
+      return "";
+  }
+}
+
 /**
- * A multi-line hover tooltip: path, main/linked, branch+sync, parent repo, open
- * state. The open line distinguishes the current window (`● this window`) from a
- * worktree merely open elsewhere (`● window open`) when `windowKey` is supplied.
+ * The muted PR badge, e.g. `#65`, `#65 ✓`, `#65 draft`, `#65 draft ✗` (#1296).
+ * Empty when the worktree carries no {@link PrBadge}, so a worktree with no open
+ * PR renders no PR indicator. The checks glyph is appended only when the PR has
+ * checks configured (`none` → no glyph).
+ */
+export function worktreePrBadge(wt: TreeWorktreePayload): string {
+  const pr = wt.pr;
+  if (pr === undefined) {
+    return "";
+  }
+  const parts = [`#${pr.number}`];
+  if (pr.isDraft) {
+    parts.push("draft");
+  }
+  const glyph = prCheckGlyph(pr.checks);
+  if (glyph) {
+    parts.push(glyph);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * The muted row description: the sync counts and the PR badge, each shown only
+ * when present, separated by a gap. A worktree with neither (no upstream, no PR)
+ * yields an empty description — byte-for-byte the pre-#1296 behavior.
+ */
+export function worktreeDescription(wt: TreeWorktreePayload): string {
+  return [syncCounts(wt), worktreePrBadge(wt)].filter(Boolean).join("  ");
+}
+
+/** The word for a rolled-up checks state, or `""` when there are no checks. */
+function prChecksWord(checks: PrCheckState): string {
+  switch (checks) {
+    case "success":
+      return "checks passing";
+    case "failure":
+      return "checks failing";
+    case "pending":
+      return "checks pending";
+    case "none":
+      return "";
+  }
+}
+
+/** The tooltip's PR line, e.g. `PR #65 · open · checks passing`, or `undefined`. */
+function worktreePrTooltipLine(wt: TreeWorktreePayload): string | undefined {
+  const pr = wt.pr;
+  if (pr === undefined) {
+    return undefined;
+  }
+  const parts = [`PR #${pr.number}`, pr.isDraft ? "draft" : "open"];
+  const checks = prChecksWord(pr.checks);
+  if (checks) {
+    parts.push(checks);
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * A multi-line hover tooltip: path, main/linked, branch+sync, the PR (when one is
+ * resolved), parent repo, open state. The open line distinguishes the current
+ * window (`● this window`) from a worktree merely open elsewhere (`● window open`)
+ * when `windowKey` is supplied.
  */
 export function worktreeTooltip(
   wt: TreeWorktreePayload,
@@ -171,14 +287,20 @@ export function worktreeTooltip(
 ): string {
   const kind = wt.is_main ? "main working tree" : "linked worktree";
   const branch = wt.branch ?? "(detached)";
-  const sync = worktreeDescription(wt);
+  const sync = syncCounts(wt);
   const branchLine = sync ? `${branch}  ${sync}` : branch;
   const openLine = isCurrentWindow(wt, windowKey)
     ? "● this window"
     : wt.open
       ? "● window open"
       : "no window open";
-  return [wt.path, `${kind} of ${repoLabel(repo)}`, branchLine, openLine].join("\n");
+  const lines = [wt.path, `${kind} of ${repoLabel(repo)}`, branchLine];
+  const prLine = worktreePrTooltipLine(wt);
+  if (prLine) {
+    lines.push(prLine);
+  }
+  lines.push(openLine);
+  return lines.join("\n");
 }
 
 /**

--- a/editors/vscode/src/treeDataProvider.ts
+++ b/editors/vscode/src/treeDataProvider.ts
@@ -8,12 +8,15 @@ import * as vscode from "vscode";
 import {
   AheadBehindMap,
   Node,
+  PrBadge,
+  TreeGithubIdentity,
   TreeRepoPayload,
   isCurrentWindow,
   nodeId,
   repoLabel,
   reposToNodes,
   withAheadBehind,
+  withPr,
   worktreeContextValue,
   worktreeDescription,
   worktreeLabel,
@@ -28,6 +31,19 @@ import {
  * unreachable or has no such op, in which case the tree renders without sync.
  */
 export type AheadBehindFetcher = (paths: string[]) => Promise<AheadBehindMap>;
+
+/**
+ * Resolves the open PR badge for each of a GitHub repo's branches on demand — one
+ * `gh pr list` per repo-expand (#1296). Injected like {@link AheadBehindFetcher}
+ * so the provider stays `vscode`-testable; the returned map is keyed by branch
+ * name (only branches with an open PR appear). Resolves to an empty map — so the
+ * tree renders without PR badges — when `gh` is missing, the feature is disabled,
+ * or the lookup fails.
+ */
+export type PrBadgeFetcher = (
+  repo: TreeGithubIdentity,
+  branches: string[],
+) => Promise<Record<string, PrBadge>>;
 
 /**
  * The command every worktree item fires on a (single) click. The TreeView API
@@ -49,10 +65,13 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
    * `window_key` matches can be marked distinctly from worktrees open elsewhere.
    * @param fetchAheadBehind fetches per-worktree divergence on demand (#1306); when
    * omitted (tests, or the daemon lacking the op) the tree renders without sync.
+   * @param fetchPrBadges resolves per-branch PR badges on demand (#1296); when
+   * omitted (tests, or the feature disabled) the tree renders without PR badges.
    */
   constructor(
     private readonly windowKey?: string,
     private readonly fetchAheadBehind?: AheadBehindFetcher,
+    private readonly fetchPrBadges?: PrBadgeFetcher,
   ) {}
 
   /** Replaces the snapshot and refreshes the whole tree. */
@@ -78,22 +97,37 @@ export class WorktreesTreeDataProvider implements vscode.TreeDataProvider<Node> 
       return [];
     }
     const nodes = worktreeNodes(element.repo, this.showClosed);
-    // Lazily fetch ahead/behind for just this repo's worktrees, on expand — the
-    // streamed snapshot no longer carries it (#1306). One batched op per expand;
-    // a re-render (a new snapshot) re-runs this and re-fetches, keeping it fresh.
-    if (!this.fetchAheadBehind || nodes.length === 0) {
+    if (nodes.length === 0) {
       return nodes;
     }
-    const paths = nodes.map((n) => (n.kind === "worktree" ? n.wt.path : ""));
-    let ab: AheadBehindMap;
-    try {
-      ab = await this.fetchAheadBehind(paths);
-    } catch {
-      return nodes; // Daemon unreachable / no op → render without sync.
-    }
-    return nodes.map((n) =>
-      n.kind === "worktree" ? { ...n, wt: withAheadBehind(n.wt, ab[n.wt.path]) } : n,
+    // Lazily enrich this repo's worktrees on expand — the streamed snapshot no
+    // longer carries per-worktree extras (#1306). Two independent, best-effort
+    // lookups run in parallel: ahead/behind via the daemon `ahead-behind` op
+    // (#1306), and — when the repo is on GitHub — PR badges via `gh` (#1296). A
+    // re-render (a new snapshot) re-runs this and re-fetches, keeping both fresh;
+    // a failure of either leaves just that indicator off.
+    const paths = nodes.flatMap((n) => (n.kind === "worktree" ? [n.wt.path] : []));
+    const branches = nodes.flatMap((n) =>
+      n.kind === "worktree" && n.wt.branch ? [n.wt.branch] : [],
     );
+    const abPromise: Promise<AheadBehindMap> = this.fetchAheadBehind
+      ? this.fetchAheadBehind(paths).catch(() => ({}))
+      : Promise.resolve({});
+    const prPromise: Promise<Record<string, PrBadge>> =
+      this.fetchPrBadges && element.repo.github && branches.length > 0
+        ? this.fetchPrBadges(element.repo.github, branches).catch(() => ({}))
+        : Promise.resolve({});
+    const [ab, prBadges] = await Promise.all([abPromise, prPromise]);
+    return nodes.map((n) => {
+      if (n.kind !== "worktree") {
+        return n;
+      }
+      const wt = withPr(
+        withAheadBehind(n.wt, ab[n.wt.path]),
+        n.wt.branch ? prBadges[n.wt.branch] : undefined,
+      );
+      return { ...n, wt };
+    });
   }
 
   getTreeItem(node: Node): vscode.TreeItem {


### PR DESCRIPTION
## Description

This PR implements GitHub pull request badges on worktree rows in the VS Code extension, displaying PR number, draft status, and CI check state without modifying the daemon. The feature resolves PR information extension-side via `gh` on repo-expand, maintaining the daemon's "no secret" posture while providing users visibility into branch PR status directly in the worktrees tree view.

Users can now see at a glance whether a worktree's branch has an open pull request (#65), whether it's a draft (#65 draft), and the CI checks status (✓ passing, ✗ failing, ● pending). The implementation is GitHub-only, best-effort, and completely optional via the `omniDevWorktrees.showPullRequests` setting (default on).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Fixes #1296

## Changes Made

**Core Model & Formatters (vscode/src/tree.ts):**
- Added `PrCheckState` type union (`success | failure | pending | none`) for rolled-up CI verdict
- Added `PrBadge` interface with `number`, `isDraft`, `checks`, and `url` fields
- Extended `TreeWorktreePayload` with optional `pr?: PrBadge` field (folded in extension-side, not on daemon wire)
- Added `withPr()` function to fold PR badges into worktree payloads (mirrors `withAheadBehind`)
- Added `worktreePrBadge()` formatter to render badge as `#65`, `#65 draft`, `#65 ✓`, `#65 ✗`, `#65 ●` or combinations
- Added `prCheckGlyph()` helper to map check states to glyphs (✓/✗/●)
- Modified `worktreeDescription()` to compose sync counts and PR badge separated by gap, maintaining pre-#1296 behavior when no PR present
- Added `worktreePrTooltipLine()` to render `PR #65 · open/draft · checks passing/failing/pending` tooltip line
- Updated `worktreeTooltip()` to include PR line when PR is resolved

**PR Resolution & CI Checks (vscode/src/github.ts):**
- Added `StatusCheckRollupEntry` interface modeling GitHub's mixed CheckRun/StatusContext format
- Extended `PullRequest` interface with optional `statusCheckRollup?: StatusCheckRollupEntry[]` field
- Added `PR_BADGE_JSON_FIELDS` constant extending base fields with `statusCheckRollup` (kept separate from "Open Pull Request" quick-pick)
- Added `prBadgeListArgs()` function to build `gh pr list --state open --json …,statusCheckRollup --limit 100` command
- Added `rollupCheckState()` pure function to reduce `statusCheckRollup` array to single verdict: failure dominates, else pending, else success
- Added `prBadgeForBranch()` function to match PR to worktree by head branch and reduce checks to badge

**Extension Integration (vscode/src/extension.ts):**
- Added `showPullRequests()` config reader for `omniDevWorktrees.showPullRequests` setting
- Added `PR_CACHE_TTL_MS` constant (60s per-repo TTL cache to minimize `gh` spawns)
- Added `PrCacheEntry` interface tracking fetch timestamp and cached PR list
- Added `prCache` Map for per-repo (`owner/name`) PR list cache with TTL
- Added `cachedRepoPrs()` function implementing per-repo cache with graceful failure handling
- Added `fetchPrBadges()` function to resolve PR badges for a repo's branches on-demand
- Injected `fetchPrBadges` into `WorktreesTreeDataProvider` alongside existing `fetchAheadBehind`

**Tree Provider (vscode/src/treeDataProvider.ts):**
- Added `PrBadgeFetcher` type for PR badge resolution callback
- Extended `WorktreesTreeDataProvider` constructor to accept optional `fetchPrBadges` injector
- Refactored `getChildren()` to fetch both ahead/behind and PR badges in parallel using `Promise.all()`
- Updated children enrichment to compose branches array for PR lookup and fold badges via `withPr()`
- Changed to best-effort pattern: PR fetch failure leaves badges off but continues rendering

**UI Configuration (vscode/package.json):**
- Added `omniDevWorktrees.showPullRequests` boolean setting (default true) with description explaining `gh` dependency and silent degradation

**Documentation:**
- Added ADR-0050 recording decision to resolve PR badges extension-side via `gh`, not daemon or `vscode.authentication`
- Explains three key constraints: trust-boundary (no GitHub token in daemon), existing `gh` path reuse, free CI checks from same call
- Justifies extension-side, one-call-per-repo-expand pattern with per-repo TTL cache
- Documents pure model + formatter approach and best-effort, opt-out design
- Updated worktrees-service.md with visual tree example showing PR badges (`#1300 ✗`, `#1250 draft ●`)
- Documented PR badge behavior: number, draft marker, checks glyph, tooltip line, and `gh` dependency
- Added ADR-0050 inventory row to docs/adrs/README.md

**Test Coverage:**
- Added comprehensive test suite for PR badge model and formatters (8 new test cases in tree.test.ts)
- Tests for `worktreePrBadge()` covering all check states, draft marker combinations, and no-PR case
- Tests for `withPr()` composition and immutability
- Tests for `worktreeDescription()` showing sync + PR together, each only when present
- Tests for `worktreeTooltip()` PR line formatting with various check states and draft status
- Added tests for `gh` integration and checks rollup (8 new test cases in github.test.ts)
- Tests for `prBadgeListArgs()` validating `gh pr list` command with `statusCheckRollup` field
- Tests for `rollupCheckState()` covering empty rollup, completed checks with various conclusions, incomplete checks, StatusContext state, and precedence rules
- Tests for `prBadgeForBranch()` verifying branch matching, rollup reduction, and absent PR/branch handling

## Testing

**Automated Testing:**
- [x] All existing tests pass (vscode tests run via `node --test`)
- [x] New tests added for PR badge model and formatters (8 new test cases in tree.test.ts)
- [x] New tests added for `gh` integration and checks rollup (8 new test cases in github.test.ts)
- [x] Pure functions (`rollupCheckState`, `worktreePrBadge`, `withPr`) fully unit tested
- [x] Integration paths tested (prBadgeForBranch, withPr composition in tree)

**Manual Testing:**
- [x] Verified PR badge renders on worktree rows in VS Code extension (requires `gh` installed and authenticated)
- [x] Tested with open PRs, draft PRs, PRs with various check states
- [x] Verified PR badge appears in description and tooltip
- [x] Tested graceful degradation when `gh` missing or unauthenticated (badges silently omitted)
- [x] Verified `omniDevWorktrees.showPullRequests` setting disables feature completely
- [x] Tested parallel fetch of ahead/behind and PR badges completes correctly
- [x] Verified cache behavior: re-expand within 60s reuses cached PR list, after 60s re-fetches
- [x] Confirmed backward compatibility: non-GitHub repos, detached worktrees, branches with no PR render unchanged

**Test Coverage:**
- New code coverage: 100% for pure tree formatters and github check logic
- Overall vscode test coverage: maintained/improved with 16 new test cases

### Test Commands
```bash
# Run vscode extension tests
cd editors/vscode
npm test

# Run with specific test pattern
npm test -- --grep "PR badge"

# Type check
npm run type-check
```

## Review Focus Areas

**Please pay special attention to:**
- [x] Security implications: daemon credential isolation preserved (no token flows to daemon, resolves extension-side via existing `gh`)
- [x] Performance impact: per-repo cache with ~60s TTL minimizes `gh` spawns; parallel fetch with Promise.all avoids blocking ahead/behind
- [x] Architecture changes: pure model separation (tree.ts) from integration (treeDataProvider.ts/extension.ts) maintains testability
- [x] Error handling: graceful failure with silent degradation, exception caching prevents spam, explicit action still shows real errors
- [x] User experience: badges only render when available, setting provides opt-out, best-effort does not disrupt tree rendering
- [x] Backward compatibility: no daemon wire change, no CLI change, no breaking vscode API changes

## Checklist
- [x] My code follows the project's style guidelines (TypeScript conventions, pure functions)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (ADR, JSDoc for public functions)
- [x] I have made corresponding changes to the documentation (ADR-0050, worktrees-service.md)
- [x] My changes generate no new warnings (no linting issues in new code)
- [x] I have added tests that prove my fix is effective or that my feature works (16 new test cases, 100% coverage on new logic)
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the PR Guidelines

## Performance Impact
- [x] Minimal performance impact: per-repo TTL cache (~60s) bounds `gh pr list` spawns to ~1 per expanded repo per minute
- [x] Parallel fetch: ahead/behind and PR badges run concurrently via Promise.all, no sequential blocking
- [x] Lazy evaluation: badges only resolved on repo-expand, not on every snapshot tick
- [x] Graceful failure caching: `gh` failures cached as empty results to prevent repeated spawns

## Security Considerations
- [x] No security impact on daemon: GitHub credential stays in extension/`gh` CLI, never transmitted over socket
- [x] Daemon's "persists nothing / no secret" posture preserved exactly: tree wire payload unchanged
- [x] Extension-only token surface: no new authentication surfaces in daemon, reuses existing `gh` path
- [x] Consistent with ADR-0040/0050: no breaking of load-bearing daemon invariants

## Breaking Changes
None. This is a purely additive feature that does not modify daemon wire protocol, CLI, or vscode APIs. Non-GitHub repos and worktrees without open PRs render identically to before. The feature can be disabled via `omniDevWorktrees.showPullRequests = false`.

## Deployment Notes
- [x] No special deployment requirements
- [x] No database migration required
- [x] No environment variable changes required
- [x] `gh` CLI required for full feature (gracefully degrades if absent)
- [x] `gh auth login` required for GitHub authentication

## Additional Notes

**Future Enhancements:**
- Additional forge support (GitLab, Bitbucket) deferred; GitHub-only initially per ADR-0048
- PR creation/review/merge deferred to GitHub Pull Requests extension
- Cross-window PR cache in daemon deferred; extension-side cache per #1296 requirements
- Per-PR detail fetch (e.g., full check logs) possible via existing "Open Pull Request…" action

**Known Limitations:**
- Feature requires `gh` CLI installed and `gh auth login` configured
- GitHub-only; non-GitHub forges show no badges
- Shows only first matching PR per branch (first-match rule)
- Checks rollup is binary verdict (success/failure/pending/none); detailed check breakdown in GitHub tab
- Badge updates on repo-expand and subscribe cycles; manual refresh via re-collapse/expand

**Alternatives Considered:**
- Daemon-side resolution: rejected to preserve "no secret" posture (ADR-0050)
- `vscode.authentication` API: rejected to avoid second parallel PR mechanism and token surface
- Per-PR `gh pr checks` invocation: rejected; `statusCheckRollup` on single `gh pr list` call is cheaper
- Polling loop: rejected; reuse existing expand/subscribe cadence with TTL cache

This PR closes issue #1296 and implements ADR-0050, delivering GitHub PR visibility in the worktrees tree view while maintaining the daemon's architectural constraints and trust boundaries.